### PR TITLE
[code-review] Share scheduler slot calculations while distinguishing future slots from catch-up work

### DIFF
--- a/crates/orbit-automation/src/auto_tasks/schedule.rs
+++ b/crates/orbit-automation/src/auto_tasks/schedule.rs
@@ -6,12 +6,19 @@
 //! single make-up task, not one per missed slot. Cron schedules reuse the
 //! routine due-math (`crate::routines::due`) under [`MissedRunPolicy::CatchUpOnce`];
 //! interval schedules fire at most one task for the most recent boundary.
+//!
+//! [`decide_due`] and [`next_scheduled_slot`] answer different questions and
+//! are expected to disagree. The first is catch-up eligibility — it can name a
+//! slot already in the past that the scheduler still owes a fire. The second is
+//! the next scheduled occurrence, always strictly ahead of `now`, and is what
+//! operator surfaces render as "next evaluation". Both derive every slot from
+//! the arithmetic in this module so the two views stay anchored identically.
 
 use chrono::{DateTime, Duration, Local, Utc};
 use orbit_common::OrbitError;
 use orbit_types::workflow::{AutoTaskSchedule, MAX_AUTO_TASK_INTERVAL_MINUTES, MissedRunPolicy};
 
-use crate::routines::due::{DueDecision, due_decision, parse_cron};
+use crate::routines::due::{DueDecision, due_decision, next_occurrence, parse_cron};
 
 /// Outcome of the due check for one definition on one scheduler pass.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -34,14 +41,7 @@ pub fn validate_schedule(schedule: &AutoTaskSchedule) -> Result<(), OrbitError> 
             parse_cron(cron)?;
             Ok(())
         }
-        AutoTaskSchedule::Interval { every_minutes }
-            if *every_minutes == 0 || *every_minutes > MAX_AUTO_TASK_INTERVAL_MINUTES =>
-        {
-            Err(OrbitError::InvalidInput(format!(
-                "auto-task interval every_minutes must be between 1 and {MAX_AUTO_TASK_INTERVAL_MINUTES}"
-            )))
-        }
-        AutoTaskSchedule::Interval { .. } => Ok(()),
+        AutoTaskSchedule::Interval { every_minutes } => interval_period(*every_minutes).map(drop),
     }
 }
 
@@ -51,6 +51,10 @@ pub fn validate_schedule(schedule: &AutoTaskSchedule) -> Result<(), OrbitError> 
 /// is the most recently consumed slot when the definition has fired before.
 /// The effective exclusive floor is `last_slot` when present, otherwise
 /// `baseline` — a definition never fires for slots predating its registration.
