### PR TITLE
fix: canonicalize Landlock test paths on macOS [ORB-11806]

### DIFF
--- a/crates/orbit-exec/src/linux_landlock/tests/host.rs
+++ b/crates/orbit-exec/src/linux_landlock/tests/host.rs
@@ -58,6 +58,8 @@ fn a_declared_tool_state_directory_is_granted_but_its_publish_token_is_not() {
     fs::write(cargo_home.join("credentials.toml"), "token").expect("write credentials");
 
     let grants = host_read_grants(&environment(&[("CARGO_HOME", &cargo_home)]));
+    // Grants use canonical paths, including when the queried child does not exist.
+    let cargo_home = cargo_home.canonicalize().expect("canonical cargo home");
 
     assert!(
         grants_read(&grants, &cargo_home.join("registry/index")),
@@ -140,6 +142,7 @@ fn every_documented_variable_actually_widens_the_grants() {
         let named = home.path().join(variable.to_lowercase());
         fs::create_dir_all(named.join("git")).expect("mkdir named directory");
         let grants = host_read_grants(&environment(&[("HOME", home.path()), (variable, &named)]));
+        let named = named.canonicalize().expect("canonical named directory");
 
         assert!(
             grants.iter().any(|grant| grant.path.starts_with(&named)),

--- a/crates/orbit-exec/src/linux_landlock/tests/platform.rs
+++ b/crates/orbit-exec/src/linux_landlock/tests/platform.rs
@@ -62,8 +62,7 @@ fn availability_requires_the_abi_that_carries_the_relocation_right() {
 #[test]
 fn a_platform_without_landlock_refuses_to_spawn_at_all() {
     let error = spawn_under_linux_landlock(&request(), Path::new("."), &profile())
-        .err()
-        .expect("an unsupported platform must not spawn");
+        .expect_err("an unsupported platform must not spawn");
 
     assert!(matches!(error, OrbitError::PolicyDenied(_)), "{error:?}");
 }


### PR DESCRIPTION
macOS resolves temporary fixture roots from `/var` to `/private/var`, but two Landlock grant tests compared those canonical grants with raw expected paths. Canonicalize the existing expected roots while retaining the original environment aliases and every allow/deny assertion. Also use `expect_err` in the non-Linux refusal test to satisfy the Mac Clippy gate. Production grant behavior is unchanged.

Reproduced both failing assertions on Mac before the fix. After the fix, `cargo test --no-fail-fast -p orbit-exec --locked` passes 92 tests, `make ci-fast` passes, and full workspace/all-target `make ci-lint` passes. Linux namespace probe is unavailable on Mac.

Task: ORB-11806. Regression introduced by ORB-11514 / #1722.
