### PR TITLE
[code-review] Recover companion RPC state after malformed or mismatched responses

### DIFF
--- a/crates/orbit-search/src/bin/orbit-search-companion.rs
+++ b/crates/orbit-search/src/bin/orbit-search-companion.rs
@@ -15,7 +15,9 @@ use std::path::PathBuf;
 use clap::Parser;
 use fastembed::{EmbeddingModel, ModelTrait, TextEmbedding, TextInitOptions};
 use orbit_common::OrbitError;
-use orbit_search::{CompanionPaths, ModelSpec, RpcError, RpcRequest, RpcResponse, RpcResult};
+use orbit_search::{
+    CompanionPaths, ModelSpec, RpcError, RpcRequest, RpcResponse, RpcResult, unparsed_request_id,
+};
 
 #[derive(Debug, Parser)]
 #[command(name = "orbit-search-companion")]
@@ -165,7 +167,14 @@ fn run() -> Result<(), OrbitError> {
                 }
                 continue;
             }
-            Err(error) => error_response(0, "invalid_request", error.to_string()),
+            // Echo the caller's own id when the line is trustworthy enough to
+            // carry one, so a client can correlate the rejection instead of
+            // reading it as a desynchronized stream.
+            Err(error) => error_response(
+                unparsed_request_id(&line),
+                "invalid_request",
+                error.to_string(),
+            ),
         };
         write_json_line(&response)?;
     }

--- a/crates/orbit-search/src/lib.rs
+++ b/crates/orbit-search/src/lib.rs
@@ -56,7 +56,10 @@ pub use lexical::docs::{
     DocSearchResult, DocSearchSource, SearchResult, score_doc_record, sort_search_results,
 };
 pub use noop::NoopEmbedder;
-pub use rpc::{RpcError, RpcRequest, RpcResponse, RpcResult, rpc_error_to_orbit};
+pub use rpc::{
+    RpcError, RpcRequest, RpcResponse, RpcResult, UNCORRELATED_REQUEST_ID, rpc_error_to_orbit,
+    unparsed_request_id,
+};
 pub use subprocess::SubprocessEmbedder;
 pub use vector::{
     DocEmbeddingSource, EmbedWorker, SOURCE_KIND_DOC, SOURCE_KIND_TASK, SemanticStats,

--- a/crates/orbit-search/src/rpc.rs
+++ b/crates/orbit-search/src/rpc.rs
@@ -28,11 +28,41 @@ impl RpcRequest {
     }
 }
 
