### PR TITLE
[code-review] `record_publication_success` idempotency check compares lowercase stored commit with raw input

### DIFF
--- a/crates/orbit-registry/src/tests/workspace_publication.rs
+++ b/crates/orbit-registry/src/tests/workspace_publication.rs
@@ -392,3 +392,69 @@ fn rejected_bind_leaves_persisted_registry_byte_identical() {
         "failed rebind must not persist"
     );
 }
+
+#[test]
+fn record_publication_success_is_idempotent_across_commit_hex_case() {
+    const UPPER: &str = "ABCDEF0123456789ABCDEF0123456789ABCDEF01";
+    const LOWER: &str = "abcdef0123456789abcdef0123456789abcdef01";
+
+    let mut upper_then_lower = owner_registry();
+    bind_publication(
+        &mut upper_then_lower,
+        "ws_orbit",
+        "git@github.com:example/tasks.git",
+        "main",
+        "tp_orbit_tasks",
+        Some("hm_owner"),
+    )
+    .expect("bind");
+    let first = record_publication_success(
+        &mut upper_then_lower,
+        "ws_orbit",
+        3,
+        UPPER,
+        Some("hm_owner"),
+    )
+    .expect("record uppercase");
+    let second = record_publication_success(
+        &mut upper_then_lower,
+        "ws_orbit",
+        3,
+        LOWER,
+        Some("hm_owner"),
+    )
+    .expect("retry lowercase");
+    assert_eq!(first, second);
+    assert_eq!(first.last_success_generation, Some(3));
+    assert_eq!(first.last_success_commit.as_deref(), Some(LOWER));
+
+    let mut lower_then_upper = owner_registry();
+    bind_publication(
+        &mut lower_then_upper,
+        "ws_orbit",
+        "git@github.com:example/tasks.git",
+        "main",
+        "tp_orbit_tasks",
+        Some("hm_owner"),
+    )
+    .expect("bind");
+    let first = record_publication_success(
+        &mut lower_then_upper,
+        "ws_orbit",
+        3,
+        LOWER,
+        Some("hm_owner"),
+    )
+    .expect("record lowercase");
+    let second = record_publication_success(
+        &mut lower_then_upper,
+        "ws_orbit",
+        3,
+        UPPER,
+        Some("hm_owner"),
+    )
+    .expect("retry uppercase");
+    assert_eq!(first, second);
+    assert_eq!(first.last_success_generation, Some(3));
+    assert_eq!(first.last_success_commit.as_deref(), Some(LOWER));
+}

--- a/crates/orbit-registry/src/workspace_registry/publication.rs
+++ b/crates/orbit-registry/src/workspace_registry/publication.rs
@@ -113,6 +113,7 @@ pub fn record_publication_success(
     commit: &str,
     local_machine_id: Option<&str>,
 ) -> Result<WorkspacePublicationBinding, OrbitError> {
+    let commit = commit.to_ascii_lowercase();
     let workspace_id = bindable_workspace(registry, id_or_name, local_machine_id)?.id;
     let binding = registry
         .publication_bindings
@@ -130,7 +131,7 @@ pub fn record_publication_success(
             )));
         }
         if generation == previous {
-            if binding.last_success_commit.as_deref() == Some(commit) {
+            if binding.last_success_commit.as_deref() == Some(commit.as_str()) {
                 return Ok(binding.clone());
             }
             return Err(publication_error(format!(
@@ -146,7 +147,7 @@ pub fn record_publication_success(
         publication_id: binding.publication_id.clone(),
         authority_machine_id: binding.authority_machine_id.clone(),
         last_success_generation: Some(generation),
-        last_success_commit: Some(commit.to_ascii_lowercase()),
+        last_success_commit: Some(commit),
     }
     .validated()
     .map_err(workspace_error)?;


### PR DESCRIPTION
## Task

[ORB-11722](https://orbit-cli.com/tasks/ORB-11722) — [code-review] `record_publication_success` idempotency check compares lowercase stored commit with raw input

### Description

## Problem
The function stores `commit.to_ascii_lowercase()` (line 149) but the same-generation idempotency check compares `binding.last_success_commit.as_deref() == Some(commit)` against the raw argument (line 133). Recording the same generation twice with an uppercase/mixed-case hex commit (e.g. copied from a GitHub UI) fails with `publication generation N already recorded a different commit` even though it is the same commit.

## Why It Matters
The retry path of a publication is meant to be idempotent; a case difference turns it into a hard error.

## Proposed Fix
Normalise `commit` once at the top (`let commit = commit.to_ascii_lowercase();`) and use it for both the comparison and the stored value.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-registry/src/workspace_registry/publication.rs:126-155`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (bug). Review area: search-registry.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test: record generation 3 with `"ABCDEF..."`, then again with `"abcdef..."` (and vice versa) — both return `Ok` with the same binding.
- Existing `tests/workspace_publication.rs` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `record_publication_success` lowercases `commit` once at entry and uses that value for both the same-generation idempotency comparison and the stored `last_success_commit`.
- Added `record_publication_success_is_idempotent_across_commit_hex_case` covering generation 3 uppercase-then-lowercase and lowercase-then-uppercase retries.
Assessment: Small local fix at the registry boundary. Stored commits remain lowercase hex. No extra files or shims.

Criteria:
1. Record generation 3 with `"ABCDEF..."` then `"abcdef..."` (and vice versa) — both return `Ok` with the same binding. PASS — new unit test records both directions, asserts equal bindings, generation 3, and lowercase stored commit.
2. Existing `tests/workspace_publication.rs` pass. PASS — `cargo test -p orbit-registry --lib workspace_publication` ran 6 tests, 0 failed.

Validation:
- `cargo test -p orbit-registry --lib workspace_publication` — passed (6 tests, including the new case-idempotency test).
- `make ci-fast` — passed.
- `cargo clippy -p orbit-registry --all-targets -- -D warnings` — passed.
- `make ci-lint` — failed. Workspace clippy stopped on a pre-existing HEAD compile error in `orbit-store` (`E0432` unresolved `bundle_io::PENDING_WRITE_FILE_NAME`; the symbol is `#[cfg(test)]`-gated in `bundle_io/mod.rs` but re-exported from non-test `task_bundle/mod.rs`). That crate is outside this task's context_files and is unmodified in this worktree (`git status` shows only the two publication files). In-scope clippy on `orbit-registry` was the crate-local substitute.
- `git diff --check` — passed. Working tree: two modified files, uncommitted.

Strategic decisions: Normalize once at the function boundary rather than comparing with a second lowercase on the stored side, matching the proposed fix.
Design weaknesses / risks: Workspace-wide `make ci-lint` stays red on this HEAD until the unrelated orbit-store re-export is fixed. This change does not depend on that crate.
Deviations from original plan: None.
Remaining risks: Mixed-case hex still stores lowercase; a genuinely different object id at the same generation still errors.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11722-6a9f90d8`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra