### PR TITLE
[code-review] Align `proc.spawn` stdin and timeout handling with the engine's shell step

### DIFF
--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -1469,7 +1469,7 @@
         "required": false
       },
       {
-        "description": "Execution timeout in milliseconds",
+        "description": "Execution timeout in milliseconds (default 15000; larger values are clamped to 60000)",
         "name": "timeout_ms",
         "param_type": "u64",
         "required": false

--- a/crates/orbit-tools/src/builtin/proc/spawn.rs
+++ b/crates/orbit-tools/src/builtin/proc/spawn.rs
@@ -13,7 +13,7 @@ use orbit_types::policy::{FsOperation, ResolvedFsProfile};
 use orbit_types::tool::{ToolParam, ToolSchema};
 use serde_json::Value;
 
-use crate::{TIMEOUT_DEFAULT_MS, Tool, ToolContext};
+use crate::{TIMEOUT_DEFAULT_MS, TIMEOUT_LONG_MS, Tool, ToolContext};
 
 pub struct ProcSpawnTool;
 
@@ -37,7 +37,9 @@ impl Tool for ProcSpawnTool {
                 },
                 ToolParam {
                     name: "timeout_ms".to_string(),
-                    description: "Execution timeout in milliseconds".to_string(),
+                    description: format!(
+                        "Execution timeout in milliseconds (default {TIMEOUT_DEFAULT_MS}; larger values are clamped to {MAX_TIMEOUT_MS})"
+                    ),
                     param_type: "u64".to_string(),
                     required: false,
                 },
@@ -66,35 +68,51 @@ impl Tool for ProcSpawnTool {
             })
             .unwrap_or_default();
 
-        let timeout_ms = proc_spawn_timeout_ms(&input);
-
-        // The runtime resolves `[execution.env]` once and hands the complete
-        // child environment to this authoritative spawn boundary. Contexts
-        // without a configuration layer receive Orbit's credential-free
-        // baseline rather than falling back to ambient inheritance.
-        let env_pairs = ctx
-            .proc_spawn_environment
-            .clone()
-            .unwrap_or_else(|| allowlisted_child_env(&[], &[]));
-
-        let current_dir = ctx
-            .workspace_root
-            .as_ref()
-            .map(|path| path.to_string_lossy().into_owned());
-
-        let request = ExecRequest {
-            program,
-            args,
-            current_dir,
-            timeout_ms: Some(timeout_ms),
-            stdin_mode: StdinMode::Inherit,
-            environment_mode: EnvironmentMode::ClearAndSet(env_pairs),
-            debug: false,
-        };
+        let request = spawn_request(ctx, program, args, proc_spawn_timeout_ms(&input));
         let exec_result = run_process(&request, &ActivityFsSandbox::new(ctx)?)?;
 
         serde_json::to_value(exec_result)
             .map_err(|e| OrbitError::Execution(format!("serialize exec result: {e}")))
+    }
+}
+
+/// Assemble the child's execution request.
+///
+/// Two properties of this request are the tool's contract rather than caller
+/// choices: the child environment and its stdin.
+///
+/// The runtime resolves `[execution.env]` once and hands the complete child
+/// environment to this authoritative spawn boundary. Contexts without a
+/// configuration layer receive Orbit's credential-free baseline rather than
+/// falling back to ambient inheritance.
+///
+/// Stdin is closed, matching the engine's `local_shell` step and the other
+/// process-spawning builtins. A `proc.spawn` child is non-interactive: with an
+/// inherited stdin, a program that reads it (`cat`, a confirmation prompt) would
+/// only ever end at the deadline, and until then it would consume the
+/// operator's terminal keystrokes.
+fn spawn_request(
+    ctx: &ToolContext,
+    program: String,
+    args: Vec<String>,
+    timeout_ms: u64,
+) -> ExecRequest {
+    let env_pairs = ctx
+        .proc_spawn_environment
+        .clone()
+        .unwrap_or_else(|| allowlisted_child_env(&[], &[]));
+
+    ExecRequest {
+        program,
+        args,
+        current_dir: ctx
+            .workspace_root
+            .as_ref()
+            .map(|path| path.to_string_lossy().into_owned()),
+        timeout_ms: Some(timeout_ms),
+        stdin_mode: StdinMode::Null,
+        environment_mode: EnvironmentMode::ClearAndSet(env_pairs),
+        debug: false,
     }
 }
 
