### PR TITLE
[code-review] `reindex_tasks` never removes rows for deleted tasks (unlike `reindex_docs`)

### DIFF
--- a/crates/orbit-cli/src/command/semantic.rs
+++ b/crates/orbit-cli/src/command/semantic.rs
@@ -26,7 +26,9 @@ pub enum SemanticSubcommand {
     /// Rebuild semantic embeddings
     ///
     /// CLI task mutations do not index in the background; run this after
-    /// installs or bulk edits.
+    /// installs or bulk edits. Sources the corpus no longer contains are
+    /// dropped and reported as stale_sources, clearing the stale rows
+    /// `orbit semantic stats` counts.
     Index(SemanticIndexArgs),
 }
 
@@ -165,10 +167,17 @@ impl Execute for SemanticIndexArgs {
 
 fn semantic_index_text(result: SemanticIndexResult) -> String {
     match result {
-        SemanticIndexResult::Tasks { model_id, report } => {
+        SemanticIndexResult::Tasks {
+            model_id,
+            report,
+            stale_sources,
+        } => {
             format!(
-                "Indexed semantic search: model={} embedded_chunks={} skipped_fields={}",
-                model_id, report.embedded_chunks, report.skipped_fields
+                "Indexed semantic search: model={} embedded_chunks={} skipped_fields={} stale_sources={}",
+                model_id,
+                report.embedded_chunks,
+                report.skipped_fields,
+                stale_sources.len()
             )
         }
         SemanticIndexResult::Docs {
@@ -188,10 +197,11 @@ fn semantic_index_text(result: SemanticIndexResult) -> String {
         }
         SemanticIndexResult::All { tasks, docs } => {
             format!(
-                "Indexed semantic search: tasks_model={} tasks_embedded_chunks={} tasks_skipped_fields={} docs_model={} docs_indexed_sources={} docs_embedded_chunks={} docs_skipped_fields={} docs_stale_sources={}",
+                "Indexed semantic search: tasks_model={} tasks_embedded_chunks={} tasks_skipped_fields={} tasks_stale_sources={} docs_model={} docs_indexed_sources={} docs_embedded_chunks={} docs_skipped_fields={} docs_stale_sources={}",
                 tasks.model_id,
                 tasks.report.embedded_chunks,
                 tasks.report.skipped_fields,
+                tasks.stale_sources.len(),
                 docs.model_id,
                 docs.indexed_sources,
                 docs.report.embedded_chunks,

--- a/crates/orbit-search/src/commands/reindex.rs
+++ b/crates/orbit-search/src/commands/reindex.rs
@@ -50,6 +50,8 @@ impl SemanticIndexParams {
 pub struct TaskIndexResult {
     pub model_id: String,
     pub report: UpsertReport,
+    /// Task sources dropped because they are no longer in the live corpus.
+    pub stale_sources: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -58,6 +60,7 @@ pub enum SemanticIndexResult {
     Tasks {
         model_id: String,
         report: UpsertReport,
+        stale_sources: Vec<String>,
     },
     Docs {
         model_id: String,
@@ -76,6 +79,7 @@ impl From<TaskIndexResult> for SemanticIndexResult {
         Self::Tasks {
             model_id: result.model_id,
             report: result.report,
+            stale_sources: result.stale_sources,
         }
     }
 }
@@ -101,9 +105,19 @@ pub fn run(
 ) -> Result<TaskIndexResult, OrbitError> {
     let model = parse_model(params.model.as_deref())?;
     let embedder = SubprocessEmbedder::with_model(model.alias)?;
-    let report = vector_store.reindex_tasks(tasks, &embedder, params.force)?;
+    run_with_embedder(vector_store, tasks, &embedder, params.force)
+}
+
+pub(crate) fn run_with_embedder(
+    vector_store: &VectorStore,
+    tasks: &[Task],
+    embedder: &dyn Embedder,
+    force: bool,
+) -> Result<TaskIndexResult, OrbitError> {
+    let report = vector_store.reindex_tasks(tasks, embedder, force)?;
     Ok(TaskIndexResult {
         model_id: embedder.model_id().to_string(),
-        report,
+        report: report.upsert,
+        stale_sources: report.stale_sources,
     })
 }

--- a/crates/orbit-search/src/commands/tests/reindex.rs
+++ b/crates/orbit-search/src/commands/tests/reindex.rs
@@ -2,9 +2,45 @@
 
 use std::str::FromStr;
 
-use super::super::reindex::{IndexKind, SemanticIndexParams, SemanticIndexResult};
-use crate::vector::UpsertReport;
+use super::super::reindex::{
+    IndexKind, SemanticIndexParams, SemanticIndexResult, SemanticReindexResult, run_with_embedder,
+};
+
+use chrono::Utc;
+use orbit_types::task::{Task, TaskPriority, TaskStatus, TaskType};
 use serde_json::json;
+
+use crate::NoopEmbedder;
+use crate::vector::{UpsertReport, VectorStore};
+
+fn task(id: &str, title: &str, description: &str) -> Task {
+    Task {
+        id: id.to_string(),
+        title: title.to_string(),
+        description: description.to_string(),
+        acceptance_criteria: Vec::new(),
+        tags: Vec::new(),
+        required_tools: Vec::new(),
+        plan: String::new(),
+        execution_summary: String::new(),
+        context_files: Vec::new(),
+        created_by: None,
+        planned_by: None,
+        implemented_by: None,
+        status: TaskStatus::Backlog,
+        priority: TaskPriority::Medium,
+        complexity: None,
+        task_type: TaskType::Chore,
+        pr_status: None,
+        external_refs: Vec::new(),
+        relations: Vec::new(),
+        job_run_id: None,
+        crew: None,
+        orchestrator: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
 
 #[test]
 fn semantic_index_params_serde_defaults_to_tasks_at_runtime() {
@@ -35,13 +71,14 @@ fn semantic_index_kind_rejects_singular_learning() {
 }
 
 #[test]
-fn tasks_variant_serializes_like_legacy_reindex_result() {
+fn tasks_variant_serializes_flat_like_the_task_index_result() {
     let result = SemanticIndexResult::Tasks {
         model_id: "bge-small-en-v1.5".to_string(),
         report: UpsertReport {
             embedded_chunks: 7,
             skipped_fields: 2,
         },
+        stale_sources: vec!["T9".to_string()],
     };
 
     let expected = json!({
@@ -49,11 +86,32 @@ fn tasks_variant_serializes_like_legacy_reindex_result() {
             "report": {
                 "embedded_chunks": 7,
                 "skipped_fields": 2
-            }
+            },
+            "stale_sources": ["T9"]
     });
     assert_eq!(serde_json::to_value(&result).unwrap(), expected);
     assert_eq!(
         serde_json::to_string(&result).unwrap(),
-        r#"{"model_id":"bge-small-en-v1.5","report":{"embedded_chunks":7,"skipped_fields":2}}"#
+        r#"{"model_id":"bge-small-en-v1.5","report":{"embedded_chunks":7,"skipped_fields":2},"stale_sources":["T9"]}"#
     );
+}
+
+/// A task deleted while this index was unwritable leaves rows that only the
+/// reindex sweep can clear, so the run must both drop them and say so.
+#[test]
+fn reindex_clears_rows_left_by_a_task_that_is_no_longer_live() {
+    let store = VectorStore::open_in_memory().unwrap();
+    let embedder = NoopEmbedder::small();
+    let indexed = vec![
+        task("T1", "still here", "live task"),
+        task("T2", "deleted elsewhere", "removed task"),
+    ];
+    run_with_embedder(&store, &indexed, &embedder, false).expect("index both tasks");
+
+    let result: SemanticReindexResult =
+        run_with_embedder(&store, &indexed[..1], &embedder, false).expect("reindex live corpus");
+    let stats = store.stats(&["T1".to_string()]).unwrap();
+
+    assert_eq!(result.stale_sources, vec!["T2".to_string()]);
+    assert_eq!(stats.stale_rows, 0);
 }

--- a/crates/orbit-search/src/vector/store/tasks.rs
+++ b/crates/orbit-search/src/vector/store/tasks.rs
@@ -3,6 +3,8 @@
 //! `index_task` and `reindex_tasks` are the convenience wrappers that wire
 //! `task_embedding_fields(...)` (per-field extraction) into `upsert_embeddings`.
 
+use std::collections::BTreeSet;
+
 use orbit_common::OrbitError;
 use orbit_types::task::Task;
 
@@ -10,6 +12,12 @@ use super::{SOURCE_KIND_TASK, VectorStore};
 use crate::Embedder;
 use crate::vector::UpsertReport;
 use crate::vector::task_fields::task_embedding_fields;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskReindexReport {
+    pub upsert: UpsertReport,
+    pub stale_sources: Vec<String>,
+}
 
 impl VectorStore {
     pub fn index_task(
@@ -27,18 +35,41 @@ impl VectorStore {
         )
     }
 
+    /// Rebuild the task corpus: upsert every live task, then drop the rows of
+    /// task sources that are no longer live.
+    ///
+    /// The delete sweep is the only way to clear rows the `task.delete`
+    /// cascade never removed — deletions taken while this index was read-only
+    /// or unopened, imported or restored state, and cascades that failed. It
+    /// is what makes the `stale_rows` count reported by `stats` recoverable
+    /// without deleting `semantic.db`.
     pub fn reindex_tasks(
         &self,
         tasks: &[Task],
         embedder: &dyn Embedder,
         force: bool,
-    ) -> Result<UpsertReport, OrbitError> {
-        let mut total = UpsertReport::default();
+    ) -> Result<TaskReindexReport, OrbitError> {
+        let mut upsert = UpsertReport::default();
+        let live = tasks
+            .iter()
+            .map(|task| task.id.clone())
+            .collect::<BTreeSet<_>>();
         for task in tasks {
             let report = self.index_task(task, embedder, force)?;
-            total.embedded_chunks += report.embedded_chunks;
-            total.skipped_fields += report.skipped_fields;
+            upsert.embedded_chunks += report.embedded_chunks;
+            upsert.skipped_fields += report.skipped_fields;
         }
-        Ok(total)
+
+        let mut stale_sources = Vec::new();
+        for source_id in self.source_ids(SOURCE_KIND_TASK)? {
+            if !live.contains(&source_id) {
+                self.delete_source(SOURCE_KIND_TASK, &source_id)?;
+                stale_sources.push(source_id);
+            }
+        }
+        Ok(TaskReindexReport {
+            upsert,
+            stale_sources,
+        })
     }
 }

--- a/crates/orbit-search/tests/parity.rs
+++ b/crates/orbit-search/tests/parity.rs
@@ -52,10 +52,12 @@ fn reindex_report_shape_is_stable_across_runs() {
 
     let first: UpsertReport = vector
         .reindex_tasks(&tasks, &embedder, false)
-        .expect("first reindex");
+        .expect("first reindex")
+        .upsert;
     let second: UpsertReport = vector
         .reindex_tasks(&tasks, &embedder, false)
-        .expect("second reindex");
+        .expect("second reindex")
+        .upsert;
 
     // First run: every field embedded, none skipped.
     assert_eq!(first.skipped_fields, 0, "first run: nothing to skip");

--- a/crates/orbit-tools/src/builtin/orbit/semantic/index.rs
+++ b/crates/orbit-tools/src/builtin/orbit/semantic/index.rs
@@ -11,7 +11,7 @@ impl Tool for OrbitSemanticIndexTool {
         ToolSchema {
             name: "orbit.semantic.index".to_string(),
             description:
-                "Rebuild semantic embeddings for tasks, docs, or all indexed corpora in the active workspace."
+                "Rebuild semantic embeddings for tasks, docs, or all indexed corpora in the active workspace. Reports the sources swept from the index as stale_sources."
                     .to_string(),
             parameters: vec![
                 ToolParam {

--- a/docs/design/orbit-search/2_design.md
+++ b/docs/design/orbit-search/2_design.md
@@ -282,7 +282,7 @@ orbit semantic stats
 
 `uninstall` removes the companion binary and (by default) the currently active model. `--model M` removes only model M. `--all` removes the companion plus every installed model.
 
-`orbit search` defaults to lexical matching across tasks and docs; ADR content participates through indexed design docs. `--hybrid` blends lexical scoring with cosine over the selected corpus; `orbit search similar <task-id>` embeds the target task and runs cosine-neighbor lookup against other tasks; `orbit search path <path>` performs applicability lookup over path-scoped artifacts. `orbit semantic index` rebuilds the selected corpus (`tasks` by default, or `docs` and `all` via `--kind`); `orbit docs index` is the docs-specific alias and sweeps stale doc paths. `--force` ignores `content_hash` and re-embeds everything. `stats` reports row counts, model distribution, stale-row count, and companion-install status. The retired `learning` kind is rejected.
+`orbit search` defaults to lexical matching across tasks and docs; ADR content participates through indexed design docs. `--hybrid` blends lexical scoring with cosine over the selected corpus; `orbit search similar <task-id>` embeds the target task and runs cosine-neighbor lookup against other tasks; `orbit search path <path>` performs applicability lookup over path-scoped artifacts. `orbit semantic index` rebuilds the selected corpus (`tasks` by default, or `docs` and `all` via `--kind`) and sweeps the sources that corpus no longer contains; `orbit docs index` is the docs-specific alias. Both report the swept sources as `stale_sources` in `--json` output (`tasks_stale_sources` / `docs_stale_sources` under `--kind all`), which is how the stale-row count reported by `stats` gets back to zero. `--force` ignores `content_hash` and re-embeds everything. `stats` reports row counts, model distribution, stale-row count, and companion-install status. The retired `learning` kind is rejected.
 
 If the companion is not installed, `orbit search similar <task-id>`, `orbit semantic index`, and `orbit docs index` exit non-zero with: `"Semantic search not enabled. Run \`orbit semantic install\` to download the inference companion."` Hybrid task and doc search are softer: they emit a warning/note and fall back to lexical results.
 
@@ -293,6 +293,8 @@ If the companion is not installed, `orbit search similar <task-id>`, `orbit sema
 - `orbit.search` — `(query?, hybrid?, semantic?, kind?, limit?, tag?, all?, status?, path?, workspaces?, all_workspaces?)` → ranked results with snippets.
 - `orbit.semantic.install`, `orbit.semantic.uninstall`, `orbit.semantic.stats`, `orbit.semantic.index` — companion lifecycle.
 - `orbit.docs.index` — docs-corpus embedding build and stale-source sweep.
+
+Both indexing tools return `stale_sources`: the source IDs dropped because the live corpus no longer contains them.
 
 `orbit.search` is read-only. Task indexing is implicit (on task mutation) or explicit (`orbit semantic index` / `orbit.semantic.index`); docs indexing is explicit (`orbit docs index` / `orbit.docs.index`).
 
@@ -379,11 +381,13 @@ Vectors and FTS rows stay workspace-local ([§3](#3-vector-storage)); only the *
 
 ### 7.2 Backfill and migration
 
-`orbit semantic index` walks the task store and embeds anything not present (or whose `content_hash` differs). A model migration (`--model`) writes new rows under the new `model_id`; the old `model_id` rows can be deleted in a follow-up `orbit semantic prune --model OLD`.
+`orbit semantic index` walks the task store and embeds anything not present (or whose `content_hash` differs), then deletes the `task` sources the store no longer lists. A model migration (`--model`) writes new rows under the new `model_id`; the old `model_id` rows can be deleted in a follow-up `orbit semantic prune --model OLD`.
 
 ### 7.3 Deletion
 
 `task.delete` cascades to `DELETE FROM embeddings WHERE source_kind = 'task' AND source_id = ?`. Tombstoned tasks (in the v2 task-sync sense, see [docs/design/_archive/task-sync/](../_archive/task-sync/1_overview.md)) are not embedded.
+
+The cascade only runs when the deletion goes through a runtime holding a writable index, so deletions taken while `semantic.db` was read-only or unopened, restored state, and failed cascades all leave rows behind. `orbit semantic index` is the recovery: its sweep is what `stats` counts as `stale_rows` and the doctor's `semantic-index` check tells the user to clear.
 
 ---
 


### PR DESCRIPTION
## Task

[ORB-11716](https://orbit-cli.com/tasks/ORB-11716) — [code-review] `reindex_tasks` never removes rows for deleted tasks (unlike `reindex_docs`)

### Description

## Problem
`reindex_docs` computes the live set and deletes stale sources; `reindex_tasks` only upserts. The cascade in orbit-core `records.rs:135` covers deletes that go through the runtime while the vector DB is writable, but any task removed while the semantic DB was read-only/unopened, imported/restored state, or a failed cascade (logged at debug) leaves rows behind forever. `semantic_stats` reports them as `stale_rows` and `orbit semantic reindex` — the obvious remedy — does not clear them, so the number can only be reset by deleting `semantic.db`.

## Why It Matters
Stale rows show up as search hits for tasks that no longer exist, and the stats number the doctor surfaces is unfixable from the CLI.

## Proposed Fix
Mirror `reindex_docs`: after upserting, delete `SOURCE_KIND_TASK` sources not present in `tasks`, and return `stale_sources` in `TaskIndexResult`.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-search/src/vector/store/tasks.rs:30-43`, `crates/orbit-search/src/commands/reindex.rs:97-109`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (bug). Review area: search-registry.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test: index two tasks, call `reindex_tasks` with one of them; `stats(&[remaining_id]).stale_rows == 0` and `SemanticReindexResult.stale_sources == [removed_id]`.
- `orbit semantic reindex --json` output documents the new field.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Outcome

`reindex_tasks` now sweeps task sources that are no longer in the live corpus, mirroring `reindex_docs`, and reports them as `stale_sources`. `orbit semantic index` is therefore a real remedy for the `stale_rows` count `orbit semantic stats` reports and `orbit doctor`'s `semantic-index` check already tells users to clear — previously that number could only be reset by deleting `semantic.db`.

## Changes

- `crates/orbit-search/src/vector/store/tasks.rs` — `reindex_tasks` collects the live task-ID set, upserts as before, then `delete_source`s every `SOURCE_KIND_TASK` source not in that set. Returns the new `TaskReindexReport { upsert, stale_sources }`, the exact shape of the existing `DocReindexReport`. The doc comment states why the sweep exists (deletes taken while the index was read-only/unopened, imported or restored state, failed cascades).
- `crates/orbit-search/src/commands/reindex.rs` — `TaskIndexResult` (= `SemanticReindexResult`) and the `SemanticIndexResult::Tasks` variant gain `stale_sources: Vec<String>`. Extracted `run_with_embedder`, mirroring `doc_index::run_with_embedder`, so the path is testable without the installed companion. No second execution path: `run` delegates to it.
- `crates/orbit-cli/src/command/semantic.rs` — human-readable summaries carry `stale_sources=` (tasks) and `tasks_stale_sources=` (`--kind all`); the `Index` clap help documents the sweep.
- `crates/orbit-tools/src/builtin/orbit/semantic/index.rs` — `orbit.semantic.index` description mentions the reported `stale_sources`.
- `docs/design/orbit-search/2_design.md` — §6.1 (task sweep + `stale_sources` in `--json`), §6.2 (both indexing tools return it), §7.2 (backfill deletes sources the store no longer lists), §7.3 (why the `task.delete` cascade is not sufficient and reindex is the recovery).
- `crates/orbit-search/tests/parity.rs` — caller updated for the new return type (`.upsert`).

Files outside the declared `context_files` were changed to keep directly affected consumers and user-facing docs consistent with the new return type and JSON field; all seven are now recorded on the task.

## Acceptance criteria

1. **Test: index two tasks, reindex with one; `stats(&[remaining_id]).stale_rows == 0` and `SemanticReindexResult.stale_sources == [removed_id]`** — met. `commands/tests/reindex.rs::reindex_clears_rows_left_by_a_task_that_is_no_longer_live` asserts exactly that, at the command boundary that owns `SemanticReindexResult`. Also verified end-to-end (below).
2. **`orbit semantic reindex --json` output documents the new field** — met. The field is emitted (`"stale_sources": [...]`, confirmed against the real CLI) and documented in the design doc §6.1/§6.2, the `orbit.semantic.index` MCP tool description, and `orbit semantic index --help`.

## Validation

| Command | Outcome |
|---|---|
| `make ci-fast` | **passed** (exit 0). One sub-check self-skips in this environment: `test-compiler-cache-namespaces: skip: cannot create a mount namespace` — unrelated to this change. |
| `make ci-lint` | **passed** (exit 0), workspace-wide clippy with warnings denied. |
| `cargo test -p orbit-search` | **passed** — 85 unit + 2 parity, 0 failed. |
| `cargo test -p orbit-cli -p orbit-tools` | **passed** — 0 failed. |
| `git diff --check` / `git status --short` | clean; only the seven intended files are modified. |

End-to-end against the real CLI and the installed embedder companion, in a throwaway Orbit root under `/tmp` (since removed):

1. Two tasks indexed → 4 task rows, `stale_rows=0`.
2. One task's bundle removed and `orbit task reindex` run, reproducing restored/imported state → `stale_rows=1` while `orbit semantic index --json` (pre-fix) would have reported nothing.
3. `orbit semantic index --json` → `"stale_sources": ["SCR-00001"]`.
4. `orbit semantic stats` → 2 rows, `stale_rows=0`.

Negative check in the same run: an **archived** task stays in `list_tasks()`, so the sweep left it alone (`stale_sources: []`, rows unchanged). The sweep's live set is exactly the one `semantic_stats` already uses to define `stale_rows`, so the two cannot disagree.

## Deviations and risks

- `commands/tests/reindex.rs::tasks_variant_serializes_like_legacy_reindex_result` asserted the exact pre-change JSON, which the required new field invalidates. Renamed to `tasks_variant_serializes_flat_like_the_task_index_result` and updated to the new shape; it still enforces the real invariant (the untagged `Tasks` variant serializes flat, identically to `TaskIndexResult`). The addition is additive and, per the orbit-search decision record, `orbit semantic reindex` has no external consumers requiring a shim.
- `stale_sources` is per-source, not per-model: a `--model NEW` migration still leaves old-`model_id` rows for live tasks, which remains `orbit semantic prune --model OLD`'s job (design doc §7.2). Unchanged by this task.
- The sweep adds one `SELECT DISTINCT source_id` plus one delete per stale source per reindex — the same cost `reindex_docs` already pays.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11716-6a9f8e2a`
- Behind base: 0
- Ahead of base: 1