### PR TITLE
[security-review] Enforce proc.spawn filesystem policy against indirect child access

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,7 +55,24 @@ plus global `denyRead` / `denyModify` rules, evaluated by `orbit-policy`.
 
 For built-in Orbit tools that still consult `orbit-policy` (today `proc.*`
 program allowlists, not a shipped `fs.*` family), evaluation applies on every
-platform and is the sole in-process enforcement point for those tools.
+platform.
+
+**Activity-scoped `proc.spawn` is confined at the process boundary on Linux.**
+An allowed program decides for itself what to open — `bash`, `sh`, `python3`,
+and `git` shell aliases are all on shipped activity allowlists — so inspecting
+path-shaped arguments cannot scope reads. Orbit compiles the activity's
+resolved `fsProfile` into a Linux Landlock ruleset and applies it to the child
+between `fork` and `exec`, so the child and every descendant it spawns are held
+to it. Outside the workspace the child reads only a fixed table of runtime,
+resolver, and CA-trust paths plus the tool state directories its own
+environment names; `/etc`, `/proc`, `$HOME`, `~/.ssh`, and `~/.aws` are never
+granted as trees. A kernel without Landlock ABI 2 — or any non-Linux host —
+makes activity-scoped `proc.spawn` fail with a capability error rather than
+run the child unconfined. Landlock rules bind to inodes that exist at spawn, so
+a `denyRead` match created *after* the ruleset is compiled is readable by that
+child; existing denied files cannot be read, renamed out of reach, or relocated
+into a readable directory. See
+`docs/design/policy-sandbox/2_design.md` §7.3.
 
 For `backend: cli` agents (an agent CLI such as Codex/Claude/Gemini/Grok
 spawned as a subprocess, making its own syscalls outside Orbit's tool

--- a/crates/orbit-exec/src/lib.rs
+++ b/crates/orbit-exec/src/lib.rs
@@ -31,11 +31,14 @@
 //! - [`ExecutionResult`] — captured stdout/stderr, exit code, and duration
 //! - [`Sandbox`] / [`NoSandbox`] — sandbox strategy trait and strategy that
 //!   adds no additional Orbit sandbox
+//! - [`spawn_under_linux_landlock`] — Linux read confinement applied to the
+//!   child itself, used by activity-scoped `proc.spawn`
 //! - [`EnvironmentMode`], [`StdinMode`] — environment and stdin control
 //!
 //! # Dependency direction
 //! `orbit-types` → `orbit-exec` → orbit-tools
 
+pub mod linux_landlock;
 pub mod linux_sandbox;
 pub mod macos_sandbox;
 pub mod process;
@@ -44,6 +47,11 @@ pub mod runner;
 pub mod sandbox;
 mod supervision;
 
+pub use linux_landlock::{
+    HOST_READ_ENV_VARS, LandlockGrant, LandlockPathGrant, LandlockProbeOutcome,
+    MINIMUM_LANDLOCK_ABI, grants_read, landlock_unavailable_message, linux_landlock_grants,
+    probe_landlock, spawn_under_linux_landlock,
+};
 pub use linux_sandbox::{
     BwrapProbeOutcome, LINUX_STABLE_BUILD_MOUNT, LINUX_STABLE_WORKSPACE_MOUNT, LinuxBwrapPlan,
     LinuxBwrapPostRunGuard, LinuxBwrapSpawnRequest, PreparedWriteGrants, UnsatisfiedWriteGrant,

--- a/crates/orbit-exec/src/linux_landlock/host.rs
+++ b/crates/orbit-exec/src/linux_landlock/host.rs
@@ -1,0 +1,391 @@
+//! The host paths a confined child may read.
+//!
+//! An activity's filesystem profile describes the workspace and nothing else,
+//! so the host side of the ruleset is decided here. Granting `$HOME` or `/etc`
+//! wholesale would hand an agent every credential on the machine, and granting
+//! nothing stops a dynamically linked program from starting at all. The tables
+//! below are the complete middle ground, in three groups:
+//!
+//! 1. **Runtime** — what any program needs to execute: the loader, its cache,
+//!    the system binaries and libraries, and the character devices a process
+//!    opens before it does anything interesting. No user data.
+//! 2. **Resolver and trust** — the world-readable files a network client
+//!    consults to turn a hostname into an address and to validate a
+//!    certificate. No secrets: `/etc/shadow` and the rest of `/etc` are absent,
+//!    and `/etc` itself is never granted as a directory.
+//! 3. **Tool state** — the directories on the child's own `PATH`, plus one
+//!    directory per tool, each named by an environment variable the operator
+//!    admitted into the child environment or by that tool's documented default
+//!    under `$HOME`. This is what makes `git`, `rg`, `cargo`, `make`, and `gh`
+//!    work through a scoped spawn.
+//!
+//! `$HOME` itself is never granted, and neither is any credential store
+//! belonging to a tool that is not on this list — `~/.ssh`, `~/.aws`, and a
+//! provider CLI's own state stay unreadable. Consequences worth knowing:
+//! SSH-authenticated `git` does not work through a scoped spawn (use HTTPS or
+//! `gh`), and a toolchain whose runtime files live outside the `bin` directory
+//! on `PATH` needs that tree named by an environment variable.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use super::{LandlockPathGrant, workspace};
+
+/// System directories a dynamically linked program executes out of.
+const RUNTIME_DIRS: &[&str] = &[
+    "/usr",
+    "/bin",
+    "/sbin",
+    "/lib",
+    "/lib32",
+    "/lib64",
+    "/libx32",
+    "/etc/alternatives",
+    "/etc/ld.so.conf.d",
+    "/dev/pts",
+];
+
+/// Loader configuration and the character devices a process opens on startup.
+const RUNTIME_FILES: &[&str] = &[
+    "/etc/ld.so.cache",
+    "/etc/ld.so.conf",
+    "/dev/null",
+    "/dev/zero",
+    "/dev/full",
+    "/dev/random",
+    "/dev/urandom",
+    "/dev/tty",
+    "/dev/ptmx",
+];
+
+/// `/proc` entries describing the machine rather than another process.
+///
+/// `/proc` as a whole is deliberately absent: `/proc/<pid>/environ` of any
+/// same-user process would hand the child the parent's credentials, which is
+/// exactly the disclosure this confinement exists to prevent. The child's own
+/// `/proc/self` is granted after `fork`, where it resolves to the child.
+const RUNTIME_PROC_DIRS: &[&str] = &["/proc/sys"];
+const RUNTIME_PROC_FILES: &[&str] = &[
+    "/proc/cpuinfo",
+    "/proc/filesystems",
+    "/proc/loadavg",
+    "/proc/meminfo",
+    "/proc/stat",
+    "/proc/uptime",
+    "/proc/version",
+];
+
+/// Name resolution, service lookup, and time zone data.
+const RESOLVER_FILES: &[&str] = &[
+    "/etc/gai.conf",
+    "/etc/gitconfig",
+    "/etc/group",
+    "/etc/host.conf",
+    "/etc/hosts",
+    "/etc/localtime",
+    "/etc/nsswitch.conf",
+    "/etc/passwd",
+    "/etc/protocols",
+    "/etc/resolv.conf",
+    "/etc/services",
+    "/etc/timezone",
+];
+
+/// Certificate authority stores.
+const TRUST_DIRS: &[&str] = &["/etc/ca-certificates", "/etc/pki", "/etc/ssl"];
+
+/// A tool's state directory: the environment variable that names it, and the
+/// tool's documented default when that variable is absent. A relative default
+/// is resolved against `$HOME`; an absolute one is used as written.
+struct ToolState {
+    variable: &'static str,
+    default_path: Option<&'static str>,
+}
+
+/// Tool state Orbit's own shipped activity allowlists depend on.
+///
+/// Every entry here is a *specific* directory. Adding one is a security
+/// decision: it grants the child read access to that path on the host.
+const TOOL_STATE: &[ToolState] = &[
+    ToolState {
+        variable: "CARGO_HOME",
+        default_path: Some(".cargo"),
+    },
+    ToolState {
+        variable: "RUSTUP_HOME",
+        default_path: Some(".rustup"),
+    },
+    ToolState {
+        variable: "GIT_CONFIG_GLOBAL",
+        default_path: Some(".gitconfig"),
+    },
+    ToolState {
+        variable: "GIT_CONFIG_SYSTEM",
+        default_path: None,
+    },
+    ToolState {
+        variable: "GH_CONFIG_DIR",
+        default_path: Some(".config/gh"),
+    },
+    ToolState {
+        variable: "SSL_CERT_DIR",
+        default_path: None,
+    },
+    ToolState {
+        variable: "SSL_CERT_FILE",
+        default_path: None,
+    },
+    // Toolchains installed outside a system prefix. Each is the variable the
+    // tool itself documents, so an operator who installs Node through `nvm` or
+    // Python into a virtualenv names that tree the same way they name it for
+    // any other consumer.
+    ToolState {
+        variable: "NVM_DIR",
+        default_path: None,
+    },
+    ToolState {
+        variable: "NPM_CONFIG_PREFIX",
+        default_path: None,
+    },
+    ToolState {
+        variable: "NODE_PATH",
+        default_path: None,
+    },
+    ToolState {
+        variable: "VIRTUAL_ENV",
+        default_path: None,
+    },
+    ToolState {
+        variable: "ORBIT_ROOT",
+        default_path: None,
+    },
+    ToolState {
+        variable: "ORBIT_REGISTRY_ROOT",
+        default_path: None,
+    },
+    ToolState {
+        variable: "ORBIT_BIN",
+        default_path: None,
+    },
+    // A temporary file is opened read-write, so a compiler or patch tool that
+    // cannot read its own scratch space fails. There is deliberately no `/tmp`
+    // default: a shared temporary directory holds other runs' work, and
+    // granting it would undo the outside-workspace boundary for everything
+    // staged there. `TMPDIR` is already an admitted baseline variable, so an
+    // executor that exports it gets a scratch grant for exactly that path.
+    ToolState {
+        variable: "TMPDIR",
+        default_path: None,
+    },
+];
+
+/// Git's XDG configuration directory, which has no dedicated variable.
+const XDG_TOOL_STATE: &[&str] = &["git"];
+
+/// Credential file names carved back out of a granted tool state directory.
+///
+/// These are publish and administrative tokens (`$CARGO_HOME/credentials.toml`
+/// is a crates.io publish token) that a tool never needs in order to build,
+/// inspect, or fetch. The tool's *own* sign-in material — `gh`'s `hosts.yml`,
+/// for instance — is deliberately not on this list: an activity that allowlists
+/// `gh` has already granted the agent that identity, so withholding the file
+/// would remove the tool rather than the capability.
+///
+/// Only the top level of a granted directory is scanned. These are the
+/// documented locations, and recursing a Cargo registry to look for them would
+/// cost more than compiling the whole ruleset.
+const CREDENTIAL_FILE_NAMES: &[&str] = &["credentials", "credentials.json", "credentials.toml"];
+
+/// Every environment variable that widens the host read set.
+///
+/// Exposed so an operator can see, and a test can pin, exactly which names in a
+/// child environment turn into filesystem grants.
+pub const HOST_READ_ENV_VARS: &[&str] = &[
+    "CARGO_HOME",
+    "GH_CONFIG_DIR",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_CONFIG_SYSTEM",
+    "NODE_PATH",
+    "NPM_CONFIG_PREFIX",
+    "NVM_DIR",
+    "ORBIT_BIN",
+    "ORBIT_REGISTRY_ROOT",
+    "ORBIT_ROOT",
+    "PATH",
+    "RUSTUP_HOME",
+    "SSL_CERT_DIR",
+    "SSL_CERT_FILE",
+    "TMPDIR",
+    "VIRTUAL_ENV",
+    "XDG_CONFIG_HOME",
+];
+
+/// Compile the host half of the ruleset for a child running with
+/// `environment`.
+pub(super) fn host_read_grants(environment: &[(String, String)]) -> Vec<LandlockPathGrant> {
+    let mut grants = Vec::new();
+    for dir in RUNTIME_DIRS
+        .iter()
+        .chain(RUNTIME_PROC_DIRS)
+        .chain(TRUST_DIRS)
+    {
+        push_existing_dir(&mut grants, Path::new(dir));
+    }
+    for file in RUNTIME_FILES
+        .iter()
+        .chain(RUNTIME_PROC_FILES)
+        .chain(RESOLVER_FILES)
+    {
+        push_existing_file(&mut grants, Path::new(file));
+    }
+    let home = lookup(environment, "HOME").map(PathBuf::from);
+    for dir in path_directories(environment, home.as_deref()) {
+        push_existing_dir(&mut grants, &dir);
+    }
+    for path in tool_state_paths(environment, home.as_deref()) {
+        push_tool_state(&mut grants, &path);
+    }
+    grants
+}
+
+/// The directories the child's `PATH` resolves executables out of.
+///
+/// A shipped allowlist names programs, not locations: `rg` may live in
+/// `~/.local/bin` and `cargo` in `~/.cargo/bin`. `PATH` is the operator's own
+/// statement of where those programs are, so it is what the grants follow.
+fn path_directories(environment: &[(String, String)], home: Option<&Path>) -> Vec<PathBuf> {
+    let Some(search_path) = lookup(environment, "PATH") else {
+        return Vec::new();
+    };
+    std::env::split_paths(search_path)
+        .filter(|dir| !dir.as_os_str().is_empty())
+        .filter(|dir| is_narrow_enough(dir, home))
+        .collect()
+}
+
+/// Grant the program itself, in case it lives outside the system directories
+/// (a `~/.cargo/bin` shim, or Orbit's own binary under `$ORBIT_BIN`).
+pub(super) fn program_grants(
+    program: &str,
+    environment: &[(String, String)],
+) -> Vec<LandlockPathGrant> {
+    resolve_program(program, environment)
+        .map(|path| vec![LandlockPathGrant::read_file(path)])
+        .unwrap_or_default()
+}
+
+/// The tool state paths admitted for `environment`, in table order.
+fn tool_state_paths(environment: &[(String, String)], home: Option<&Path>) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for entry in TOOL_STATE {
+        let candidate = lookup(environment, entry.variable)
+            .map(PathBuf::from)
+            .or_else(|| default_path(entry.default_path?, home));
+        if let Some(candidate) = candidate {
+            paths.push(candidate);
+        }
+    }
+    if let Some(config) = xdg_config_home(environment, home) {
+        paths.extend(XDG_TOOL_STATE.iter().map(|tool| config.join(tool)));
+    }
+    paths
+        .into_iter()
+        .filter(|path| is_narrow_enough(path, home))
+        .collect()
+}
+
+/// Resolve a table default: absolute as written, relative against `$HOME`.
+fn default_path(default: &str, home: Option<&Path>) -> Option<PathBuf> {
+    let path = Path::new(default);
+    if path.is_absolute() {
+        Some(path.to_path_buf())
+    } else {
+        Some(home?.join(path))
+    }
+}
+
+fn xdg_config_home(environment: &[(String, String)], home: Option<&Path>) -> Option<PathBuf> {
+    lookup(environment, "XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| Some(home?.join(".config")))
+}
+
+/// Reject a tool state path broad enough to defeat the point of the table:
+/// the filesystem root, `$HOME`, or any ancestor of `$HOME`.
+fn is_narrow_enough(path: &Path, home: Option<&Path>) -> bool {
+    if path.parent().is_none() {
+        return false;
+    }
+    match home {
+        Some(home) => !home.starts_with(path),
+        None => true,
+    }
+}
+
+/// Grant one tool state path with its credential files carved back out.
+///
+/// A directory that cannot be walked is skipped rather than granted whole: the
+/// carve-out is what makes granting it acceptable in the first place.
+fn push_tool_state(grants: &mut Vec<LandlockPathGrant>, path: &Path) {
+    let Ok(canonical) = path.canonicalize() else {
+        return;
+    };
+    let credentials = top_level_credential_files(&canonical);
+    if let Ok(carved) = workspace::carve_out(&canonical, &credentials) {
+        grants.extend(carved);
+    }
+}
+
+fn top_level_credential_files(dir: &Path) -> BTreeSet<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return BTreeSet::new();
+    };
+    entries
+        .flatten()
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| CREDENTIAL_FILE_NAMES.contains(&name))
+        })
+        .filter_map(|entry| entry.path().canonicalize().ok())
+        .collect()
+}
+
+fn lookup<'a>(environment: &'a [(String, String)], name: &str) -> Option<&'a str> {
+    environment
+        .iter()
+        .find(|(key, _)| key == name)
+        .map(|(_, value)| value.as_str())
+        .filter(|value| !value.is_empty())
+}
+
+fn resolve_program(program: &str, environment: &[(String, String)]) -> Option<PathBuf> {
+    if program.contains('/') {
+        return Path::new(program).canonicalize().ok();
+    }
+    let search_path = lookup(environment, "PATH")?;
+    std::env::split_paths(search_path).find_map(|dir| {
+        let candidate = dir.join(program);
+        candidate.is_file().then(|| candidate.canonicalize().ok())?
+    })
+}
+
+fn push_existing_dir(grants: &mut Vec<LandlockPathGrant>, path: &Path) {
+    if let Ok(canonical) = path.canonicalize()
+        && canonical.is_dir()
+    {
+        grants.push(LandlockPathGrant::read_tree(canonical));
+    }
+}
+
+/// Grant one non-directory path. Character devices such as `/dev/null` are not
+/// regular files, so the check is "exists and is not a directory" rather than
+/// `is_file`.
+fn push_existing_file(grants: &mut Vec<LandlockPathGrant>, path: &Path) {
+    if let Ok(canonical) = path.canonicalize()
+        && !canonical.is_dir()
+    {
+        grants.push(LandlockPathGrant::read_file(canonical));
+    }
+}