@@ -222,11 +240,29 @@ fn path_argument(argument: &str, cwd: &Path) -> Option<PathBuf> {
     .then_some(resolved)
 }
 
+/// Ceiling for a caller-supplied `timeout_ms`.
+///
+/// The supervisor deadline is the only thing that ends a child that never
+/// exits on its own, and `proc.spawn` reads that deadline straight from tool
+/// input — so an asset asking for `u64::MAX` would otherwise disable it. The
+/// ceiling is the longest timeout this crate defines, well above the read-only
+/// commands the shipped activities grant `proc.spawn`.
+const MAX_TIMEOUT_MS: u64 = TIMEOUT_LONG_MS;
+
 fn proc_spawn_timeout_ms(input: &Value) -> u64 {
-    input
-        .get("timeout_ms")
-        .and_then(Value::as_u64)
-        .unwrap_or(TIMEOUT_DEFAULT_MS)
+    let Some(requested) = input.get("timeout_ms").and_then(Value::as_u64) else {
+        return TIMEOUT_DEFAULT_MS;
+    };
+    if requested > MAX_TIMEOUT_MS {
+        tracing::warn!(
+            target: "orbit.tool.proc_spawn",
+            requested_timeout_ms = requested,
+            timeout_ms = MAX_TIMEOUT_MS,
+            "proc.spawn timeout exceeds the supervisor maximum and was clamped",
+        );
+        return MAX_TIMEOUT_MS;
+    }
+    requested
 }
 
 pub(crate) fn enforce_program_allowlist(

--- a/crates/orbit-tools/src/builtin/proc/tests/spawn.rs
+++ b/crates/orbit-tools/src/builtin/proc/tests/spawn.rs
@@ -1,9 +1,21 @@
 use serde_json::json;
 
+use std::io::Write;
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
-use super::{path_argument, proc_spawn_timeout_ms};
-use crate::TIMEOUT_DEFAULT_MS;
+use orbit_exec::StdinMode;
+
+use super::{MAX_TIMEOUT_MS, path_argument, proc_spawn_timeout_ms, spawn_request};
+use crate::{TIMEOUT_DEFAULT_MS, ToolContext};
+
+// Used only by the child-execution test below, which runs a real Unix `cat`.
+#[cfg(unix)]
+use super::ProcSpawnTool;
+#[cfg(unix)]
+use crate::Tool;
+#[cfg(unix)]
+use std::time::{Duration, Instant};
 
 #[test]
 fn missing_proc_spawn_timeout_uses_default_timeout() {
@@ -16,6 +28,60 @@ fn explicit_proc_spawn_timeout_is_preserved() {
 }
 
 #[test]
+fn proc_spawn_timeout_at_the_maximum_is_preserved() {
+    assert_eq!(
+        proc_spawn_timeout_ms(&json!({ "timeout_ms": MAX_TIMEOUT_MS })),
+        MAX_TIMEOUT_MS
+    );
+}
+
+#[test]
+fn proc_spawn_timeout_above_the_maximum_is_clamped_and_logged() {
+    let mut resolved = 0;
+    let logs = captured_warnings(|| {
+        resolved = proc_spawn_timeout_ms(&json!({ "timeout_ms": u64::MAX }));
+    });
+
+    assert_eq!(resolved, MAX_TIMEOUT_MS);
+    assert!(
+        logs.contains("orbit.tool.proc_spawn")
+            && logs.contains(&format!("requested_timeout_ms={}", u64::MAX))
+            && logs.contains(&format!("timeout_ms={MAX_TIMEOUT_MS}")),
+        "clamping an oversized timeout must be visible in the logs, got: {logs}"
+    );
+}
+
+#[test]
+fn spawned_children_run_with_stdin_closed() {
+    let request = spawn_request(&ToolContext::default(), "cat".to_string(), vec![], 1_000);
+    assert_eq!(request.stdin_mode, StdinMode::Null);
+}
+
+/// `cat` reads until stdin reaches EOF. With an inherited stdin it would hold
+/// the operator's terminal until the deadline; with stdin closed it sees EOF
+/// at once and exits with no output.
+#[cfg(unix)]
+#[test]
+fn stdin_reading_program_returns_without_waiting_for_the_deadline() {
+    let requested_timeout_ms = 10_000;
+    let started = Instant::now();
+    let result = ProcSpawnTool
+        .execute(
+            &ToolContext::default(),
+            json!({ "program": "cat", "timeout_ms": requested_timeout_ms }),
+        )
+        .expect("proc.spawn cat");
+    let elapsed = started.elapsed();
+
+    assert_eq!(result["success"], json!(true));
+    assert_eq!(result["stdout"], json!(""));
+    assert!(
+        elapsed < Duration::from_millis(requested_timeout_ms / 2),
+        "`cat` took {elapsed:?}, which suggests it waited on an open stdin"
+    );
+}
+
+#[test]
 fn option_value_paths_are_recognized_without_treating_flags_as_paths() {
     let cwd = Path::new("/workspace");
     assert_eq!(
@@ -23,4 +89,37 @@ fn option_value_paths_are_recognized_without_treating_flags_as_paths() {
         Some(cwd.join("./secret.txt"))
     );
     assert_eq!(path_argument("--verbose", cwd), None);
+}
+
+/// Run `action` with a warning-level subscriber installed for this thread and
+/// return everything it recorded.
+fn captured_warnings(action: impl FnOnce()) -> String {
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&buffer);
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .with_max_level(tracing::Level::WARN)
+        .with_writer(move || SharedBuffer(Arc::clone(&sink)))
+        .finish();
+
+    tracing::subscriber::with_default(subscriber, action);
+
+    let recorded = buffer.lock().expect("captured log buffer").clone();
+    String::from_utf8(recorded).expect("log output is utf-8")
+}
+
+struct SharedBuffer(Arc<Mutex<Vec<u8>>>);
+
+impl Write for SharedBuffer {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .lock()
+            .expect("captured log buffer")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Task

[ORB-11713](https://orbit-cli.com/tasks/ORB-11713) — [code-review] Align `proc.spawn` stdin and timeout handling with the engine's shell step

### Description

## Problem
`proc.spawn` runs its child with `StdinMode::Inherit` and an unbounded caller-supplied `timeout_ms` (`Value::as_u64`, no ceiling). The engine's `local_shell` step deliberately closes stdin (`crates/orbit-engine/src/executor/automation/shell.rs:132-135`: "a child left reading an open-but-silent stdin would only ever end at the deadline") and resolves the timeout from the executor definition. Scenario: a foreground `orbit run` whose tool step spawns a program that reads stdin (`cat`, `python -c 'input()'`, any CLI with a confirmation prompt) sits on the terminal until `timeout_ms` — which the step may set to `18446744073709551615`, i.e. forever — while the inherited terminal keystrokes go to the child instead of the operator's shell.

## Why It Matters
Two subprocess boundaries in the same product have opposite stdin contracts, and one of them lets an asset disable the supervisor deadline entirely.

## Proposed Fix
Use `StdinMode::Bytes(Vec::new())` (closed stdin) in `proc.spawn`, and clamp `timeout_ms` to a configured maximum (e.g. the executor's `timeout_seconds` or `TIMEOUT_LONG_MS`), rejecting or clamping larger values with a logged warning.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-tools/src/builtin/proc/spawn.rs:102-110`, `crates/orbit-tools/src/builtin/proc/spawn.rs:195-200`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (bug). Review area: mcp-tools.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test in `crates/orbit-tools/src/builtin/proc/tests/spawn.rs`: `proc.spawn {program: "cat"}` returns immediately with empty stdout instead of waiting for the deadline.
- `timeout_ms: u64::MAX` is clamped and the clamp is visible in the result or logs.

## Execution Summary

<details>
<summary>Click to expand</summary>

Aligned `proc.spawn` with the engine's `local_shell` stdin contract and bounded its caller-supplied deadline.

## Changes
- `crates/orbit-tools/src/builtin/proc/spawn.rs`
  - Child stdin is now closed: request assembly moved into a new `spawn_request` helper that sets `StdinMode::Null` (the mode the sibling process builtins `git.commit`, `git.stage_paths`, and `github` already use) instead of `StdinMode::Inherit`. `Null` rather than the ticket's suggested `Bytes(Vec::new())`: both give the child an immediate EOF, but `Null` needs no stdin pipe or writer thread and matches the existing builtin convention. The helper also carries the pre-existing environment resolution, so `execute` reads validate -> assemble -> run.
  - `proc_spawn_timeout_ms` clamps a caller-supplied `timeout_ms` to `MAX_TIMEOUT_MS` (= `TIMEOUT_LONG_MS`, 60_000), emitting `tracing::warn!(target: "orbit.tool.proc_spawn", requested_timeout_ms, timeout_ms, ...)` when it clamps. 60 s is the longest timeout the crate defines and is well above the read-only `git`/`rg` work the shipped activities grant `proc.spawn`; the existing `supervised_parent_signal` tests already request exactly 60_000 and are unaffected.
  - `timeout_ms` schema description now states the default and the ceiling.
- `crates/orbit-cli/tests/output_goldens/tool_list.json` — golden refreshed for that description (unlisted file, appended to `context_files`: it is a snapshot of the changed schema).
- `crates/orbit-tools/src/builtin/proc/tests/spawn.rs` — new tests (unlisted file, appended to `context_files`: acceptance criterion 1 names it).

The result payload (`ExecutionResult`) is unchanged; the clamp is surfaced in logs, which criterion 2 permits, rather than by extending a serialized tool output contract.

## Acceptance criteria
1. *`proc.spawn {program: "cat"}` returns immediately with empty stdout* — met. `stdin_reading_program_returns_without_waiting_for_the_deadline` runs the tool with `timeout_ms: 10_000` and asserts `success == true`, `stdout == ""`, and elapsed < 5 s. Fault detection was demonstrated: with `StdinMode::Inherit` restored and the test binary's own stdin held open (`cargo test ... < <(sleep 25)`), the test fails after 10.10 s with `success == false` (the supervisor killed `cat` at the deadline); with the fix it passes in 0.00 s under the same held-open stdin.
2. *`timeout_ms: u64::MAX` is clamped and the clamp is visible in the result or logs* — met. `proc_spawn_timeout_above_the_maximum_is_clamped_and_logged` captures WARN-level tracing through a thread-local subscriber and asserts the resolved value is `MAX_TIMEOUT_MS` and that the record carries the `orbit.tool.proc_spawn` target with `requested_timeout_ms=18446744073709551615` and `timeout_ms=60000`. `proc_spawn_timeout_at_the_maximum_is_preserved` pins the boundary; `spawned_children_run_with_stdin_closed` pins the stdin contract independently of the ambient stdin the test process happens to have.

## Validation (all on Linux, this worktree)
- `make ci-fast` — passed (exit 0). One informational skip inside it: `test-compiler-cache-namespaces` skipped because the kernel denies unprivileged user namespaces (bwrap); unrelated to this change.
- `make ci-lint` — passed (exit 0).
- `cargo fmt --all -- --check` — passed.
- `cargo test -p orbit-tools` — passed (119 lib + all integration targets; 7 in `builtin::proc::spawn::tests`).
- `cargo test -p orbit-cli --test output_goldens` — passed (8).
- `cargo test -p orbit-cli --test proc_spawn_managed` — passed (1).
- `cargo test -p orbit-cli --test supervised_parent_signal` — passed (2).
- Full `make ci` not run (per AGENTS.md it is the PR-level merge gate, not a per-task local run).

## Risks / notes
- Behavior change for callers: a `proc.spawn` request above 60_000 ms is now silently shortened (with a logged warning) rather than honored, and a child that read the operator's terminal no longer can. No shipped activity or test requests more than 60_000 ms.
- The macOS path is not exercised here; the change is platform-independent (`Stdio::null` and an integer clamp), and both spawn paths — `NoSandbox` and `spawn_under_linux_landlock` — build the child through the same `process::command`, so the stdin mode applies to each.
- `git diff --check` clean; `git status --short` lists only the three files above.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11713-6a9f96cf`
- Behind base: 0
- Ahead of base: 1