### PR TITLE
[code-review] Derive agent timeout classification from the supervisor verdict, not from stderr text

### DIFF
--- a/crates/orbit-agent/src/providers/antigravity/tests/antigravity_output.rs
+++ b/crates/orbit-agent/src/providers/antigravity/tests/antigravity_output.rs
@@ -14,6 +14,7 @@ const ORBIT_SUCCESS: &str =
 fn exec_result(stdout: &str, stderr: &str, exit_code: i32) -> ExecutionResult {
     ExecutionResult {
         success: exit_code == 0,
+        timed_out: false,
         stdout: String::from_utf8(
             normalize_cli_stdout("antigravity", stdout.as_bytes()).into_owned(),
         )

--- a/crates/orbit-agent/src/providers/copilot/tests/copilot_stream.rs
+++ b/crates/orbit-agent/src/providers/copilot/tests/copilot_stream.rs
@@ -47,6 +47,7 @@ fn projected(stdout: &str) -> String {
 fn exec_result(stdout: &str, stderr: &str, exit_code: i32) -> ExecutionResult {
     ExecutionResult {
         success: exit_code == 0,
+        timed_out: false,
         stdout: normalized(stdout),
         stderr: stderr.to_string(),
         exit_code: Some(exit_code),

--- a/crates/orbit-agent/src/providers/cursor/tests/cursor_output.rs
+++ b/crates/orbit-agent/src/providers/cursor/tests/cursor_output.rs
@@ -31,6 +31,7 @@ fn cursor_result(result: serde_json::Value) -> String {
 fn exec_result(stdout: &str, stderr: &str, exit_code: i32) -> ExecutionResult {
     ExecutionResult {
         success: exit_code == 0,
+        timed_out: false,
         stdout: String::from_utf8(normalize_cli_stdout("cursor", stdout.as_bytes()).into_owned())
             .expect("utf8 normalized stdout"),
         stderr: stderr.to_string(),

--- a/crates/orbit-agent/src/providers/grok/tests/grok_output.rs
+++ b/crates/orbit-agent/src/providers/grok/tests/grok_output.rs
@@ -18,6 +18,7 @@ fn projected(stdout: &str) -> String {
 fn exec_result(stdout: String, exit_code: i32) -> ExecutionResult {
     ExecutionResult {
         success: exit_code == 0,
+        timed_out: false,
         stdout,
         stderr: String::new(),
         exit_code: Some(exit_code),
@@ -77,7 +78,7 @@ fn grok_final_timeout_overrides_success_shaped_metadata() {
     })
     .to_string();
     let mut execution = exec_result(projected(&stdout), 1);
-    execution.stderr = "process timed out".to_string();
+    execution.timed_out = true;
 
     let (envelope, status, _) =
         parse_and_validate_response(&execution).expect("final timeout parses");

--- a/crates/orbit-agent/src/providers/opencode/tests/opencode_output.rs
+++ b/crates/orbit-agent/src/providers/opencode/tests/opencode_output.rs
@@ -99,6 +99,7 @@ fn opencode_stream(final_text: &str) -> String {
 fn exec_result(stdout: &str, stderr: &str, exit_code: i32) -> ExecutionResult {
     ExecutionResult {
         success: exit_code == 0,
+        timed_out: false,
         stdout: String::from_utf8(normalize_cli_stdout("opencode", stdout.as_bytes()).into_owned())
             .expect("utf8 normalized stdout"),
         stderr: stderr.to_string(),

--- a/crates/orbit-agent/src/providers/pi/tests/pi_output.rs
+++ b/crates/orbit-agent/src/providers/pi/tests/pi_output.rs
@@ -64,6 +64,7 @@ fn pi_stream(final_text: &str) -> String {
 fn exec_result(stdout: &str, stderr: &str, exit_code: i32) -> ExecutionResult {
     ExecutionResult {
         success: exit_code == 0,
+        timed_out: false,
         stdout: String::from_utf8(normalize_cli_stdout("pi", stdout.as_bytes()).into_owned())
             .expect("utf8 normalized stdout"),
         stderr: stderr.to_string(),

--- a/crates/orbit-agent/src/types/response/envelope.rs
+++ b/crates/orbit-agent/src/types/response/envelope.rs
@@ -23,7 +23,7 @@ pub fn parse_and_validate_response(exec_result: &ExecutionResult) -> ResponsePar
 }
 
 pub fn is_timeout(exec_result: &ExecutionResult) -> bool {
-    !exec_result.success && exec_result.stderr.contains("process timed out")
+    exec_result.timed_out
 }
 
 /// Best-effort lookup of an embedded Orbit response envelope's `status` field

--- a/crates/orbit-agent/src/types/tests/envelope.rs
+++ b/crates/orbit-agent/src/types/tests/envelope.rs
@@ -9,6 +9,7 @@ use super::super::response::envelope::*;
 fn exec(stdout: &str, exit_code: Option<i32>) -> ExecutionResult {
     ExecutionResult {
         success: exit_code == Some(0),
+        timed_out: false,
         stdout: stdout.to_string(),
         stderr: String::new(),
         exit_code,

--- a/crates/orbit-agent/src/types/tests/response.rs
+++ b/crates/orbit-agent/src/types/tests/response.rs
@@ -11,12 +11,26 @@ mod parse {
     fn exec(stdout: &str, stderr: &str, exit_code: Option<i32>, success: bool) -> ExecutionResult {
         ExecutionResult {
             success,
+            timed_out: false,
             stdout: stdout.to_string(),
             stderr: stderr.to_string(),
             exit_code,
             duration_ms: 1234,
             output: None,
         }
+    }
+
+    #[test]
+    fn stderr_timeout_phrase_without_supervisor_verdict_is_invocation_failure() {
+        let exec = exec("", "tool: process timed out", Some(1), false);
+
+        let (envelope, status, _) = synthesize_response(&exec).expect("failure is synthesized");
+
+        assert_eq!(status, AgentResponseStatus::Failed);
+        assert_eq!(
+            envelope.error.expect("failure error").code,
+            "AGENT_INVOCATION_FAILED"
+        );
     }
 
     #[test]
@@ -731,6 +745,7 @@ mod structured_output {
     fn exec(stdout: &str, stderr: &str, exit_code: Option<i32>, success: bool) -> ExecutionResult {
         ExecutionResult {
             success,
+            timed_out: false,
             stdout: stdout.to_string(),
             stderr: stderr.to_string(),
             exit_code,

--- a/crates/orbit-core/src/runtime/command_exec.rs
+++ b/crates/orbit-core/src/runtime/command_exec.rs
@@ -72,6 +72,7 @@ impl OrbitRuntime {
             .output()
             .map(|output| ExecutionResult {
                 success: output.status.success(),
+                timed_out: false,
                 stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
                 stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
                 exit_code: output.status.code(),

--- a/crates/orbit-engine/src/activity_job/cli_runner/envelope.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/envelope.rs
@@ -60,6 +60,7 @@ pub(super) fn parse_cli_invocation_trace(
 ) -> Option<InvocationTrace> {
     let exec_result = ExecutionResult {
         success,
+        timed_out: false,
         stdout: String::from_utf8_lossy(stdout).into_owned(),
         stderr: String::from_utf8_lossy(stderr).into_owned(),
         exit_code,
@@ -89,6 +90,7 @@ pub(super) fn parse_cli_response_result(
 ) -> Result<serde_json::Map<String, Value>, String> {
     let exec_result = ExecutionResult {
         success,
+        timed_out: false,
         stdout: String::from_utf8_lossy(stdout).into_owned(),
         stderr: String::from_utf8_lossy(stderr).into_owned(),
         exit_code,

--- a/crates/orbit-exec/src/runner.rs
+++ b/crates/orbit-exec/src/runner.rs
@@ -86,6 +86,7 @@ pub fn run_process(
 
     Ok(ExecutionResult {
         success: result.exit_success,
+        timed_out: result.timed_out,
         stdout: String::from_utf8_lossy(&result.stdout).to_string(),
         stderr: String::from_utf8_lossy(&result.stderr).to_string(),
         exit_code: result.exit_code,
@@ -96,9 +97,8 @@ pub fn run_process(
 
 /// Outcome of supervising a child Orbit did not spawn itself.
 ///
-/// [`ExecutionResult`] cannot say *why* a run produced no exit code, so the
-/// deadline verdict travels alongside it rather than being re-derived from
-/// stderr text.
+/// The deadline verdict is retained separately for callers that need it
+/// alongside the complete process result.
 #[derive(Debug, Clone)]
 pub struct SupervisedOutcome {
     pub result: ExecutionResult,
@@ -132,6 +132,7 @@ pub fn supervise_child(
     Ok(SupervisedOutcome {
         result: ExecutionResult {
             success: result.exit_success,
+            timed_out: result.timed_out,
             stdout: String::from_utf8_lossy(&result.stdout).to_string(),
             stderr: String::from_utf8_lossy(&result.stderr).to_string(),
             exit_code: result.exit_code,
@@ -185,6 +186,7 @@ where
     Ok((
         ExecutionResult {
             success: result.exit_success,
+            timed_out: result.timed_out,
             stdout: String::new(),
             stderr: String::from_utf8_lossy(&result.stderr).to_string(),
             exit_code: result.exit_code,

--- a/crates/orbit-types/src/tool/definition.rs
+++ b/crates/orbit-types/src/tool/definition.rs
@@ -398,6 +398,8 @@ pub struct StoredTool {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ExecutionResult {
     pub success: bool,
+    /// Whether the process supervisor terminated the child after its deadline.
+    pub timed_out: bool,
     pub stdout: String,
     pub stderr: String,
     pub exit_code: Option<i32>,


### PR DESCRIPTION
## Task

[ORB-11701](https://orbit-cli.com/tasks/ORB-11701) — [code-review] Derive agent timeout classification from the supervisor verdict, not from stderr text

### Description

## Problem
`is_timeout` returns true whenever the child exited non-zero and its stderr *contains* the substring `process timed out`. `orbit-exec` already reports the deadline verdict structurally (`SupervisedOutcome::timed_out`, `runner.rs:97-108`, whose doc comment says the verdict travels alongside the result "rather than being re-derived from stderr text"), yet `orbit-agent` re-derives it from prose. Scenario: a provider CLI exits 1 after an inner tool (`gh`, `npm`, a nested `orbit` call whose own `orbit-exec` supervisor appends exactly that string) printed "process timed out" on stderr; `parse_json_envelope` then fails `validate_exit_alignment` ("timeout process must report status=timeout") and `synthesize_response` fabricates an `AGENT_TIMEOUT` envelope, so a plain failure is recorded and retried as a timeout. Conversely nothing stops a real timeout from being classified from text if the stderr capture was truncated before the marker.

## Why It Matters
Timeout vs failure drives retry policy and operator diagnostics; a substring match on an agent-controlled stream is neither reliable nor tamper-resistant.

## Proposed Fix
Add a `timed_out: bool` to `ExecutionResult` (populated by `wait_with_optional_timeout`) or make `parse_and_validate_response`/`synthesize_response` take the supervisor's `timed_out` explicitly, and delete the stderr substring check.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-agent/src/types/response/envelope.rs:25-27`, `crates/orbit-agent/src/types/response/envelope.rs:152-166`, `crates/orbit-agent/src/types/response/envelope.rs:230-249`, `crates/orbit-exec/src/runner.rs:97-108`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (bug). Review area: mcp-tools.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test: an `ExecutionResult` with `exit_code: Some(1)`, stderr `"tool: process timed out"`, `timed_out: false` classifies as `AGENT_INVOCATION_FAILED`, not `AGENT_TIMEOUT`.
- `rg '"process timed out"' crates/orbit-agent` finds no classification use.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `ExecutionResult.timed_out`, populated directly from `wait_with_optional_timeout` in every orbit-exec result path; direct, unsupervised command construction explicitly sets it false.
- Made agent timeout classification depend exclusively on that supervisor verdict; removed stderr-text classification.
- Added the required regression: a non-zero result with stderr `tool: process timed out` and `timed_out: false` synthesizes `AGENT_INVOCATION_FAILED`; updated the real-timeout test to set the structured verdict.

Criteria evidence:
1. Passed `cargo test -p orbit-agent stderr_timeout_phrase_without_supervisor_verdict_is_invocation_failure`; it asserts `AgentResponseStatus::Failed` and error code `AGENT_INVOCATION_FAILED` for the specified result.
2. Passed `rg '"process timed out"' crates/orbit-agent` (no matches), confirming no exact marker remains in agent classification code.

Validation:
- Passed: `cargo fmt --check` after formatting.
- Passed: `cargo test -p orbit-agent timeout --lib` (8 tests, including the new regression and structured Grok timeout case).
- Passed: `cargo test -p orbit-exec` (74 unit, 9 Landlock, 20 Linux sandbox, and 3 signal-fanout tests; one existing platform-dependent test ignored).
- Passed: `make ci-fast`.
- Passed: `make ci-lint`.
- Passed: `git diff --check`.

Assessment: Small, canonical data-flow correction with all direct `ExecutionResult` constructors made explicit. No remaining task-specific risks; changes intentionally remain uncommitted for the pipeline.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11701-6a9f96cf`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*

Orchestrated-By: astra