### PR TITLE
[BLOCKED] [code-review] Two selector grammars for the same id-or-name lookup (`find_workspace` first-match vs `resolve_logical_workspace` fail-closed)

### DIFF
--- a/crates/orbit-cli/src/command/run/ship.rs
+++ b/crates/orbit-cli/src/command/run/ship.rs
@@ -141,7 +141,10 @@ pub(crate) fn resolve_ship_mode(
         .iter()
         .find(|checkout| checkout.orbit_dir == orbit_dir)
         .and_then(|checkout| {
-            orbit_registry::workspace_registry::find_workspace(&registry, &checkout.workspace_id)
+            registry
+                .workspaces
+                .iter()
+                .find(|workspace| workspace.id == checkout.workspace_id)
         })
         .map(orbit_core::resolved_ship_mode);
     let Some(mode) = mode else {

--- a/crates/orbit-cli/src/command/task/publication.rs
+++ b/crates/orbit-cli/src/command/task/publication.rs
@@ -115,7 +115,7 @@ impl Execute for TaskPublicationPublishArgs {
         let host = load_host_identity(&global_root)?;
         let registry_path = workspace_registry::registry_path_for(&global_root);
         let mut registry = workspace_registry::load_registry_from(&registry_path)?;
-        let binding = workspace_registry::find_publication_binding(&registry, &workspace_id)
+        let binding = workspace_registry::find_publication_binding(&registry, &workspace_id)?
             .cloned()
             .ok_or_else(|| {
                 orbit_core::OrbitError::WorkspaceError(format!(
@@ -123,7 +123,7 @@ impl Execute for TaskPublicationPublishArgs {
                 ))
             })?;
         let checkout =
-            workspace_registry::find_checkout(&registry, &workspace_id).ok_or_else(|| {
+            workspace_registry::find_checkout(&registry, &workspace_id)?.ok_or_else(|| {
                 orbit_core::OrbitError::WorkspaceError(format!(
                     "workspace '{workspace_id}' has no local checkout"
                 ))
@@ -188,7 +188,7 @@ impl Execute for TaskPublicationStatusArgs {
         let registry = workspace_registry::load_registry_from(
             &workspace_registry::registry_path_for(&runtime.global_root()),
         )?;
-        let binding = workspace_registry::find_publication_binding(&registry, &workspace_id)
+        let binding = workspace_registry::find_publication_binding(&registry, &workspace_id)?
             .ok_or_else(|| {
                 orbit_core::OrbitError::WorkspaceError(format!(
                     "workspace '{workspace_id}' has no publication binding"
@@ -476,7 +476,7 @@ fn assert_restore_authority(
     let registry = workspace_registry::load_registry_from(&workspace_registry::registry_path_for(
         &global_root,
     ))?;
-    let workspace = workspace_registry::find_workspace(&registry, &selected).ok_or_else(|| {
+    let workspace = workspace_registry::find_workspace(&registry, &selected)?.ok_or_else(|| {
         orbit_core::OrbitError::WorkspaceError(format!("workspace '{selected}' is not registered"))
     })?;
     if workspace.owner_machine_id.as_deref() != Some(local_machine_id.as_str()) {
@@ -484,7 +484,7 @@ fn assert_restore_authority(
             "workspace '{selected}' is not owned by local machine '{local_machine_id}'"
         )));
     }
-    let checkout = workspace_registry::find_checkout(&registry, &selected).ok_or_else(|| {
+    let checkout = workspace_registry::find_checkout(&registry, &selected)?.ok_or_else(|| {
         orbit_core::OrbitError::WorkspaceError(format!(
             "workspace '{selected}' has no local checkout"
         ))

--- a/crates/orbit-cli/src/command/workspace/list.rs
+++ b/crates/orbit-cli/src/command/workspace/list.rs
@@ -39,11 +39,17 @@ pub(super) fn workspace_list_json(registry: &WorkspaceRegistry, include_replicas
             .iter()
             .filter(|workspace| {
                 include_replicas
-                    || workspace_registry::find_checkout(registry, &workspace.id)
+                    || registry
+                        .checkouts
+                        .iter()
+                        .find(|checkout| checkout.workspace_id == workspace.id)
                         .is_none_or(|checkout| checkout.role != Some(orbit_types::workspace::WorkspaceCheckoutRole::Replica))
             })
             .map(|workspace| {
-                let checkout = workspace_registry::find_checkout(registry, &workspace.id);
+                let checkout = registry
+                    .checkouts
+                    .iter()
+                    .find(|checkout| checkout.workspace_id == workspace.id);
                 json!({
                     "id": workspace.id,
                     "name": workspace.name,
@@ -67,12 +73,14 @@ pub(super) fn format_workspace_list(
         .iter()
         .filter(|workspace| {
             include_replicas
-                || workspace_registry::find_checkout(registry, &workspace.id).is_none_or(
-                    |checkout| {
+                || registry
+                    .checkouts
+                    .iter()
+                    .find(|checkout| checkout.workspace_id == workspace.id)
+                    .is_none_or(|checkout| {
                         checkout.role
                             != Some(orbit_types::workspace::WorkspaceCheckoutRole::Replica)
-                    },
-                )
+                    })
         })
         .collect();
     if workspaces.is_empty() {
@@ -96,7 +104,10 @@ pub(super) fn format_workspace_list(
         id_width = id_width
     );
     for workspace in workspaces {
-        let checkout = workspace_registry::find_checkout(registry, &workspace.id);
+        let checkout = registry
+            .checkouts
+            .iter()
+            .find(|checkout| checkout.workspace_id == workspace.id);
         let root = checkout
             .map(|checkout| checkout.repo_root.display().to_string())
             .unwrap_or_else(|| "-".to_string());

--- a/crates/orbit-cli/src/command/workspace/publication.rs
+++ b/crates/orbit-cli/src/command/workspace/publication.rs
@@ -115,7 +115,7 @@ impl Execute for WorkspacePublicationShowArgs {
         let registry = workspace_registry::load_registry_from(
             &workspace_registry::registry_path_for(&runtime.global_root()),
         )?;
-        match workspace_registry::find_publication_binding(&registry, &workspace_id) {
+        match workspace_registry::find_publication_binding(&registry, &workspace_id)? {
             Some(binding) => {
                 Ok(Payload::detail(binding_json(binding, "shown"), format_binding(binding)).into())
             }

--- a/crates/orbit-cli/src/command/workspace/show.rs
+++ b/crates/orbit-cli/src/command/workspace/show.rs
@@ -62,7 +62,10 @@ pub(super) fn registered_workspace_for_repo_root<'a>(
             .iter()
             .find(|checkout| checkout.repo_root == repo_root)
     })?;
-    workspace_registry::find_workspace(registry, &checkout.workspace_id)
+    registry
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == checkout.workspace_id)
         .map(|workspace| (workspace, checkout))
 }
 

--- a/crates/orbit-cli/src/command/workspace/source_remote.rs
+++ b/crates/orbit-cli/src/command/workspace/source_remote.rs
@@ -51,7 +51,7 @@ impl Execute for WorkspaceSourceRemoteShowArgs {
             &workspace_registry::registry_path_for(&runtime.global_root()),
         )?;
         let workspace =
-            workspace_registry::find_workspace(&registry, &workspace_id).ok_or_else(|| {
+            workspace_registry::find_workspace(&registry, &workspace_id)?.ok_or_else(|| {
                 OrbitError::WorkspaceError(format!("unknown workspace '{workspace_id}'"))
             })?;
 

--- a/crates/orbit-cli/src/command/workspace/sync.rs
+++ b/crates/orbit-cli/src/command/workspace/sync.rs
@@ -42,7 +42,7 @@ impl WorkspaceSyncArgs {
             })
             .max_by_key(|checkout| checkout.repo_root.components().count())
             .ok_or_else(workspace_init_required)?;
-        if workspace_registry::find_workspace(&registry, &checkout.workspace_id).is_none() {
+        if workspace_registry::find_workspace(&registry, &checkout.workspace_id)?.is_none() {
             return Err(workspace_init_required());
         }
         let host_id = match inspect_host_identity(&global_root)? {

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -1559,6 +1559,7 @@ fn workspace_init_in_independent_nested_git_repo_preserves_parent_binding() {
     .expect("serialize parent workspace registration");
     let parent_checkout_before = serde_json::to_vec(
         workspace_registry::find_checkout(&registry_before, &parent_id)
+            .expect("lookup parent checkout")
             .expect("parent checkout registration"),
     )
     .expect("serialize parent checkout registration");
@@ -1615,6 +1616,7 @@ fn workspace_init_in_independent_nested_git_repo_preserves_parent_binding() {
         .find(|workspace| workspace.id == child_id)
         .expect("child workspace registration");
     let child_checkout = workspace_registry::find_checkout(&registry_after, &child_id)
+        .expect("lookup child checkout")
         .expect("child checkout registration");
     assert_eq!(child_workspace.name, "independent-child");
     assert_eq!(
@@ -1633,6 +1635,7 @@ fn workspace_init_in_independent_nested_git_repo_preserves_parent_binding() {
     .expect("serialize preserved parent workspace registration");
     let parent_checkout_after = serde_json::to_vec(
         workspace_registry::find_checkout(&registry_after, &parent_id)
+            .expect("lookup parent checkout")
             .expect("preserved parent checkout registration"),
     )
     .expect("serialize preserved parent checkout registration");
@@ -1686,6 +1689,7 @@ fn workspace_init_with_root_override_uses_custom_registry() {
         .find(|workspace| workspace.name == "custom-root")
         .expect("registered workspace");
     let checkout = workspace_registry::find_checkout(&registry, &workspace_record.id)
+        .expect("lookup registered checkout")
         .expect("registered checkout");
     assert_eq!(
         std::fs::canonicalize(&checkout.repo_root).expect("canonical registered root"),

--- a/crates/orbit-cmd/src/registry_runtime.rs
+++ b/crates/orbit-cmd/src/registry_runtime.rs
@@ -475,7 +475,7 @@ fn resolve_cli_workspace_path<'a>(
     if let Some(checkout) = find_checkout_for_canonical_path(registry, &canonical)
         .or_else(|| find_checkout_for_git_common_dir(registry, &canonical))
     {
-        let workspace = workspace_registry::find_workspace(registry, &checkout.workspace_id)
+        let workspace = workspace_registry::find_workspace(registry, &checkout.workspace_id)?
             .ok_or_else(|| unsupported_cli_workspace(selector))?;
         return Ok(CliWorkspaceTarget::Checkout {
             workspace,
@@ -676,13 +676,15 @@ pub(crate) fn select_workspace_for_cwd_and_roots(
 
     if let Some(checkout) = workspace_registry::find_checkout_by_path(&registry, cwd)
         && canonical_or_original(&checkout.orbit_dir) == shared
-        && let Some(workspace) =
-            workspace_registry::find_workspace(&registry, &checkout.workspace_id)
     {
-        return Ok(Some(ResolvedWorkspaceSelection {
-            workspace: workspace.clone(),
-            checkout: checkout.clone(),
-        }));
+        if let Some(workspace) =
+            workspace_registry::find_workspace(&registry, &checkout.workspace_id)?
+        {
+            return Ok(Some(ResolvedWorkspaceSelection {
+                workspace: workspace.clone(),
+                checkout: checkout.clone(),
+            }));
+        }
     }
 
     // An explicit --root pins global_root to shared_root. In that mode an

--- a/crates/orbit-registry/src/tests/workspace_publication.rs
+++ b/crates/orbit-registry/src/tests/workspace_publication.rs
@@ -131,7 +131,9 @@ fn bind_round_trips_through_atomic_save_and_rebind_is_the_only_replace_path() {
     save_registry_to(&registry, &path).expect("save binding");
 
     let loaded = load_registry_from(&path).expect("reload");
-    let binding = find_publication_binding(&loaded, "orbit").expect("find by name");
+    let binding = find_publication_binding(&loaded, "orbit")
+        .expect("lookup by name")
+        .expect("find binding");
     assert_eq!(binding.publication_id, "tp_orbit_tasks");
     assert_eq!(binding.last_success_generation, Some(3));
 
@@ -157,7 +159,11 @@ fn bind_round_trips_through_atomic_save_and_rebind_is_the_only_replace_path() {
     assert_eq!(removed.publication_id, "tp_orbit_tasks_v2");
     save_registry_to(&unbound, &path).expect("save unbind");
     let empty = load_registry_from(&path).expect("reload empty");
-    assert!(find_publication_binding(&empty, "ws_orbit").is_none());
+    assert!(
+        find_publication_binding(&empty, "ws_orbit")
+            .expect("lookup empty registry")
+            .is_none()
+    );
     let persisted: Value =
         serde_json::from_slice(&fs::read(&path).expect("read")).expect("parse saved registry");
     assert!(persisted.get("publication_bindings").is_none());

--- a/crates/orbit-registry/src/tests/workspace_registry.rs
+++ b/crates/orbit-registry/src/tests/workspace_registry.rs
@@ -12,7 +12,7 @@ use tempfile::tempdir;
 
 use crate::workspace_registry::{
     assign_checkout_role, find_checkout_by_path, find_workspace, find_workspace_by_path,
-    load_registry_from, load_registry_from_with_writer, register_checkout,
+    load_registry_from, load_registry_from_with_writer, register_checkout, remove_workspace,
     rename_local_owner_host_id, resolve_logical_workspace, save_registry_to, set_path_override,
     validate_workspaces,
 };
@@ -348,11 +348,15 @@ fn identity_lookup_is_path_independent_and_path_lookup_is_checkout_only() {
         .push(PathBuf::from("/repos/inner"));
 
     assert_eq!(
-        find_workspace(&registry, "ws_remote").map(|workspace| workspace.id.as_str()),
+        find_workspace(&registry, "ws_remote")
+            .expect("lookup by id")
+            .map(|workspace| workspace.id.as_str()),
         Some("ws_remote")
     );
     assert_eq!(
-        find_workspace(&registry, "remote").map(|workspace| workspace.id.as_str()),
+        find_workspace(&registry, "remote")
+            .expect("lookup by name")
+            .map(|workspace| workspace.id.as_str()),
         Some("ws_remote")
     );
     assert_eq!(
@@ -524,6 +528,57 @@ fn resolve_logical_workspace_accepts_name_or_id_and_fails_closed() {
         }
         other => panic!("expected InvalidInput, got {other}"),
     }
+}
+
+#[test]
+fn mutation_helpers_reject_a_name_that_matches_another_workspace_id() {
+    let mut registry = WorkspaceRegistry {
+        workspaces: vec![
+            logical_workspace("ws_1", None),
+            logical_workspace("ws_2", None),
+        ],
+        checkouts: vec![WorkspaceCheckout::owner(
+            "ws_1".to_string(),
+            PathBuf::from("/repos/one"),
+            PathBuf::from("/repos/one/.orbit"),
+        )],
+        ..Default::default()
+    };
+    registry.workspaces[0].name = "x".to_string();
+    registry.workspaces[1].name = "ws_1".to_string();
+    let before = registry.clone();
+
+    let resolved = resolve_logical_workspace(&registry, "ws_1")
+        .expect_err("selector must be ambiguous")
+        .to_string();
+    assert!(
+        resolved.contains("ambiguous workspace selector"),
+        "{resolved}"
+    );
+
+    let removed = remove_workspace(&mut registry, "ws_1")
+        .expect_err("removal must reject an ambiguous selector")
+        .to_string();
+    assert!(
+        removed.contains("ambiguous workspace selector"),
+        "{removed}"
+    );
+    assert_eq!(registry, before);
+
+    let assigned = assign_checkout_role(
+        &mut registry,
+        "ws_1",
+        WorkspaceCheckoutRole::Owner,
+        None,
+        None,
+    )
+    .expect_err("role assignment must reject an ambiguous selector")
+    .to_string();
+    assert!(
+        assigned.contains("ambiguous workspace selector"),
+        "{assigned}"
+    );
+    assert_eq!(registry, before);
 }
 
 #[test]

--- a/crates/orbit-registry/src/workspace_registry/catalog.rs
+++ b/crates/orbit-registry/src/workspace_registry/catalog.rs
@@ -113,7 +113,7 @@ pub fn rebind_workspace_source_remote(
     })?;
     validate_machine_id(local_machine_id)?;
 
-    let workspace = find_workspace(registry, id_or_name)
+    let workspace = find_workspace(registry, id_or_name)?
         .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, id_or_name.to_string()))?;
     let workspace_id = workspace.id.clone();
     let old_remote = workspace.git_remote.clone().ok_or_else(|| {
@@ -217,7 +217,7 @@ pub fn assign_checkout_role(
     owner_machine_id: Option<&str>,
     local_machine_id: Option<&str>,
 ) -> Result<(), OrbitError> {
-    let workspace = find_workspace(registry, id_or_name)
+    let workspace = find_workspace(registry, id_or_name)?
         .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, id_or_name.to_string()))?;
     let workspace_id = workspace.id.clone();
     let declared_owner = workspace.owner_machine_id.clone();
@@ -314,10 +314,14 @@ pub fn remove_workspace(
     registry: &mut WorkspaceRegistry,
     id_or_name: &str,
 ) -> Result<Workspace, OrbitError> {
+    let workspace_id = find_workspace(registry, id_or_name)?
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, id_or_name.to_string()))?
+        .id
+        .clone();
     let idx = registry
         .workspaces
         .iter()
-        .position(|w| w.id == id_or_name || w.name == id_or_name)
+        .position(|workspace| workspace.id == workspace_id)
         .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, id_or_name.to_string()))?;
     let removed = registry.workspaces.remove(idx);
     registry
@@ -337,15 +341,16 @@ pub fn remove_workspace(
     Ok(removed)
 }
 
-/// Finds a workspace by id or name.
+/// Finds a workspace by id or name, rejecting ambiguous selectors.
 pub fn find_workspace<'a>(
     registry: &'a WorkspaceRegistry,
     id_or_name: &str,
-) -> Option<&'a Workspace> {
-    registry
-        .workspaces
-        .iter()
-        .find(|w| w.id == id_or_name || w.name == id_or_name)
+) -> Result<Option<&'a Workspace>, OrbitError> {
+    match resolve_logical_workspace_match(registry, id_or_name) {
+        LogicalWorkspaceMatch::Found(workspace) => Ok(Some(workspace)),
+        LogicalWorkspaceMatch::NotFound => Ok(None),
+        LogicalWorkspaceMatch::Ambiguous => Err(ambiguous_workspace_selector(id_or_name)),
+    }
 }
 
 /// Resolve a logical selector (registered name or `ws_*` id) to exactly one workspace.
@@ -357,15 +362,34 @@ pub fn resolve_logical_workspace<'a>(
     registry: &'a WorkspaceRegistry,
     selector: &str,
 ) -> Result<&'a Workspace, OrbitError> {
-    let matches: Vec<&Workspace> = registry
+    match resolve_logical_workspace_match(registry, selector) {
+        LogicalWorkspaceMatch::Found(workspace) => Ok(workspace),
+        LogicalWorkspaceMatch::NotFound => Err(unknown_workspace_selector(selector)),
+        LogicalWorkspaceMatch::Ambiguous => Err(ambiguous_workspace_selector(selector)),
+    }
+}
+
+enum LogicalWorkspaceMatch<'a> {
+    Found(&'a Workspace),
+    NotFound,
+    Ambiguous,
+}
+
+fn resolve_logical_workspace_match<'a>(
+    registry: &'a WorkspaceRegistry,
+    selector: &str,
+) -> LogicalWorkspaceMatch<'a> {
+    let mut matches = registry
         .workspaces
         .iter()
-        .filter(|workspace| workspace.id == selector || workspace.name == selector)
-        .collect();
-    match matches.as_slice() {
-        [workspace] => Ok(workspace),
-        [] => Err(unknown_workspace_selector(selector)),
-        _ => Err(ambiguous_workspace_selector(selector)),
+        .filter(|workspace| workspace.id == selector || workspace.name == selector);
+    let Some(workspace) = matches.next() else {
+        return LogicalWorkspaceMatch::NotFound;
+    };
+    if matches.next().is_some() {
+        LogicalWorkspaceMatch::Ambiguous
+    } else {
+        LogicalWorkspaceMatch::Found(workspace)
     }
 }
 
@@ -385,12 +409,14 @@ pub(crate) fn ambiguous_workspace_selector(selector: &str) -> OrbitError {
 pub fn find_checkout<'a>(
     registry: &'a WorkspaceRegistry,
     id_or_name: &str,
-) -> Option<&'a WorkspaceCheckout> {
-    let workspace = find_workspace(registry, id_or_name)?;
-    registry
+) -> Result<Option<&'a WorkspaceCheckout>, OrbitError> {
+    let Some(workspace) = find_workspace(registry, id_or_name)? else {
+        return Ok(None);
+    };
+    Ok(registry
         .checkouts
         .iter()
-        .find(|checkout| checkout.workspace_id == workspace.id)
+        .find(|checkout| checkout.workspace_id == workspace.id))
 }
 
 /// Iterates logical workspaces that have a machine-local checkout binding.

--- a/crates/orbit-registry/src/workspace_registry/publication.rs
+++ b/crates/orbit-registry/src/workspace_registry/publication.rs
@@ -16,12 +16,14 @@ use super::{WorkspaceRegistryHostContext, find_checkout, find_workspace};
 pub fn find_publication_binding<'a>(
     registry: &'a WorkspaceRegistry,
     id_or_name: &str,
-) -> Option<&'a WorkspacePublicationBinding> {
-    let workspace = find_workspace(registry, id_or_name)?;
-    registry
+) -> Result<Option<&'a WorkspacePublicationBinding>, OrbitError> {
+    let Some(workspace) = find_workspace(registry, id_or_name)? else {
+        return Ok(None);
+    };
+    Ok(registry
         .publication_bindings
         .iter()
-        .find(|binding| binding.workspace_id == workspace.id)
+        .find(|binding| binding.workspace_id == workspace.id))
 }
 
 /// Create a publication binding. Fails when one already exists; use
@@ -251,7 +253,7 @@ fn bindable_workspace(
     if let Some(machine_id) = local_machine_id {
         validate_machine_id(machine_id)?;
     }
-    let workspace = find_workspace(registry, id_or_name)
+    let workspace = find_workspace(registry, id_or_name)?
         .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, id_or_name.to_string()))?;
     publisher_allowed(registry, workspace, local_machine_id).map_err(publication_error)?;
     Ok(BindableWorkspace {
@@ -264,7 +266,9 @@ fn publisher_allowed(
     workspace: &Workspace,
     local_machine_id: Option<&str>,
 ) -> Result<(), String> {
-    if let Some(checkout) = find_checkout(registry, &workspace.id) {
+    if let Some(checkout) =
+        find_checkout(registry, &workspace.id).map_err(|error| error.to_string())?
+    {
         if checkout.role == Some(WorkspaceCheckoutRole::Replica) {
             return Err(format!(
                 "workspace '{}' is a replica checkout; only the declared owner can manage a publication binding",
@@ -301,7 +305,7 @@ fn build_binding(
     publication_branch: &str,
     publication_id: &str,
 ) -> Result<WorkspacePublicationBinding, OrbitError> {
-    let workspace = find_workspace(registry, workspace_id)
+    let workspace = find_workspace(registry, workspace_id)?
         .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, workspace_id.to_string()))?;
     let Some(fingerprint) = workspace.git_remote.as_deref() else {
         return Err(publication_error(format!(


### PR DESCRIPTION
Registry id-or-name lookups now share ambiguity detection, so removal, checkout-role changes, publication, and CLI/runtime consumers reject a selector matching different workspaces instead of choosing the first entry. Stored-ID joins remain explicit.

Mac recovery preserves candidate bd2cd121 and integrates agent-main af3069bfc. It also fixes the verified production compile blocker introduced by ORB-11686 / PR #1711 / 98a0b8c3d: archive export consumes PENDING_WRITE_FILE_NAME, but its inner re-export was test-only. Only that constant becomes available in production; fault injection remains test-only. Hosted integration coverage run 34186696885 independently reproduced E0432 at af3069bfc.

Validation on Mac, CARGO_BUILD_JOBS=2, affected package artifacts cleaned before compilation:
- Full registry suite: 50 passed.
- Runtime-binding suite: 16 passed.
- Archive export regression suite: 4 passed.
- Native make ci-fast: passed (bwrap namespace probe unavailable on Mac).
- Workspace/all-target make ci-lint: passed; corrected the candidate's collapsible conditional without suppressions.
- git diff --check: passed.

Original provider run remains terminal failed; no Linux build/restart. Recovery commit authored and committed by Codex.

<details>
<summary>Preserved failure-handoff evidence</summary>

## Delivery failure handoff

Orbit preserved and pushed this task's candidate after the shipment pipeline failed. This PR is intentionally blocked; inspect the recorded failure before retrying delivery.

- Task: `ORB-11723`
- Run: `jrun-20260908-0436-10`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `0c03d430766b13f9f06279190b66737ee881a8d0`
- Target base: `ae7033738321dce3496d4b32bd33c4b1477b785c`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess reported declared envelope status="failed" despite exit 0: error.code=validation_blocked; error.message=make ci-lint is blocked by an unrelated orbit-store cfg-gated import error for PENDING_WRITE_FILE_NAME. Task state and execution summary were persisted as blocked.
```

</details>