--- a/crates/orbit-exec/src/linux_landlock/mod.rs
+++ b/crates/orbit-exec/src/linux_landlock/mod.rs
@@ -1,0 +1,266 @@
+//! Linux Landlock read confinement for activity-scoped `proc.spawn`.
+//!
+//! Guessing which argv strings look like paths cannot see what an allowed
+//! program will do with them. `git`, `bash`, and `python3` are all on shipped
+//! activity allowlists, and every one of them will interpret text supplied on
+//! its command line — `git -c alias.x='!cat /etc/shadow' x` reaches the host
+//! without a single path-shaped argument. The read boundary therefore has to
+//! live where the child does, not in the request.
+//!
+//! This module compiles the activity's resolved read profile into a Landlock
+//! ruleset and applies it between `fork` and `exec`, so the child and every
+//! descendant it spawns inherit it. The request-time argv check remains, but
+//! only as an early, explainable deny for `git -C /etc`; it is no longer the
+//! security boundary.
+//!
+//! # What the ruleset covers
+//! Read and execute access (`READ_FILE`, `READ_DIR`, `EXECUTE`) plus
+//! `REFER`, which governs moving a file between directories. Writes are not
+//! handled here: agent write confinement belongs to the Bubblewrap mount
+//! namespace in [`crate::linux_sandbox`], and handling writes in two places
+//! would leave two answers to one question.
+//!
+//! `REFER` is handled because Landlock refuses a rename or link that would
+//! give a file *more* access at its destination. Without it, a child could
+//! move a denied file into a fully readable sibling directory and read it
+//! there. See [`workspace`] for how denied paths are carved out.
+//!
+//! # Limits
+//! Landlock rules bind to the inodes that exist when the ruleset is compiled.
+//! A file that appears *later* under an already-granted directory inherits
+//! that directory's access. See [`workspace::grant_read_tree`] for exactly
+//! what that does and does not expose.
+
+mod host;
+mod workspace;
+
+#[cfg(target_os = "linux")]
+mod ruleset;
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Child;
+
+use orbit_common::OrbitError;
+use orbit_types::policy::ResolvedFsProfile;
+
+use crate::runner::{EnvironmentMode, ExecRequest};
+
+pub use host::HOST_READ_ENV_VARS;
+
+/// Lowest Landlock ABI this enforcement accepts.
+///
+/// ABI 2 (Linux 5.19) is the first to expose `LANDLOCK_ACCESS_FS_REFER`.
+/// Below it a confined child could relocate a denied file into a readable
+/// directory, so an older kernel is reported as unavailable rather than
+/// enforced with a known hole.
+pub const MINIMUM_LANDLOCK_ABI: i64 = 2;
+
+/// What a compiled grant lets the child do with one path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LandlockGrant {
+    /// Read, execute, and relocate anything beneath a directory.
+    ReadTree,
+    /// List a directory without reading the files directly inside it.
+    ///
+    /// Applied to a directory that holds a denied path: its allowed children
+    /// are granted individually, so the denied one keeps no readable
+    /// ancestor while the rest of the tree stays usable.
+    ListOnly,
+    /// Read and execute one file.
+    ReadFile,
+}
+
+/// One compiled Landlock rule: a path and what the child may do beneath it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LandlockPathGrant {
+    pub path: PathBuf,
+    pub grant: LandlockGrant,
+}
+
+impl LandlockPathGrant {
+    fn read_tree(path: PathBuf) -> Self {
+        Self {
+            path,
+            grant: LandlockGrant::ReadTree,
+        }
+    }
+
+    fn list_only(path: PathBuf) -> Self {
+        Self {
+            path,
+            grant: LandlockGrant::ListOnly,
+        }
+    }
+
+    fn read_file(path: PathBuf) -> Self {
+        Self {
+            path,
+            grant: LandlockGrant::ReadFile,
+        }
+    }
+
+    /// Whether this grant alone lets the child open `path` for reading.
+    pub fn reads(&self, path: &Path) -> bool {
+        match self.grant {
+            LandlockGrant::ReadTree => path.starts_with(&self.path),
+            LandlockGrant::ReadFile => path == self.path,
+            LandlockGrant::ListOnly => false,
+        }
+    }
+}
+
+/// Whether any compiled grant lets the child read `path`.
+pub fn grants_read(grants: &[LandlockPathGrant], path: &Path) -> bool {
+    let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    grants.iter().any(|grant| grant.reads(&path))
+}
+
+/// Result of asking the running kernel whether it can enforce a ruleset.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LandlockProbeOutcome {
+    pub available: bool,
+    pub abi: i64,
+    pub detail: String,
+}
+
+/// Ask the running kernel which Landlock ABI it supports.
+pub fn probe_landlock() -> LandlockProbeOutcome {
+    let abi = landlock_abi();
+    if abi >= MINIMUM_LANDLOCK_ABI {
+        LandlockProbeOutcome {
+            available: true,
+            abi,
+            detail: format!("Landlock ABI {abi}"),
+        }
+    } else {
+        LandlockProbeOutcome {
+            available: false,
+            abi,
+            detail: unavailable_detail(abi),
+        }
+    }
+}
+
+/// Message for a host that cannot enforce an activity-scoped filesystem
+/// profile. Activity-scoped `proc.spawn` fails with this rather than running
+/// the child unconfined.
+pub fn landlock_unavailable_message(probe: &LandlockProbeOutcome) -> String {
+    format!(
+        "activity-scoped proc.spawn cannot run here: enforcing the filesystem profile at the \
+         process boundary requires Linux Landlock ABI {MINIMUM_LANDLOCK_ABI} or later ({})",
+        probe.detail
+    )
+}
+
+/// Compile every path grant a confined child needs: the host paths its own
+/// runtime requires, and the workspace paths the resolved profile allows.
+///
+/// `environment` is the child's own environment, which is what names the tool
+/// state directories in [`HOST_READ_ENV_VARS`]. Nothing outside those grants
+/// is readable.
+pub fn linux_landlock_grants(
+    workspace_root: &Path,
+    profile: &ResolvedFsProfile,
+    environment: &[(String, String)],
+) -> Result<Vec<LandlockPathGrant>, OrbitError> {
+    let workspace_root = workspace_root.canonicalize().map_err(|error| {
+        OrbitError::InvalidInput(format!(
+            "landlock workspace `{}` must exist and resolve canonically: {error}",
+            workspace_root.display()
+        ))
+    })?;
+
+    let mut grants = host::host_read_grants(environment);
+    grants.extend(workspace::workspace_read_grants(&workspace_root, profile)?);
+    Ok(dedupe(grants))
+}
+
+/// Spawn `req` with the child restricted to the compiled ruleset.
+///
+/// Fails closed: a host that cannot apply Landlock gets a capability error,
+/// never an unconfined child.
+pub fn spawn_under_linux_landlock(
+    req: &ExecRequest,
+    workspace_root: &Path,
+    profile: &ResolvedFsProfile,
+) -> Result<Child, OrbitError> {
+    let probe = probe_landlock();
+    if !probe.available {
+        return Err(OrbitError::PolicyDenied(landlock_unavailable_message(
+            &probe,
+        )));
+    }
+
+    let environment = child_environment(req);
+    let mut grants = linux_landlock_grants(workspace_root, profile, &environment)?;
+    grants.extend(host::program_grants(&req.program, &environment));
+    spawn_restricted(req, &dedupe(grants))
+}
+
+/// The environment the child will actually run with, which decides the tool
+/// state grants. `Inherit` means the parent's own environment reaches the
+/// child, so it is what the grants must be read from.
+fn child_environment(req: &ExecRequest) -> Vec<(String, String)> {
+    match &req.environment_mode {
+        EnvironmentMode::ClearAndSet(pairs) => pairs.clone(),
+        EnvironmentMode::Inherit => std::env::vars().collect(),
+    }
+}
+
+fn dedupe(grants: Vec<LandlockPathGrant>) -> Vec<LandlockPathGrant> {
+    let mut seen = BTreeSet::new();
+    grants
+        .into_iter()
+        .filter(|grant| seen.insert((grant.path.clone(), grant.grant)))
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn landlock_abi() -> i64 {
+    ruleset::abi_version()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn landlock_abi() -> i64 {
+    -1
+}
+
+#[cfg(target_os = "linux")]
+fn unavailable_detail(abi: i64) -> String {
+    if abi >= 1 {
+        format!("this kernel supports only Landlock ABI {abi}")
+    } else {
+        format!(
+            "landlock_create_ruleset version probe failed: {}",
+            std::io::Error::last_os_error()
+        )
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn unavailable_detail(_abi: i64) -> String {
+    format!(
+        "Landlock is a Linux facility and {} is not Linux",
+        std::env::consts::OS
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn spawn_restricted(req: &ExecRequest, grants: &[LandlockPathGrant]) -> Result<Child, OrbitError> {
+    ruleset::spawn_restricted(req, grants)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn spawn_restricted(
+    _req: &ExecRequest,
+    _grants: &[LandlockPathGrant],
+) -> Result<Child, OrbitError> {
+    Err(OrbitError::PolicyDenied(landlock_unavailable_message(
+        &probe_landlock(),
+    )))
+}
+
+#[cfg(test)]
+#[path = "tests/mod.rs"]
+mod tests;

--- a/crates/orbit-exec/src/linux_landlock/ruleset.rs
+++ b/crates/orbit-exec/src/linux_landlock/ruleset.rs
@@ -1,0 +1,203 @@
+//! The Landlock syscall layer: build a ruleset, then restrict the child to it.
+//!
+//! `libc` has no wrappers for the three Landlock syscalls, so they are issued
+//! through `syscall(2)` with the ABI's own structures. Everything here is
+//! Linux-only; the platform decision itself lives in the parent module.
+
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::process::CommandExt;
+use std::process::Child;
+
+use orbit_common::OrbitError;
+
+use super::{LandlockGrant, LandlockPathGrant};
+use crate::runner::ExecRequest;
+
+const ACCESS_FS_EXECUTE: u64 = 1 << 0;
+const ACCESS_FS_READ_FILE: u64 = 1 << 2;
+const ACCESS_FS_READ_DIR: u64 = 1 << 3;
+/// Moving or linking a file into a different directory. Landlock refuses a
+/// reparent that would give the file more access at its destination, which is
+/// what keeps a denied file from being relocated into a readable directory.
+const ACCESS_FS_REFER: u64 = 1 << 13;
+
+const HANDLED_FS_ACCESS: u64 =
+    ACCESS_FS_EXECUTE | ACCESS_FS_READ_FILE | ACCESS_FS_READ_DIR | ACCESS_FS_REFER;
+
+const LANDLOCK_CREATE_RULESET_VERSION: u32 = 1 << 0;
+const LANDLOCK_RULE_PATH_BENEATH: u32 = 1;
+
+#[repr(C)]
+struct RulesetAttr {
+    handled_access_fs: u64,
+}
+
+#[repr(C, packed)]
+struct PathBeneathAttr {
+    allowed_access: u64,
+    parent_fd: i32,
+}
+
+/// Ask the kernel which Landlock ABI it implements. A negative result means
+/// Landlock is absent or disabled.
+pub(super) fn abi_version() -> i64 {
+    // SAFETY: the version probe is defined as a null attribute pointer and a
+    // zero size; it reads nothing from user space.
+    unsafe {
+        libc::syscall(
+            libc::SYS_landlock_create_ruleset,
+            std::ptr::null::<RulesetAttr>(),
+            0usize,
+            LANDLOCK_CREATE_RULESET_VERSION,
+        )
+    }
+}
+
+pub(super) fn spawn_restricted(
+    req: &ExecRequest,
+    grants: &[LandlockPathGrant],
+) -> Result<Child, OrbitError> {
+    let ruleset = Ruleset::create()?;
+    for grant in grants {
+        ruleset.add_path(grant)?;
+    }
+
+    let mut command = crate::process::command(req);
+    restrict_child(&mut command, ruleset.as_raw_fd());
+    command.spawn().map_err(|error| {
+        OrbitError::Execution(format!("failed to spawn `{}`: {error}", req.program))
+    })
+}
+
+/// Apply the ruleset in the child, between `fork` and `exec`, so the confined
+/// process and every descendant it later spawns inherit it.
+fn restrict_child(command: &mut std::process::Command, ruleset_fd: i32) {
+    // SAFETY: the closure runs in the forked child before exec and issues only
+    // async-signal-safe syscalls on the inherited ruleset descriptor.
+    unsafe {
+        command.pre_exec(move || {
+            if libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::syscall(
+                libc::SYS_landlock_restrict_self,
+                ruleset_fd as libc::c_long,
+                0u32,
+            ) != 0
+            {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+}
+
+struct Ruleset {
+    fd: OwnedFd,
+}
+
+impl Ruleset {
+    fn create() -> Result<Self, OrbitError> {
+        let attr = RulesetAttr {
+            handled_access_fs: HANDLED_FS_ACCESS,
+        };
+        // SAFETY: `attr` is a well-formed `landlock_ruleset_attr` and its size
+        // is passed alongside it.
+        let fd = unsafe {
+            libc::syscall(
+                libc::SYS_landlock_create_ruleset,
+                std::ptr::addr_of!(attr),
+                std::mem::size_of::<RulesetAttr>(),
+                0u32,
+            )
+        };
+        if fd < 0 {
+            return Err(OrbitError::PolicyDenied(format!(
+                "landlock_create_ruleset failed: {}",
+                std::io::Error::last_os_error()
+            )));
+        }
+        // SAFETY: `fd` is a freshly created ruleset descriptor this scope owns.
+        let ruleset = Self {
+            fd: unsafe { OwnedFd::from_raw_fd(fd as i32) },
+        };
+        set_cloexec(ruleset.as_raw_fd())?;
+        Ok(ruleset)
+    }
+
+    fn as_raw_fd(&self) -> i32 {
+        self.fd.as_raw_fd()
+    }
+
+    fn add_path(&self, grant: &LandlockPathGrant) -> Result<(), OrbitError> {
+        use std::os::unix::ffi::OsStrExt;
+
+        let path = std::ffi::CString::new(grant.path.as_os_str().as_bytes()).map_err(|_| {
+            OrbitError::InvalidInput(format!(
+                "landlock path `{}` contains an interior NUL",
+                grant.path.display()
+            ))
+        })?;
+        // SAFETY: `path` is a NUL-terminated absolute path. `O_PATH` opens a
+        // descriptor that names the inode without granting access to it.
+        let parent_fd = unsafe { libc::open(path.as_ptr(), libc::O_PATH | libc::O_CLOEXEC) };
+        if parent_fd < 0 {
+            return Err(OrbitError::Io(format!(
+                "open landlock grant `{}`: {}",
+                grant.path.display(),
+                std::io::Error::last_os_error()
+            )));
+        }
+        let rule = PathBeneathAttr {
+            allowed_access: access_bits(grant.grant),
+            parent_fd,
+        };
+        // SAFETY: `rule` holds the live `O_PATH` descriptor opened above and an
+        // access mask that is a subset of the handled set.
+        let added = unsafe {
+            libc::syscall(
+                libc::SYS_landlock_add_rule,
+                self.as_raw_fd() as libc::c_long,
+                LANDLOCK_RULE_PATH_BENEATH as libc::c_long,
+                std::ptr::addr_of!(rule),
+                0u32,
+            )
+        };
+        // SAFETY: `parent_fd` is the descriptor opened in this function and is
+        // no longer referenced by the kernel after `landlock_add_rule` returns.
+        unsafe { libc::close(parent_fd) };
+        if added != 0 {
+            return Err(OrbitError::PolicyDenied(format!(
+                "landlock_add_rule failed for `{}`: {}",
+                grant.path.display(),
+                std::io::Error::last_os_error()
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// `REFER` is only meaningful on a directory, so a file grant omits it along
+/// with `READ_DIR`.
+fn access_bits(grant: LandlockGrant) -> u64 {
+    match grant {
+        LandlockGrant::ReadTree => {
+            ACCESS_FS_EXECUTE | ACCESS_FS_READ_FILE | ACCESS_FS_READ_DIR | ACCESS_FS_REFER
+        }
+        LandlockGrant::ListOnly => ACCESS_FS_READ_DIR | ACCESS_FS_REFER,
+        LandlockGrant::ReadFile => ACCESS_FS_EXECUTE | ACCESS_FS_READ_FILE,
+    }
+}
+
+fn set_cloexec(fd: i32) -> Result<(), OrbitError> {
+    // SAFETY: `fd` is an open descriptor owned by the caller.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    // SAFETY: as above; only the close-on-exec flag is added.
+    if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) } < 0 {
+        return Err(OrbitError::Io(format!(
+            "set close-on-exec on landlock ruleset: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(())
+}

--- a/crates/orbit-exec/src/linux_landlock/tests/host.rs
+++ b/crates/orbit-exec/src/linux_landlock/tests/host.rs
@@ -1,0 +1,153 @@
+//! What the host grant table does and does not admit.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::super::host::{HOST_READ_ENV_VARS, host_read_grants};
+use crate::linux_landlock::grants_read;
+
+fn environment(pairs: &[(&str, &Path)]) -> Vec<(String, String)> {
+    pairs
+        .iter()
+        .map(|(name, path)| (name.to_string(), path.display().to_string()))
+        .collect()
+}
+
+#[test]
+fn the_loader_and_system_binaries_are_granted_so_a_program_can_start() {
+    let grants = host_read_grants(&[]);
+
+    assert!(grants_read(&grants, Path::new("/bin/sh")), "{grants:?}");
+    assert!(grants_read(&grants, Path::new("/dev/null")), "{grants:?}");
+}
+
+/// `/etc` holds `shadow` and every application's secrets. Individual
+/// resolver files are granted; the directory never is.
+#[test]
+fn resolver_files_are_granted_without_granting_etc() {
+    let grants = host_read_grants(&[]);
+
+    assert!(grants_read(&grants, Path::new("/etc/hosts")), "{grants:?}");
+    assert!(
+        !grants_read(&grants, Path::new("/etc/shadow")),
+        "{grants:?}"
+    );
+}
+
+/// A tree-wide `/proc` grant would expose any same-user process's `environ`,
+/// including the credentials of the process that launched the child.
+#[test]
+fn proc_is_not_granted_as_a_tree() {
+    let grants = host_read_grants(&[]);
+
+    assert!(
+        !grants_read(
+            &grants,
+            &PathBuf::from(format!("/proc/{}/environ", std::process::id()))
+        ),
+        "{grants:?}"
+    );
+}
+
+#[test]
+fn a_declared_tool_state_directory_is_granted_but_its_publish_token_is_not() {
+    let home = tempfile::tempdir().expect("home");
+    let cargo_home = home.path().join("cargo");
+    fs::create_dir_all(cargo_home.join("registry")).expect("mkdir registry");
+    fs::write(cargo_home.join("config.toml"), "config").expect("write config");
+    fs::write(cargo_home.join("credentials.toml"), "token").expect("write credentials");
+
+    let grants = host_read_grants(&environment(&[("CARGO_HOME", &cargo_home)]));
+
+    assert!(
+        grants_read(&grants, &cargo_home.join("registry/index")),
+        "{grants:?}"
+    );
+    assert!(
+        grants_read(&grants, &cargo_home.join("config.toml")),
+        "{grants:?}"
+    );
+    assert!(
+        !grants_read(&grants, &cargo_home.join("credentials.toml")),
+        "{grants:?}"
+    );
+}
+
+/// The table's whole purpose is to be narrower than `$HOME`. A variable that
+/// names the home directory itself, or an ancestor of it, is refused rather
+/// than silently widening every grant.
+#[test]
+fn a_tool_state_variable_cannot_widen_the_grant_to_the_home_directory() {
+    let home = tempfile::tempdir().expect("home");
+    let secret = home.path().join(".ssh/id_ed25519");
+    fs::create_dir_all(home.path().join(".ssh")).expect("mkdir .ssh");
+    fs::write(&secret, "key").expect("write key");
+
+    for named_home in [home.path(), Path::new("/")] {
+        let grants = host_read_grants(&environment(&[
+            ("HOME", home.path()),
+            ("CARGO_HOME", named_home),
+        ]));
+        assert!(!grants_read(&grants, &secret), "{named_home:?}: {grants:?}");
+    }
+}
+
+/// An unlisted credential store stays unreadable even when `$HOME` is known.
+#[test]
+fn an_unlisted_credential_store_is_never_granted() {
+    let home = tempfile::tempdir().expect("home");
+    for relative in [".ssh/id_ed25519", ".aws/credentials", ".netrc"] {
+        let path = home.path().join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("mkdir");
+        }
+        fs::write(&path, "secret").expect("write secret");
+    }
+
+    let grants = host_read_grants(&environment(&[("HOME", home.path())]));
+
+    for relative in [".ssh/id_ed25519", ".aws/credentials", ".netrc"] {
+        assert!(
+            !grants_read(&grants, &home.path().join(relative)),
+            "{relative} was granted: {grants:?}"
+        );
+    }
+}
+
+/// A shipped allowlist names programs, not locations, so `PATH` is what turns
+/// `rg` into a grant.
+#[test]
+fn path_directories_are_granted_so_an_allowlisted_program_can_be_executed() {
+    let tools = tempfile::tempdir().expect("tools");
+    let program = tools.path().join("rg");
+    fs::write(&program, "#!/bin/sh\n").expect("write program");
+
+    let grants = host_read_grants(&environment(&[("PATH", tools.path())]));
+
+    assert!(grants_read(&grants, &program), "{grants:?}");
+}
+
+/// The documented list is what an operator reads to understand how a child
+/// environment turns into host access, so it must not drift from the code.
+#[test]
+fn every_documented_variable_actually_widens_the_grants() {
+    let home = tempfile::tempdir().expect("home");
+    let baseline = host_read_grants(&environment(&[("HOME", home.path())])).len();
+
+    for variable in HOST_READ_ENV_VARS {
+        // `XDG_CONFIG_HOME` names a parent of per-tool directories rather than
+        // a tool's own state, so the grant lands beneath it.
+        let named = home.path().join(variable.to_lowercase());
+        fs::create_dir_all(named.join("git")).expect("mkdir named directory");
+        let grants = host_read_grants(&environment(&[("HOME", home.path()), (variable, &named)]));
+
+        assert!(
+            grants.iter().any(|grant| grant.path.starts_with(&named)),
+            "`{variable}` granted nothing at or beneath the directory it names"
+        );
+        assert!(
+            grants.len() > baseline,
+            "`{variable}` added no grant at all"
+        );
+    }
+}

--- a/crates/orbit-exec/src/linux_landlock/tests/mod.rs
+++ b/crates/orbit-exec/src/linux_landlock/tests/mod.rs
@@ -1,0 +1,3 @@
+mod host;
+mod platform;
+mod workspace;

--- a/crates/orbit-exec/src/linux_landlock/tests/platform.rs
+++ b/crates/orbit-exec/src/linux_landlock/tests/platform.rs
@@ -1,0 +1,69 @@
+//! Platform availability. Enforcement is Linux-only, and a host that cannot
+//! enforce must say so rather than run the child unconfined.
+
+use crate::linux_landlock::{MINIMUM_LANDLOCK_ABI, landlock_unavailable_message, probe_landlock};
+
+#[cfg(not(target_os = "linux"))]
+use {
+    crate::linux_landlock::spawn_under_linux_landlock,
+    crate::runner::{EnvironmentMode, ExecRequest, StdinMode},
+    orbit_common::OrbitError,
+    orbit_types::policy::ResolvedFsProfile,
+    std::path::Path,
+};
+
+#[cfg(not(target_os = "linux"))]
+fn request() -> ExecRequest {
+    ExecRequest {
+        program: "/bin/echo".to_string(),
+        args: vec!["must-not-run".to_string()],
+        current_dir: None,
+        timeout_ms: Some(1_000),
+        stdin_mode: StdinMode::Null,
+        environment_mode: EnvironmentMode::ClearAndSet(Vec::new()),
+        debug: false,
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn profile() -> ResolvedFsProfile {
+    ResolvedFsProfile {
+        name: "test".to_string(),
+        read: vec!["**".to_string()],
+        modify: vec!["**".to_string()],
+    }
+}
+
+#[test]
+fn an_unenforceable_host_explains_what_it_needs() {
+    let probe = probe_landlock();
+    let message = landlock_unavailable_message(&probe);
+
+    assert!(
+        message.contains("Landlock") && message.contains(&MINIMUM_LANDLOCK_ABI.to_string()),
+        "the capability error must name the requirement: {message}"
+    );
+}
+
+/// The ABI floor exists because `REFER` — the right that stops a denied file
+/// from being relocated into a readable directory — arrived in ABI 2.
+#[cfg(target_os = "linux")]
+#[test]
+fn availability_requires_the_abi_that_carries_the_relocation_right() {
+    let probe = probe_landlock();
+
+    assert_eq!(probe.available, probe.abi >= MINIMUM_LANDLOCK_ABI);
+}
+
+/// Off Linux there is no ruleset to apply, so the spawn is refused. Falling
+/// back to an unconfined child would leave the alias bypass open on that
+/// platform while every other layer claimed it was closed.
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn a_platform_without_landlock_refuses_to_spawn_at_all() {
+    let error = spawn_under_linux_landlock(&request(), Path::new("."), &profile())
+        .err()
+        .expect("an unsupported platform must not spawn");
+
+    assert!(matches!(error, OrbitError::PolicyDenied(_)), "{error:?}");
+}

--- a/crates/orbit-exec/src/linux_landlock/tests/workspace.rs
+++ b/crates/orbit-exec/src/linux_landlock/tests/workspace.rs
@@ -1,0 +1,139 @@
+//! Compiling a resolved read profile into workspace grants.
+//!
+//! These decide grants without applying a ruleset, so they run anywhere. The
+//! kernel behaviour they stand for is covered by `tests/linux_landlock.rs`.
+
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use orbit_types::policy::ResolvedFsProfile;
+
+use crate::linux_landlock::{LandlockPathGrant, grants_read, linux_landlock_grants};
+
+const DEFAULT_DENY_READ: &[&str] = &["**/.env", "**/.env.*", "**/*.env", "**/*.env.*"];
+
+fn profile(read: &[&str], denies: &[&str]) -> ResolvedFsProfile {
+    let mut rules: Vec<String> = read.iter().map(ToString::to_string).collect();
+    rules.extend(denies.iter().map(|rule| format!("!{rule}")));
+    ResolvedFsProfile {
+        name: "test".to_string(),
+        read: rules,
+        modify: vec!["**".to_string()],
+    }
+}
+
+fn compile(workspace: &Path, profile: &ResolvedFsProfile) -> Vec<LandlockPathGrant> {
+    linux_landlock_grants(workspace, profile, &[]).expect("compile grants")
+}
+
+#[test]
+fn a_workspace_profile_grants_the_workspace_and_not_a_host_sibling() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let host = tempfile::tempdir().expect("host");
+    let visible = workspace.path().join("visible.txt");
+    let outside = host.path().join("secret.txt");
+    fs::write(&visible, "ok").expect("write visible");
+    fs::write(&outside, "secret").expect("write outside");
+
+    let grants = compile(workspace.path(), &profile(&["**"], &[]));
+
+    assert!(grants_read(&grants, &visible), "{grants:?}");
+    assert!(!grants_read(&grants, &outside), "{grants:?}");
+}
+
+#[test]
+fn a_denied_file_keeps_no_readable_ancestor() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let allowed = workspace.path().join("src/main.rs");
+    let denied = workspace.path().join("src/.env");
+    fs::create_dir(workspace.path().join("src")).expect("mkdir src");
+    fs::write(&allowed, "code").expect("write allowed");
+    fs::write(&denied, "token").expect("write denied");
+
+    let grants = compile(workspace.path(), &profile(&["**"], DEFAULT_DENY_READ));
+
+    assert!(grants_read(&grants, &allowed), "{grants:?}");
+    assert!(!grants_read(&grants, &denied), "{grants:?}");
+}
+
+#[test]
+fn a_profile_that_reads_one_subtree_grants_nothing_beside_it() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    fs::create_dir(workspace.path().join("allowed")).expect("mkdir allowed");
+    let inside = workspace.path().join("allowed/visible.txt");
+    let beside = workspace.path().join("hidden.txt");
+    fs::write(&inside, "visible").expect("write inside");
+    fs::write(&beside, "hidden").expect("write beside");
+
+    let grants = compile(workspace.path(), &profile(&["allowed/**"], &[]));
+
+    assert!(grants_read(&grants, &inside), "{grants:?}");
+    assert!(!grants_read(&grants, &beside), "{grants:?}");
+}
+
+#[test]
+fn an_empty_read_profile_grants_no_workspace_path() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let file = workspace.path().join("visible.txt");
+    fs::write(&file, "ok").expect("write file");
+
+    let grants = compile(
+        workspace.path(),
+        &ResolvedFsProfile {
+            name: "pure_compute".to_string(),
+            read: Vec::new(),
+            modify: Vec::new(),
+        },
+    );
+
+    assert!(!grants_read(&grants, &file), "{grants:?}");
+}
+
+/// A symlink out of the workspace must not smuggle its target into the
+/// ruleset. The child following it is denied where the target really lives,
+/// which is where the profile has authority to speak.
+#[cfg(unix)]
+#[test]
+fn a_symlink_leaving_the_workspace_is_not_granted() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let host = tempfile::tempdir().expect("host");
+    let outside = host.path().join("secret.txt");
+    fs::write(&outside, "secret").expect("write outside");
+    std::os::unix::fs::symlink(&outside, workspace.path().join("link.txt")).expect("symlink");
+
+    let grants = compile(workspace.path(), &profile(&["**"], &[]));
+
+    assert!(!grants_read(&grants, &outside), "{grants:?}");
+}
+
+/// Grant compilation runs before every activity-scoped spawn, so it has to
+/// stay proportional to the tree rather than to the rule set. Evaluating the
+/// profile's globs per visited path — which rebuilds a regex each time — turned
+/// an ordinary repository into a minute of setup per spawn. [ORB-11514]
+#[test]
+fn grant_compilation_stays_within_budget_on_a_large_workspace() {
+    const DIRECTORIES: usize = 30;
+    const FILES_PER_DIRECTORY: usize = 100;
+    const BUDGET: Duration = Duration::from_secs(10);
+
+    let workspace = tempfile::tempdir().expect("workspace");
+    for directory in 0..DIRECTORIES {
+        let path = workspace.path().join(format!("bucket{directory}"));
+        fs::create_dir(&path).expect("mkdir bucket");
+        for file in 0..FILES_PER_DIRECTORY {
+            fs::write(path.join(format!("file{file}.txt")), "x").expect("write file");
+        }
+    }
+
+    let started = Instant::now();
+    let grants = compile(workspace.path(), &profile(&["**"], DEFAULT_DENY_READ));
+    let elapsed = started.elapsed();
+
+    assert!(!grants.is_empty(), "the workspace should still be granted");
+    assert!(
+        elapsed < BUDGET,
+        "compiling grants for {} files took {elapsed:?}, over the {BUDGET:?} budget",
+        DIRECTORIES * FILES_PER_DIRECTORY
+    );
+}

--- a/crates/orbit-exec/src/linux_landlock/workspace.rs
+++ b/crates/orbit-exec/src/linux_landlock/workspace.rs
@@ -1,0 +1,196 @@
+//! Compiling the resolved read profile into workspace path grants.
+//!
+//! The profile is a last-match-wins list of globs; a Landlock ruleset is a set
+//! of inodes. Translating one into the other means walking the workspace once
+//! and deciding, per path, whether the child may read it.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use orbit_common::OrbitError;
+use orbit_types::policy::{CompiledFsRules, FsOperation, ResolvedFsProfile};
+
+use super::LandlockPathGrant;
+
+/// Compile the workspace half of the ruleset for `profile`.
+pub(super) fn workspace_read_grants(
+    workspace_root: &Path,
+    profile: &ResolvedFsProfile,
+) -> Result<Vec<LandlockPathGrant>, OrbitError> {
+    let rules = profile.compile(FsOperation::Read)?;
+    if rules.grants_nothing() {
+        return Ok(Vec::new());
+    }
+
+    if rules.allows(".")? {
+        return grant_read_tree(workspace_root, workspace_root, &rules);
+    }
+    allowed_subtrees(workspace_root, workspace_root, &rules)
+}
+
+/// Grant `root` as a readable tree, carving out every denied path beneath it.
+///
+/// A directory holding a denied path cannot be granted as a tree, because a
+/// path-beneath rule reaches every descendant. Such a directory is granted
+/// list-only and each allowed child is granted in its own right, recursively.
+/// The denied path is then left with no readable ancestor at all.
+///
+/// # What this does and does not deny
+/// The carve-out is computed from the paths that exist when the ruleset is
+/// compiled, and Landlock rules bind to inodes. Consequences, all covered by
+/// tests:
+///
+/// - A denied file that exists at spawn stays unreadable for the child's whole
+///   life, including after the child renames it within its directory: the
+///   inode keeps no readable ancestor.
+/// - The child cannot move a denied file into a readable directory. Landlock
+///   refuses a rename that would give a file more access at its destination,
+///   which is why `REFER` is handled.
+/// - A file matching a deny rule that is *created* later under an
+///   already-granted directory is readable by that child. That discloses
+///   nothing the child could not already obtain — either the child wrote those
+///   bytes, or it copied them from somewhere this ruleset already allowed.
+///   A concurrent third party writing a new secret into the workspace during
+///   the child's lifetime is the residual race, and it is why `denyRead` is
+///   also enforced at request time by the policy engine.
+pub(super) fn grant_read_tree(
+    workspace_root: &Path,
+    root: &Path,
+    rules: &CompiledFsRules,
+) -> Result<Vec<LandlockPathGrant>, OrbitError> {
+    let denied = denied_paths(workspace_root, root, rules)?;
+    carve_out(root, &denied)
+}
+
+/// Walk into a workspace whose root is not itself allowed, granting the
+/// allowed subtrees found along the way.
+fn allowed_subtrees(
+    workspace_root: &Path,
+    dir: &Path,
+    rules: &CompiledFsRules,
+) -> Result<Vec<LandlockPathGrant>, OrbitError> {
+    let mut grants = Vec::new();
+    for child in children_under(workspace_root, dir)? {
+        if rules.allows(&relative_to(workspace_root, &child)?)? {
+            grants.extend(grant_read_tree(workspace_root, &child, rules)?);
+        } else if child.is_dir() {
+            grants.extend(allowed_subtrees(workspace_root, &child, rules)?);
+        }
+    }
+    Ok(grants)
+}
+
+/// Every path beneath `root` the profile denies. Empty when the profile has no
+/// exclusion, in which case no walk is needed at all.
+fn denied_paths(
+    workspace_root: &Path,
+    root: &Path,
+    rules: &CompiledFsRules,
+) -> Result<BTreeSet<PathBuf>, OrbitError> {
+    let mut denied = BTreeSet::new();
+    if rules.has_exclusion() {
+        collect_denied(workspace_root, root, rules, &mut denied)?;
+    }
+    Ok(denied)
+}
+
+fn collect_denied(
+    workspace_root: &Path,
+    dir: &Path,
+    rules: &CompiledFsRules,
+    denied: &mut BTreeSet<PathBuf>,
+) -> Result<(), OrbitError> {
+    for child in children_under(workspace_root, dir)? {
+        if !rules.allows(&relative_to(workspace_root, &child)?)? {
+            denied.insert(child);
+        } else if child.is_dir() {
+            collect_denied(workspace_root, &child, rules, denied)?;
+        }
+    }
+    Ok(())
+}
+
+/// Grant `root` while leaving every path in `denied` without a readable
+/// ancestor. Shared with the host grants, which carve credential files out of
+/// an otherwise readable tool state directory the same way.
+pub(super) fn carve_out(
+    root: &Path,
+    denied: &BTreeSet<PathBuf>,
+) -> Result<Vec<LandlockPathGrant>, OrbitError> {
+    if denied.contains(root) {
+        return Ok(Vec::new());
+    }
+    let holds_denied_path = denied.iter().any(|path| path.starts_with(root));
+    if !holds_denied_path {
+        return Ok(vec![whole_path_grant(root)]);
+    }
+    if !root.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let mut grants = vec![LandlockPathGrant::list_only(root.to_path_buf())];
+    for child in children_under(root, root)? {
+        grants.extend(carve_out(&child, denied)?);
+    }
+    Ok(grants)
+}
+
+fn whole_path_grant(path: &Path) -> LandlockPathGrant {
+    if path.is_dir() {
+        LandlockPathGrant::read_tree(path.to_path_buf())
+    } else {
+        LandlockPathGrant::read_file(path.to_path_buf())
+    }
+}
+
+/// Canonical children of `dir`, dropping any entry that resolves outside
+/// `boundary`. A symlink pointing out of the workspace must not smuggle an
+/// outside path into the ruleset; the child following that link is denied at
+/// the resolved location, which is where the profile is defined.
+///
+/// This runs once per directory before every activity-scoped spawn, so it
+/// avoids per-entry syscalls: `dir` is already canonical, which makes a
+/// non-symlink child canonical by construction, and the entry kind comes from
+/// the directory read itself. Only a symlink pays for full resolution.
+///
+/// An unreadable directory yields nothing rather than failing the whole
+/// compilation: the child could not have read it either.
+fn children_under(boundary: &Path, dir: &Path) -> Result<Vec<PathBuf>, OrbitError> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Ok(Vec::new());
+    };
+    let mut children = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            OrbitError::Io(format!("read landlock path `{}`: {error}", dir.display()))
+        })?;
+        let symlinked = entry.file_type().is_ok_and(|kind| kind.is_symlink());
+        let path = if symlinked {
+            let Ok(resolved) = entry.path().canonicalize() else {
+                continue;
+            };
+            resolved
+        } else {
+            entry.path()
+        };
+        if path.starts_with(boundary) {
+            children.push(path);
+        }
+    }
+    Ok(children)
+}
+
+fn relative_to(workspace_root: &Path, path: &Path) -> Result<String, OrbitError> {
+    let relative = path.strip_prefix(workspace_root).map_err(|_| {
+        OrbitError::InvalidInput(format!(
+            "landlock path `{}` escaped workspace `{}`",
+            path.display(),
+            workspace_root.display()
+        ))
+    })?;
+    if relative.as_os_str().is_empty() {
+        Ok(".".to_string())
+    } else {
+        Ok(relative.to_string_lossy().replace('\\', "/"))
+    }
+}

--- a/crates/orbit-exec/src/process.rs
+++ b/crates/orbit-exec/src/process.rs
@@ -4,7 +4,9 @@ use orbit_common::OrbitError;
 
 use crate::runner::{EnvironmentMode, ExecRequest, StdinMode};
 
-pub(crate) fn spawn(req: &ExecRequest) -> Result<Child, OrbitError> {
+/// Build the child process description shared by every spawn path, so a
+/// sandbox that confines the child cannot drift from the unconfined one.
+pub(crate) fn command(req: &ExecRequest) -> Command {
     let mut command = Command::new(&req.program);
     command.args(&req.args).stdout(Stdio::piped());
     command.stderr(Stdio::piped());
@@ -41,6 +43,10 @@ pub(crate) fn spawn(req: &ExecRequest) -> Result<Child, OrbitError> {
     }
 
     command
+}
+
+pub(crate) fn spawn(req: &ExecRequest) -> Result<Child, OrbitError> {
+    command(req)
         .spawn()
         .map_err(|e| OrbitError::Execution(format!("failed to spawn `{}`: {e}", req.program)))
 }

--- a/crates/orbit-exec/src/runner.rs
+++ b/crates/orbit-exec/src/runner.rs
@@ -72,7 +72,7 @@ pub fn run_process(
     sandbox.validate(req)?;
 
     let started = Instant::now();
-    let child = crate::process::spawn(req)?;
+    let child = sandbox.spawn(req)?;
     let stdin_payload = match &req.stdin_mode {
         StdinMode::Bytes(bytes) => Some(bytes.clone()),
         StdinMode::Inherit | StdinMode::Null => None,
@@ -160,7 +160,7 @@ where
     sandbox.validate(req)?;
 
     let started = Instant::now();
-    let mut child = crate::process::spawn(req)?;
+    let mut child = sandbox.spawn(req)?;
     let stdout = child
         .stdout
         .take()

--- a/crates/orbit-exec/src/sandbox.rs
+++ b/crates/orbit-exec/src/sandbox.rs
@@ -1,9 +1,21 @@
+use std::process::Child;
+
 use orbit_common::OrbitError;
 
 use crate::runner::ExecRequest;
 
 pub trait Sandbox {
     fn validate(&self, req: &ExecRequest) -> Result<(), OrbitError>;
+
+    /// Create the child once [`Self::validate`] has accepted the request.
+    ///
+    /// This is the seam a strategy overrides to confine the process itself.
+    /// Argv rewriting cannot express a read boundary, because an allowed
+    /// program decides for itself what to open; a strategy that must enforce
+    /// one applies it here, between `fork` and `exec`.
+    fn spawn(&self, req: &ExecRequest) -> Result<Child, OrbitError> {
+        crate::process::spawn(req)
+    }
 }
 
 /// A sandbox strategy that adds no Orbit-specific validation or containment.

--- a/crates/orbit-exec/tests/linux_landlock.rs
+++ b/crates/orbit-exec/tests/linux_landlock.rs
@@ -1,0 +1,376 @@
+#![allow(missing_docs)]
+// Fixture setup uses unwrap/expect for readability; `println!` reports a skip
+// on a kernel that cannot enforce the ruleset at all.
+#![allow(clippy::expect_used, clippy::print_stdout, clippy::unwrap_used)]
+#![cfg(target_os = "linux")]
+
+//! Kernel-level behavior of the activity-scoped read boundary. [ORB-11514]
+//!
+//! These exercise the real Landlock ruleset against real children, because the
+//! whole point of the change is that a compiled grant list is not evidence: the
+//! child has to actually fail to open the file.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use orbit_exec::{
+    EnvironmentMode, ExecRequest, StdinMode, linux_landlock_grants, probe_landlock,
+    spawn_under_linux_landlock,
+};
+use orbit_types::policy::ResolvedFsProfile;
+
+const DEFAULT_DENY_READ: &[&str] = &["**/.env", "**/.env.*", "**/*.env", "**/*.env.*"];
+
+struct Fixture {
+    workspace: tempfile::TempDir,
+    host: tempfile::TempDir,
+    environment: Vec<(String, String)>,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        Self {
+            workspace: tempfile::tempdir().expect("workspace"),
+            host: tempfile::tempdir().expect("host"),
+            environment: vec![("PATH".to_string(), "/usr/bin:/bin".to_string())],
+        }
+    }
+
+    fn with_env(mut self, name: &str, value: &Path) -> Self {
+        self.environment
+            .push((name.to_string(), value.display().to_string()));
+        self
+    }
+
+    /// Carry a real host variable into the child environment, which is how an
+    /// operator declares a tool state directory.
+    fn inheriting(mut self, names: &[&str]) -> Self {
+        self.environment.retain(|(name, _)| name != "PATH");
+        self.environment.push((
+            "PATH".to_string(),
+            std::env::var("PATH").unwrap_or_else(|_| "/usr/bin:/bin".to_string()),
+        ));
+        for name in names {
+            if let Ok(value) = std::env::var(name) {
+                self.environment.push((name.to_string(), value));
+            }
+        }
+        self
+    }
+
+    fn root(&self) -> PathBuf {
+        self.workspace
+            .path()
+            .canonicalize()
+            .expect("canonical root")
+    }
+
+    fn host_root(&self) -> PathBuf {
+        self.host.path().canonicalize().expect("canonical host")
+    }
+
+    fn write(&self, relative: &str, contents: &str) -> PathBuf {
+        let path = self.root().join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent");
+        }
+        fs::write(&path, contents).expect("write fixture file");
+        path
+    }
+
+    /// Run `script` through `sh` inside the confined child and return its
+    /// combined output. `sh` is on every shipped activity allowlist, so this is
+    /// the shape of the bypass this change closes.
+    fn run(&self, profile: &ResolvedFsProfile, script: &str) -> Output {
+        let request = ExecRequest {
+            program: "/bin/sh".to_string(),
+            args: vec!["-c".to_string(), script.to_string()],
+            current_dir: Some(self.root().display().to_string()),
+            timeout_ms: Some(10_000),
+            stdin_mode: StdinMode::Null,
+            environment_mode: EnvironmentMode::ClearAndSet(self.environment.clone()),
+            debug: false,
+        };
+        let output = spawn_under_linux_landlock(&request, &self.root(), profile)
+            .expect("spawn confined child")
+            .wait_with_output()
+            .expect("wait for confined child");
+        Output {
+            succeeded: output.status.success(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        }
+    }
+}
+
+struct Output {
+    succeeded: bool,
+    stdout: String,
+    stderr: String,
+}
+
+impl Output {
+    fn assert_withheld(&self, sentinel: &str) {
+        assert!(
+            !self.stdout.contains(sentinel),
+            "sentinel `{sentinel}` reached the caller: stdout={:?} stderr={:?}",
+            self.stdout,
+            self.stderr
+        );
+    }
+
+    fn assert_returned(&self, sentinel: &str) {
+        assert!(
+            self.stdout.contains(sentinel),
+            "expected `{sentinel}`: succeeded={} stdout={:?} stderr={:?}",
+            self.succeeded,
+            self.stdout,
+            self.stderr
+        );
+    }
+}
+
+fn profile(read: &[&str]) -> ResolvedFsProfile {
+    let mut rules: Vec<String> = read.iter().map(ToString::to_string).collect();
+    rules.extend(DEFAULT_DENY_READ.iter().map(|rule| format!("!{rule}")));
+    ResolvedFsProfile {
+        name: "test".to_string(),
+        read: rules,
+        modify: vec!["**".to_string()],
+    }
+}
+
+fn on_path(program: &str, environment: &[(String, String)]) -> bool {
+    let Some((_, search_path)) = environment.iter().find(|(name, _)| name == "PATH") else {
+        return false;
+    };
+    std::env::split_paths(search_path).any(|dir| dir.join(program).is_file())
+}
+
+fn unenforceable() -> bool {
+    let probe = probe_landlock();
+    if !probe.available {
+        println!("skipping: {}", probe.detail);
+    }
+    !probe.available
+}
+
+#[test]
+fn a_confined_child_cannot_read_outside_the_workspace() {
+    if unenforceable() {
+        return;
+    }
+    let fixture = Fixture::new();
+    fixture.write("visible.txt", "WORKSPACE_OK");
+    let outside = fixture.host_root().join("secret.txt");
+    fs::write(&outside, "HOST_SENTINEL").expect("write host sentinel");
+    let profile = profile(&["**"]);
+
+    fixture
+        .run(&profile, "cat visible.txt")
+        .assert_returned("WORKSPACE_OK");
+    fixture
+        .run(&profile, &format!("cat {}", outside.display()))
+        .assert_withheld("HOST_SENTINEL");
+}
+
+/// The reviewed bypass: an allowlisted program is asked to interpret a shell
+/// fragment, so no argument ever looks like a path.
+#[test]
+fn a_git_shell_alias_cannot_reach_a_host_sentinel() {
+    if unenforceable() || !Path::new("/usr/bin/git").exists() {
+        return;
+    }
+    let fixture = Fixture::new();
+    let outside = fixture.host_root().join("secret.txt");
+    fs::write(&outside, "ALIAS_SENTINEL").expect("write host sentinel");
+    fs::create_dir(fixture.root().join("repo")).expect("create repo");
+
+    let script = format!(
+        "cd repo && git init -q . && git -c alias.probe='!cat {}' probe",
+        outside.display()
+    );
+    fixture
+        .run(&profile(&["**"]), &script)
+        .assert_withheld("ALIAS_SENTINEL");
+}
+
+#[test]
+fn a_deny_read_file_is_withheld_and_stays_withheld_after_a_rename() {
+    if unenforceable() {
+        return;
+    }
+    let fixture = Fixture::new();
+    fixture.write(".env", "DENIED_SENTINEL");
+    fixture.write("src/main.rs", "ALLOWED_SENTINEL");
+    let profile = profile(&["**"]);
+
+    fixture
+        .run(&profile, "cat .env")
+        .assert_withheld("DENIED_SENTINEL");
+    fixture
+        .run(&profile, "cat src/main.rs")
+        .assert_returned("ALLOWED_SENTINEL");
+    // Renaming within the directory cannot launder the inode: the denied file
+    // keeps no readable ancestor for the life of the child.
+    fixture
+        .run(&profile, "mv .env laundered.txt; cat laundered.txt")
+        .assert_withheld("DENIED_SENTINEL");
+}
+
+/// `REFER` is handled precisely so a denied file cannot be relocated into a
+/// directory that grants more access than the one holding it.
+#[test]
+fn a_denied_file_cannot_be_moved_into_a_readable_directory() {
+    if unenforceable() {
+        return;
+    }
+    let fixture = Fixture::new();
+    fixture.write(".env", "RELOCATED_SENTINEL");
+    fixture.write("src/main.rs", "code");
+
+    fixture
+        .run(
+            &profile(&["**"]),
+            "mv .env src/laundered.txt; cat src/laundered.txt",
+        )
+        .assert_withheld("RELOCATED_SENTINEL");
+}
+
+/// A generated file has to be usable, or the confinement breaks every build.
+#[test]
+fn a_file_the_child_generates_is_readable() {
+    if unenforceable() {
+        return;
+    }
+    let fixture = Fixture::new();
+    fixture.write("src/main.rs", "code");
+
+    fixture
+        .run(
+            &profile(&["**"]),
+            "printf GENERATED_SENTINEL > src/build.out; cat src/build.out",
+        )
+        .assert_returned("GENERATED_SENTINEL");
+}
+
+/// `/proc` is not granted as a tree, because a process can read any same-user
+/// process's `environ` — including the Orbit process that launched the child,
+/// whose environment may hold provider credentials.
+#[test]
+fn the_child_cannot_read_another_processs_environment() {
+    if unenforceable() {
+        return;
+    }
+    let fixture = Fixture::new();
+
+    fixture
+        .run(
+            &profile(&["**"]),
+            &format!(
+                "cat /proc/{}/environ && echo PARENT_ENVIRON_READ",
+                std::process::id()
+            ),
+        )
+        .assert_withheld("PARENT_ENVIRON_READ");
+}
+
+/// Criterion 3: the programs shipped activity allowlists name still work, and
+/// they work for the reasons the host grants claim — `cargo` needs its
+/// toolchain home, `gh` and networked `git` need the resolver and trust store.
+#[test]
+fn allowlisted_programs_still_run_through_the_boundary() {
+    if unenforceable() {
+        return;
+    }
+    let fixture = Fixture::new().inheriting(&["HOME", "CARGO_HOME", "RUSTUP_HOME"]);
+    fixture.write("a.txt", "needle");
+    let profile = profile(&["**"]);
+
+    for (program, script, sentinel) in [
+        (
+            "git",
+            "git init -q . && git status --short && echo GIT_OK",
+            "GIT_OK",
+        ),
+        ("rg", "rg needle a.txt && echo RG_OK", "RG_OK"),
+        ("cargo", "cargo --version && echo CARGO_OK", "CARGO_OK"),
+        (
+            "make",
+            "make --version >/dev/null && echo MAKE_OK",
+            "MAKE_OK",
+        ),
+        ("gh", "gh --version >/dev/null && echo GH_OK", "GH_OK"),
+        (
+            "getent",
+            "getent hosts localhost >/dev/null && echo RESOLVER_OK",
+            "RESOLVER_OK",
+        ),
+    ] {
+        if !on_path(program, &fixture.environment) {
+            continue;
+        }
+        fixture.run(&profile, script).assert_returned(sentinel);
+    }
+}
+
+/// Criterion 5: an allowlisted program's declared tool state is readable
+/// through the actual spawn boundary, while its neighbours are not.
+#[test]
+fn declared_tool_state_is_readable_but_its_credentials_and_neighbours_are_not() {
+    if unenforceable() {
+        return;
+    }
+    let fixture = Fixture::new();
+    let cargo_home = fixture.host_root().join("cargo-home");
+    fs::create_dir_all(cargo_home.join("registry")).expect("create registry");
+    fs::write(cargo_home.join("config.toml"), "CONFIG_SENTINEL").expect("write config");
+    fs::write(cargo_home.join("credentials.toml"), "TOKEN_SENTINEL").expect("write credentials");
+    let unrelated = fixture.host_root().join("unrelated.txt");
+    fs::write(&unrelated, "UNRELATED_SENTINEL").expect("write unrelated");
+
+    let fixture = fixture.with_env("CARGO_HOME", &cargo_home);
+    let profile = profile(&["**"]);
+
+    fixture
+        .run(
+            &profile,
+            &format!("cat {}/config.toml", cargo_home.display()),
+        )
+        .assert_returned("CONFIG_SENTINEL");
+    fixture
+        .run(
+            &profile,
+            &format!("cat {}/credentials.toml", cargo_home.display()),
+        )
+        .assert_withheld("TOKEN_SENTINEL");
+    fixture
+        .run(&profile, &format!("cat {}", unrelated.display()))
+        .assert_withheld("UNRELATED_SENTINEL");
+}
+
+/// A profile that allows nothing must not leak the workspace through a
+/// compiled grant, even though the child still needs to execute.
+#[test]
+fn a_profile_that_reads_nothing_grants_no_workspace_path() {
+    if unenforceable() {
+        return;
+    }
+    let fixture = Fixture::new();
+    fixture.write("visible.txt", "PURE_COMPUTE_SENTINEL");
+    let profile = ResolvedFsProfile {
+        name: "pure_compute".to_string(),
+        read: Vec::new(),
+        modify: Vec::new(),
+    };
+
+    let grants =
+        linux_landlock_grants(&fixture.root(), &profile, &fixture.environment).expect("grants");
+    assert!(
+        !orbit_exec::grants_read(&grants, &fixture.root().join("visible.txt")),
+        "an empty read profile must not grant a workspace file: {grants:?}"
+    );
+    fixture
+        .run(&profile, "cat visible.txt")
+        .assert_withheld("PURE_COMPUTE_SENTINEL");
+}

--- a/crates/orbit-tools/src/builtin/proc/spawn.rs
+++ b/crates/orbit-tools/src/builtin/proc/spawn.rs
@@ -1,10 +1,15 @@
 use std::path::{Path, PathBuf};
+use std::process::Child;
 
 use orbit_common::OrbitError;
 use orbit_common::security::child_env::allowlisted_child_env;
 use orbit_common::tracing;
-use orbit_exec::{EnvironmentMode, ExecRequest, Sandbox, StdinMode, run_process};
-use orbit_types::policy::FsOperation;
+use orbit_exec::{
+    EnvironmentMode, ExecRequest, NoSandbox, Sandbox, StdinMode, run_process,
+    spawn_under_linux_landlock,
+};
+use orbit_policy::PolicyEngine;
+use orbit_types::policy::{FsOperation, ResolvedFsProfile};
 use orbit_types::tool::{ToolParam, ToolSchema};
 use serde_json::Value;
 
@@ -86,56 +91,88 @@ impl Tool for ProcSpawnTool {
             environment_mode: EnvironmentMode::ClearAndSet(env_pairs),
             debug: false,
         };
-        let sandbox = ActivityFsSandbox::new(ctx);
-        let exec_result = run_process(&request, &sandbox)?;
+        let exec_result = run_process(&request, &ActivityFsSandbox::new(ctx)?)?;
 
         serde_json::to_value(exec_result)
             .map_err(|e| OrbitError::Execution(format!("serialize exec result: {e}")))
     }
 }
 
-/// Request-time filesystem gate for activity-scoped subprocesses.
+/// Filesystem confinement for an activity-scoped subprocess.
 ///
-/// An allowed program does not grant access to a path that the owning
-/// activity cannot read. Existing path arguments (including `--key=path`)
-/// are resolved symlink-safely by the same policy engine used by filesystem
-/// tools before the child is created.
+/// Two layers, doing two different jobs. Explicit path arguments (including
+/// `--key=path`) are resolved symlink-safely by the same policy engine the
+/// filesystem tools use, so `git -C /etc` is refused before the child exists
+/// and the caller is told which rule refused it. That check cannot be the
+/// boundary, though: `bash`, `python3`, and `git` shell aliases all reach the
+/// filesystem from text that never looks like a path argument. The read
+/// boundary is therefore the ruleset applied to the child itself at spawn.
+///
+/// Outside an activity-scoped context there is no resolved profile to enforce,
+/// and `proc.spawn` keeps its unconfined behavior with the program allowlist as
+/// the only gate.
 pub(crate) struct ActivityFsSandbox<'a> {
-    ctx: &'a ToolContext,
+    scope: Option<ActivityScope<'a>>,
+}
+
+/// The resolved policy an activity-scoped child is confined to, read once so
+/// the request-time check and the enforced ruleset cannot disagree.
+struct ActivityScope<'a> {
+    policy: &'a PolicyEngine,
+    workspace_root: &'a Path,
+    profile_name: &'a str,
+    profile: ResolvedFsProfile,
 }
 
 impl<'a> ActivityFsSandbox<'a> {
-    pub(crate) fn new(ctx: &'a ToolContext) -> Self {
-        Self { ctx }
-    }
-}
-
-impl Sandbox for ActivityFsSandbox<'_> {
-    fn validate(&self, request: &ExecRequest) -> Result<(), OrbitError> {
-        if !self.ctx.proc_spawn_activity_scoped {
-            return Ok(());
+    /// Fails closed: an activity-scoped context without a resolved filesystem
+    /// policy cannot spawn anything.
+    pub(crate) fn new(ctx: &'a ToolContext) -> Result<Self, OrbitError> {
+        if !ctx.proc_spawn_activity_scoped {
+            return Ok(Self { scope: None });
         }
-        let (Some(policy), Some(profile), Some(workspace_root)) = (
-            self.ctx.policy_engine.as_ref(),
-            self.ctx.fs_profile.as_deref(),
-            self.ctx.workspace_root.as_deref(),
+        let (Some(policy), Some(profile_name), Some(workspace_root)) = (
+            ctx.policy_engine.as_deref(),
+            ctx.fs_profile.as_deref(),
+            ctx.workspace_root.as_deref(),
         ) else {
             return Err(OrbitError::PolicyDenied(
                 "activity-scoped proc.spawn is missing its resolved filesystem policy".to_string(),
             ));
         };
+        let profile = policy.def().effective_profile(profile_name)?;
+        Ok(Self {
+            scope: Some(ActivityScope {
+                policy,
+                workspace_root,
+                profile_name,
+                profile,
+            }),
+        })
+    }
+}
+
+impl Sandbox for ActivityFsSandbox<'_> {
+    fn validate(&self, request: &ExecRequest) -> Result<(), OrbitError> {
+        let Some(scope) = &self.scope else {
+            return Ok(());
+        };
         let cwd = request
             .current_dir
             .as_deref()
             .map(PathBuf::from)
-            .unwrap_or_else(|| workspace_root.to_path_buf());
+            .unwrap_or_else(|| scope.workspace_root.to_path_buf());
         for path in request
             .args
             .iter()
             .filter_map(|arg| path_argument(arg, &cwd))
         {
-            let evaluation =
-                policy.check_resolved(workspace_root, profile, FsOperation::Read, &path)?;
+            let evaluation = scope.policy.check_resolved(
+                scope.workspace_root,
+                scope.profile_name,
+                FsOperation::Read,
+                &path,
+            )?;
             if evaluation.allowed {
                 continue;
             }
@@ -152,6 +189,15 @@ impl Sandbox for ActivityFsSandbox<'_> {
             )));
         }
         Ok(())
+    }
+
+    fn spawn(&self, request: &ExecRequest) -> Result<Child, OrbitError> {
+        match &self.scope {
+            Some(scope) => {
+                spawn_under_linux_landlock(request, scope.workspace_root, &scope.profile)
+            }
+            None => NoSandbox.spawn(request),
+        }
     }
 }
 

--- a/crates/orbit-tools/src/external.rs
+++ b/crates/orbit-tools/src/external.rs
@@ -59,7 +59,7 @@ impl Tool for ExternalTool {
                 environment_mode,
                 debug: false,
             },
-            &ActivityFsSandbox::new(ctx),
+            &ActivityFsSandbox::new(ctx)?,
         )?;
 
         if !output.success {

--- a/crates/orbit-tools/tests/proc_spawn_lockdown.rs
+++ b/crates/orbit-tools/tests/proc_spawn_lockdown.rs
@@ -16,6 +16,9 @@ use orbit_types::policy::{FsProfile, PolicyDef};
 use serde_json::{Value, json};
 use tempfile::tempdir;
 
+/// The `denyRead` set shipped in `crates/orbit-core/assets/policies/default.yaml`.
+const DEFAULT_DENY_READ: &[&str] = &["**/.env", "**/.env.*", "**/*.env", "**/*.env.*"];
+
 fn registry() -> ToolRegistry {
     let mut registry = ToolRegistry::new();
     registry.register_builtins();
@@ -275,6 +278,34 @@ fn spawn_runs_inside_workspace_root() {
     );
 }
 
+/// An activity context over `workspace_root` with the shipped `denyRead` set,
+/// so the regressions below reason about the profile agents actually run with.
+fn workspace_activity_context(workspace_root: &std::path::Path, programs: &[&str]) -> ToolContext {
+    let mut policy = policy_with_profile("unrestricted", vec!["./**".to_string()]);
+    policy.deny_read = DEFAULT_DENY_READ.iter().map(ToString::to_string).collect();
+    ToolContext {
+        workspace_root: Some(workspace_root.to_path_buf()),
+        policy_engine: Some(Arc::new(PolicyEngine::from_def(&policy).expect("policy"))),
+        fs_profile: Some("unrestricted".to_string()),
+        proc_allowed_programs: programs.iter().map(ToString::to_string).collect(),
+        proc_spawn_activity_scoped: true,
+        proc_spawn_environment: Some(vec![("PATH".to_string(), path_env())]),
+        ..Default::default()
+    }
+}
+
+fn path_env() -> String {
+    std::env::var("PATH").unwrap_or_else(|_| "/usr/bin:/bin".to_string())
+}
+
+fn on_path(program: &str) -> bool {
+    std::env::split_paths(&path_env()).any(|dir| dir.join(program).is_file())
+}
+
+fn stdout_of(value: &Value) -> String {
+    value["stdout"].as_str().unwrap_or_default().to_string()
+}
+
 fn restricted_policy() -> PolicyDef {
     policy_with_profile("restricted", vec!["./allowed/**".to_string()])
 }
@@ -297,5 +328,169 @@ fn policy_with_profile(name: &str, read: Vec<String>) -> PolicyDef {
         fs_profiles,
         created_at: Utc::now(),
         updated_at: Utc::now(),
+    }
+}
+
+/// The reviewed bypass, reproduced through the tool itself. `git` is on every
+/// shipped activity allowlist and will run a `!`-prefixed alias as a shell
+/// command, so no argument the request can inspect ever names the sentinel's
+/// path. [ORB-11514]
+#[test]
+fn a_git_shell_alias_cannot_read_a_host_sentinel() {
+    if !on_path("git") {
+        return;
+    }
+    let workspace = tempdir().expect("workspace tempdir");
+    let host = tempdir().expect("host tempdir");
+    let workspace_root = workspace
+        .path()
+        .canonicalize()
+        .expect("canonical workspace");
+    let sentinel = host
+        .path()
+        .canonicalize()
+        .expect("canonical host")
+        .join("sentinel.txt");
+    fs::write(&sentinel, "HOST_SENTINEL_ORB11514").expect("write host sentinel");
+
+    let ctx = workspace_activity_context(&workspace_root, &["git"]);
+    let value = registry()
+        .execute(
+            "proc.spawn",
+            &ctx,
+            json!({
+                "program": "git",
+                "args": [
+                    "-c",
+                    format!("alias.orbitsecurityprobe=!cat {}", sentinel.display()),
+                    "orbitsecurityprobe",
+                ],
+                "timeout_ms": 10000,
+            }),
+        )
+        .expect("the alias may run; it must not return the sentinel");
+
+    assert!(
+        !stdout_of(&value).contains("HOST_SENTINEL_ORB11514"),
+        "the host sentinel reached the caller: {value:?}"
+    );
+}
+
+/// The same trampoline aimed at a `denyRead` match inside the workspace.
+#[test]
+fn a_git_shell_alias_cannot_read_a_deny_read_file() {
+    if !on_path("git") {
+        return;
+    }
+    let workspace = tempdir().expect("workspace tempdir");
+    let workspace_root = workspace
+        .path()
+        .canonicalize()
+        .expect("canonical workspace");
+    fs::write(workspace_root.join(".env"), "DENY_READ_SECRET").expect("write secret");
+    fs::write(workspace_root.join("notes.txt"), "ALLOWED_CONTENT").expect("write allowed");
+
+    let ctx = workspace_activity_context(&workspace_root, &["git"]);
+    let alias = |target: &str| {
+        registry()
+            .execute(
+                "proc.spawn",
+                &ctx,
+                json!({
+                    "program": "git",
+                    "args": [
+                        "-c",
+                        format!("alias.orbitsecurityprobe=!cat {target}"),
+                        "orbitsecurityprobe",
+                    ],
+                    "timeout_ms": 10000,
+                }),
+            )
+            .expect("the alias may run")
+    };
+
+    // The trampoline itself still works, so the denial below is the read
+    // boundary rather than a broken fixture.
+    assert!(
+        stdout_of(&alias("notes.txt")).contains("ALLOWED_CONTENT"),
+        "the alias mechanism should still reach an allowed file"
+    );
+    assert!(
+        !stdout_of(&alias(".env")).contains("DENY_READ_SECRET"),
+        "a denyRead file reached the caller"
+    );
+}
+
+/// The request-time check still refuses an explicit outside-workspace path
+/// before the child exists, and still explains which rule refused it.
+#[test]
+fn an_explicit_path_outside_the_workspace_is_still_refused_before_spawn() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let workspace_root = workspace
+        .path()
+        .canonicalize()
+        .expect("canonical workspace");
+    let ctx = workspace_activity_context(&workspace_root, &["git"]);
+
+    let error = registry()
+        .execute(
+            "proc.spawn",
+            &ctx,
+            json!({
+                "program": "git",
+                "args": ["-C", "/etc", "rev-parse", "--show-toplevel"],
+                "timeout_ms": 5000,
+            }),
+        )
+        .expect_err("an explicit /etc path must be denied");
+
+    match error {
+        OrbitError::PolicyDenied(message) => {
+            assert!(message.contains("/etc"), "{message}");
+            assert!(message.contains("outside workspace"), "{message}");
+        }
+        other => panic!("expected a policy denial, got {other:?}"),
+    }
+}
+
+/// Confinement is only useful if the allowlisted tools still work.
+#[test]
+fn allowlisted_git_and_rg_still_work_inside_the_workspace() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let workspace_root = workspace
+        .path()
+        .canonicalize()
+        .expect("canonical workspace");
+    fs::write(workspace_root.join("haystack.txt"), "needle\n").expect("write haystack");
+    let ctx = workspace_activity_context(&workspace_root, &["git", "rg"]);
+
+    if on_path("git") {
+        let value = registry()
+            .execute(
+                "proc.spawn",
+                &ctx,
+                json!({ "program": "git", "args": ["init", "-q", "."], "timeout_ms": 10000 }),
+            )
+            .expect("git should run");
+        assert_eq!(value["exit_code"], json!(0), "{value:?}");
+        assert!(
+            workspace_root.join(".git").is_dir(),
+            "git init made no repo"
+        );
+    }
+
+    if on_path("rg") {
+        let value = registry()
+            .execute(
+                "proc.spawn",
+                &ctx,
+                json!({
+                    "program": "rg",
+                    "args": ["needle", "haystack.txt"],
+                    "timeout_ms": 10000,
+                }),
+            )
+            .expect("rg should run");
+        assert!(stdout_of(&value).contains("needle"), "{value:?}");
     }
 }

--- a/crates/orbit-types/src/policy/fs_rules.rs
+++ b/crates/orbit-types/src/policy/fs_rules.rs
@@ -1,0 +1,133 @@
+//! Compiled evaluation of a resolved profile's filesystem rules.
+//!
+//! Two layers ask the same question about a path: [`PolicyDef::check_path`]
+//! answers it for a single request, and the process-boundary sandbox in
+//! `orbit-exec` answers it for every path in a workspace while compiling a
+//! kernel ruleset. Both go through this type, so last-match-wins precedence
+//! and the reported `matched_rule` are defined once instead of drifting
+//! between the request-time deny and the enforced grant.
+//!
+//! Compiling is also what makes the sandbox's whole-tree walk affordable:
+//! matching a rule set through [`match_glob`](crate::policy::match_glob)
+//! rebuilds a regex per call, which is fine for one path and quadratic-feeling
+//! for thousands.
+
+use regex::Regex;
+
+use crate::policy::PolicyError;
+use crate::policy::glob::{compile_glob_regex, normalize_glob_path};
+use crate::policy::policy_def::FsCheckResult;
+
+/// `matched_rule` reported when rules exist but none matched the path.
+const NO_MATCHING_RULE: &str = "<no matching rule>";
+/// `matched_rule` reported when the rule set cannot allow anything.
+const EMPTY_RULESET: &str = "[]";
+
+/// A resolved profile's rule set for one operation, compiled for reuse.
+#[derive(Debug)]
+pub struct CompiledFsRules {
+    rules: Vec<CompiledFsRule>,
+}
+
+#[derive(Debug)]
+struct CompiledFsRule {
+    negated: bool,
+    /// The rule as written, minus any `!` prefix — the deny form reports the
+    /// bare pattern while the allow form reports the rule itself.
+    pattern: String,
+    matcher: Regex,
+}
+
+impl CompiledFsRules {
+    /// Compile `rules` as produced by
+    /// [`PolicyDef::effective_profile`](crate::policy::PolicyDef::effective_profile).
+    ///
+    /// `label` names the rule set in error messages.
+    pub fn compile(rules: &[String], label: &str) -> Result<Self, PolicyError> {
+        let compiled = rules
+            .iter()
+            .map(|rule| CompiledFsRule::compile(rule, label))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self { rules: compiled })
+    }
+
+    /// True when no path can ever be allowed, because the rule set is empty or
+    /// contains only exclusions. A caller walking a tree can stop immediately.
+    pub fn grants_nothing(&self) -> bool {
+        self.rules.iter().all(|rule| rule.negated)
+    }
+
+    /// True when an exclusion could carve a denied path out of an allowed
+    /// subtree. Without one, an allowed subtree needs no further inspection.
+    pub fn has_exclusion(&self) -> bool {
+        self.rules.iter().any(|rule| rule.negated)
+    }
+
+    /// Decide `path`, reporting the rule that settled it.
+    ///
+    /// `path` is normalized here, so callers may pass either the `./a/b` or
+    /// `a/b` spelling of a workspace-relative path.
+    pub fn evaluate(&self, path: &str) -> Result<FsCheckResult, PolicyError> {
+        let normalized = normalize_glob_path(path)?;
+        Ok(self.evaluate_normalized(&normalized))
+    }
+
+    /// Decide `path`, discarding the explanation.
+    pub fn allows(&self, path: &str) -> Result<bool, PolicyError> {
+        Ok(self.evaluate(path)?.allowed)
+    }
+
+    /// Last matching rule wins: a later exclusion overrides an earlier grant,
+    /// which is how `denyRead` is appended to a profile's own read rules.
+    fn evaluate_normalized(&self, normalized: &str) -> FsCheckResult {
+        let mut decision = None;
+        for rule in &self.rules {
+            if rule.matcher.is_match(normalized) {
+                decision = Some(rule.decision());
+            }
+        }
+
+        decision.unwrap_or_else(|| FsCheckResult {
+            allowed: false,
+            matched_rule: if self.grants_nothing() {
+                EMPTY_RULESET.to_string()
+            } else {
+                NO_MATCHING_RULE.to_string()
+            },
+        })
+    }
+}
+
+impl CompiledFsRule {
+    fn compile(rule: &str, label: &str) -> Result<Self, PolicyError> {
+        let (negated, body) = rule
+            .strip_prefix('!')
+            .map(|rest| (true, rest))
+            .unwrap_or((false, rule));
+        let mut pattern = body.replace('\\', "/");
+        while let Some(stripped) = pattern.strip_prefix("./") {
+            pattern = stripped.to_string();
+        }
+        if pattern.is_empty() {
+            pattern = ".".to_string();
+        }
+
+        let matcher = compile_glob_regex(&pattern).map_err(|error| {
+            PolicyError::Invalid(format!(
+                "{label} rule `{rule}` is not a valid filesystem glob: {error}"
+            ))
+        })?;
+        Ok(Self {
+            negated,
+            pattern,
+            matcher,
+        })
+    }
+
+    fn decision(&self) -> FsCheckResult {
+        FsCheckResult {
+            allowed: !self.negated,
+            matched_rule: self.pattern.clone(),
+        }
+    }
+}

--- a/crates/orbit-types/src/policy/mod.rs
+++ b/crates/orbit-types/src/policy/mod.rs
@@ -1,11 +1,13 @@
 //! Domain contracts for this Orbit types module.
 
 mod error;
+mod fs_rules;
 mod glob;
 mod policy_decision;
 mod policy_def;
 mod role;
 pub use error::PolicyError;
+pub use fs_rules::CompiledFsRules;
 
 pub use glob::{compile_glob_regex, join_normal_components, match_glob, normalize_glob_path};
 pub use policy_decision::PolicyDecision;

--- a/crates/orbit-types/src/policy/policy_def.rs
+++ b/crates/orbit-types/src/policy/policy_def.rs
@@ -5,13 +5,12 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::policy::PolicyError;
-use crate::policy::glob::{compile_glob_regex, match_glob, normalize_glob_path};
+use crate::policy::fs_rules::CompiledFsRules;
+use crate::policy::glob::compile_glob_regex;
 use crate::resource::validate_resource_name;
 
 pub const DEFAULT_POLICY_NAME: &str = "default";
 pub const UNRESTRICTED_FS_PROFILE: &str = "unrestricted";
-const NO_MATCHING_RULE: &str = "<no matching rule>";
-const EMPTY_RULESET: &str = "[]";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -49,6 +48,21 @@ pub struct ResolvedFsProfile {
     pub name: String,
     pub read: Vec<String>,
     pub modify: Vec<String>,
+}
+
+impl ResolvedFsProfile {
+    /// Compile this profile's rules for `operation` so a caller can decide
+    /// many paths against one rule set.
+    pub fn compile(&self, operation: FsOperation) -> Result<CompiledFsRules, PolicyError> {
+        let rules = match operation {
+            FsOperation::Read => &self.read,
+            FsOperation::Modify => &self.modify,
+        };
+        CompiledFsRules::compile(
+            rules,
+            &format!("fsProfile `{}` {}", self.name, operation.as_str()),
+        )
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -220,46 +234,7 @@ impl PolicyDef {
         path: &str,
     ) -> Result<FsCheckResult, PolicyError> {
         let profile = self.effective_profile(profile_name)?;
-        let normalized_path = normalize_glob_path(path)?;
-        let rules = match operation {
-            FsOperation::Read => &profile.read,
-            FsOperation::Modify => &profile.modify,
-        };
-
-        if rules.is_empty() {
-            return Ok(FsCheckResult {
-                allowed: false,
-                matched_rule: EMPTY_RULESET.to_string(),
-            });
-        }
-
-        let mut saw_positive_rule = false;
-        let mut decision = None;
-        for rule in rules {
-            let (negated, pattern) = split_rule(rule);
-            if !negated {
-                saw_positive_rule = true;
-            }
-            if match_glob(pattern, &normalized_path)? {
-                decision = Some(FsCheckResult {
-                    allowed: !negated,
-                    matched_rule: if negated {
-                        pattern.to_string()
-                    } else {
-                        rule.clone()
-                    },
-                });
-            }
-        }
-
-        Ok(decision.unwrap_or_else(|| FsCheckResult {
-            allowed: false,
-            matched_rule: if saw_positive_rule {
-                NO_MATCHING_RULE.to_string()
-            } else {
-                EMPTY_RULESET.to_string()
-            },
-        }))
+        profile.compile(operation)?.evaluate(path)
     }
 }
 

--- a/crates/orbit-types/src/policy/tests/fs_rules.rs
+++ b/crates/orbit-types/src/policy/tests/fs_rules.rs
@@ -1,0 +1,110 @@
+//! Precedence and reporting for the shared filesystem rule evaluator.
+
+use crate::policy::{CompiledFsRules, FsOperation, ResolvedFsProfile};
+
+fn rules(rules: &[&str]) -> CompiledFsRules {
+    CompiledFsRules::compile(
+        &rules.iter().map(ToString::to_string).collect::<Vec<_>>(),
+        "test",
+    )
+    .expect("compile rules")
+}
+
+#[test]
+fn a_later_exclusion_overrides_an_earlier_grant() {
+    let compiled = rules(&["**", "!**/.env"]);
+
+    assert!(compiled.allows("src/main.rs").expect("allow source"));
+    assert!(!compiled.allows("src/.env").expect("deny env"));
+}
+
+#[test]
+fn the_reported_rule_names_the_pattern_that_settled_the_path() {
+    let compiled = rules(&["**", "!**/.env"]);
+
+    assert_eq!(
+        compiled
+            .evaluate("src/.env")
+            .expect("evaluate")
+            .matched_rule,
+        "**/.env"
+    );
+    assert_eq!(
+        compiled
+            .evaluate("src/main.rs")
+            .expect("evaluate")
+            .matched_rule,
+        "**"
+    );
+}
+
+#[test]
+fn an_unmatched_path_is_denied_and_distinguished_from_an_empty_rule_set() {
+    let with_grants = rules(&["docs/**"]);
+    let only_exclusions = rules(&["!**/.env"]);
+    let empty = rules(&[]);
+
+    assert_eq!(
+        with_grants
+            .evaluate("src/main.rs")
+            .expect("evaluate")
+            .matched_rule,
+        "<no matching rule>"
+    );
+    assert_eq!(
+        only_exclusions
+            .evaluate("src/main.rs")
+            .expect("evaluate")
+            .matched_rule,
+        "[]"
+    );
+    assert_eq!(
+        empty
+            .evaluate("src/main.rs")
+            .expect("evaluate")
+            .matched_rule,
+        "[]"
+    );
+}
+
+#[test]
+fn a_rule_set_without_a_grant_cannot_allow_anything() {
+    assert!(rules(&[]).grants_nothing());
+    assert!(rules(&["!**/.env"]).grants_nothing());
+    assert!(!rules(&["**", "!**/.env"]).grants_nothing());
+}
+
+#[test]
+fn exclusions_are_reported_so_a_caller_can_skip_a_hole_punching_walk() {
+    assert!(rules(&["**", "!**/.env"]).has_exclusion());
+    assert!(!rules(&["**"]).has_exclusion());
+}
+
+#[test]
+fn both_spellings_of_a_workspace_relative_path_decide_the_same() {
+    let compiled = rules(&["**", "!**/.env"]);
+
+    assert_eq!(
+        compiled.allows("./src/.env").expect("dot slash"),
+        compiled.allows("src/.env").expect("bare"),
+    );
+    assert!(compiled.allows(".").expect("workspace root"));
+}
+
+#[test]
+fn a_resolved_profile_compiles_the_rule_set_for_the_requested_operation() {
+    let profile = ResolvedFsProfile {
+        name: "docs_writer".to_string(),
+        read: vec!["**".to_string()],
+        modify: vec!["docs/**".to_string()],
+    };
+
+    let read = profile.compile(FsOperation::Read).expect("compile read");
+    let modify = profile
+        .compile(FsOperation::Modify)
+        .expect("compile modify");
+
+    assert!(read.allows("src/main.rs").expect("read source"));
+    assert!(!modify.allows("src/main.rs").expect("modify source"));
+    assert!(modify.allows("docs/guide.md").expect("modify docs"));
+}

--- a/crates/orbit-types/src/policy/tests/mod.rs
+++ b/crates/orbit-types/src/policy/tests/mod.rs
@@ -1,1 +1,2 @@
+mod fs_rules;
 mod glob;

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -123,11 +123,33 @@ Legacy pipeline contexts are different. `crates/orbit-core/src/runtime/tool_exec
 - `EnvironmentMode::Inherit` or `ClearAndSet(Vec<(String, String)>)`; debug output redacts sensitive env values.
 - `StdinMode::Inherit` / `Null` / `Bytes(Vec<u8>)`.
 - `Sandbox::validate(req) -> Result<()>`; the default `NoSandbox` always returns `Ok`.
+- `Sandbox::spawn(req) -> Result<Child>`; the default creates an unconfined child. A strategy that confines the process overrides this seam.
 - `run_process(req, sandbox) -> ExecutionResult`.
 
-`run_process` calls `sandbox.validate`, then `process::spawn`, then `supervision::wait_with_optional_timeout`. Spawn applies the requested environment, pipes stdout/stderr, and on Unix calls `command.process_group(0)` so cleanup can kill orphan subprocesses.
+`run_process` calls `sandbox.validate`, then `sandbox.spawn`, then `supervision::wait_with_optional_timeout`. Spawn applies the requested environment, pipes stdout/stderr, and on Unix calls `command.process_group(0)` so cleanup can kill orphan subprocesses.
 
-Activity-scoped `proc.spawn` supplies a request-time `Sandbox` validator at this seam. The runtime passes the child environment already resolved from `[execution.env]`, the owning `fsProfile`, workspace root, and program allowlist into `ToolContext`; CLI-backed agents receive the same values in their trusted `ORBIT_*` envelope for nested `orbit tool run` calls. Missing activity policy data fails closed. The validator resolves existing path arguments symlink-safely and rejects reads denied by the profile before creating the process. [ORB-11031]
+Activity-scoped `proc.spawn` supplies `ActivityFsSandbox` at this seam. The runtime passes the child environment already resolved from `[execution.env]`, the owning `fsProfile`, workspace root, and program allowlist into `ToolContext`; CLI-backed agents receive the same values in their trusted `ORBIT_*` envelope for nested `orbit tool run` calls. Missing activity policy data fails closed. `validate` resolves existing path arguments symlink-safely and rejects reads denied by the profile before creating the process, and `spawn` confines the child itself. [ORB-11031]
+
+### 7.3 Linux Landlock read boundary for activity-scoped `proc.spawn`
+
+Argv inspection cannot be the read boundary: `bash`, `sh`, `python3`, and `git` are all on shipped activity allowlists, and every one interprets text handed to it on the command line. `git -c alias.x='!cat <path>' x` reaches any same-user file without a single path-shaped argument. `crates/orbit-exec/src/linux_landlock/` therefore compiles the resolved profile into a Landlock ruleset and applies it in the child between `fork` and `exec`, so the child and every descendant inherit it. The request-time argument check remains as an early, explainable deny; it is no longer the boundary. [ORB-11514]
+
+The ruleset handles `EXECUTE | READ_FILE | READ_DIR | REFER`. Writes stay with the Bubblewrap mount namespace in §7.1 — one write answer, in one place. `REFER` governs moving a file between directories, and Landlock refuses a move that would give a file *more* access at its destination; without handling it, a child could relocate a denied file into a fully readable sibling directory and read it there.
+
+Grants come from three places:
+
+- **Workspace.** The resolved `read` rules are compiled once (`CompiledFsRules`, §3) and the tree is walked once. A directory holding a denied path is granted list-only and its allowed children are granted individually, so the denied path keeps no readable ancestor.
+- **Host runtime, resolver, and trust.** A fixed table: system binaries and libraries, the loader and its cache, the character devices a process opens on startup, the world-readable resolver files (`/etc/hosts`, `/etc/nsswitch.conf`, `/etc/resolv.conf`, `/etc/passwd`, …), and the CA stores. `/etc` is never granted as a directory, and neither is `/proc` — a tree-wide `/proc` grant would expose any same-user process's `environ`, including the launching Orbit process's credentials.
+- **Tool state.** The directories on the child's own `PATH`, plus one directory per tool named by an environment variable the operator admitted into the child environment (`CARGO_HOME`, `RUSTUP_HOME`, `GH_CONFIG_DIR`, `TMPDIR`, `ORBIT_ROOT`, …) or by that tool's documented default under `$HOME`. `$HOME` itself is refused, as is any variable naming an ancestor of it, and publish tokens such as `$CARGO_HOME/credentials.toml` are carved back out.
+
+Availability is fail-closed. `REFER` arrived in Landlock ABI 2, so a kernel below that — or any non-Linux host — makes activity-scoped `proc.spawn` return a capability error naming the requirement. There is no unconfined fallback.
+
+**Known limits, all covered by tests.** Landlock rules bind to the inodes that exist when the ruleset is compiled:
+
+- A denied file present at spawn stays unreadable for the child's whole life, including after the child renames it within its directory, and it cannot be moved into a readable directory.
+- A file matching a deny rule that is *created* later under an already-granted directory is readable by that child. That discloses nothing the child could not already obtain — either the child wrote those bytes, or it copied them from somewhere the ruleset already allowed. A concurrent third party writing a new secret into the workspace during the child's lifetime is the residual race; `denyRead` is also enforced at request time for that reason.
+- Bytes already read into the child's memory cannot be withdrawn by any later filesystem rule; the boundary governs acquisition, not recall.
+- SSH-authenticated `git` does not work through a scoped spawn, because `~/.ssh` is not granted (use HTTPS or `gh`). A toolchain whose runtime files live outside the `bin` directory on `PATH` — an `nvm`-style install — needs its tree named by the tool's own environment variable.
 
 `ExecutionResult { success, stdout, stderr, exit_code, duration_ms, output }` is defined in `orbit-common`. Captured bytes use `String::from_utf8_lossy`, so non-UTF-8 output becomes replacement characters instead of failing the call.
 
@@ -350,6 +372,17 @@ Risk-weighted regression tests sit beside the implementations they guard
   modify checks ([T20260509-27]). The same surface proves host modify
   exceptions intersect profile authority, workspace exceptions cannot exceed
   the host surface, and later workspace denies still win ([ORB-10560]).
+- `crates/orbit-exec/src/linux_landlock/tests/` and
+  `crates/orbit-exec/tests/linux_landlock.rs` — grant compilation decides the
+  workspace and host tables without applying a ruleset, while the integration
+  suite applies the real ruleset to real children: a host sentinel and a
+  `denyRead` match are withheld from a `git` shell alias, a denied file survives
+  neither an in-place rename nor a move into a readable directory, a generated
+  file stays readable, another process's `environ` is not, declared tool state
+  is readable while its publish token is not, and `git` / `rg` / `cargo` /
+  `make` / `gh` still run. `crates/orbit-tools/tests/proc_spawn_lockdown.rs`
+  reproduces the same alias bypass through the tool itself and pins the
+  request-time `/etc` denial ([ORB-11514]).
 - `crates/orbit-exec/src/macos_sandbox/compile.rs#tests` and
   `crates/orbit-exec/src/macos_sandbox/tests/provider_dirs.rs` — trusted wrapper
   resolution ignores `PATH`, including a macOS runtime test that places a fake
@@ -394,13 +427,14 @@ asserts 100 collision-free dense IDs per artifact kind ([ORB-10596]).
 5. **macOS provenance syscall allowances are private.** `vnguard` and `Sandbox`/67 mirror current Codex startup needs and may require review after OS changes.
 6. **Legacy contexts can leave `fs_profile = None`.** Non-activity callers retain that compatibility shape. Activity-scoped `proc.spawn` rejects a missing profile, and CLI-backed activities export `ORBIT_ACTIVITY_FS_PROFILE` so nested tool calls reconstruct the owning profile.
 7. **No in-process `fs.*` enforcement remains.** A revived harness would need to rebuild the retired helper (or move enforcement below the tool layer) rather than rely on leftover builtins.
-8. **Generic exec path admission is request-time.** Activity-scoped `proc.spawn` validates existing path arguments against the owning activity's resolved `fsProfile` before launch, while CLI-agent OS wrappers remain the kernel-level boundary. The program allowlist is mandatory rather than opt-in: asset load rejects an activity whose `tools` cover `proc.spawn` while `proc_allowed_programs` is absent, and the v2 activity tool context always marks `proc.spawn` activity-scoped, so a missing list denies every program instead of degrading to allow-all ([ORB-10959], [ORB-11031]).
+8. **Generic exec path admission has two layers.** Activity-scoped `proc.spawn` validates existing path arguments against the owning activity's resolved `fsProfile` before launch, and on Linux confines the child itself with Landlock (§7.3); CLI-agent OS wrappers remain the kernel-level boundary for `backend: cli` agents. The program allowlist is mandatory rather than opt-in: asset load rejects an activity whose `tools` cover `proc.spawn` while `proc_allowed_programs` is absent, and the v2 activity tool context always marks `proc.spawn` activity-scoped, so a missing list denies every program instead of degrading to allow-all ([ORB-10959], [ORB-11031]).
 9. **Symlink semantics are implicit.** `workspace_relative_path` follows symlinks and rejects out-of-workspace targets, but no spec states that invariant.
 10. **Glob syntax is narrow.** Character classes, brace expansion, and POSIX bracket expressions are unsupported.
 11. **Policy result shapes are parallel.** `PolicyDecision` and `FsPolicyEvaluation` have no bridge for future non-fs evaluators.
 12. **Empty rule sets are safe but opaque.** A profile with only deny rules reports `matched_rule = "[]"`, not the matching deny rule.
 13. **Signal handling is process-global.** SIGINT/SIGTERM dispositions are shared across concurrent waits (refcounted install, lock-free pgid fan-out). A waiter that cannot claim a pgid slot still terminates from the generation counter within one poll interval.
-14. **Workspace canonicalization errors collapse to denial.** A missing workspace root can surface as `PolicyDenied("path is outside workspace")` rather than a clearer root-missing error.
+14. **`denyRead` binds to inodes that exist at spawn.** The Landlock carve-out in §7.3 cannot name a file that does not exist yet, so a deny-matching file created under an already-granted directory after the ruleset is compiled is readable by that child. Relocation and rename of an existing denied file are closed; concurrent third-party creation is not.
+15. **Workspace canonicalization errors collapse to denial.** A missing workspace root can surface as `PolicyDenied("path is outside workspace")` rather than a clearer root-missing error.
 
 ---
 


### PR DESCRIPTION
## Task

[ORB-11514](https://orbit-cli.com/tasks/ORB-11514) — [security-review] Enforce proc.spawn filesystem policy against indirect child access

### Description

## Revised production repair mandate
Repair the activity-scoped proc.spawn indirect-read bypass: request-time argv path guessing allows an admitted executable (for example a git !alias) to execute a shell and read forbidden host/workspace files. Original sentinel evidence, candidate 2c40c4309f7b7f6f84bd28c9c39c592b18163a7c and failed Landlock create/rename probes remain in this task's history and artifacts.

A broader live process/filesystem enforcement implementation through existing policy and spawn owners is explicitly in scope. The previous instruction to stop merely because mount/Landlock composition cannot express dynamic names is superseded. Use ORB-11546's measured mechanism work rather than repeating its investigation; implement the production integration after that prerequisite. Do not apply the unsafe candidate as a complete fix.

Preserve the full required behavior: indirect outside-workspace reads and dynamic denyRead names/aliases are denied before forbidden bytes reach children/output, newly generated allowed files remain usable, and legitimate git/rg/cargo/make/gh runtime needs use explicit narrow grants. Reuse the canonical policy evaluator and separate runtime/config/resolver access from arbitrary host data and unrelated provider credentials. Define descriptor/mmap/rename behavior explicitly and test it; do not silently narrow confidentiality to existing-at-spawn paths or disable needed tools. Unsupported scoped enforcement must return an explicit capability error, never fall back unconfined.

Extend the minimum existing policy/grant and process-tree enforcement seams needed for the selected mechanism. Refresh selectors before modifying additional existing targets. Preserve useful candidate performance work without duplicating the evaluator. Add real scoped-spawn regression coverage, fixture runtime/credential positives and negative sentinels, plus bounded setup measurements. Missing live host capability does not prevent writing the implementation and runnable integration tests; it does prevent claiming final enforcement validation. Escalate the exact executable host prerequisite after completing unaffected work.

ORB-11546 owns mechanism evidence; this task owns production integration. Original failure summaries remain historical evidence and are not an instruction to repeat the same failed approach. Daniel authorized this revised scope and resumption. No releases.

### Acceptance Criteria

- Activity-scoped proc.spawn cannot read a path outside the workspace or matching denyRead through a git shell alias or another code-interpreting mode of an allowed executable.
- A deterministic regression reproduces the reviewed git -c alias command against a sentinel file and proves the sentinel is not returned, while the direct /etc path control remains denied.
- Legitimate allowlisted git and rg invocations inside the workspace continue to work, and the program allowlist plus cleared child environment remain fail-closed.
- The resolved filesystem profile is enforced at an authoritative process boundary, with focused orbit-tools/orbit-exec tests plus make ci-fast and make ci-lint passing.
- Allowed tool runtime/config/resolver needs are exercised through the actual scoped spawn boundary using explicit narrow grants; arbitrary sensitive host reads remain denied.
- Dynamic creation cannot bypass denyRead, unsupported-platform behavior is explicit and fail-closed, and the repaired grant-compilation performance remains bounded.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success — the indirect-read bypass is closed at the process boundary on Linux, with the residual limit stated and tested rather than hidden.

## What changed

**Enforcement moved to the child.** `Sandbox` gains a `spawn` seam (`crates/orbit-exec/src/sandbox.rs`); `run_process` and `run_process_streaming_stdout` create the child through it instead of calling `process::spawn` directly. `crates/orbit-exec/src/linux_landlock/` compiles the activity's resolved `fsProfile` into a Landlock ruleset and applies it in `pre_exec` between fork and exec, so the child and every descendant inherit it. `ActivityFsSandbox` (orbit-tools) resolves its policy once at construction and fails closed when it is missing; the argv check remains only as an early, explainable deny for `git -C /etc`.

**Handled access is `EXECUTE | READ_FILE | READ_DIR | REFER`.** Writes stay with linux-bwrap. `REFER` is handled deliberately: Landlock refuses a rename or link that would give a file *more* access at its destination, which is what stops a child from relocating a denied file into a readable sibling directory. That also sets the ABI floor at 2.

**Host grants (reviewer F1).** Three enumerated groups in `linux_landlock/host.rs`: runtime (loader, `/usr`, `/bin`, `/lib*`, startup character devices), resolver and trust (individual `/etc` files plus the CA stores — never `/etc` itself), and tool state (the child's own `PATH` directories plus a table of per-tool directories named by an environment variable or that tool's documented `$HOME` default). `$HOME` and any variable naming an ancestor of it are refused; `~/.ssh`, `~/.aws`, and unlisted provider state are never granted; publish tokens such as `$CARGO_HOME/credentials.toml` are carved back out. `/proc` is **not** granted as a tree — a tree grant would expose any same-user process's `environ`, including the launching Orbit process's credentials, which the previous candidate did.

**Single evaluator (reviewer F5).** `CompiledFsRules` in `crates/orbit-types/src/policy/fs_rules.rs` owns last-match-wins precedence and `matched_rule` reporting. `PolicyDef::check_path` now routes through it, so the request-time deny and the kernel-level grant cannot desynchronise. No new crate dependency: the sandbox needs no `regex` of its own, which also removes the reviewer's out-of-scope `orbit-exec/Cargo.toml` change.

**Grant-compilation cost (reviewer F2).** Rules compile once; the walk skips entirely for a profile that grants nothing and skips hole-punching when the profile has no exclusion; directory entries avoid a per-entry `canonicalize` by using the entry kind from `read_dir` (only symlinks pay for resolution). Measured on this worktree (10,930 entries, 56 grants): **1.29 s → 87 ms** release. A sibling test pins a budget.

Also fixed: `crates/orbit-core/src/bootstrap/global_defaults.rs` imported `DEFAULT_ACTIVITY_FILES` through a private `use` in `bootstrap::activity`, so **orbit-core did not compile at HEAD `b8ada6e83`** (introduced by `724cadc07`/ORB-11631). One-line import fix; without it `make ci-lint` is unrunnable for any task. Filed as F2026-09-079, selector added to this task.

## Acceptance criteria

1. **Indirect reads denied — MET.** `git -c alias.probe='!cat <path>' probe` returns neither a host sentinel nor a `denyRead` match, through both `orbit-exec` directly and the `proc.spawn` tool. `sh -c` scripts, which the same allowlists permit, are equally confined.
2. **Deterministic alias regression + `/etc` control — MET.** `a_git_shell_alias_cannot_read_a_host_sentinel` and `a_git_shell_alias_cannot_read_a_deny_read_file` in `proc_spawn_lockdown.rs`; the second first proves the alias trampoline still reaches an *allowed* file, so the denial is the boundary and not a broken fixture. `an_explicit_path_outside_the_workspace_is_still_refused_before_spawn` pins `git -C /etc` as `PolicyDenied` with `<outside workspace>`.
3. **Allowlisted tools still work; allowlist and env stay fail-closed — MET.** `allowlisted_git_and_rg_still_work_inside_the_workspace` (tool level) and `allowlisted_programs_still_run_through_the_boundary` (kernel level, covering git, rg, cargo, make, gh, getent). The four pre-existing allowlist/environment lockdown tests are unchanged and pass.
4. **Authoritative boundary + focused tests + both gates — MET.** Enforcement is `landlock_restrict_self` in the child's `pre_exec`. 16 sibling unit tests, 9 kernel-level integration tests, 13 tool-level tests. `make ci-fast` and `make ci-lint` both exit 0.
5. **Narrow declared runtime/config/resolver grants — MET.** `declared_tool_state_is_readable_but_its_credentials_and_neighbours_are_not` runs a real child with a fixture `CARGO_HOME`: `config.toml` is returned, `credentials.toml` is not, and an unrelated sibling directory is not. Unit tests pin that no documented variable can widen the grant to `$HOME`, that `~/.ssh` / `~/.aws` / `~/.netrc` are never granted, that `/etc/hosts` is readable while `/etc/shadow` is not, and that another process's `environ` is not.
6. **Dynamic creation, platform, performance — MET with one stated limit.** Non-Linux and sub-ABI-2 hosts return a capability error naming the requirement; there is no unconfined fallback (`platform.rs`). Performance as measured above. On dynamic creation, what is closed: a denied file present at spawn stays unreadable for the child's whole life, survives an in-place rename (`a_deny_read_file_is_withheld_and_stays_withheld_after_a_rename`), and cannot be moved into a readable directory (`a_denied_file_cannot_be_moved_into_a_readable_directory`) — both of which the prior candidate leaked. **What remains open:** Landlock binds rules to inodes that exist at compile time, so a file matching a deny rule *created* under an already-granted directory after spawn is readable by that child. No configuration of Landlock closes this while keeping newly generated allowed files usable — per-file grants deny generated files, and there is no name-based deny primitive in any ABI. It is not a disclosure of bytes the child could not already obtain (the child either wrote them or copied them from somewhere already granted); the genuine residual is a concurrent third party writing a new secret into the workspace during the child's lifetime, which is why `denyRead` is also enforced at request time. Stated in `SECURITY.md`, in §7.3 and limitation 14 of the design doc, and in the module docs next to the code.

## Validation

Passed: `make ci-fast`; `make ci-lint` (workspace clippy, `-D warnings`); `cargo fmt --all --check`; `cargo test -p orbit-types -p orbit-policy -p orbit-exec -p orbit-tools --offline` (19 result lines, 0 failures — includes 9 kernel-level Landlock tests, 16 sibling unit tests, 13 `proc_spawn_lockdown` tests, 29 orbit-policy tests, and the policy matrix); `cargo test -p orbit-cli --test proc_spawn_managed`; `git diff --check`.

Environment: Linux 6.8.0-139-generic, Landlock ABI 4, so every kernel-level test really applied a ruleset rather than skipping. The suites do skip gracefully on a host without Landlock and on a host missing a probed program.

Pre-existing failures, **not** caused by this change — proved by running each against a pristine `git archive HEAD` tree (only the one-line import fix applied so it compiles), where all three fail identically: `orbit-core` `dogfood_task_pilot_routine_matches_the_rendered_default_template` (host routine cron `*/40` vs seeded template `*/15` — environment drift), `concurrent_explicit_edit_preserves_the_newer_status`, `gate_pipeline_releases_reservation_before_child_success_guard`. A fourth, `claimed_sleeping_worker_does_not_keep_polling_the_run_store`, failed under parallel load and passed serially. Not run: macOS/Windows behaviour (no such host available — the fail-closed path there is covered by a `cfg(not(target_os = "linux"))` test that cannot execute here), and the full `make ci` (per-task policy).

## Risks and deviations

- **Compatibility consequences of the host table, all documented:** SSH-authenticated `git` does not work through a scoped spawn (`~/.ssh` is not granted — use HTTPS or `gh`). `TMPDIR` has no `/tmp` default, so an activity that links or compiles through `proc.spawn` needs `TMPDIR` in its child environment; a `/tmp` default was implemented, measured, and removed because granting a shared temporary directory undoes the outside-workspace boundary for everything staged there. A toolchain whose runtime files live outside the `bin` directory on `PATH` (an `nvm`-style install) needs its tree named by that tool's own variable — `NVM_DIR`, `NPM_CONFIG_PREFIX`, `NODE_PATH`, and `VIRTUAL_ENV` are in the table for exactly that. Directly spawning such a program works; reaching it through `sh -c` does not.
- `gh`'s `hosts.yml` is granted rather than carved out. An activity that allowlists `gh` has already granted the agent that GitHub identity, so withholding the token file removes the tool without removing the capability. That reasoning is recorded next to the carve-out list; it is the one place where a credential file is deliberately readable, and it is scoped to the tool's own state directory.
- The reviewed candidate `2c40c4309f7b7f6f84bd28c9c39c592b18163a7c` was read for its structure and its F2 repair intent, then reimplemented rather than applied: it granted `/proc` and `/dev` as trees (parent-credential exposure), left `REFER` unhandled (relocation leak), duplicated the policy evaluator, and had no host grants at all.
- Left uncommitted for the pipeline. No commit, push, PR, status transition, or agent dispatch. Starting and final HEAD both `b8ada6e836e0cefcd69008954faa72725ee11e82`; `pwd -P`, `git rev-parse --show-toplevel`, and both supplied roots matched. Temporary probe files and the baseline tree under `/tmp` were removed; `git status --short` contains exactly the intended changes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11514-6a9f84aa`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra