### PR TITLE
[code-review] Bound `cosine_top_k` memory: it materialises and sorts every row

### DIFF
--- a/crates/orbit-search/src/vector/query/cosine.rs
+++ b/crates/orbit-search/src/vector/query/cosine.rs
@@ -31,7 +31,7 @@ pub fn cosine_top_k(
         .lock()
         .map_err(|error| OrbitError::Store(format!("mutex poisoned: {error}")))?;
 
-    let mut candidates = Vec::new();
+    let mut candidates: Vec<CosineHit> = Vec::with_capacity(limit);
     let mut stmt = conn
         .prepare(
             r#"
@@ -50,23 +50,50 @@ pub fn cosine_top_k(
         .next()
         .map_err(|error| OrbitError::Store(error.to_string()))?
     {
-        candidates.push(row_to_hit(row, query)?);
+        let score = row_score(row, query)?;
+        let should_retain = if candidates.len() < limit {
+            true
+        } else {
+            let worst = match candidates.last() {
+                Some(worst) => worst,
+                None => unreachable!("a candidate list at the limit is non-empty"),
+            };
+            match score.total_cmp(&worst.score) {
+                std::cmp::Ordering::Greater => true,
+                std::cmp::Ordering::Less => false,
+                std::cmp::Ordering::Equal => {
+                    compare_row_to_hit(row, worst)? == std::cmp::Ordering::Less
+                }
+            }
+        };
+        if !should_retain {
+            continue;
+        }
+
+        candidates.push(row_to_hit(row, score)?);
+        candidates.sort_by(compare_cosine_hits);
+        if candidates.len() > limit {
+            candidates.pop();
+        }
     }
 
-    candidates.sort_by(compare_cosine_hits);
-    candidates.truncate(limit);
     for (idx, hit) in candidates.iter_mut().enumerate() {
         hit.rank = idx + 1;
     }
     Ok(candidates)
 }
 
-fn row_to_hit(row: &rusqlite::Row<'_>, query: &[f32]) -> Result<CosineHit, OrbitError> {
-    let embedding_blob: Vec<u8> = row
-        .get(4)
+fn row_score(row: &rusqlite::Row<'_>, query: &[f32]) -> Result<f32, OrbitError> {
+    let embedding_blob = row
+        .get_ref(4)
+        .map_err(|error| OrbitError::Store(error.to_string()))?
+        .as_blob()
         .map_err(|error| OrbitError::Store(error.to_string()))?;
-    let embedding = decode_f32_blob(&embedding_blob)?;
-    let score = cosine_similarity(query, &embedding)?;
+    let embedding = decode_f32_blob(embedding_blob)?;
+    cosine_similarity(query, &embedding)
+}
+
+fn row_to_hit(row: &rusqlite::Row<'_>, score: f32) -> Result<CosineHit, OrbitError> {
     Ok(CosineHit {
         source_kind: row
             .get(0)
@@ -83,6 +110,38 @@ fn row_to_hit(row: &rusqlite::Row<'_>, query: &[f32]) -> Result<CosineHit, Orbit
         score,
         rank: 0,
     })
+}
+
+fn compare_row_to_hit(
+    row: &rusqlite::Row<'_>,
+    right: &CosineHit,
+) -> Result<std::cmp::Ordering, OrbitError> {
+    let source_kind = row
+        .get_ref(0)
+        .map_err(|error| OrbitError::Store(error.to_string()))?
+        .as_str()
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+    let source_id = row
+        .get_ref(1)
+        .map_err(|error| OrbitError::Store(error.to_string()))?
+        .as_str()
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+    let field = row
+        .get_ref(2)
+        .map_err(|error| OrbitError::Store(error.to_string()))?
+        .as_str()
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+    let chunk_idx = row
+        .get_ref(3)
+        .map_err(|error| OrbitError::Store(error.to_string()))?
+        .as_i64()
+        .map_err(|error| OrbitError::Store(error.to_string()))? as usize;
+
+    Ok(source_kind
+        .cmp(&right.source_kind)
+        .then_with(|| source_id.cmp(&right.source_id))
+        .then_with(|| field.cmp(&right.field))
+        .then_with(|| chunk_idx.cmp(&right.chunk_idx)))
 }
 
 pub(crate) fn compare_cosine_hits(left: &CosineHit, right: &CosineHit) -> std::cmp::Ordering {

--- a/crates/orbit-search/src/vector/query/tests/cosine.rs
+++ b/crates/orbit-search/src/vector/query/tests/cosine.rs
@@ -1,8 +1,10 @@
 //! Unit tests for `cosine` — sibling layout under vector/query/tests/.
 
+use rusqlite::params;
+
 use super::super::cosine::cosine_top_k;
 
-use crate::vector::{EmbeddingField, VectorStore};
+use crate::vector::{EmbeddingField, VectorStore, cosine_similarity, encode_f32_blob};
 use crate::{Embedder, NoopEmbedder};
 
 #[test]
@@ -44,4 +46,164 @@ fn cosine_top_k_returns_expected_ordering_with_noop_vectors() {
     assert_eq!(hits[0].source_id, "T2");
     assert_eq!(hits[0].rank, 1);
     assert!((hits[0].score - 1.0).abs() < 0.0001);
+}
+
+#[test]
+fn cosine_top_k_matches_exhaustive_reference_for_limits_ties_and_filters() {
+    let store = VectorStore::open_in_memory().unwrap();
+    let query = [1.0, 0.0];
+    let rows = [
+        ("doc", "D2", "summary", 2, "model-a", [1.0, 0.0]),
+        ("task", "T2", "purpose", 1, "model-a", [1.0, 0.0]),
+        ("task", "T1", "zeta", 4, "model-a", [1.0, 0.0]),
+        ("task", "T1", "alpha", 3, "model-a", [1.0, 0.0]),
+        ("task", "T0", "purpose", 0, "model-a", [0.0, 1.0]),
+        ("task", "T3", "purpose", 5, "model-a", [0.6, 0.8]),
+        ("task", "B1", "purpose", 0, "model-b", [1.0, 0.0]),
+    ];
+    for (source_kind, source_id, field, chunk_idx, model_id, embedding) in rows {
+        insert_embedding(
+            &store,
+            source_kind,
+            source_id,
+            field,
+            chunk_idx,
+            model_id,
+            &embedding,
+        );
+    }
+
+    let mut reference = rows
+        .iter()
+        .filter(|(_, _, _, _, model_id, _)| *model_id == "model-a")
+        .map(|(source_kind, source_id, field, chunk_idx, _, embedding)| {
+            let score = cosine_similarity(&query, embedding).unwrap();
+            super::super::cosine::CosineHit {
+                source_kind: (*source_kind).to_string(),
+                source_id: (*source_id).to_string(),
+                field: (*field).to_string(),
+                chunk_idx: *chunk_idx,
+                score,
+                rank: 0,
+            }
+        })
+        .collect::<Vec<_>>();
+    reference.sort_by(super::super::cosine::compare_cosine_hits);
+
+    for limit in [1, 2, 3, 4, 6, 10] {
+        let hits = cosine_top_k(&store, &query, "model-a", limit, None, None).unwrap();
+        let expected = ranked(&reference[..limit.min(reference.len())]);
+        assert_eq!(hits, expected);
+    }
+
+    let task_reference = reference
+        .iter()
+        .filter(|hit| hit.source_kind == "task")
+        .cloned()
+        .collect::<Vec<_>>();
+    let task_hits = cosine_top_k(&store, &query, "model-a", 10, Some("task"), None).unwrap();
+    assert_eq!(task_hits, ranked(&task_reference));
+
+    let purpose_reference = task_reference
+        .iter()
+        .filter(|hit| hit.field == "purpose")
+        .cloned()
+        .collect::<Vec<_>>();
+    let purpose_hits =
+        cosine_top_k(&store, &query, "model-a", 10, Some("task"), Some("purpose")).unwrap();
+    assert_eq!(purpose_hits, ranked(&purpose_reference));
+
+    assert!(
+        cosine_top_k(&store, &[], "model-a", 10, None, None)
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        cosine_top_k(&store, &query, "model-a", 0, None, None)
+            .unwrap()
+            .is_empty()
+    );
+    assert_eq!(
+        cosine_top_k(&store, &query, "model-b", 10, None, None)
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn cosine_top_k_keeps_large_corpus_results_bounded_by_limit() {
+    let store = VectorStore::open_in_memory().unwrap();
+    let connection = store.connection();
+    let mut connection = connection.lock().unwrap();
+    let transaction = connection.transaction().unwrap();
+    for index in 0..4096 {
+        let source_id = format!("source-{index:04}");
+        transaction
+            .execute(
+                "INSERT INTO embeddings(source_kind, source_id, field, chunk_idx, content_hash, model_id, dim, embedding, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    "task",
+                    source_id,
+                    "purpose",
+                    0_i64,
+                    "test-hash",
+                    "model-a",
+                    2_i64,
+                    encode_f32_blob(&[1.0, 0.0]),
+                    "2026-01-01T00:00:00Z",
+                ],
+            )
+            .unwrap();
+    }
+    transaction.commit().unwrap();
+    drop(connection);
+
+    let limit = 7;
+    let hits = cosine_top_k(&store, &[1.0, 0.0], "model-a", limit, None, None).unwrap();
+
+    assert_eq!(hits.len(), limit);
+    assert!(hits.capacity() <= limit);
+    assert_eq!(hits[0].source_id, "source-0000");
+    assert_eq!(hits[limit - 1].source_id, "source-0006");
+}
+
+fn ranked(hits: &[super::super::cosine::CosineHit]) -> Vec<super::super::cosine::CosineHit> {
+    hits.iter()
+        .cloned()
+        .enumerate()
+        .map(|(index, mut hit)| {
+            hit.rank = index + 1;
+            hit
+        })
+        .collect()
+}
+
+fn insert_embedding(
+    store: &VectorStore,
+    source_kind: &str,
+    source_id: &str,
+    field: &str,
+    chunk_idx: usize,
+    model_id: &str,
+    embedding: &[f32],
+) {
+    let connection = store.connection();
+    let connection = connection.lock().unwrap();
+    connection
+        .execute(
+            "INSERT INTO embeddings(source_kind, source_id, field, chunk_idx, content_hash, model_id, dim, embedding, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                source_kind,
+                source_id,
+                field,
+                chunk_idx as i64,
+                "test-hash",
+                model_id,
+                embedding.len() as i64,
+                encode_f32_blob(embedding),
+                "2026-01-01T00:00:00Z",
+            ],
+        )
+        .unwrap();
 }


### PR DESCRIPTION
## Task

[ORB-11718](https://orbit-cli.com/tasks/ORB-11718) — [code-review] Bound `cosine_top_k` memory: it materialises and sorts every row

### Description

## Problem
`cosine_top_k` allocates metadata for every matching embedding, retains all candidates, sorts them, then truncates to the requested limit. This unnecessarily grows retained candidate memory with corpus size.

## Required behavior and constraints
Bound retained candidate metadata by the requested limit while preserving the complete existing score and source-kind/id/field/chunk tie-break order. Exact cosine still requires scanning matching vectors; do not promise limit-only runtime or an unmeasured speedup. Choose a small, measured implementation and avoid per-row metadata allocation where practical.

## Evidence and validation
Validated against local da21eb15; affected implementation files were unchanged at fetched origin/agent-main 09dec5183. `crates/orbit-search/src/vector/query/cosine.rs:33,74,82,106`. Re-locate by symbol if lines move. Follow current AGENTS.md; preserve authoritative ownership and existing contracts. Run focused regression tests plus `make ci-fast` and `make ci-lint` before review.

### Acceptance Criteria

- Compare output against an exhaustive reference over varied limits, equal scores, source kinds, fields and chunk indices; rankings and ties remain identical.
- On a deterministic large corpus, demonstrate retained candidate memory bounded by limit and record before/after runtime and allocation measurements without a fixed speedup requirement.
- Existing cosine/query tests pass, including empty query, zero limit and model/kind filtering.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Reworked `cosine_top_k` to scan every matching embedding while retaining only the best `limit` hits in a pre-sized bounded buffer.
- Scores are computed from borrowed SQLite BLOB data; rejected rows do not allocate hit metadata, and equal-score rows use borrowed source-kind/id/field/chunk values for the existing tie order.
- Added exhaustive ordering/filter/edge-case coverage and a deterministic 4,096-row large-corpus bounded-result regression.

Assessment: The implementation preserves the existing score-descending, source-kind/id/field/chunk ordering and rank assignment while changing retained candidate memory from corpus-sized to limit-sized.

Criteria:
1. Passed: exhaustive reference comparison across limits 1/2/3/4/6/10, equal scores, varied source kinds, fields, chunk indices, model filtering, kind filtering, and field filtering matched exactly.
2. Passed: deterministic 4,096-row corpus with limit 7 returned capacity 7. Baseline/current isolated test measurements were 0.08s/11,936 KB RSS and 0.08s/11,392 KB RSS respectively. Candidate allocation is bounded to 7 hit slots after the change versus corpus-sized materialization (4,096 rows) before; no fixed speedup is claimed.
3. Passed: 12 vector-query tests, including empty query, zero limit, model filtering, and existing cosine/query coverage.

Validation:
- Passed: `cargo fmt --all`
- Passed: `cargo test -p orbit-search vector::query::tests --lib` (12 passed)
- Passed: `make ci-fast`; compiler-cache namespace probe skipped because unprivileged bubblewrap namespaces are unavailable in this environment, while all other guardrails passed.
- Passed: `make ci-lint`
- Passed: `git diff --check`
- Passed: `git status --short` (only the two scoped cosine source/test files modified)
- Not run: full `make ci`, per workspace guidance that CI is the canonical PR merge gate and should not be run per task.

Risks/deviations: RSS is a process-level proxy rather than allocator-event tracing; runtime measurements are unoptimized isolated test-binary runs and show no meaningful speed change.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11718-6a9f8f12`
- Behind base: 0
- Ahead of base: 1