### PR TITLE
Ensure code-scanning sweeps populate context_files from alert locations at task creation

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs
@@ -3,8 +3,10 @@
 mod duplicates;
 
 use std::collections::BTreeMap;
+use std::path::Path;
 
 use orbit_common::OrbitError;
+use orbit_common::fs::selector::{canonical_selector_in_workspace, exists_in_workspace};
 use orbit_types::task::{TaskComplexity, TaskPriority, TaskStatus, TaskType};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -298,6 +300,7 @@ where
                 format!("{CODE_KEY_PREFIX}{key}"),
                 "security".to_string(),
             ],
+            context_files: code_context_files(&alert, &runtime.paths().repo_root),
             required_tools: Vec::new(),
             crew: system_crew.clone(),
             priority: priority_for_rank(rank),
@@ -650,6 +653,34 @@ fn location_url(location: &Value) -> String {
         }
     }
     "no location URL".to_string()
+}
+
+/// Scope a Code scanning repair task to the alert's remediation target, read
+/// from the alert's structured `path` rather than the rendered evidence.
+///
+/// The path GitHub reports is repository-relative and may not name anything in
+/// this checkout — the alert can predate a rename or deletion, or describe a
+/// path that escapes the workspace. Emit a selector only when it canonicalizes
+/// and still resolves inside the workspace, so an unusable location yields no
+/// scope instead of an invented one, and one bad alert cannot fail the sweep.
+///
+/// Line numbers stay in the alert evidence: `context_files` selectors address
+/// whole files, and a line suffix would not canonicalize as a `file:` anchor.
+fn code_context_files(alert: &Value, workspace_root: &Path) -> Vec<String> {
+    let path = field(alert, "path");
+    if path.is_empty() {
+        return Vec::new();
+    }
+
+    let Ok(selector) = canonical_selector_in_workspace(&format!("file:{path}"), workspace_root)
+    else {
+        return Vec::new();
+    };
+    if exists_in_workspace(&selector, workspace_root) {
+        vec![selector]
+    } else {
+        Vec::new()
+    }
 }
 
 fn line_suffix(value: &Value) -> String {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dependabot_alert_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dependabot_alert_tasks.rs
@@ -5,7 +5,9 @@ use serde_json::{Value, json};
 use tempfile::tempdir;
 
 use crate::OrbitRuntime;
-use crate::adapter::engine_host::v2_host::test_support::runtime_with_workspace_layout;
+use crate::adapter::engine_host::v2_host::test_support::{
+    runtime_with_workspace_layout, write_workspace_file,
+};
 
 pub(super) fn alert(number: u64, severity: &str, range: &str, ghsa: &str) -> Value {
     json!({
@@ -571,4 +573,157 @@ fn unavailable_family_does_not_hide_findings_from_collected_family() {
         output["family_outcomes"]["secret_scanning"]["outcome"],
         "capability_unavailable"
     );
+}
+
+/// The location ORB-11779 was filed from: alert #165 reported this path at
+/// line 426, and the minted task must already carry it as scope.
+const ALERT_165_PATH: &str =
+    "crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs";
+
+fn code_alert_at(number: u64, path: Value, start_line: Value, end_line: Value) -> Value {
+    let mut alert = code_alert(number, "high");
+    alert["path"] = path;
+    alert["start_line"] = start_line;
+    alert["end_line"] = end_line;
+    alert
+}
+
+fn code_task(runtime: &OrbitRuntime, output: &Value) -> orbit_types::task::Task {
+    let task_id = output["filed"]
+        .as_array()
+        .expect("filed")
+        .iter()
+        .find(|entry| entry["family"] == "code_scanning")
+        .and_then(|entry| entry["task_id"].as_str())
+        .expect("code task id");
+    runtime.get_task(task_id).expect("code task")
+}
+
+#[test]
+fn code_scanning_task_is_scoped_to_the_alert_location_at_creation() {
+    let (_root, runtime, repo) = runtime_with_workspace_layout();
+    write_workspace_file(&repo, ALERT_165_PATH);
+
+    let output = file(
+        &runtime,
+        expanded_snapshot(
+            Vec::new(),
+            vec![code_alert_at(
+                165,
+                json!(ALERT_165_PATH),
+                json!(426),
+                json!(426),
+            )],
+            Vec::new(),
+        ),
+        json!({}),
+    );
+    assert_eq!(output["filed_count"], json!(1));
+
+    // Read straight back from the store: no task-pilot pass and no manual
+    // update ran between minting and this assertion.
+    let task = code_task(&runtime, &output);
+    assert_eq!(task.context_files, vec![format!("file:{ALERT_165_PATH}")]);
+    assert!(
+        task.description.contains("line 426"),
+        "alert evidence lost the line: {}",
+        task.description
+    );
+    assert!(
+        task.acceptance_criteria
+            .iter()
+            .any(|criterion| criterion.contains("line 426"))
+    );
+    assert!(
+        task.context_files
+            .iter()
+            .all(|selector| !selector.contains("426")),
+        "selector must not carry a line suffix: {:?}",
+        task.context_files
+    );
+}
+
+#[test]
+fn code_scanning_locations_outside_the_workspace_produce_no_scope() {
+    let (_root, runtime, repo) = runtime_with_workspace_layout();
+    write_workspace_file(&repo, ALERT_165_PATH);
+
+    for (number, path) in [
+        (30, Value::Null),
+        (31, json!("")),
+        (32, json!("   ")),
+        (33, json!("../outside/leaked.rs")),
+        (34, json!("/etc/passwd")),
+        (35, json!("crates/orbit-core/src/does_not_exist.rs")),
+    ] {
+        let output = file(
+            &runtime,
+            expanded_snapshot(
+                Vec::new(),
+                vec![code_alert_at(number, path.clone(), json!(1), json!(1))],
+                Vec::new(),
+            ),
+            json!({}),
+        );
+        assert_eq!(output["filed_count"], json!(1), "alert #{number} not filed");
+        assert!(
+            code_task(&runtime, &output).context_files.is_empty(),
+            "alert #{number} with location {path} invented a selector"
+        );
+    }
+}
+
+#[test]
+fn an_absolute_in_workspace_location_is_stored_as_a_workspace_relative_selector() {
+    let (_root, runtime, repo) = runtime_with_workspace_layout();
+    write_workspace_file(&repo, ALERT_165_PATH);
+    let absolute = repo.join(ALERT_165_PATH).to_string_lossy().into_owned();
+
+    let output = file(
+        &runtime,
+        expanded_snapshot(
+            Vec::new(),
+            vec![code_alert_at(36, json!(absolute), json!(426), json!(426))],
+            Vec::new(),
+        ),
+        json!({}),
+    );
+    assert_eq!(
+        code_task(&runtime, &output).context_files,
+        vec![format!("file:{ALERT_165_PATH}")]
+    );
+}
+
+#[test]
+fn resweeping_the_same_alert_preserves_the_scoped_task_without_duplicating_it() {
+    let (_root, runtime, repo) = runtime_with_workspace_layout();
+    write_workspace_file(&repo, ALERT_165_PATH);
+    let snapshot = expanded_snapshot(
+        Vec::new(),
+        vec![code_alert_at(
+            165,
+            json!(ALERT_165_PATH),
+            json!(426),
+            json!(426),
+        )],
+        Vec::new(),
+    );
+
+    let first = file(&runtime, snapshot.clone(), json!({}));
+    let task = code_task(&runtime, &first);
+    let expected = vec![format!("file:{ALERT_165_PATH}")];
+    assert_eq!(task.context_files, expected);
+
+    let second = file(&runtime, snapshot, json!({}));
+    assert_eq!(second["filed_count"], json!(0));
+    assert_eq!(
+        second["skipped_existing"]
+            .as_array()
+            .expect("skipped existing")
+            .len(),
+        1
+    );
+
+    let after = runtime.get_task(&task.id).expect("code task");
+    assert_eq!(after.context_files, expected);
 }

--- a/crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs
+++ b/crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs
@@ -25,12 +25,12 @@ use crate::fs::yaml::{parse_yaml_with, write_yaml_durable_with};
 mod commit;
 
 pub(crate) use commit::{
-    BundleWriteFault, PendingWriteGuard, fail_if_injected, publish_envelope,
-    recover_pending_bundle_at,
+    BundleWriteFault, PENDING_WRITE_FILE_NAME, PendingWriteGuard, fail_if_injected,
+    publish_envelope, recover_pending_bundle_at,
 };
 
 #[cfg(test)]
-pub(crate) use commit::{PENDING_WRITE_FILE_NAME, inject_bundle_write_faults};
+pub(crate) use commit::inject_bundle_write_faults;
 
 static STAGING_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 


### PR DESCRIPTION
## Task

[ORB-11786](https://orbit-cli.com/tasks/ORB-11786) — Ensure code-scanning sweeps populate context_files from alert locations at task creation

### Description

## Requested behavior
Populate code-scanning-sweep repair tasks' context_files automatically from the alert's structured location when it identifies an existing in-workspace remediation target. Use a canonical file: selector; retain line information in the alert evidence rather than appending it to the selector.

## Evidence and qualification
Daniel cited ORB-11779, alert #165, whose description reports Location: `crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs` line 426. Live inspection through orbit-linux shows that task already has `file:crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs` in context_files. Its creation history alone does not establish whether the selector was populated at mint time or later. Do not claim that the current task is missing context or assume the minting implementation is absent.

## Scope
Verify the current collector-to-task-creation path and ensure the location is persisted as context_files without requiring task-pilot or manual enrichment. Prefer structured alert location over parsing rendered Markdown. If already implemented, preserve the existing path and add only missing meaningful regression coverage. Keep existing selector validation and deduplication semantics; missing or invalid locations must not produce invented or out-of-workspace selectors. This is a sweep automation follow-up, not remediation of alert #165 itself. The example file is evidence, not automatically a modification target for this follow-up; leave implementation selectors for task-pilot after inspection.

### Acceptance Criteria

- A deterministic sweep filing test using the ORB-11779 location proves the newly created task immediately contains file:crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs, before task-pilot or manual updates.
- The rendered evidence retains line 426 while context_files contains a canonical file selector without a line suffix.
- Tests cover absent/invalid locations and repeated observations: no invented or out-of-workspace selectors, duplicate selectors, or duplicate repair tasks; existing valid metadata is preserved.
- Document whether the behavior was already present or what creation-path gap was repaired, and run focused tests for the changed behavior.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Finding: this was a real creation-path gap, not existing behavior

`file_dependabot_alert_tasks_with_lookup`
(`crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs`)
built the code-scanning `TaskAddParams` with no `context_files` field at all,
falling through to `TaskAddParams::default()` (empty vec). Code-scanning sweep
tasks were therefore minted with an empty scope, and ORB-11779's
`file:crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs`
selector must have come from later task-pilot or manual enrichment, not from
mint time. The task description correctly warned against assuming either way;
reading the creation path settled it.

## Change

1. `dependabot_alert_tasks.rs` — the code-scanning branch now sets
   `context_files: code_context_files(&alert, &runtime.paths().repo_root)`.
2. New `code_context_files` helper reads the alert's **structured** `path`
   member (the projection `project_code_scanning_alert` already carries, from
   `most_recent_instance.location.path`) — no parsing of rendered Markdown.
   It emits at most one `file:` selector, and only when
   `canonical_selector_in_workspace` succeeds *and* `exists_in_workspace`
   confirms the anchor. An absent, empty, traversing, absolute-outside, or
   stale path yields an empty vec rather than an invented selector, so one bad
   alert can never fail the whole sweep — `add_task`'s
   `normalize_context_files_for_write` returns `Err` on an escaping anchor, and
   returning the empty vec keeps that error off the sweep path entirely.
3. Line information is untouched: `line_suffix` still renders it in the
   description ("Location: `<path>` line 426") and in the first acceptance
   criterion. The selector never carries a line suffix — a `path:line` string
   would not canonicalize as a `file:` anchor.

Dedup and validation semantics are unchanged: `code_duplicate_candidate`,
`find_covering_task`, the severity floor, and the `max_tasks` cap were not
touched, and existing tasks are never rewritten by a later sweep.

Scope is one selector per alert, so duplicate selectors are structurally
impossible; `add_task` also re-runs normalize + prune, so the stored value is
deterministic. Only the code-scanning family was changed — Dependabot's
`manifest_path` and secret-scanning's location list were out of this task's
scope and are untouched.

## Criteria → results

1. **Deterministic test using the ORB-11779 location.** PASS —
   `code_scanning_task_is_scoped_to_the_alert_location_at_creation` writes that
   exact path into the fixture workspace, files alert #165 at line 426, then
   reads the task straight back from the store with `runtime.get_task` and
   asserts `context_files == ["file:crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs"]`.
   No task-pilot pass or manual update runs in between.
2. **Line 426 retained in evidence; selector has no line suffix.** PASS — same
   test asserts the description and an acceptance criterion contain "line 426",
   and that no `context_files` entry contains "426".
3. **Absent/invalid locations and repeated observations.** PASS —
   `code_scanning_locations_outside_the_workspace_produce_no_scope` tables six
   cases (null, empty, whitespace, `../outside/leaked.rs`, `/etc/passwd`,
   in-workspace-but-missing) and asserts each still files a task with empty
   `context_files`. `an_absolute_in_workspace_location_is_stored_as_a_workspace_relative_selector`
   proves an absolute in-workspace path is stored canonically relative.
   `resweeping_the_same_alert_preserves_the_scoped_task_without_duplicating_it`
   files twice: second run reports `filed_count: 0` with one `skipped_existing`
   entry, and the original task's `context_files` is unchanged.
4. **Document the gap and run focused tests.** PASS — documented above;
   commands below.

## Regression proof

Fault injection: replacing the new line with `context_files: Vec::new()` and
re-running made exactly the three positive tests fail
(`left: []`, `right: ["file:crates/.../workspace_auto_pipeline.rs"]`); the
negative-case test passes either way by design. The line was then restored and
the suite re-run green.

## Validation

| Command | Outcome |
| --- | --- |
| `cargo test -p orbit-core --lib dependabot_alert_tasks` | passed — 16 passed, 0 failed (4 new, 12 pre-existing) |
| `cargo test -p orbit-core --lib v2_host` | passed — 293 passed, 0 failed, 2 ignored |
| `cargo test -p orbit-store --lib` | passed — 485 passed, 0 failed, 7 ignored |
| `make ci-fast` | passed (exit 0) |
| `make ci-lint` | passed (exit 0) |
| `git diff --check` / `git status --short` | clean; three modified files, no stray artifacts |

`make ci` was not run locally — it is the PR merge gate per CLAUDE.md.
`test-compiler-cache-namespaces` self-skipped inside `ci-fast` (bwrap cannot
create a user namespace on this host); that is a runner limitation, not a
result, and it is unrelated to this change.

## Deviation: one unlisted file changed, out of necessity

`crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs` was **not**
in the task's scope and has now been added to `context_files`.

HEAD `f7b89fa3a` does not compile. Commit `98a0b8c3d` (ORB-11686, PR #1711)
added a non-test consumer of `PENDING_WRITE_FILE_NAME` in
`workflow/task/archive.rs:14,97` while its re-export stayed `#[cfg(test)]`-gated
in `bundle_io/mod.rs:32-33`. `orbit-store` therefore fails to build as a
dependency, which blocks `cargo test -p orbit-core`, `make ci-lint`, and any
other validation — acceptance criterion 4 was unreachable. I moved the constant
into the unconditional `pub(crate) use` block (one line, leaving
`inject_bundle_write_faults` test-gated), which is the minimal fix and matches
the non-test use the commit introduced.

Reviewer's call: if a dedicated repair for that break is already in flight, drop
this hunk and rebase — but note the branch will not compile without it. Recorded
as friction `F2026-09-083`, which also flags that a plain workspace compile
failure survived two merges.

## Remaining risk

Low. The alert path is validated against the runtime's `repo_root`, which is
also the root `add_task` prunes against (these tasks set no `workspace_path`),
so the pre-check and the store agree. A code-scanning alert whose location names
a directory would produce a `file:` selector pointing at a directory; GitHub
code-scanning locations are always file paths, so no guard was added for a case
the collector cannot produce.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11786-6a9f9119`
- Behind base: 0
- Ahead of base: 1