### PR TITLE
[code-review] Host Git timeout verdict is re-derived from stderr text instead of the supervisor's structural verdict

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/git.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/git.rs
@@ -137,10 +137,6 @@ pub(crate) struct GitOutcome {
     pub timeout_ms: u64,
 }
 
-pub(crate) fn git_process_timed_out(stderr: &str) -> bool {
-    stderr.contains("process timed out")
-}
-
 pub(crate) fn git_timeout_error(
     current_dir: &Path,
     args: &[&str],
@@ -166,14 +162,16 @@ pub(crate) fn git_failure_error(current_dir: &Path, args: &[&str], stderr: &str)
 
 /// Run Git under the current budget. Callers that recover from timeout must
 /// inspect [`GitOutcome::timed_out`] instead of treating it as a Git exit.
+/// That flag is the supervisor's deadline verdict, not a match against
+/// captured stderr.
 pub(crate) fn git_run(current_dir: &Path, args: &[&str]) -> Result<GitOutcome, OrbitError> {
     let timeout_ms = GitTimeoutBudget::current().timeout_for(args);
     let result = run_process(&git_request(current_dir, args, timeout_ms), &NoSandbox)?;
     Ok(GitOutcome {
         stdout: result.stdout,
-        stderr: result.stderr.clone(),
+        stderr: result.stderr,
         success: result.success,
-        timed_out: git_process_timed_out(&result.stderr),
+        timed_out: result.timed_out,
         timeout_ms,
     })
 }

--- a/crates/orbit-engine/src/executor/automation/vcs/tests/freshness.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/tests/freshness.rs
@@ -115,6 +115,61 @@ fn owned_rebase_timeout_aborts_and_retry_is_not_permanently_wedged() {
     assert!(workspace.repo.join("BASE_ADVANCE.md").exists());
 }
 
+#[cfg(unix)]
+#[test]
+fn rebase_stderr_timeout_phrase_is_ordinary_failure_not_timeout_recovery() {
+    if !with_fake_git(
+        module_path!(),
+        "rebase_stderr_timeout_phrase_is_ordinary_failure_not_timeout_recovery",
+        &[("ORBIT_TEST_GIT_PHRASE_FAIL", "rebase".to_string())],
+    ) {
+        return;
+    }
+
+    let workspace = pr_workspace();
+    advance_base(&workspace.repo);
+    let task_id = "ORB-11802-REBASE-PHRASE";
+    let host = PrOpenTestHost::new(
+        vec![batch_task(
+            task_id,
+            "Phrase rebase",
+            "Outcome: success\nChanges:\n- Candidate remains mergeable.",
+        )],
+        workspace.repo.clone(),
+    );
+    let common = json!({
+        "workspace_path": workspace.repo,
+        "job_run_id": "batch-1",
+        "completed_task_ids": [task_id],
+        "base": "agent-main",
+        "base_sync": "local",
+    });
+    let prepared = prepare_pr_handoff(&host, &common).expect("prepare");
+    let error = rebase_pr_branch(&host, &rebase_input(&common, &prepared))
+        .expect_err("injected stderr phrase must fail as ordinary Git");
+    let message = error.to_string();
+    assert!(
+        message.contains("failed in"),
+        "expected ordinary Git failure, got {message}"
+    );
+    assert!(
+        !message.contains("timed out after"),
+        "stderr phrase must not be a deadline error: {message}"
+    );
+    assert!(
+        !message.contains("timeout recovery") && !message.contains("Timeout recovery"),
+        "timeout recovery must not run: {message}"
+    );
+    assert!(
+        !matches!(error, OrbitError::RecoverableVcsConflict(_)),
+        "phrase failure is not a conflict: {error}"
+    );
+    assert!(
+        !rebase_in_progress(&workspace.repo),
+        "ordinary rebase failure must not leave timeout-aborted rebase state"
+    );
+}
+
 #[test]
 fn pre_existing_rebase_without_conflicts_is_refused_and_left_intact() {
     let workspace = pr_workspace();

--- a/crates/orbit-engine/src/executor/automation/vcs/tests/git.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/tests/git.rs
@@ -10,8 +10,11 @@ use orbit_exec::EnvironmentMode;
 use serde_json::json;
 
 use super::super::git::{
-    BaseSyncMode, GitTimeoutBudget, fetch_remote_base, git_request, resolve_worktree_start_point,
+    BaseSyncMode, GitTimeoutBudget, fetch_remote_base, git_command_success, git_request, git_run,
+    resolve_worktree_start_point,
 };
+#[cfg(unix)]
+use super::with_fake_git;
 
 #[test]
 fn remote_mode_fetches_origin_base_when_local_base_is_stale() {
@@ -242,6 +245,48 @@ fn git_timeout_budget_rejects_invalid_and_extreme_values() {
             "expected '{needle}' in {error} for {input}"
         );
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn git_command_success_treats_stderr_timeout_phrase_as_ordinary_failure() {
+    if !with_fake_git(
+        module_path!(),
+        "git_command_success_treats_stderr_timeout_phrase_as_ordinary_failure",
+        &[("ORBIT_TEST_GIT_PHRASE_FAIL", "show-ref".to_string())],
+    ) {
+        return;
+    }
+
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo, "agent-main");
+    commit_file(&repo, "base.txt", "v1");
+
+    let outcome = git_run(
+        &repo,
+        &["show-ref", "--verify", "--quiet", "refs/heads/agent-main"],
+    )
+    .unwrap();
+    assert!(
+        !outcome.timed_out,
+        "stderr phrase must not classify as a supervisor timeout: {outcome:?}"
+    );
+    assert!(!outcome.success, "injected probe must fail: {outcome:?}");
+    assert!(
+        outcome.stderr.contains("process timed out"),
+        "fixture must print the misleading phrase: {outcome:?}"
+    );
+
+    let success = git_command_success(
+        &repo,
+        &["show-ref", "--verify", "--quiet", "refs/heads/agent-main"],
+    )
+    .expect("ordinary Git failure is Ok(false), not a timeout error");
+    assert!(
+        !success,
+        "failed probe with timeout prose must stay a boolean no"
+    );
 }
 
 #[test]

--- a/crates/orbit-engine/src/executor/automation/vcs/tests/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/tests/mod.rs
@@ -83,12 +83,18 @@ pub(crate) fn with_fake_git(module: &str, test: &str, extra_env: &[(&str, String
         .find(|(key, _)| *key == "ORBIT_TEST_GIT_REBASE_ONCE")
         .map(|(_, value)| value.as_str())
         .unwrap_or("");
+    let phrase_fail = extra_env
+        .iter()
+        .find(|(key, _)| *key == "ORBIT_TEST_GIT_PHRASE_FAIL")
+        .map(|(_, value)| value.as_str())
+        .unwrap_or("");
     let script = format!(
         r#"#!/bin/bash
 set -eu
 real={real}
 worktree_once={worktree_once}
 rebase_once={rebase_once}
+phrase_fail={phrase_fail}
 cmd=""
 sub=""
 skip=0
@@ -108,6 +114,19 @@ for arg in "$@"; do
     sub="$arg"
   fi
 done
+
+if [ -n "$phrase_fail" ] && [ "$cmd" = "$phrase_fail" ]; then
+  if [ "$cmd" = "rebase" ]; then
+    case "$sub" in
+      --abort|--continue|--skip|--quit) exec "$real" "$@" ;;
+    esac
+  fi
+  if [ "$cmd" = "worktree" ] && [ "$sub" != "add" ]; then
+    exec "$real" "$@"
+  fi
+  echo "process timed out" >&2
+  exit 1
+fi
 
 if [ "$cmd" = "worktree" ] && [ "$sub" = "add" ]; then
   if [ -n "$worktree_once" ] && [ ! -f "$worktree_once" ]; then
@@ -151,7 +170,8 @@ exec "$real" "$@"
 "#,
         real = quote(&real_git),
         worktree_once = quote(worktree_once),
-        rebase_once = quote(rebase_once)
+        rebase_once = quote(rebase_once),
+        phrase_fail = quote(phrase_fail)
     );
 
     let bin = tempfile::tempdir().expect("fake git directory");

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/setup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/setup.rs
@@ -402,6 +402,52 @@ fn worktree_add_timeout_after_registration_is_not_admitted_on_retry() {
     }
 }
 
+#[cfg(unix)]
+#[test]
+fn worktree_add_stderr_timeout_phrase_is_ordinary_failure_not_timeout_recovery() {
+    if !with_fake_git(
+        module_path!(),
+        "worktree_add_stderr_timeout_phrase_is_ordinary_failure_not_timeout_recovery",
+        &[("ORBIT_TEST_GIT_PHRASE_FAIL", "worktree".to_string())],
+    ) {
+        return;
+    }
+
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo, "agent-main");
+    commit_file(&repo, "base.txt", "v1");
+    let host = FakeHost::new(&repo, &["ORB-11802"]);
+    let run_id = "jrun-phrase-worktree";
+    let input = json!({
+        "task_ids": ["ORB-11802"],
+        "run_id": run_id,
+        "base": "agent-main",
+        "base_sync": "local",
+        "dependency_delivery": "ignore",
+    });
+
+    let error = setup_worktree(&host, &input)
+        .expect_err("injected stderr phrase must fail as ordinary Git");
+    let message = error.to_string();
+    assert!(
+        message.contains("failed in"),
+        "expected ordinary Git failure, got {message}"
+    );
+    assert!(
+        !message.contains("timed out after"),
+        "stderr phrase must not be a deadline error: {message}"
+    );
+    assert!(
+        !message.contains("timeout recovery") && !message.contains("Timeout recovery"),
+        "timeout recovery must not run: {message}"
+    );
+    assert!(
+        host.admitted().is_empty(),
+        "ordinary worktree add failure must not admit the task"
+    );
+}
+
 #[test]
 fn setup_worktree_refuses_stale_registered_checkout_before_admission() {
     let temp = tempdir().unwrap();


### PR DESCRIPTION
## Task

[ORB-11802](https://orbit-cli.com/tasks/ORB-11802) — [code-review] Host Git timeout verdict is re-derived from stderr text instead of the supervisor's structural verdict

### Description

## Problem

The new bounded-Git layer decides whether a `git` child hit its deadline by substring-matching the captured stderr:

- `crates/orbit-engine/src/executor/automation/vcs/git.rs:140-142` — `pub(crate) fn git_process_timed_out(stderr: &str) -> bool { stderr.contains("process timed out") }`
- `crates/orbit-engine/src/executor/automation/vcs/git.rs:169-180` — `git_run` sets `timed_out: git_process_timed_out(&result.stderr)` on every Git invocation.

The supervisor already knows the answer structurally. `crates/orbit-exec/src/supervision/wait.rs:161-166` appends the literal `"process timed out"` to stderr *and* returns `WaitResult.timed_out` (`wait.rs:31`, `wait.rs:194`), and `SupervisedOutcome` documents the intent explicitly: "`ExecutionResult` cannot say *why* a run produced no exit code, so the deadline verdict travels alongside it rather than being re-derived from stderr text" (`crates/orbit-exec/src/runner.rs:97-108`). `run_process` (`runner.rs:68-95`) is the one entry point that drops `result.timed_out` on the floor, which is why the new Git layer had to reconstruct it from prose.

## Why It Matters

Git stderr is not Orbit's channel. Anything a credential helper, remote helper, hook, or nested tool writes there is matched too, and the consequences are no longer cosmetic now that the classification is load-bearing:

- `git_command_success` (`git.rs:309-319`) used to return `Ok(false)` for a failed probe; it now returns `Err(git_timeout_error(..))`. A predicate such as `["show-ref", "--verify", "--quiet", ..]` or `["rev-parse", "--is-inside-work-tree"]` whose stderr happens to carry the phrase turns a routine "no" into a hard step failure.
- `refuse_or_recover_existing_rebase` / `recover_started_rebase_timeout` (`crates/orbit-engine/src/executor/automation/vcs/freshness.rs:259-330`) and `recover_worktree_add_timeout` branch on `GitOutcome::timed_out`, so a false positive routes an ordinary Git failure into timeout recovery — including `git rebase --abort` on state this attempt owns — and reports it to the operator as a deadline breach.

This is the same defect class as the already-filed ORB-11701, but at a second, newer call site: ORB-11701 is scoped to `orbit-agent`'s `envelope.rs`, and its proposed fix ("add a `timed_out: bool` to `ExecutionResult` … and delete the stderr substring check") does not cover `orbit-engine`'s Git layer, which was added afterwards.

## Reproduction

Run any host Git command under `git_command_success` whose child emits `process timed out` on stderr (for example a credential or remote helper relaying that text). The call returns `Err("git … timed out after 30000ms")` although the child exited well inside its budget and was never signalled.

## Proposed Fix

Carry the verdict instead of parsing it: surface `WaitResult.timed_out` through `run_process` (either on `ExecutionResult` or via a `run_process` variant returning `SupervisedOutcome`), populate `GitOutcome::timed_out` from it, and delete `git_process_timed_out`. Coordinate with ORB-11701 so `ExecutionResult` grows the field once and both consumers switch to it.

## Constraints / Notes

- Introduced by ORB-11606 (commit `1f8c346f4`) in the `bcf007dc88..ab480b754` window. Line numbers are at `ab480b754`; re-locate by symbol if the files move.
- Related but not duplicate: ORB-11701 covers `crates/orbit-agent/src/types/response/envelope.rs`.
- Follow AGENTS.md: put the rule at its authoritative boundary and keep one canonical path. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- The Git layer's `timed_out` verdict comes from the supervisor's structural deadline result, not from matching text in the child's stderr.
- A test proves a Git child that exits non-zero within its budget while printing `process timed out` on stderr is reported as an ordinary failure: `git_command_success` returns `Ok(false)` and no timeout-recovery branch runs.
- A test proves a genuinely timed-out Git child is still classified as a timeout and still reaches the existing rebase and worktree-add recovery paths.
- `git_process_timed_out` is removed rather than left as an unused or parallel classifier.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `git_run` now copies `ExecutionResult.timed_out` from `run_process` (ORB-11701's canonical supervisor verdict) into `GitOutcome.timed_out`.
- Deleted `git_process_timed_out`; Git no longer classifies timeouts by matching `process timed out` in stderr.
- Extended the Unix Git test shim with `ORBIT_TEST_GIT_PHRASE_FAIL` so a named command can exit 1 immediately while printing that phrase.
- Added regressions: `git_command_success` returns `Ok(false)` for a phrase-bearing non-timeout child; rebase and worktree-add take ordinary failure, not timeout recovery. Existing genuine-timeout rebase and worktree-add recovery tests still pass.
- `crates/orbit-exec/src/runner.rs` was left unchanged: ORB-11701 already populates `ExecutionResult.timed_out`. Extra context files (`tests/mod.rs`, `tests/freshness.rs`, `worktree/tests/setup.rs`) were added because the shim and recovery-path tests had to change.

Criteria evidence:
1. Passed: `git_run` sets `timed_out: result.timed_out`. `rg git_process_timed_out` is empty. A child that prints `process timed out` and exits 1 has `GitOutcome.timed_out == false`.
2. Passed `git_command_success_treats_stderr_timeout_phrase_as_ordinary_failure` (`Ok(false)`), plus rebase and worktree-add phrase-fail tests that assert `failed in`, no `timed out after`, and no timeout-recovery branch.
3. Passed `owned_rebase_timeout_aborts_and_retry_is_not_permanently_wedged` and `worktree_add_timeout_after_registration_is_not_admitted_on_retry`: genuine supervisor timeouts still classify as timeout and still enter the existing recovery paths.
4. Passed: `git_process_timed_out` is removed, not retained as an unused classifier.

Validation:
- Passed: `cargo test -p orbit-engine --lib -- git_command_success_treats_stderr_timeout_phrase rebase_stderr_timeout_phrase worktree_add_stderr_timeout_phrase owned_rebase_timeout_aborts worktree_add_timeout_after_registration` (5 passed, 0 failed; CARGO_TARGET_DIR=/tmp/orbit-jrun-20260908-0508-9-target).
- Passed: `make ci-fast`.
- Passed: `make ci-lint`.
- Passed: `git diff --check`.
- Passed: `GIT_OPTIONAL_LOCKS=0 git status --short` shows only the five intended files.

Assessment: Small, canonical data-flow correction at the Git consumer. No remaining task-specific risks beyond Unix-only shim coverage (same as the existing hang fixtures). Changes left uncommitted for the pipeline.

Strategic decisions: Reused ORB-11701's `ExecutionResult.timed_out` rather than a Git-local API.
Deviations from original plan: none.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11802-6a9f9845`
- Behind base: 0
- Ahead of base: 1