+///
+/// The returned slot may already be in the past: that is a catch-up fire the
+/// scheduler still owes, not a prediction. Use [`next_scheduled_slot`] for the
+/// forward-looking projection.
 pub fn decide_due(
     schedule: &AutoTaskSchedule,
     baseline: DateTime<Utc>,
@@ -66,6 +70,37 @@ pub fn decide_due(
         AutoTaskSchedule::Interval { every_minutes } => {
             decide_interval(*every_minutes, baseline, lower_bound, now)
         }
+    }
+}
+
+/// Project the schedule's next occurrence, strictly after `now`.
+///
+/// This is the canonical answer for "when does this definition next come
+/// around?" — the one operator surfaces render. It never reports a pending
+/// catch-up slot, which by definition already passed; ask [`decide_due`] for
+/// that.
+///
+/// `baseline` is the cursor's first-observed slot. Interval schedules are
+/// anchored to it and cannot be projected without one; cron schedules are
+/// absolute, so they project with or without a cursor. Delivery schedules have
+/// no time-based occurrence at all and always project `None`.
+pub fn next_scheduled_slot(
+    schedule: &AutoTaskSchedule,
+    baseline: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> Result<Option<DateTime<Utc>>, OrbitError> {
+    match schedule {
+        AutoTaskSchedule::Deliveries { .. } => Ok(None),
+        AutoTaskSchedule::Cron { cron } => {
+            // Cron is evaluated in host-local time, as the due path does; the
+            // projection is reported in UTC like every other stored slot.
+            let cron = parse_cron(cron)?;
+            let next = next_occurrence(&cron, &now.with_timezone(&Local))?;
+            Ok(Some(next.with_timezone(&Utc)))
+        }
+        AutoTaskSchedule::Interval { every_minutes } => baseline
+            .map(|baseline| next_interval_slot(*every_minutes, baseline, now))
+            .transpose(),
     }
 }
 
@@ -99,25 +134,11 @@ fn decide_interval(
     lower_bound: DateTime<Utc>,
     now: DateTime<Utc>,
 ) -> Result<AutoTaskDueDecision, OrbitError> {
-    let every_minutes = i64::try_from(every_minutes).map_err(|_| {
-        OrbitError::InvalidInput(
-            "auto-task interval every_minutes exceeds the supported signed duration".to_string(),
-        )
-    })?;
-    if every_minutes == 0 {
-        return Err(OrbitError::InvalidInput(
-            "auto-task interval every_minutes must be at least 1".to_string(),
-        ));
-    }
-    if now < baseline {
+    let period = interval_period(every_minutes)?;
+    let Some(latest_slot) = interval_slot_at_or_before(period, baseline, now)? else {
         return Ok(AutoTaskDueDecision::NotDue);
-    }
-    // Most recent interval boundary at or before `now`, anchored at baseline.
-    // A single fire covers however many boundaries fell in a downtime gap
-    // (catch-up collapse), because we jump straight to the latest boundary.
-    let elapsed_minutes = now.signed_duration_since(baseline).num_minutes();
-    let periods = elapsed_minutes / every_minutes;
-    let latest_slot = baseline + Duration::minutes(every_minutes * periods);
+    };
+
     if latest_slot > lower_bound {
         Ok(AutoTaskDueDecision::Fire {
             slot: latest_slot.to_rfc3339(),
@@ -125,4 +146,80 @@ fn decide_interval(
     } else {
         Ok(AutoTaskDueDecision::NotDue)
     }
+}
+
+/// The first interval boundary strictly after `now`.
+///
+/// The boundary `now` falls in has already been offered to the scheduler, and
+/// the baseline boundary itself is the exclusive due floor that never fires, so
+/// the projection is always one period past whichever of those applies.
+fn next_interval_slot(
+    every_minutes: u64,
+    baseline: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> Result<DateTime<Utc>, OrbitError> {
+    let period = interval_period(every_minutes)?;
+    let current = interval_slot_at_or_before(period, baseline, now)?.unwrap_or(baseline);
+
+    interval_slot(current, period, 1)
+}
+
+/// The interval period as a duration, rejecting anything outside the supported
+/// range before slot arithmetic runs. This is the single range rule: validation
+/// and both slot calculations go through it, so an interval that CRUD rejects
+/// can never reach the arithmetic below.
+fn interval_period(every_minutes: u64) -> Result<Duration, OrbitError> {
+    if !(1..=MAX_AUTO_TASK_INTERVAL_MINUTES).contains(&every_minutes) {
+        return Err(interval_range_error());
+    }
+
+    i64::try_from(every_minutes)
+        .ok()
+        .and_then(Duration::try_minutes)
+        .ok_or_else(interval_range_error)
+}
+
+/// The most recent interval boundary at or before `now`, or `None` when `now`
+/// precedes the anchor and no boundary has arrived yet.
+///
+/// Jumping straight to the latest boundary is what collapses a downtime gap
+/// into one catch-up fire instead of one fire per missed boundary.
+fn interval_slot_at_or_before(
+    period: Duration,
+    baseline: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> Result<Option<DateTime<Utc>>, OrbitError> {
+    if now < baseline {
+        return Ok(None);
+    }
+
+    let periods = now.signed_duration_since(baseline).num_minutes() / period.num_minutes();
+
+    interval_slot(baseline, period, periods).map(Some)
+}
+
+/// `anchor + periods · period`, refusing to wrap or saturate. A cursor holding
+/// an extreme baseline must surface an error, never a silently wrapped slot
+/// that the scheduler would treat as due.
+fn interval_slot(
+    anchor: DateTime<Utc>,
+    period: Duration,
+    periods: i64,
+) -> Result<DateTime<Utc>, OrbitError> {
+    period
+        .num_minutes()
+        .checked_mul(periods)
+        .and_then(Duration::try_minutes)
+        .and_then(|offset| anchor.checked_add_signed(offset))
+        .ok_or_else(|| {
+            OrbitError::InvalidInput(
+                "auto-task interval slot falls outside the representable date range".to_string(),
+            )
+        })
+}
+
+fn interval_range_error() -> OrbitError {
+    OrbitError::InvalidInput(format!(
+        "auto-task interval every_minutes must be between 1 and {MAX_AUTO_TASK_INTERVAL_MINUTES}"
+    ))
 }

--- a/crates/orbit-automation/src/auto_tasks/tests/schedule.rs
+++ b/crates/orbit-automation/src/auto_tasks/tests/schedule.rs
@@ -1,10 +1,13 @@
 //! Due-math tests [ORB-10149]: cron + interval, natural fire, not-due, and
-//! catch-up collapse.
+//! catch-up collapse — plus the forward projection, which deliberately does
+//! not agree with a pending catch-up decision.
 
 use chrono::{DateTime, Duration, TimeZone, Utc};
-use orbit_types::workflow::AutoTaskSchedule;
+use orbit_types::workflow::{AutoTaskSchedule, MAX_AUTO_TASK_INTERVAL_MINUTES};
 
-use crate::auto_tasks::schedule::{AutoTaskDueDecision, decide_due, validate_schedule};
+use crate::auto_tasks::schedule::{
+    AutoTaskDueDecision, decide_due, next_scheduled_slot, validate_schedule,
+};
 
 fn at(y: i32, m: u32, d: u32, h: u32, min: u32) -> DateTime<Utc> {
     Utc.with_ymd_and_hms(y, m, d, h, min, 0)
@@ -15,6 +18,14 @@ fn at(y: i32, m: u32, d: u32, h: u32, min: u32) -> DateTime<Utc> {
 fn interval(minutes: u64) -> AutoTaskSchedule {
     AutoTaskSchedule::Interval {
         every_minutes: minutes,
+    }
+}
+
+/// Every minute in every host-local zone, so slot assertions stay deterministic
+/// wherever the suite runs.
+fn every_minute_cron() -> AutoTaskSchedule {
+    AutoTaskSchedule::Cron {
+        cron: "* * * * *".to_string(),
     }
 }
 
@@ -82,19 +93,100 @@ fn interval_not_due_when_last_slot_covers_the_latest_boundary() {
 }
 
 #[test]
-fn cron_fires_for_the_latest_slot_after_the_lower_bound() {
-    // Every hour on the hour.
-    let schedule = AutoTaskSchedule::Cron {
-        cron: "0 * * * *".to_string(),
-    };
+fn interval_never_fires_for_a_now_before_the_baseline() {
+    let baseline = at(2026, 1, 1, 12, 0);
+    // A backwards host clock must not manufacture a boundary behind the anchor.
+    let decision = decide_due(
+        &interval(60),
+        baseline,
+        None,
+        baseline - Duration::minutes(90),
+    )
+    .expect("decide");
+    assert_eq!(decision, AutoTaskDueDecision::NotDue);
+}
+
+#[test]
+fn interval_projection_skips_the_boundary_now_falls_in() {
     let baseline = at(2026, 1, 1, 0, 0);
-    // An hour and change past the baseline; the shared cron machinery
-    // evaluates in host-local time, so assert only that *a* fire is produced.
-    let now = at(2026, 1, 1, 3, 1);
-    let decision = decide_due(&schedule, baseline, None, now).expect("decide");
+
+    // Exactly on a boundary: that boundary has already been offered, so the
+    // projection is the following one.
+    assert_eq!(
+        next_scheduled_slot(
+            &interval(60),
+            Some(baseline),
+            baseline + Duration::minutes(60)
+        )
+        .expect("project"),
+        Some(baseline + Duration::minutes(120))
+    );
+    // Mid-period: still the end of the period `now` sits in.
+    assert_eq!(
+        next_scheduled_slot(
+            &interval(60),
+            Some(baseline),
+            baseline + Duration::minutes(90)
+        )
+        .expect("project"),
+        Some(baseline + Duration::minutes(120))
+    );
+}
+
+#[test]
+fn interval_projection_before_the_baseline_is_the_first_firing_boundary() {
+    let baseline = at(2026, 1, 1, 12, 0);
+    // The baseline boundary is the exclusive due floor and never fires, so the
+    // first occurrence a caller can wait for is one period past it.
+    assert_eq!(
+        next_scheduled_slot(
+            &interval(30),
+            Some(baseline),
+            baseline - Duration::minutes(90)
+        )
+        .expect("project"),
+        Some(baseline + Duration::minutes(30))
+    );
+}
+
+#[test]
+fn interval_projection_looks_forward_while_a_missed_slot_is_still_due() {
+    let baseline = at(2026, 1, 1, 0, 0);
+    // Six hours of downtime: the scheduler still owes the +360m boundary.
+    let now = baseline + Duration::minutes(370);
+
+    let due = decide_due(&interval(60), baseline, None, now).expect("decide");
+    let projected = next_scheduled_slot(&interval(60), Some(baseline), now)
+        .expect("project")
+        .expect("interval projects with a baseline");
+
+    assert_eq!(
+        due,
+        AutoTaskDueDecision::Fire {
+            slot: (baseline + Duration::minutes(360)).to_rfc3339(),
+        }
+    );
+    assert_eq!(projected, baseline + Duration::minutes(420));
     assert!(
-        matches!(decision, AutoTaskDueDecision::Fire { .. }),
-        "expected an hourly cron to fire after its slot, got {decision:?}"
+        projected > now,
+        "the projection is the next arrival, not the pending catch-up slot"
+    );
+    assert_ne!(
+        AutoTaskDueDecision::Fire {
+            slot: projected.to_rfc3339(),
+        },
+        due,
+        "a future projection must not be asserted equal to an owed catch-up slot"
+    );
+}
+
+#[test]
+fn interval_projection_requires_a_baseline_anchor() {
+    // Interval slots are anchored at registration; without a cursor there is
+    // nothing to anchor to, and the caller labels the row never-observed.
+    assert_eq!(
+        next_scheduled_slot(&interval(60), None, at(2026, 1, 1, 0, 0)).expect("project"),
+        None
     );
 }
 
@@ -112,16 +204,154 @@ fn validate_schedule_rejects_bad_cron_and_out_of_range_intervals() {
 }
 
 #[test]
-fn interval_decision_rejects_values_outside_signed_duration_range() {
+fn interval_arithmetic_rejects_out_of_range_values_on_both_consumers() {
     let baseline = at(2026, 1, 1, 0, 0);
+    let now = baseline + Duration::minutes(1);
 
+    // Zero, one past the supported maximum, and a value that cannot survive the
+    // conversion at all: every one is an error, never an overflow or a panic.
+    for every_minutes in [0, MAX_AUTO_TASK_INTERVAL_MINUTES + 1, u64::MAX] {
+        assert!(
+            decide_due(&interval(every_minutes), baseline, None, now).is_err(),
+            "due decision accepted every_minutes={every_minutes}"
+        );
+        assert!(
+            next_scheduled_slot(&interval(every_minutes), Some(baseline), now).is_err(),
+            "projection accepted every_minutes={every_minutes}"
+        );
+    }
+
+    // The supported maximum still computes on both paths.
     assert!(
         decide_due(
-            &interval(u64::MAX),
+            &interval(MAX_AUTO_TASK_INTERVAL_MINUTES),
             baseline,
             None,
-            baseline + Duration::minutes(1),
+            now
+        )
+        .is_ok()
+    );
+    assert!(
+        next_scheduled_slot(
+            &interval(MAX_AUTO_TASK_INTERVAL_MINUTES),
+            Some(baseline),
+            now
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn interval_slot_near_the_date_range_edge_errors_instead_of_wrapping() {
+    let baseline = DateTime::<Utc>::MAX_UTC - Duration::minutes(5);
+
+    // A cursor anchored at the end of representable time cannot produce a
+    // wrapped slot that the scheduler would mistake for a due boundary.
+    assert!(
+        next_scheduled_slot(
+            &interval(MAX_AUTO_TASK_INTERVAL_MINUTES),
+            Some(baseline),
+            baseline
         )
         .is_err()
+    );
+}
+
+#[test]
+fn cron_fires_for_the_latest_slot_after_the_lower_bound() {
+    // Every hour on the hour.
+    let schedule = AutoTaskSchedule::Cron {
+        cron: "0 * * * *".to_string(),
+    };
+    let baseline = at(2026, 1, 1, 0, 0);
+    // An hour and change past the baseline; the shared cron machinery
+    // evaluates in host-local time, so assert only that *a* fire is produced.
+    let now = at(2026, 1, 1, 3, 1);
+    let decision = decide_due(&schedule, baseline, None, now).expect("decide");
+    assert!(
+        matches!(decision, AutoTaskDueDecision::Fire { .. }),
+        "expected an hourly cron to fire after its slot, got {decision:?}"
+    );
+}
+
+#[test]
+fn cron_slots_are_minute_pinned_regardless_of_sub_minute_now() {
+    let baseline = at(2026, 7, 2, 21, 59);
+    // "now" carries seconds and nanos, as real scheduler passes do; the slot
+    // that becomes the idempotency key must not.
+    let now = Utc
+        .with_ymd_and_hms(2026, 7, 2, 22, 0, 42)
+        .single()
+        .expect("valid ts")
+        + Duration::nanoseconds(785_766_897);
+
+    let decision = decide_due(&every_minute_cron(), baseline, None, now).expect("decide");
+    assert_eq!(
+        decision,
+        AutoTaskDueDecision::Fire {
+            slot: at(2026, 7, 2, 22, 0).to_rfc3339(),
+        }
+    );
+
+    let projected = next_scheduled_slot(&every_minute_cron(), None, now)
+        .expect("project")
+        .expect("cron projects without a cursor");
+    assert_eq!(projected, at(2026, 7, 2, 22, 1));
+    assert!(projected > now, "the projection must stay ahead of now");
+}
+
+#[test]
+fn cron_does_not_refire_a_consumed_slot() {
+    let consumed = at(2026, 7, 2, 22, 0);
+    // The pass re-runs 30 seconds later with the cursor already on this slot.
+    let now = consumed + Duration::seconds(30);
+    let decision = decide_due(&every_minute_cron(), consumed, Some(consumed), now).expect("decide");
+    assert_eq!(decision, AutoTaskDueDecision::NotDue);
+}
+
+#[test]
+fn cron_projection_looks_forward_while_a_missed_slot_is_still_due() {
+    let baseline = at(2026, 7, 2, 22, 0);
+    // Well past the natural-slot grace: the scheduler owes a catch-up fire for
+    // the 23:30 slot while the schedule's next arrival is 23:31.
+    let now = at(2026, 7, 2, 23, 30) + Duration::seconds(30);
+
+    let due = decide_due(&every_minute_cron(), baseline, None, now).expect("decide");
+    let projected = next_scheduled_slot(&every_minute_cron(), None, now)
+        .expect("project")
+        .expect("cron projects without a cursor");
+
+    assert_eq!(
+        due,
+        AutoTaskDueDecision::Fire {
+            slot: at(2026, 7, 2, 23, 30).to_rfc3339(),
+        }
+    );
+    assert_eq!(projected, at(2026, 7, 2, 23, 31));
+    assert!(projected > now);
+}
+
+#[test]
+fn delivery_schedules_have_no_time_based_projection_or_due_decision() {
+    let schedule = AutoTaskSchedule::Deliveries {
+        deliveries_landed: orbit_types::workflow::automation::DeliveryTrigger {
+            owner_machine: None,
+            branch: "agent-main".to_string(),
+            threshold: 3,
+            max_wait_minutes: 60,
+            coverage: orbit_types::workflow::automation::CoverageClass::IntegratedQaV1,
+            max_items: 20,
+            retries: 0,
+        },
+    };
+    let now = at(2026, 1, 1, 0, 0);
+
+    assert_eq!(
+        next_scheduled_slot(&schedule, Some(now), now).expect("project"),
+        None
+    );
+    assert!(
+        decide_due(&schedule, now, None, now).is_err(),
+        "delivery schedules are decided against their source, not the clock"
     );
 }

--- a/crates/orbit-automation/src/routines/due.rs
+++ b/crates/orbit-automation/src/routines/due.rs
@@ -6,6 +6,14 @@
 //! `now`, compared against the cursor — never an iteration over every slot
 //! in a gap, so a week of downtime against a minutely cron costs the same
 //! as one minute.
+//!
+//! Two different questions live here and must not be conflated. [`due_decision`]
+//! answers *catch-up eligibility*: "is there an unconsumed slot this sweep may
+//! fire?", and under `catch_up_once` that answer is a slot already in the past.
+//! [`next_occurrence`] answers *the next scheduled occurrence*: "when does this
+//! cron next come around?", always strictly ahead of `now`. Operator surfaces
+//! render the second; the scheduler acts on the first. They disagree exactly
+//! when a missed slot is pending, and that disagreement is correct.
 
 use chrono::{DateTime, Duration, TimeZone, Timelike};
 use croner::Cron;
@@ -67,6 +75,28 @@ pub fn parse_cron(expression: &str) -> Result<Cron, OrbitError> {
     expression.parse::<Cron>().map_err(|error| {
         OrbitError::InvalidInput(format!("invalid cron expression '{expression}': {error}"))
     })
+}
+
+/// The next scheduled occurrence strictly after `now`, pinned to its minute.
+///
+/// This projects the schedule forward; it is not a due decision. A routine
+/// carrying a missed slot is still due for that earlier slot under
+/// `catch_up_once` ([`due_decision`]) while this reports the upcoming one, so
+/// callers rendering both must not expect them to agree.
+pub fn next_occurrence<Tz: TimeZone>(
+    cron: &Cron,
+    now: &DateTime<Tz>,
+) -> Result<DateTime<Tz>, OrbitError> {
+    let next = cron
+        .find_next_occurrence(now, false)
+        .map_err(|error| OrbitError::InvalidInput(format!("cron evaluation failed: {error}")))?;
+
+    // croner carries `now`'s sub-minute component into the occurrence it
+    // returns, which would move the projection on every poll within the same
+    // minute. Pinning is safe here as well as in the due path: the occurrence
+    // already lies in a later minute than `now`, so dropping its sub-minute
+    // component cannot pull it back to or before `now`.
+    Ok(truncate_to_minute(next))
 }
 
 /// Decide whether a routine is due.

--- a/crates/orbit-automation/src/routines/tests/due.rs
+++ b/crates/orbit-automation/src/routines/tests/due.rs
@@ -3,7 +3,7 @@ use chrono_tz::Europe::Berlin;
 
 use super::super::due::{
     DueDecision, NATURAL_SLOT_GRACE_SECONDS, due_decision, due_decision_with_grace,
-    natural_slot_grace_for_cadence, parse_cron, truncate_to_minute,
+    natural_slot_grace_for_cadence, next_occurrence, parse_cron, truncate_to_minute,
 };
 use orbit_types::workflow::MissedRunPolicy;
 
@@ -270,4 +270,68 @@ fn baseline_in_the_future_of_all_slots_suppresses_firing() {
     let decision =
         due_decision(&cron, MissedRunPolicy::CatchUpOnce, &baseline, &now).expect("decision");
     assert_eq!(decision, DueDecision::NotDue);
+}
+
+#[test]
+fn next_occurrence_is_minute_pinned_and_strictly_after_a_sub_minute_now() {
+    let cron = parse_cron("* * * * *").expect("cron");
+    let now = at(2026, 7, 2, 22, 0, 42) + Duration::nanoseconds(785_766_897);
+
+    let next = next_occurrence(&cron, &now).expect("projection");
+
+    assert_eq!(next, at(2026, 7, 2, 22, 1, 0));
+    assert!(
+        next > now,
+        "pinning the occurrence to its minute must not pull it back to now"
+    );
+}
+
+#[test]
+fn next_occurrence_is_stable_across_polls_within_one_minute() {
+    let cron = parse_cron("0 22 * * *").expect("cron");
+    let first = next_occurrence(&cron, &at(2026, 7, 2, 10, 0, 3)).expect("first poll");
+    let second = next_occurrence(&cron, &at(2026, 7, 2, 10, 0, 47)).expect("second poll");
+
+    assert_eq!(first, at(2026, 7, 2, 22, 0, 0));
+    assert_eq!(first, second);
+}
+
+#[test]
+fn next_occurrence_looks_forward_while_a_missed_slot_is_still_due() {
+    let cron = parse_cron("0 22 * * *").expect("cron");
+    // A week of laptop sleep after the July 1 fire.
+    let lower = at(2026, 7, 1, 22, 0, 0);
+    let now = at(2026, 7, 8, 9, 30, 0);
+
+    let due = due_decision(&cron, MissedRunPolicy::CatchUpOnce, &lower, &now).expect("decision");
+    let projected = next_occurrence(&cron, &now).expect("projection");
+
+    // Catch-up eligibility names the latest missed slot, already in the past.
+    assert_eq!(
+        due,
+        DueDecision::Fire {
+            slot: at(2026, 7, 7, 22, 0, 0),
+            is_catch_up: true,
+        }
+    );
+    // The projection names the schedule's next arrival, always ahead of now.
+    assert_eq!(projected, at(2026, 7, 8, 22, 0, 0));
+    assert!(projected > now);
+}
+
+#[test]
+fn next_occurrence_reports_the_same_upcoming_slot_under_either_missed_run_policy() {
+    let cron = parse_cron("0 22 * * *").expect("cron");
+    let lower = at(2026, 7, 1, 22, 0, 0);
+    let now = at(2026, 7, 8, 9, 30, 0);
+
+    // `skip` declines the missed slot entirely; the projection is unchanged,
+    // because a projection is not a policy decision.
+    let skipped = due_decision(&cron, MissedRunPolicy::Skip, &lower, &now).expect("decision");
+
+    assert_eq!(skipped, DueDecision::NotDue);
+    assert_eq!(
+        next_occurrence(&cron, &now).expect("projection"),
+        at(2026, 7, 8, 22, 0, 0)
+    );
 }

--- a/crates/orbit-core/src/application/routines/status.rs
+++ b/crates/orbit-core/src/application/routines/status.rs
@@ -11,7 +11,7 @@ use orbit_common::fs::io::atomic_write_text;
 use orbit_common::protocol::yaml::{parse_local_routine_yaml, parse_routine_yaml};
 use orbit_store::contracts::RoutineFireRecord;
 
-use super::due::{parse_cron, truncate_to_minute};
+use super::due::{next_occurrence, parse_cron};
 use super::loader::{LoadedRoutine, RoutineLoadError, RoutineWorkspaceProvider, collect_routines};
 use super::validation::{
     RoutinePinValidation, RoutinePlacementProjection, RoutinePlacementProvider,
@@ -159,11 +159,7 @@ pub fn routine_statuses_with_providers(
 
     let mut statuses = Vec::with_capacity(collection.routines.len());
     for routine in collection.routines {
-        let next_due = parse_cron(&routine.definition.trigger.cron)
-            .ok()
-            .and_then(|cron| cron.find_next_occurrence(&now, false).ok())
-            .map(truncate_to_minute)
-            .map(|slot| slot.to_rfc3339());
+        let next_due = next_scheduled_occurrence(&routine.definition.trigger.cron, &now);
         let last_fire = store.routine_latest_fire(&routine.definition.name)?;
         let cursor = store.routine_cursor(&routine.definition.name)?;
         let paused_at = pauses
@@ -199,6 +195,21 @@ pub fn routine_statuses_with_providers(
         statuses,
         load_errors,
     })
+}
+
+/// The routine's next scheduled occurrence, rendered host-local.
+///
+/// This is the schedule coming around again, not the sweep's catch-up
+/// eligibility: a routine holding a missed slot under `catch_up_once` is due
+/// for that earlier slot while this still points forward. The projection comes
+/// from the shared cron owner so routine status and auto-task status pin slots
+/// to the minute identically. An unparseable cron projects nothing; the display
+/// state reports why.
+pub(crate) fn next_scheduled_occurrence(cron: &str, now: &DateTime<Local>) -> Option<String> {
+    parse_cron(cron)
+        .and_then(|cron| next_occurrence(&cron, now))
+        .ok()
+        .map(|slot| slot.to_rfc3339())
 }
 
 /// Optimistic outcome for a versioned routine-definition toggle.

--- a/crates/orbit-core/src/application/routines/tests/status.rs
+++ b/crates/orbit-core/src/application/routines/tests/status.rs
@@ -1,13 +1,15 @@
 use std::fs;
 use std::path::PathBuf;
 
+use chrono::{Duration, Local, TimeZone, Timelike, Utc};
 use orbit_automation::routines::validation::RoutinePinValidation;
 use orbit_common::protocol::yaml::parse_routine_yaml;
 use tempfile::tempdir;
 
 use super::super::loader::{LoadedRoutine, RoutineOrigin};
 use super::super::status::{
-    RoutineStatus, RoutineToggleOutcome, ScheduleDisplayState, set_routine_enabled,
+    RoutineStatus, RoutineToggleOutcome, ScheduleDisplayState, next_scheduled_occurrence,
+    set_routine_enabled,
 };
 
 fn loaded(path: std::path::PathBuf) -> LoadedRoutine {
@@ -177,4 +179,36 @@ fn schedule_display_state_distinguishes_paused_disabled_waiting_and_unobserved()
         .schedule_display_state(),
         ScheduleDisplayState::Unavailable
     );
+}
+
+#[test]
+fn next_scheduled_occurrence_is_minute_pinned_and_ahead_of_a_sub_minute_now() {
+    // The routine projection uses the shared cron owner, so a poll carrying
+    // seconds and nanos still yields a stable minute-pinned slot.
+    let now = Utc
+        .with_ymd_and_hms(2026, 7, 2, 22, 0, 42)
+        .single()
+        .expect("valid ts")
+        + Duration::nanoseconds(785_766_897);
+    let now = now.with_timezone(&Local);
+
+    let projected = next_scheduled_occurrence("* * * * *", &now).expect("every-minute cron");
+    let parsed = chrono::DateTime::parse_from_rfc3339(&projected).expect("rfc3339 slot");
+
+    assert_eq!(parsed.second(), 0, "slot must be pinned to its minute");
+    assert_eq!(parsed.nanosecond(), 0, "slot must be pinned to its minute");
+    assert!(parsed.with_timezone(&Utc) > now.with_timezone(&Utc));
+}
+
+#[test]
+fn next_scheduled_occurrence_is_absent_for_an_unparseable_cron() {
+    let now = Utc
+        .with_ymd_and_hms(2026, 7, 2, 22, 0, 0)
+        .single()
+        .expect("valid ts")
+        .with_timezone(&Local);
+
+    // A malformed trigger projects nothing; the display state, not a fabricated
+    // timestamp, tells the operator why.
+    assert_eq!(next_scheduled_occurrence("not a cron", &now), None);
 }

--- a/crates/orbit-web/src/api/auto_tasks.rs
+++ b/crates/orbit-web/src/api/auto_tasks.rs
@@ -6,15 +6,16 @@ use std::time::Instant;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
-use chrono::{DateTime, Duration, Local, Utc};
+use chrono::{DateTime, Utc};
 use orbit_common::governance::authorization::{
     DASHBOARD_AUTO_TASK_MINT, DASHBOARD_AUTO_TASK_TOGGLE,
 };
 use orbit_core::OrbitRuntime;
+use orbit_core::application::auto_tasks::schedule::next_scheduled_slot;
 use orbit_core::application::auto_tasks::{
     AutoTaskCursor, collect_auto_tasks, cursor_state_path, load_cursor_state,
 };
-use orbit_core::application::routines::{ScheduleDisplayState, parse_cron};
+use orbit_core::application::routines::ScheduleDisplayState;
 use orbit_types::task::TaskStatus;
 use orbit_types::workflow::{
     AutoTaskDefinition, AutoTaskSchedule, AutoTaskTemplate, DedupePolicy, auto_task_tag,
@@ -509,7 +510,7 @@ fn next_evaluation_projection(
     if !enabled {
         return next_evaluation_json(
             ScheduleDisplayState::Disabled,
-            theoretical_next(schedule, cursor, now),
+            projected_next_slot(schedule, cursor, now),
         );
     }
     if cursor_state_unavailable || automation_unavailable(automation) {
@@ -523,7 +524,7 @@ fn next_evaluation_projection(
             if cursor.is_none() {
                 return next_evaluation_json(ScheduleDisplayState::NeverObserved, None);
             }
-            match theoretical_next(schedule, cursor, now) {
+            match projected_next_slot(schedule, cursor, now) {
                 Some(at) => next_evaluation_json(ScheduleDisplayState::Scheduled, Some(at)),
                 None => next_evaluation_json(ScheduleDisplayState::Unavailable, None),
             }
@@ -538,58 +539,30 @@ fn automation_unavailable(automation: Option<&Value>) -> bool {
         .is_some_and(|reason| reason == "source_unavailable" || reason == "state_unavailable")
 }
 
-fn theoretical_next(
+/// The schedule's next occurrence, rendered for the dashboard.
+///
+/// This is the next scheduled arrival, never catch-up eligibility: a definition
+/// with a missed slot pending is due for that earlier slot while this points
+/// forward. The arithmetic belongs to the auto-task scheduler, so this only
+/// adapts the cursor and renders the result; a schedule that cannot be
+/// projected (unparseable cron, interval with no anchor) yields `None` and the
+/// caller labels the row.
+fn projected_next_slot(
     schedule: &AutoTaskSchedule,
     cursor: Option<&AutoTaskCursor>,
     now: DateTime<Utc>,
 ) -> Option<String> {
-    match schedule {
-        AutoTaskSchedule::Deliveries { .. } => None,
-        AutoTaskSchedule::Cron { cron } => {
-            let parsed = parse_cron(cron).ok()?;
-            let now_local = now.with_timezone(&Local);
-            parsed
-                .find_next_occurrence(&now_local, false)
-                .ok()
-                .map(|slot| slot.to_rfc3339())
-        }
-        AutoTaskSchedule::Interval { every_minutes } => {
-            next_interval(*every_minutes, cursor?, now).map(|slot| slot.to_rfc3339())
-        }
-    }
+    let baseline = cursor.and_then(cursor_baseline);
+
+    next_scheduled_slot(schedule, baseline, now)
+        .ok()
+        .flatten()
+        .map(|slot| slot.to_rfc3339())
 }
 
-fn next_interval(
-    every_minutes: u64,
-    cursor: &AutoTaskCursor,
-    now: DateTime<Utc>,
-) -> Option<DateTime<Utc>> {
-    if every_minutes == 0 {
-        return None;
-    }
-    let baseline = DateTime::parse_from_rfc3339(&cursor.baseline_at)
-        .ok()?
-        .with_timezone(&Utc);
-    let last_slot = cursor
-        .last_slot
-        .as_deref()
-        .and_then(|slot| DateTime::parse_from_rfc3339(slot).ok())
-        .map(|slot| slot.with_timezone(&Utc));
-    let interval = Duration::minutes(i64::try_from(every_minutes).ok()?);
-    let floor = last_slot.unwrap_or(baseline);
-    if now < baseline {
-        return Some(baseline + interval);
-    }
-    let elapsed = now.signed_duration_since(baseline).num_minutes();
-    let period = i64::try_from(every_minutes).ok()?;
-    let mut periods = elapsed / period;
-    let mut next = baseline + Duration::minutes(period * periods);
-    if next <= floor || next <= now {
-        periods += 1;
-        next = baseline + Duration::minutes(period * periods);
-    }
-    if next <= now {
-        next += interval;
-    }
-    Some(next)
+/// The cursor's first-observed slot, which anchors interval projections.
+fn cursor_baseline(cursor: &AutoTaskCursor) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(&cursor.baseline_at)
+        .ok()
+        .map(|baseline| baseline.with_timezone(&Utc))
 }

--- a/crates/orbit-web/src/api/tests/auto_tasks.rs
+++ b/crates/orbit-web/src/api/tests/auto_tasks.rs
@@ -322,6 +322,111 @@ async fn list_labels_disabled_next_evaluation_as_hypothetical() {
     assert!(item["next_evaluation"]["at"].as_str().is_some(), "{item}");
 }
 
+/// A cursor whose baseline and last consumed slot are both far in the past, so
+/// the scheduler still owes a catch-up fire the moment it next runs.
+fn write_stale_cursor(runtime: &OrbitRuntime, name: &str) {
+    let path = cursor_state_path(&runtime.paths().state_dir);
+    std::fs::create_dir_all(path.parent().expect("state dir")).expect("mkdir");
+    let doc = serde_json::json!({"definitions": {name: {
+        "baseline_at": "2020-01-01T00:00:00+00:00",
+        "last_slot": "2020-01-01T01:00:00+00:00",
+        "last_fired_at": "2020-01-01T01:00:05+00:00",
+        "last_task_id": "ORB-00001"
+    }}});
+    std::fs::write(
+        path,
+        serde_json::to_string_pretty(&doc).expect("serialize cursor"),
+    )
+    .expect("write cursor");
+}
+
+#[tokio::test]
+async fn list_projects_the_next_interval_slot_not_the_owed_catch_up_slot() {
+    let runtime = runtime();
+    runtime.auto_task_add(chore_params("stale")).expect("add");
+    write_stale_cursor(&runtime, "stale");
+
+    let (state, runtime) = state(runtime);
+    let json =
+        body_json(send(state, Method::GET, "/auto-tasks?workspace=default", None).await).await;
+    let item = &json["definitions"].as_array().expect("definitions")[0];
+
+    let now = chrono::Utc::now();
+    let baseline = chrono::DateTime::parse_from_rfc3339("2020-01-01T00:00:00+00:00")
+        .expect("baseline")
+        .with_timezone(&chrono::Utc);
+    let projected = chrono::DateTime::parse_from_rfc3339(
+        item["next_evaluation"]["at"]
+            .as_str()
+            .expect("projected slot"),
+    )
+    .expect("rfc3339 projection")
+    .with_timezone(&chrono::Utc);
+
+    assert_eq!(item["next_evaluation"]["state"], "scheduled");
+    assert!(
+        projected > now,
+        "the dashboard projects the schedule's next arrival: {item}"
+    );
+
+    // The scheduler, meanwhile, still owes a fire for a boundary years in the
+    // past. The two answers are different by design, so the row must not claim
+    // the owed slot as its next evaluation.
+    let owed = orbit_core::application::auto_tasks::schedule::decide_due(
+        &runtime
+            .auto_task_show("stale")
+            .expect("show")
+            .expect("definition")
+            .schedule,
+        baseline,
+        Some(baseline + chrono::Duration::hours(1)),
+        now,
+    )
+    .expect("due decision");
+    let orbit_core::application::auto_tasks::AutoTaskDueDecision::Fire { slot: owed_slot } = owed
+    else {
+        panic!("a years-old cursor must still owe a catch-up fire");
+    };
+    let owed_slot = chrono::DateTime::parse_from_rfc3339(&owed_slot)
+        .expect("rfc3339 owed slot")
+        .with_timezone(&chrono::Utc);
+    assert!(owed_slot <= now, "an owed catch-up slot is in the past");
+    assert_ne!(projected, owed_slot);
+
+    // Both answers come from the same anchored arithmetic: consecutive
+    // 60-minute boundaries off the recorded baseline.
+    assert_eq!(projected, owed_slot + chrono::Duration::minutes(60));
+}
+
+#[tokio::test]
+async fn list_projects_cron_definitions_pinned_to_the_minute() {
+    let runtime = runtime();
+    let mut params = chore_params("minutely");
+    params.schedule = AutoTaskSchedule::Cron {
+        cron: "* * * * *".to_string(),
+    };
+    runtime.auto_task_add(params).expect("add");
+    write_cursor(&runtime, "minutely", "ORB-00001");
+
+    let (state, _) = state(runtime);
+    let json =
+        body_json(send(state, Method::GET, "/auto-tasks?workspace=default", None).await).await;
+    let item = &json["definitions"].as_array().expect("definitions")[0];
+    let projected = chrono::DateTime::parse_from_rfc3339(
+        item["next_evaluation"]["at"]
+            .as_str()
+            .expect("projected slot"),
+    )
+    .expect("rfc3339 projection");
+
+    assert_eq!(item["next_evaluation"]["state"], "scheduled");
+    // The canonical cron projection pins every occurrence to its minute, so the
+    // rendered slot never carries the poll's sub-minute component.
+    assert_eq!(chrono::Timelike::second(&projected), 0, "{item}");
+    assert_eq!(chrono::Timelike::nanosecond(&projected), 0, "{item}");
+    assert!(projected.with_timezone(&chrono::Utc) > chrono::Utc::now());
+}
+
 #[tokio::test]
 async fn list_reports_never_observed_when_the_cursor_is_missing() {
     let runtime = runtime();

--- a/docs/design/auto-tasks/2_design.md
+++ b/docs/design/auto-tasks/2_design.md
@@ -59,6 +59,27 @@ interval math jumps straight to the most recent boundary
 `baseline + floor((now-baseline)/interval)·interval`. Either way a downtime gap
 collapses to **one** fire, never one per missed slot.
 
+## 2b. Catch-up eligibility is not the next scheduled occurrence
+
+`decide_due` answers **catch-up eligibility**: is there an unconsumed slot this
+pass may fire? After downtime that answer is a slot *already in the past* — a
+fire the scheduler still owes. `schedule::next_scheduled_slot(schedule,
+baseline, now)` answers a different question: when does the schedule **next
+come around**? It is always strictly after `now`, and it is what operator
+surfaces render as next evaluation. The two disagree exactly while a missed
+slot is pending, and that disagreement is correct — neither output is a check
+on the other.
+
+Both derive every slot from one place so the two views stay anchored
+identically. `routines::due::next_occurrence` is the cron owner: it pins each
+occurrence to its minute, as the due path does, so a slot is stable across
+polls within one minute. Interval slots share one anchoring rule
+(`baseline + n·interval`), one range check, and checked date arithmetic — an
+out-of-range interval or an extreme cursor baseline is an error, never a
+wrapped slot the scheduler would mistake for a due boundary. Interval
+projections need the cursor's baseline to anchor to; cron projections are
+absolute and need no cursor.
+
 ## 3. Cursor state
 
 `state.rs` stores one cursor per definition in
@@ -206,10 +227,13 @@ The dashboard Operations tab exposes the same CRUD/mint runtime rather than a
 second scheduler. `#operations/auto-tasks` lists the selected workspace's
 definitions (name, enabled, schedule, template summary, dedupe, last
 scheduler evaluation, last minted task id, and a structured next-evaluation
-state). Next evaluation is never an unqualified future timestamp: disabled
-rows show `Disabled` (a theoretical slot is labeled hypothetical), delivery
-rows show waiting-for-deliveries, a missing cursor is never observed, and
-inspect failures are unavailable. Last scheduler evaluation is the host-local
+state). Next evaluation is the schedule's next occurrence (§2b) computed by
+the scheduler's own arithmetic, never catch-up eligibility: a definition owed
+a make-up fire still shows the upcoming slot, not the owed one. It is also
+never an unqualified future timestamp: disabled rows show `Disabled` (a
+theoretical slot is labeled hypothetical), delivery rows show
+waiting-for-deliveries, a missing cursor is never observed, and inspect
+failures are unavailable. Last scheduler evaluation is the host-local
 cursor; last minted task is the newest tagged instance and is labeled a
 manual mint when the two ids differ. Enable/disable writes `enabled` through `auto_task_toggle`
 with `expected_enabled` compare-and-swap, operator authorization

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -49,7 +49,11 @@ The dashboard Operations view projects the same typed status and control functio
 `enabled` value; the host clock remains one independent host-scoped card.
 Next evaluation uses schedule display state (`scheduled`, `disabled`, `paused`,
 `waiting`, `never_observed`, `unavailable`) so a disabled or paused routine
-does not look armed; a theoretical next slot is labeled hypothetical.
+does not look armed; a theoretical next slot is labeled hypothetical. The time
+itself is `due::next_occurrence` — the cron's next scheduled occurrence,
+strictly ahead of now and pinned to its minute — not the sweep's catch-up
+eligibility. A routine holding a missed slot under `catch_up_once` is due for
+that earlier slot while the row still points forward, which is correct.
 Clock last/next tick are wall-clock times; systemd `NextElapseUSecMonotonic`
 is used only for schedulability, never as a displayed next tick. Cadence is a
 duration. A routine


### PR DESCRIPTION
## Task

[ORB-11732](https://orbit-cli.com/tasks/ORB-11732) — [code-review] Share scheduler slot calculations while distinguishing future slots from catch-up work

### Description

## Problem
Auto-task scheduling and its web/status projections separately calculate cron and interval slots. The scheduler truncates cron slots to minute precision and uses an unchecked interval conversion; the web interval projection uses checked conversion. A theoretical future occurrence is not the same answer as a pending catch-up fire, so requiring those outputs to always match is incorrect.

## Required behavior and constraints
Keep schedule arithmetic under orbit-automation and make web/Core status consume that owner. Define the existing next-scheduled-slot projection separately from the current due/catch-up decision; preserve disabled, never-observed and delivery-trigger display states. Share interval anchoring, checked arithmetic and minute-granular cron normalization. Preserve host-local timezone, grace and missed-run policy semantics. No blanket ban on croner calls or new generic scheduling framework is required.

## Evidence and validation
Source validation against agent-main 09dec5183 (original review 7f3a8f5fa); re-locate symbols on the implementation revision. crates/orbit-automation/src/auto_tasks/schedule.rs (decide_interval), routines/due.rs (due_decision_with_grace); crates/orbit-web/src/api/auto_tasks.rs (theoretical_next/next_interval); crates/orbit-core/src/application/routines/status.rs.
These are source-level findings, not measured performance or executed fault-injection results. Use focused deterministic regression tests at the owning boundary. Follow AGENTS.md and pass make ci-fast and make ci-lint before review; no release work is included.

### Acceptance Criteria

- Deterministic cron tests cover sub-minute input, consumed slots, natural-slot grace, skip and catch-up policies; projected future occurrences and due decisions each satisfy their documented semantics.
- Interval tests cover baseline, before-baseline now, last consumed slot, multi-period downtime, zero and out-of-range values without overflow/panic; both consumers use the shared arithmetic.
- Web auto-task and routine-status tests demonstrate use of canonical slot calculations and preserve disabled/never-observed/delivery states. A future projection is not asserted equal to an already-pending catch-up slot.
- Existing scheduler due/dedupe tests pass, and changed current documentation distinguishes next scheduled occurrence from catch-up eligibility.

## Execution Summary

<details>
<summary>Click to expand</summary>

Shared the scheduler slot arithmetic under orbit-automation and made the web/Core status surfaces consume it, while separating the next-scheduled-occurrence projection from the due/catch-up decision.

## Changes

**orbit-automation `routines/due.rs`** — added `next_occurrence(cron, now)`: the next cron occurrence strictly after `now`, pinned to its minute by the same `truncate_to_minute` the due path uses, so a projection is stable across polls within one minute. Module doc now names the two distinct questions (catch-up eligibility vs next occurrence) and states that they disagree exactly while a missed slot is pending.

**orbit-automation `auto_tasks/schedule.rs`** — extracted the interval arithmetic into `interval_period` (one range rule, now also used by `validate_schedule`), `interval_slot_at_or_before` (the catch-up-collapse anchor), and `interval_slot` (checked multiply/add — `checked_mul` + `Duration::try_minutes` + `checked_add_signed`, replacing `Duration::minutes(every_minutes * periods)` which could overflow or panic). `decide_interval` is rewritten on top of these. Added `next_scheduled_slot(schedule, baseline, now)` as the canonical forward projection for all three schedule kinds.

**orbit-web `api/auto_tasks.rs`** — deleted the duplicated `next_interval` math and the untruncated cron projection; `projected_next_slot` now adapts the cursor's baseline and calls `next_scheduled_slot` through the existing `orbit_core` re-export (no new crate edge). Display states are byte-for-byte preserved: disabled still carries a hypothetical slot, delivery still waits, a missing cursor is still never-observed, an unprojectable schedule is still unavailable.

**orbit-core `application/routines/status.rs`** — named the projection phase `next_scheduled_occurrence` and routed it through `due::next_occurrence`, so routine status and auto-task status share one cron projection.

**Docs** — `docs/design/auto-tasks/2_design.md` gains §2b ("Catch-up eligibility is not the next scheduled occurrence") and §5c now states that next evaluation is the next occurrence, never catch-up eligibility. `docs/design/routines/2_design.md` says the same for the routines Operations row.

## Acceptance criteria

1. **Cron tests** — `auto_tasks/tests/schedule.rs`: `cron_slots_are_minute_pinned_regardless_of_sub_minute_now` (a `now` carrying seconds + nanos yields a minute-pinned slot and a projection strictly ahead of it), `cron_does_not_refire_a_consumed_slot`, `cron_projection_looks_forward_while_a_missed_slot_is_still_due`, `cron_fires_for_the_latest_slot_after_the_lower_bound` (kept). `routines/tests/due.rs`: `next_occurrence_is_minute_pinned_and_strictly_after_a_sub_minute_now`, `next_occurrence_is_stable_across_polls_within_one_minute`, `next_occurrence_looks_forward_while_a_missed_slot_is_still_due` (catch_up_once fires the past slot while the projection points forward), `next_occurrence_reports_the_same_upcoming_slot_under_either_missed_run_policy` (skip). Natural-slot grace remains covered by the existing `natural_slot_fires_within_grace`, `default_cadence_keeps_its_existing_two_minute_natural_window`, and `cadence_grace_handles_poll_phase_without_masking_real_downtime`, all still passing. Deterministic cron assertions use `* * * * *` so host-local evaluation cannot make them zone-dependent.

2. **Interval tests** — baseline (`interval_not_due_before_first_period`, `interval_fires_once_past_the_period_boundary`), before-baseline now (`interval_never_fires_for_a_now_before_the_baseline`, `interval_projection_before_the_baseline_is_the_first_firing_boundary`), last consumed slot (`interval_not_due_when_last_slot_covers_the_latest_boundary`, `interval_projection_skips_the_boundary_now_falls_in`), multi-period downtime (`interval_catch_up_collapses_a_long_gap_to_one_slot`), and zero/out-of-range without overflow or panic (`interval_arithmetic_rejects_out_of_range_values_on_both_consumers` covers 0, MAX+1 and u64::MAX against *both* `decide_due` and `next_scheduled_slot`, plus `interval_slot_near_the_date_range_edge_errors_instead_of_wrapping`). Both consumers now route through `interval_period`/`interval_slot`.

3. **Web and routine-status tests** — `api/tests/auto_tasks.rs`: `list_projects_the_next_interval_slot_not_the_owed_catch_up_slot` asserts the rendered slot is strictly future, computes what `decide_due` still owes for the same cursor, asserts the owed slot is in the past and *not equal* to the projection, and pins both to the same anchored arithmetic (exactly one 60-minute period apart). `list_projects_cron_definitions_pinned_to_the_minute` shows the canonical minute pinning now reaching the dashboard. The pre-existing `list_labels_disabled_next_evaluation_as_hypothetical`, `list_reports_never_observed_when_the_cursor_is_missing`, and `list_reports_disabled_and_unavailable_delivery_definitions` still pass unchanged. `routines/tests/status.rs`: `next_scheduled_occurrence_is_minute_pinned_and_ahead_of_a_sub_minute_now` and `next_scheduled_occurrence_is_absent_for_an_unparseable_cron`, alongside the untouched `schedule_display_state_distinguishes_paused_disabled_waiting_and_unobserved`.

4. **Existing tests and docs** — all 27 pre-existing `auto_tasks::tests::{schedule,scheduler}` cases (due, dedupe, claim/checkpoint reconciliation) pass, as do the 12 pre-existing `routines::tests::due` cases. Documentation changes are listed above.

## Validation

- `cargo test -p orbit-automation` — **passed** (109 passed, 0 failed).
- `cargo test -p orbit-web --lib api::tests::auto_tasks` — **passed** (22 passed, 0 failed).
- `cargo test -p orbit-core --lib application::routines` — **passed** (34 passed, 0 failed).
- `cargo test -p orbit-core --lib application::auto_tasks` — **passed** (36 passed, 0 failed).
- `make ci-fast` — **passed** (exit 0).
- `make ci-lint` — **passed** (exit 0).
- `cargo fmt --all -- --check`, `git diff --check`, `git status --short` — clean; only the ten intended files are modified.

Whole-crate runs surface three failures that are **pre-existing and unrelated**. I verified this by restoring HEAD content for every file I touched and re-running them: `application::routine::tests::dogfood_task_pilot_routine_matches_the_rendered_default_template` (committed `.orbit/routines/task_pilot.yaml` says `*/15`, the seeded template asset says `*/40`), `application::task::tests::update::concurrent_explicit_edit_preserves_the_newer_status`, and `orbit-web tests::health::detailed_healthz_fails_when_store_db_is_broken` all fail identically at unmodified HEAD (adf8b1832). None touches scheduler code. The working tree was then restored and byte-compared against the pre-check diff.

## Notes and risks

- One deliberate behavior change: the web cron projection is now minute-pinned (previously it carried the poll's sub-minute component) and is rendered in UTC rather than a host-local offset. The instant is the same; the dashboard formats it through `time(at)`, and no other surface consumes this field.
- `decide_interval` now rejects intervals above `MAX_AUTO_TASK_INTERVAL_MINUTES` rather than only those exceeding the signed-duration range. This aligns it with `validate_schedule`, so any interval CRUD accepts still computes; a value CRUD would reject is now an error on both paths instead of silently computing.
- Interval projections deliberately return the boundary one period past the one `now` falls in, and one period past the baseline when `now` precedes it — the baseline boundary is the exclusive due floor and never fires, so reporting it would advertise a slot the scheduler will not take.
- No new cross-crate dependency edge: orbit-web reaches the arithmetic through the pre-existing `orbit_core::application::auto_tasks::schedule` re-export, so `ARCHITECTURE.md` is unchanged.
- Changes left uncommitted for the pipeline. Sandbox note: `git checkout --` is denied in this worktree (read-only `.git/worktrees/.../index.lock`); the HEAD-baseline check was done by writing `git show HEAD:<path>` content to the files and restoring from a saved patch, with no git index writes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11732-6a9f89bd`
- Behind base: 0
- Ahead of base: 1