+/// Response id used when a malformed request line carries no trustworthy id.
+///
+/// Clients number their requests from 1, so `0` can never collide with an
+/// in-flight request and such a response reads as uncorrelated.
+pub const UNCORRELATED_REQUEST_ID: u64 = 0;
+
+/// Best-effort correlation id for a line that failed to parse as an
+/// [`RpcRequest`].
+///
+/// A line is trustworthy only when it is a JSON object whose `id` member is an
+/// unsigned integer — enough to answer the right caller without treating
+/// arbitrary malformed input as a valid request. Anything else (non-JSON, a
+/// JSON array or scalar, a missing/negative/fractional/string `id`) yields
+/// [`UNCORRELATED_REQUEST_ID`].
+pub fn unparsed_request_id(line: &str) -> u64 {
+    serde_json::from_str::<serde_json::Value>(line)
+        .ok()
+        .and_then(|value| value.get("id")?.as_u64())
+        .unwrap_or(UNCORRELATED_REQUEST_ID)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum RpcResponse {
     Result { id: u64, result: RpcResult },
     Error { id: u64, error: RpcError },
+}
+
+impl RpcResponse {
+    /// The request id this response claims to answer.
+    pub fn id(&self) -> u64 {
+        match self {
+            Self::Result { id, .. } | Self::Error { id, .. } => *id,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/orbit-search/src/subprocess.rs
+++ b/crates/orbit-search/src/subprocess.rs
@@ -5,14 +5,23 @@
 //! `Exit`, closes stdin, and reaps the child within a bounded wait
 //! (killing the process group if it ignores `exit`).
 //!
-//! ## Retry hygiene (ORB-10006)
+//! ## Retry hygiene (ORB-10006, ORB-11705)
 //!
 //! Transport-level failures — spawn resource exhaustion, a crashed/exited
 //! companion (EOF), broken pipes, a wedged companion that misses its read
 //! deadline — are transient: the request is retried a bounded number of
 //! times with exponential backoff + full jitter, respawning the companion
-//! between attempts. Companion-reported RPC errors and protocol violations
-//! are permanent and surface immediately.
+//! between attempts.
+//!
+//! A companion whose stdout stream has lost sync with the request stream —
+//! an unparseable line, or a response addressed to another request id — is
+//! treated the same way, because the offending child also holds however many
+//! queued lines the next request would otherwise consume. It is reaped and
+//! respawned so the retry reads from a clean stream; if every attempt is
+//! spent the failure still surfaces as a protocol violation.
+//!
+//! Only a companion-reported error carrying the request's own id is
+//! permanent: that is the companion answering, not losing sync.
 
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
@@ -47,6 +56,10 @@ pub(crate) const DEFAULT_DROP_TIMEOUT: Duration = Duration::from_secs(2);
 
 const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
+/// Cap on how much of an unparseable response line is quoted back in an
+/// error message: enough to diagnose, bounded for an arbitrarily long line.
+const RESPONSE_EXCERPT_CHARS: usize = 200;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CompanionStderr {
     Inherit,
@@ -55,11 +68,60 @@ pub(crate) enum CompanionStderr {
 
 /// Classification of a single RPC attempt failure (ORB-10006).
 pub(crate) enum RequestFailure {
-    /// The companion is gone or the pipe broke — a respawn may fix it.
-    Transient(String),
-    /// Deterministic failure (companion-reported error, protocol violation,
-    /// serialization) — retrying cannot fix it.
+    /// The companion is unusable for this attempt — a respawn may fix it.
+    Transient(TransientFailure),
+    /// Deterministic failure (companion-reported error, serialization) —
+    /// retrying cannot fix it.
     Permanent(OrbitError),
+}
+
+/// A retryable attempt failure: `detail` explains this attempt, and `kind`
+/// selects the error surfaced once the retry budget is spent.
+pub(crate) struct TransientFailure {
+    kind: TransientKind,
+    detail: String,
+}
+
+/// Why an attempt is retryable. Both kinds force a respawn; they differ only
+/// in the diagnosis a caller sees after the last attempt (ORB-11705).
+#[derive(Clone, Copy)]
+enum TransientKind {
+    /// Spawn, pipe, EOF or read-deadline failure.
+    Transport,
+    /// The companion's response stream no longer matches the request stream.
+    Desync,
+}
+
+impl TransientFailure {
+    fn transport(detail: impl Into<String>) -> Self {
+        Self {
+            kind: TransientKind::Transport,
+            detail: detail.into(),
+        }
+    }
+
+    fn desync(detail: impl Into<String>) -> Self {
+        Self {
+            kind: TransientKind::Desync,
+            detail: detail.into(),
+        }
+    }
+
+    fn detail(&self) -> &str {
+        &self.detail
+    }
+
+    /// Error to surface once every attempt has been spent.
+    fn into_exhausted_error(self) -> OrbitError {
+        let message = format!(
+            "search companion RPC failed after {RPC_MAX_ATTEMPTS} attempts: {}",
+            self.detail
+        );
+        match self.kind {
+            TransientKind::Transport => OrbitError::Execution(message),
+            TransientKind::Desync => OrbitError::AgentProtocolViolation(message),
+        }
+    }
 }
 
 /// Whether a spawn `io::Error` is deterministic. `NotFound` / rejected
@@ -184,8 +246,9 @@ impl SubprocessEmbedder {
     }
 
     fn request(&self, request: RpcRequest) -> Result<RpcResult, OrbitError> {
+        // Every request gets its own id: an id reused across requests would
+        // let a stale queued response pass the correlation check below.
         let request = match request {
-            RpcRequest::Info { id: 0 } => RpcRequest::Info { id: 1 },
             RpcRequest::Info { .. } => RpcRequest::Info {
                 id: self.next_request_id(),
             },
@@ -215,7 +278,7 @@ impl SubprocessEmbedder {
             .lock()
             .map_err(|error| OrbitError::Execution(format!("companion mutex poisoned: {error}")))?;
         let mut jitter = JitterRng::seeded(&self.model_arg);
-        let mut last_transient = String::new();
+        let mut last_transient: Option<TransientFailure> = None;
         for attempt in 0..RPC_MAX_ATTEMPTS {
             if attempt > 0 {
                 let sleep_ms = jitter.full_jitter(retry_backoff_bound_ms(attempt));
@@ -224,18 +287,23 @@ impl SubprocessEmbedder {
                 {
                     Ok(fresh) => {
                         io.kill_and_reap();
+                        // Installing the fresh `ChildIo` also drops the old
+                        // response channel, so lines the previous companion
+                        // left queued cannot leak into this attempt.
                         *io = fresh;
                     }
                     Err(error) => {
                         if spawn_error_is_permanent(&error) {
                             return Err(spawn_error_to_orbit(&self.companion_path, &error));
                         }
-                        last_transient = format!("companion respawn failed: {error}");
                         tracing::warn!(
                             attempt,
                             error = %error,
                             "search companion respawn failed; will retry"
                         );
+                        last_transient = Some(TransientFailure::transport(format!(
+                            "companion respawn failed: {error}"
+                        )));
                         continue;
                     }
                 }
@@ -243,19 +311,22 @@ impl SubprocessEmbedder {
             match request_once(&mut io, &line, id, deadline) {
                 Ok(result) => return Ok(result),
                 Err(RequestFailure::Permanent(error)) => return Err(error),
-                Err(RequestFailure::Transient(message)) => {
+                Err(RequestFailure::Transient(failure)) => {
                     tracing::warn!(
                         attempt,
-                        error = %message,
-                        "search companion RPC transport failure; respawning companion"
+                        error = %failure.detail(),
+                        "search companion RPC attempt failed; respawning companion"
                     );
-                    last_transient = message;
+                    last_transient = Some(failure);
                 }
             }
         }
-        Err(OrbitError::Execution(format!(
-            "search companion RPC failed after {RPC_MAX_ATTEMPTS} attempts: {last_transient}"
-        )))
+        Err(match last_transient {
+            Some(failure) => failure.into_exhausted_error(),
+            None => OrbitError::Execution(
+                "search companion RPC made no attempts; retry budget is zero".to_string(),
+            ),
+        })
     }
 
     fn next_request_id(&self) -> u64 {
@@ -264,33 +335,38 @@ impl SubprocessEmbedder {
 }
 
 /// One request/response round-trip against the current companion child.
-/// Transport failures (write/read errors, EOF, deadline) are transient;
-/// malformed or mismatched responses and companion-reported errors are
-/// permanent.
+///
+/// Transport failures (write/read errors, EOF, deadline) and a stream that
+/// has lost sync (unparseable line, foreign response id) are transient and
+/// leave the child reaped for the caller to respawn. Only a companion-reported
+/// error carrying this request's id is permanent.
 fn request_once(
     io: &mut ChildIo,
     line: &str,
     id: u64,
     deadline: Duration,
 ) -> Result<RpcResult, RequestFailure> {
-    let stdin = io
-        .stdin
-        .as_mut()
-        .ok_or_else(|| RequestFailure::Transient("search companion stdin is closed".to_string()))?;
+    let stdin = io.stdin.as_mut().ok_or_else(|| {
+        RequestFailure::Transient(TransientFailure::transport(
+            "search companion stdin is closed",
+        ))
+    })?;
     stdin
         .write_all(line.as_bytes())
         .and_then(|_| stdin.write_all(b"\n"))
         .and_then(|_| stdin.flush())
         .map_err(|error| {
-            RequestFailure::Transient(format!("failed to write companion RPC: {error}"))
+            RequestFailure::Transient(TransientFailure::transport(format!(
+                "failed to write companion RPC: {error}"
+            )))
         })?;
 
     let response_line = match io.lines.recv_timeout(deadline) {
         Ok(Ok(response)) => response,
         Ok(Err(error)) => {
             io.kill_and_reap();
-            return Err(RequestFailure::Transient(format!(
-                "failed to read companion RPC: {error}"
+            return Err(RequestFailure::Transient(TransientFailure::transport(
+                format!("failed to read companion RPC: {error}"),
             )));
         }
         Err(RecvTimeoutError::Timeout) => {
@@ -299,35 +375,57 @@ fn request_once(
                 "search companion RPC timed out; killing companion"
             );
             io.kill_and_reap();
-            return Err(RequestFailure::Transient(format!(
-                "search companion RPC timed out after {}ms",
-                deadline.as_millis()
+            return Err(RequestFailure::Transient(TransientFailure::transport(
+                format!(
+                    "search companion RPC timed out after {}ms",
+                    deadline.as_millis()
+                ),
             )));
         }
         Err(RecvTimeoutError::Disconnected) => {
             io.kill_and_reap();
-            return Err(RequestFailure::Transient(
-                "search companion exited before sending a response".to_string(),
-            ));
+            return Err(RequestFailure::Transient(TransientFailure::transport(
+                "search companion exited before sending a response",
+            )));
         }
     };
-    let response: RpcResponse = serde_json::from_str(&response_line).map_err(|error| {
-        RequestFailure::Permanent(OrbitError::AgentProtocolViolation(error.to_string()))
-    })?;
+
+    // A line we cannot parse, or one addressed to a different request, means
+    // the stream is no longer request-aligned. Whatever else this companion
+    // has queued would be misread by the next call, so discard the child
+    // along with its response channel rather than surfacing a bare error.
+    let Ok(response) = serde_json::from_str::<RpcResponse>(&response_line) else {
+        io.kill_and_reap();
+        return Err(RequestFailure::Transient(TransientFailure::desync(
+            format!(
+                "companion sent an unparseable response to request {id}: {}",
+                response_excerpt(&response_line)
+            ),
+        )));
+    };
+    if response.id() != id {
+        io.kill_and_reap();
+        return Err(RequestFailure::Transient(TransientFailure::desync(
+            format!(
+                "companion answered request {id} with response id {}",
+                response.id()
+            ),
+        )));
+    }
+
     match response {
-        RpcResponse::Result {
-            id: response_id,
-            result,
-        } if response_id == id => Ok(result),
-        RpcResponse::Error {
-            id: response_id,
-            error,
-        } if response_id == id => Err(RequestFailure::Permanent(rpc_error_to_orbit(error))),
-        other => Err(RequestFailure::Permanent(
-            OrbitError::AgentProtocolViolation(format!(
-                "companion response id mismatch for request {id}: {other:?}"
-            )),
-        )),
+        RpcResponse::Result { result, .. } => Ok(result),
+        RpcResponse::Error { error, .. } => {
+            Err(RequestFailure::Permanent(rpc_error_to_orbit(error)))
+        }
+    }
+}
+
+fn response_excerpt(line: &str) -> String {
+    let line = line.trim();
+    match line.char_indices().nth(RESPONSE_EXCERPT_CHARS) {
+        Some((cut, _)) => format!("{}...", &line[..cut]),
+        None => line.to_string(),
     }
 }
 

--- a/crates/orbit-search/src/tests/rpc.rs
+++ b/crates/orbit-search/src/tests/rpc.rs
@@ -1,9 +1,12 @@
-//! Unit tests for the RPC envelope's boundary translator (ORB-10013) —
-//! sibling layout.
+//! Unit tests for the RPC envelope's boundary translator (ORB-10013) and
+//! response correlation (ORB-11705) — sibling layout.
 
 use orbit_common::OrbitError;
 
-use crate::rpc::{RpcError, rpc_error_to_orbit};
+use crate::rpc::{
+    RpcError, RpcResponse, RpcResult, UNCORRELATED_REQUEST_ID, rpc_error_to_orbit,
+    unparsed_request_id,
+};
 
 #[test]
 fn rpc_error_to_orbit_renders_code_and_message_into_execution() {
@@ -15,4 +18,50 @@ fn rpc_error_to_orbit_renders_code_and_message_into_execution() {
         rpc_error_to_orbit(error),
         OrbitError::Execution(m) if m == "search companion embed_failed: model not loaded"
     ));
+}
+
+#[test]
+fn unparsed_request_id_correlates_only_a_trustworthy_object_id() {
+    // A malformed line may still identify the caller it belongs to. Accept
+    // that only when the line is a JSON object carrying an unsigned integer
+    // `id`; everything else must stay uncorrelated so a client never reads a
+    // garbled line as an answer to one of its in-flight requests.
+    let table = [
+        (r#"{"id":7,"method":"nope"}"#, 7),
+        (r#"{"method":"embed","id":42}"#, 42),
+        (r#"  {"id":1}  "#, 1),
+        (r#"{"id":0}"#, UNCORRELATED_REQUEST_ID),
+        (r#"{"method":"embed"}"#, UNCORRELATED_REQUEST_ID),
+        (r#"{"id":-3}"#, UNCORRELATED_REQUEST_ID),
+        (r#"{"id":1.5}"#, UNCORRELATED_REQUEST_ID),
+        (r#"{"id":"7"}"#, UNCORRELATED_REQUEST_ID),
+        (r#"[{"id":7}]"#, UNCORRELATED_REQUEST_ID),
+        (r#"{"id":7"#, UNCORRELATED_REQUEST_ID),
+        ("this is not json", UNCORRELATED_REQUEST_ID),
+        ("", UNCORRELATED_REQUEST_ID),
+    ];
+    for (line, expected) in table {
+        assert_eq!(
+            unparsed_request_id(line),
+            expected,
+            "line {line:?} correlated to the wrong id"
+        );
+    }
+}
+
+#[test]
+fn rpc_response_reports_the_id_it_answers() {
+    let result = RpcResponse::Result {
+        id: 9,
+        result: RpcResult::Exit { ok: true },
+    };
+    let error = RpcResponse::Error {
+        id: 11,
+        error: RpcError {
+            code: "invalid_request".to_string(),
+            message: "bad".to_string(),
+        },
+    };
+    assert_eq!(result.id(), 9);
+    assert_eq!(error.id(), 11);
 }

--- a/crates/orbit-search/src/tests/subprocess.rs
+++ b/crates/orbit-search/src/tests/subprocess.rs
@@ -1,5 +1,5 @@
-//! Unit tests for `subprocess` retry hygiene (ORB-10006) and RPC/Drop
-//! deadlines — sibling layout.
+//! Unit tests for `subprocess` retry hygiene (ORB-10006), RPC-stream
+//! resynchronization (ORB-11705) and RPC/Drop deadlines — sibling layout.
 
 use std::time::Duration;
 
@@ -61,6 +61,8 @@ mod fake_companion {
     use std::path::{Path, PathBuf};
     use std::process::Command;
     use std::time::{Duration, Instant};
+
+    use orbit_common::OrbitError;
 
     use crate::embedder::Embedder;
     use crate::subprocess::{
@@ -131,6 +133,7 @@ done
 
         let embedder =
             SubprocessEmbedder::with_path_and_model(script, "fake").expect("construct embedder");
+        let pid = embedder.child_id().expect("companion pid");
         let err = embedder
             .embed(&["hello"])
             .expect_err("companion error must surface");
@@ -138,8 +141,127 @@ done
             err.to_string().contains("input_too_large"),
             "error should carry the companion code: {err}"
         );
+        assert!(
+            err.to_string().contains("nope"),
+            "error should carry the companion message: {err}"
+        );
         let attempts = std::fs::read(&log).expect("embed log").len();
         assert_eq!(attempts, 1, "permanent RPC error must not be retried");
+        assert_eq!(
+            embedder.child_id().expect("companion pid"),
+            pid,
+            "an answered request must not discard the companion"
+        );
+    }
+
+    #[test]
+    fn stray_response_line_recovers_through_respawn() {
+        // The first-generation companion prefixes its first embed answer with
+        // one extra stdout line, exactly once across restarts. The stray line
+        // desynchronizes the response stream — and leaves the real answer
+        // queued behind it — so the embedder must discard that companion,
+        // respawn, and answer from a clean stream. Later calls must see no
+        // trace of the stale queue.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let marker = temp.path().join("stray-emitted");
+        let embed_body = format!(
+            r#"if [ ! -f "{marker}" ]; then touch "{marker}"; printf '{{"id":424242,"result":{{"ok":true}}}}\n'; fi
+      printf '{{"id":%s,"result":{{"vectors":[[0.5,0.25]]}}}}\n' "$id""#,
+            marker = marker.display()
+        );
+        let script = write_companion_script(temp.path(), &embed_body);
+
+        let embedder =
+            SubprocessEmbedder::with_path_and_model(script, "fake").expect("construct embedder");
+        let first_pid = embedder.child_id().expect("companion pid");
+
+        assert_eq!(
+            embedder
+                .embed(&["hello"])
+                .expect("embed must recover from the stray line"),
+            vec![vec![0.5, 0.25]]
+        );
+        assert!(marker.exists(), "first generation must emit the stray line");
+        assert_ne!(
+            embedder.child_id().expect("companion pid"),
+            first_pid,
+            "the desynchronized companion must be replaced, not reused"
+        );
+
+        assert_eq!(
+            embedder
+                .embed(&["world"])
+                .expect("stream must stay clean after recovery"),
+            vec![vec![0.5, 0.25]]
+        );
+    }
+
+    #[test]
+    fn unparseable_response_exhausts_the_retry_budget_without_orphans() {
+        let err = assert_protocol_violation_exhausts_budget("printf 'this is not json\\n'");
+        assert!(
+            err.contains("unparseable") && err.contains("this is not json"),
+            "error should quote the offending line: {err}"
+        );
+    }
+
+    #[test]
+    fn mismatched_response_id_exhausts_the_retry_budget_without_orphans() {
+        let err = assert_protocol_violation_exhausts_budget(
+            r#"printf '{"id":%s,"result":{"vectors":[[0.5,0.25]]}}\n' "$((id+1000))""#,
+        );
+        assert!(
+            err.contains("response id"),
+            "error should name the foreign response id: {err}"
+        );
+    }
+
+    /// Drive a companion that violates the protocol on every embed and assert
+    /// the shared contract: the retry budget is spent exactly once per
+    /// attempt, the failure surfaces as a protocol violation naming the
+    /// budget, and no child or reader is left behind. Returns the rendered
+    /// error so each caller can check its own diagnosis.
+    fn assert_protocol_violation_exhausts_budget(bad_response: &str) -> String {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let log = temp.path().join("embed-requests.log");
+        let embed_body = format!(
+            r#"printf 'x' >> "{log}"
+      {bad_response}"#,
+            log = log.display()
+        );
+        let script = write_companion_script(temp.path(), &embed_body);
+        let embedder = SubprocessEmbedder::with_path_model_stderr_and_timeouts(
+            script.clone(),
+            "fake",
+            CompanionStderr::Suppress,
+            Duration::from_millis(500),
+            Duration::from_millis(200),
+        )
+        .expect("construct embedder");
+        let first_pid = embedder.child_id().expect("companion pid");
+
+        let err = embedder
+            .embed(&["hello"])
+            .expect_err("a persistent protocol violation must fail");
+        assert!(
+            matches!(err, OrbitError::AgentProtocolViolation(_)),
+            "persistent violations must stay diagnosable as protocol violations: {err:?}"
+        );
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains(&format!("after {RPC_MAX_ATTEMPTS} attempts")),
+            "error should name the exhausted budget: {rendered}"
+        );
+
+        let attempts = std::fs::read(&log).expect("embed log").len();
+        assert_eq!(
+            attempts, RPC_MAX_ATTEMPTS as usize,
+            "each attempt must respawn and retry exactly once"
+        );
+        // Every generation is reaped on its own failing attempt; a hung
+        // reader thread would deadlock the join inside that reap.
+        assert_no_companion_processes(&script, first_pid);
+        rendered
     }
 
     #[test]


### PR DESCRIPTION
## Task

[ORB-11705](https://orbit-cli.com/tasks/ORB-11705) — [code-review] Recover companion RPC state after malformed or mismatched responses

### Description

## Problem
Malformed responses and response-id mismatches return permanent errors while retaining the child and its channel-backed response stream. An extra stdout line can leave a pending response that is consumed by the next request, causing repeated mismatches.

## Required behavior and constraints
Invalidate and reap an unsynchronized child and recover through the existing bounded restart policy, ensuring subsequent calls cannot reuse stale queued responses. Preserve matching-id companion errors as application failures without restart. Correlate companion invalid-request errors when a trustworthy id can be extracted, without treating arbitrary malformed input as a valid request. Persistent protocol violations must terminate within the retry budget and remain diagnosable.

## Evidence and validation
Validated against local da21eb15; affected implementation files were unchanged at fetched origin/agent-main 09dec5183. `crates/orbit-search/src/subprocess.rs:239,310,322`; companion invalid-request response handling. Re-locate by symbol if lines move. Follow current AGENTS.md; preserve authoritative ownership and existing contracts. Run focused regression tests plus `make ci-fast` and `make ci-lint` before review.

### Acceptance Criteria

- A fake companion emits one stray line once across process restarts; recovery succeeds within the bounded policy and a subsequent embed call succeeds without stale-response contamination.
- Exercise malformed JSON, mismatched ids and repeated protocol violations; persistent failures exhaust a bounded retry budget and leave no orphan child/reader.
- A matching-id error surfaces its existing code/message without respawn; invalid-request id handling has focused coverage.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Outcome

Companion RPC stream desynchronization now recovers through the existing bounded
restart policy instead of returning a permanent error while keeping the
unsynchronized child alive.

### Changes (all uncommitted; pipeline owns commit/PR)

- `crates/orbit-search/src/subprocess.rs`
  - `request_once`: an unparseable response line, or a response whose id is not
    this request's id, now reaps the child (`kill_and_reap`) and returns
    `RequestFailure::Transient` instead of `Permanent`. The retry loop's
    `*io = fresh` replaces the whole `ChildIo`, dropping the old response
    channel, so lines the discarded companion left queued cannot leak into a
    later request. Restructured the tail into an explicit id check followed by a
    two-arm match; the mismatch message names only the foreign id rather than
    `{other:?}`-dumping a whole embedding vector.
  - New `TransientFailure` { `TransientKind::Transport` | `Desync` } carries the
    per-attempt detail plus the error to surface once the budget is spent, so a
    persistent protocol violation still exits as
    `OrbitError::AgentProtocolViolation` (stable `agent_protocol_violation`
    code in CLI/MCP JSON) rather than degrading to `Execution`.
  - Removed the `RpcRequest::Info { id: 0 } => Info { id: 1 }` special case, which
    made the constructor's info request reuse id 1 with the first embed. Unique
    ids close the residual hole where a stale queued info response would pass
    the correlation check. Constructor behaviour is unchanged (`next_id` starts
    at 1).
  - `response_excerpt` bounds the quoted offending line to 200 chars on a char
    boundary.
- `crates/orbit-search/src/rpc.rs`: added `RpcResponse::id()` (mirrors
  `RpcRequest::id()`) and `unparsed_request_id` / `UNCORRELATED_REQUEST_ID`.
  `unparsed_request_id` correlates only a JSON object with an unsigned-integer
  `id`; non-JSON, arrays/scalars, and missing/negative/fractional/string ids fall
  back to 0, which clients never use.
- `crates/orbit-search/src/bin/orbit-search-companion.rs`: the `invalid_request`
  error response echoes `unparsed_request_id(&line)` instead of a hardcoded 0.
- `crates/orbit-search/src/lib.rs`: exports the two new `rpc` items (the
  companion bin consumes the crate through its public surface).

Placed the id helper in `rpc.rs` (the module both sides share) rather than in the
bin, so it is testable at the protocol boundary; the bin keeps a one-line call
site. No new crate dependency edges.

### Acceptance criteria

1. **Stray line once across restarts** — MET.
   `tests::subprocess::fake_companion::stray_response_line_recovers_through_respawn`:
   a marker file makes generation 1 prefix its first embed answer with one stray
   line, exactly once across restarts. The embed succeeds (via respawn, inside
   `RPC_MAX_ATTEMPTS`), the child pid changes, and a second embed is clean —
   proving the stale queued answer did not survive.
2. **Malformed JSON, mismatched ids, bounded exhaustion, no orphans** — MET.
   `unparseable_response_exhausts_the_retry_budget_without_orphans` and
   `mismatched_response_id_exhausts_the_retry_budget_without_orphans` share
   `assert_protocol_violation_exhausts_budget`, which asserts exactly
   `RPC_MAX_ATTEMPTS` companion-side embed attempts, an
   `OrbitError::AgentProtocolViolation` naming the exhausted budget, a
   diagnosis naming the offending line / foreign id, and
   `assert_no_companion_processes` (pgrep by process group and by full command)
   for every generation. A leaked reader thread would deadlock the join inside
   `kill_and_reap`.
3. **Matching-id error without respawn; invalid-request id coverage** — MET.
   `companion_reported_error_is_permanent_and_not_retried` now also asserts the
   message text and that `child_id()` is unchanged (no respawn) alongside the
   existing single-attempt assertion. `tests::rpc::unparsed_request_id_correlates_only_a_trustworthy_object_id`
   is a 12-case table over the trustworthy/untrustworthy boundary;
   `tests::rpc::rpc_response_reports_the_id_it_answers` covers `RpcResponse::id()`.

### Regression evidence

Restored the pre-fix `subprocess.rs` from HEAD and re-ran the new tests: all three
new fake-companion tests FAIL against it (stray line -> permanent
`AgentProtocolViolation`; both exhaustion tests -> a single unretried attempt),
and all pre-existing tests still pass. The fix was then restored and re-verified.

### Validation

- `cargo test -p orbit-search --lib` — PASSED, 87/87, run 4x after forcing a
  rebuild. The 5 new tests passed 4/4.
- `make ci-fast` — PASSED (exit 0).
- `make ci-lint` — PASSED (exit 0, workspace-wide clippy, all targets, warnings denied).
- `git diff --check` clean; `git status --short` shows only the 6 intended files;
  no build artifacts in the patch.

### Risks / deviations

- Scope: changed 4 files beyond `context_files` and appended them to the task —
  `rpc.rs` (owns the shared envelope; new id helpers), `lib.rs` (export the two
  items the companion bin needs), and the two sibling test files. Smallest change
  that satisfies the criteria at the owning boundary.
- Behavior change: a companion that persistently emits garbage now costs up to
  `RPC_MAX_ATTEMPTS` spawns plus ~150ms of jittered backoff before failing,
  instead of failing on the first response. This is the requested trade.
- PRE-EXISTING FLAKE, unrelated: `commands::tests::install::companion_install_streams_a_slow_one_mebibyte_download_without_a_total_timeout`
  fails intermittently with `error sending request for url (http://127.0.0.1:PORT/companion)`.
  Reproduced at pristine HEAD (4 failures in 5 runs of the install module alone,
  with all new tests filtered out) and with only install tests selected, so it is
  not caused by this change; it is load-sensitive. Friction filed.
- The wrong-shaped-but-matching-id result (e.g. an `Info` payload answering an
  embed) remains a permanent `AgentProtocolViolation` raised in `embed()`. With
  unique request ids this is a genuine companion bug rather than desync, so it
  was deliberately left as-is.
- Companion-side `invalid_request` correlation is covered by unit tests on
  `unparsed_request_id`; it is not reachable end-to-end through
  `SubprocessEmbedder`, which only ever sends well-formed requests. The real
  companion binary was not executed (it requires a downloaded ONNX model);
  the fake-companion tests exercise the client half only. NOT RUN, stated as a limit.
- Checks were run on Linux only.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11705-6a9f8855`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra