### PR TITLE
[code-review] `semantic uninstall --all` leaves the integrity manifest and temp files behind

### DIFF
--- a/crates/orbit-search/src/commands/install.rs
+++ b/crates/orbit-search/src/commands/install.rs
@@ -602,7 +602,7 @@ pub(crate) fn write_companion_integrity(path: &Path, checksum: &str) -> Result<(
     fs::write(manifest_path, content).map_err(|error| OrbitError::Io(error.to_string()))
 }
 
-fn companion_integrity_path(path: &Path) -> Option<std::path::PathBuf> {
+pub(crate) fn companion_integrity_path(path: &Path) -> Option<std::path::PathBuf> {
     let file_name = path.file_name()?.to_string_lossy();
     Some(path.with_file_name(format!("{file_name}.sha256")))
 }

--- a/crates/orbit-search/src/commands/tests/mod.rs
+++ b/crates/orbit-search/src/commands/tests/mod.rs
@@ -5,3 +5,4 @@ mod install;
 mod reindex;
 mod related;
 mod search;
+mod uninstall;

--- a/crates/orbit-search/src/commands/tests/uninstall.rs
+++ b/crates/orbit-search/src/commands/tests/uninstall.rs
@@ -1,0 +1,55 @@
+//! Unit tests for `uninstall` — sibling layout under commands/tests/.
+
+use super::super::uninstall::{SemanticUninstallParams, run_with_paths};
+
+use crate::CompanionPaths;
+
+use tempfile::tempdir;
+
+#[test]
+fn uninstall_all_removes_companion_metadata_and_stale_temporary_files() {
+    let temporary = tempdir().expect("temporary fixture");
+    let paths = CompanionPaths::new(temporary.path().join("embed"));
+    let companion = paths.companion_path();
+    let companion_name = companion
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("platform companion file name");
+    let manifest = companion.with_file_name(format!("{companion_name}.sha256"));
+    let stale_temporary = paths.bin_dir.join(format!(".{companion_name}.tmp-123"));
+
+    std::fs::create_dir_all(&paths.bin_dir).expect("create bin directory");
+    std::fs::write(&companion, "binary").expect("write companion");
+    std::fs::write(&manifest, "checksum").expect("write manifest");
+    std::fs::write(&stale_temporary, "partial binary").expect("write stale temporary");
+
+    let result = run_with_paths(
+        &paths,
+        SemanticUninstallParams {
+            model: None,
+            all: true,
+        },
+    )
+    .expect("uninstall all");
+
+    assert!(result.removed_companion);
+    assert!(result.removed_companion_integrity);
+    assert_eq!(
+        result.removed_temporary_companions,
+        vec![format!(".{companion_name}.tmp-123")]
+    );
+    let json = serde_json::to_value(&result).expect("serialize uninstall result");
+    assert_eq!(json["removed_companion_integrity"], true);
+    assert_eq!(
+        json["removed_temporary_companions"],
+        serde_json::json!([format!(".{companion_name}.tmp-123")])
+    );
+    assert!(
+        !paths.bin_dir.exists(),
+        "the empty bin directory should be removed"
+    );
+    assert!(
+        !paths.root.exists(),
+        "the empty embed root should be removed"
+    );
+}

--- a/crates/orbit-search/src/commands/uninstall.rs
+++ b/crates/orbit-search/src/commands/uninstall.rs
@@ -4,6 +4,7 @@ use orbit_common::OrbitError;
 use serde::Serialize;
 
 use crate::CompanionPaths;
+use crate::commands::install::companion_integrity_path;
 use crate::commands::{active_model, remove_file_if_exists};
 use crate::{ModelSpec, default_model};
 
@@ -16,13 +17,29 @@ pub struct SemanticUninstallParams {
 #[derive(Debug, Clone, Serialize)]
 pub struct SemanticUninstallResult {
     pub removed_companion: bool,
+    pub removed_companion_integrity: bool,
+    pub removed_temporary_companions: Vec<String>,
     pub removed_models: Vec<String>,
 }
 
 pub fn run(params: SemanticUninstallParams) -> Result<SemanticUninstallResult, OrbitError> {
     let paths = CompanionPaths::default_under_home()?;
+    run_with_paths(&paths, params)
+}
+
+pub(crate) fn run_with_paths(
+    paths: &CompanionPaths,
+    params: SemanticUninstallParams,
+) -> Result<SemanticUninstallResult, OrbitError> {
     if params.all {
-        let removed_companion = remove_file_if_exists(&paths.companion_path())?;
+        let companion_path = paths.companion_path();
+        let removed_companion = remove_file_if_exists(&companion_path)?;
+        let removed_companion_integrity = companion_integrity_path(&companion_path)
+            .map(|path| remove_file_if_exists(&path))
+            .transpose()?
+            .unwrap_or(false);
+        let removed_temporary_companions =
+            remove_temporary_companions(&paths.bin_dir, &companion_path)?;
         let mut removed_models = Vec::new();
         if paths.models_dir.exists() {
             for entry in fs::read_dir(&paths.models_dir)
@@ -37,15 +54,19 @@ pub fn run(params: SemanticUninstallParams) -> Result<SemanticUninstallResult, O
                 .map_err(|error| OrbitError::Io(error.to_string()))?;
         }
         let _ = remove_file_if_exists(&paths.active_model_path)?;
+        remove_empty_directory(&paths.bin_dir)?;
+        remove_empty_directory(&paths.root)?;
         return Ok(SemanticUninstallResult {
             removed_companion,
+            removed_companion_integrity,
+            removed_temporary_companions,
             removed_models,
         });
     }
 
     let model = match params.model {
         Some(model) => ModelSpec::parse(&model)?.alias.to_string(),
-        None => active_model(&paths).unwrap_or_else(|| default_model().alias.to_string()),
+        None => active_model(paths).unwrap_or_else(|| default_model().alias.to_string()),
     };
     let model_dir = paths.model_dir(&model);
     let removed = if model_dir.exists() {
@@ -54,12 +75,51 @@ pub fn run(params: SemanticUninstallParams) -> Result<SemanticUninstallResult, O
     } else {
         false
     };
-    if active_model(&paths).as_deref() == Some(model.as_str()) {
+    if active_model(paths).as_deref() == Some(model.as_str()) {
         let _ = remove_file_if_exists(&paths.active_model_path)?;
     }
 
     Ok(SemanticUninstallResult {
         removed_companion: false,
+        removed_companion_integrity: false,
+        removed_temporary_companions: Vec::new(),
         removed_models: if removed { vec![model] } else { Vec::new() },
     })
+}
+
+fn remove_temporary_companions(
+    bin_dir: &std::path::Path,
+    companion_path: &std::path::Path,
+) -> Result<Vec<String>, OrbitError> {
+    let Some(companion_name) = companion_path.file_name().and_then(|name| name.to_str()) else {
+        return Ok(Vec::new());
+    };
+    let temporary_prefix = format!(".{companion_name}.tmp-");
+    let mut removed = Vec::new();
+
+    if !bin_dir.exists() {
+        return Ok(removed);
+    }
+
+    for entry in fs::read_dir(bin_dir).map_err(|error| OrbitError::Io(error.to_string()))? {
+        let entry = entry.map_err(|error| OrbitError::Io(error.to_string()))?;
+        let name = entry.file_name();
+        if name.to_string_lossy().starts_with(&temporary_prefix) {
+            fs::remove_file(entry.path()).map_err(|error| OrbitError::Io(error.to_string()))?;
+            removed.push(name.to_string_lossy().to_string());
+        }
+    }
+
+    Ok(removed)
+}
+
+fn remove_empty_directory(path: &std::path::Path) -> Result<(), OrbitError> {
+    if path.exists() {
+        match fs::remove_dir(path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::DirectoryNotEmpty => {}
+            Err(error) => return Err(OrbitError::Io(error.to_string())),
+        }
+    }
+    Ok(())
 }


### PR DESCRIPTION
## Task

[ORB-11720](https://orbit-cli.com/tasks/ORB-11720) — [code-review] `semantic uninstall --all` leaves the integrity manifest and temp files behind

### Description

## Problem
`uninstall --all` removes `companion_path()`, the models dir and `active-model`, but not the sibling `<companion>.sha256` manifest written by `write_companion_integrity`, nor any `.<companion>.tmp-<pid>` file left by an interrupted install (only the installing process cleans its own pid-suffixed temp). After uninstall `~/.orbit/embed/bin/` still contains `orbit-search-companion-<platform>.sha256` (present on this Mac now), so "uninstalled" is not a clean state and the next install's "needs reinstall" debug log is confusing (manifest present, binary absent).

## Why It Matters
Uninstall is the documented remedy for a corrupt install; leaving state behind undermines it.

## Proposed Fix
In `--all`, also remove `companion_integrity_path(&companion_path)`, any `.<companion>.tmp-*` entries in `bin_dir`, and remove `bin_dir`/`root` when empty; report the manifest removal in `SemanticUninstallResult`.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-search/src/commands/uninstall.rs:24-44`, `crates/orbit-search/src/commands/install.rs:553-556`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (ux). Review area: search-registry.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test: install fixture files (binary + `.sha256` + a stale `.tmp-123`), run `uninstall --all`, assert `bin_dir` is empty/removed.
- `orbit semantic uninstall --all --json` lists what was removed.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Extended semantic uninstall --all to remove the companion integrity manifest and matching stale install temporary files, then prune empty bin and embed directories without disturbing non-empty directories.
- Added JSON result fields for the removed integrity manifest and temporary filenames; the CLI already serializes this result as its JSON detail payload.
- Added a focused uninstall fixture test covering binary, manifest, stale temporary cleanup, empty-directory pruning, and JSON serialization.
Assessment: The cleanup remains scoped to the managed companion filename and its installer temp-file prefix.

Criteria:
1. Passed — the new fixture creates the binary, .sha256 manifest, and .tmp-123 file; uninstall --all removes them and asserts bin_dir and root are gone when empty.
2. Passed — the fixture serializes SemanticUninstallResult and asserts the manifest and temporary-removal fields present in the CLI JSON payload.

Validation:
- cargo fmt --check — passed.
- cargo test -p orbit-search uninstall_all_removes_companion_metadata_and_stale_temporary_files — passed (1 test).
- make ci-fast — passed. Its compiler-cache namespace check was skipped because the runner disallows unprivileged mount namespaces; this is an environment limitation reported by the check, not a task validation failure.
- make ci-lint — passed (workspace all-target clippy with warnings denied).
- git diff --check — passed.

Risks: The focused test verifies the command boundary plus result serialization rather than spawning the CLI binary; CLI output uses json!(result), so the serialized fields are the same payload.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11720-6a9f90b8`
- Behind base: 0
- Ahead of base: 1