### PR TITLE
[BLOCKED] [code-review] Escaped-pipe fallback drops all CLI subprocess output when `UnixStream::pair()` fails

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -459,6 +459,8 @@ pub fn run_cli_backend(
         on_spawn: Some(&on_spawn),
         wait: None,
         live_readers: None,
+        #[cfg(unix)]
+        cancel_pair: None,
     });
 
     let (stdout, stderr, exit_code, duration, timed_out) = match spawn_result {

--- a/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
@@ -64,6 +64,8 @@ const OUTPUT_LINE_EVENT_LIMIT_BYTES: usize = 64 * 1024;
 
 type SharedOutputCapture = Arc<Mutex<RollingOutputCapture>>;
 type WaitHook<'a> = &'a dyn Fn(&mut Child) -> std::io::Result<Option<ExitStatus>>;
+#[cfg(unix)]
+type CancelPairHook<'a> = &'a dyn Fn() -> io::Result<(UnixStream, UnixStream)>;
 
 #[derive(Debug)]
 pub(super) struct CapturedOutput {
@@ -204,6 +206,10 @@ pub(super) struct SpawnWithTimeoutRequest<'a> {
     /// lifetime of its thread so tests can observe finalization without
     /// sampling process-wide thread counts.
     pub(super) live_readers: Option<Arc<AtomicUsize>>,
+    /// Test seam for exercising output capture when the pollable cancellation
+    /// channel cannot be constructed.
+    #[cfg(unix)]
+    pub(super) cancel_pair: Option<CancelPairHook<'a>>,
 }
 
 struct OutputReaderContext {
@@ -259,6 +265,8 @@ pub(super) fn spawn_with_timeout(
         on_spawn,
         wait,
         live_readers,
+        #[cfg(unix)]
+        cancel_pair,
     } = request;
 
     let started = Instant::now();
@@ -303,6 +311,8 @@ pub(super) fn spawn_with_timeout(
                 dispatch: dispatch.clone(),
             },
             live_readers.clone(),
+            #[cfg(unix)]
+            cancel_pair,
         )
     });
     let stderr_reader = child.stderr.take().map(|handle| {
@@ -318,6 +328,8 @@ pub(super) fn spawn_with_timeout(
                 dispatch,
             },
             live_readers,
+            #[cfg(unix)]
+            cancel_pair,
         )
     });
 
@@ -406,6 +418,7 @@ fn spawn_output_reader<R>(
     buf: SharedOutputCapture,
     context: OutputReaderContext,
     live_readers: Option<Arc<AtomicUsize>>,
+    cancel_pair: Option<CancelPairHook<'_>>,
 ) -> OutputReaderHandle
 where
     R: Read + IntoRawFd + Send + 'static,
@@ -413,9 +426,12 @@ where
     let fd = handle.into_raw_fd();
     // SAFETY: `into_raw_fd` transferred ownership of a valid pipe descriptor.
     let mut reader = unsafe { File::from_raw_fd(fd) };
-    let _ = set_nonblocking(reader.as_raw_fd());
-    let (wakeup, cancel) = match UnixStream::pair() {
+    let pair_result = cancel_pair.map_or_else(UnixStream::pair, |make_pair| make_pair());
+    let (wakeup, cancel) = match pair_result {
         Ok((wakeup, cancel)) => {
+            // The fallback below uses a blocking read loop, so only make the
+            // pipe nonblocking when its pollable cancel channel exists.
+            let _ = set_nonblocking(reader.as_raw_fd());
             let _ = wakeup.set_nonblocking(true);
             let _ = cancel.set_nonblocking(true);
             (Some(wakeup), Some(cancel))

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/supervisor.rs
@@ -35,6 +35,8 @@ fn spawn_test_request<'a>(
         on_spawn: None,
         wait: None,
         live_readers: None,
+        #[cfg(unix)]
+        cancel_pair: None,
     }
 }
 
@@ -227,6 +229,36 @@ fn spawn_with_timeout_redacts_tracing_line_without_redacting_raw_stdout() {
         !formatted_output.contains("abc123"),
         "formatted tracing output leaked secret: {formatted_output}"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn spawn_with_timeout_captures_delayed_stdout_when_cancel_pair_creation_fails() {
+    use std::io;
+
+    let args = sh_args("sleep 0.1; printf '%s\\n' delayed-output");
+    let cancel_pair = || Err(io::Error::other("injected cancel pair failure"));
+    let mut request = spawn_test_request(
+        "/bin/sh",
+        &args,
+        None,
+        Duration::from_secs(5),
+        SpawnTraceContext {
+            provider: "codex",
+            job_run_id: "job-cancel-pair-failure",
+            task_id: Some("TCANCELPAIR"),
+            cwd: None,
+        },
+    );
+    request.cancel_pair = Some(&cancel_pair);
+
+    let (stdout, stderr, exit_code, _duration, timed_out) =
+        spawn_with_timeout(request).expect("spawn succeeds without a cancel pair");
+
+    assert_eq!(stdout.bytes(), b"delayed-output\n");
+    assert!(stderr.bytes().is_empty());
+    assert_eq!(exit_code, Some(0));
+    assert!(!timed_out);
 }
 
 #[test]


### PR DESCRIPTION
## Delivery failure handoff

Orbit preserved and pushed this task's candidate after the shipment pipeline failed. This PR is intentionally blocked; inspect the recorded failure before retrying delivery.

- Task: `ORB-11801`
- Run: `jrun-20260908-0452-2`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `af3069bfcd1f3e1929e496f1ff196e0836bf5576`
- Target base: `bd145d3af2682ef1b4e2d997b45a77d3d11b5112`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess reported declared envelope status="failed" despite exit 0: error.code=validation_blocker; error.message=Required make ci-lint fails on a pre-existing orbit-store unresolved PENDING_WRITE_FILE_NAME re-export. The ta[REDACTED_API_KEY] changes pass ci-lint when that unrelated export defect is temporarily corrected; the temporary correction was restored and is not in the diff. Task state and execution_summary were persisted as blocked.
```