### PR TITLE
[qa-sweep] Workspace ID/name collision makes the ID-owning checkout unusable

### DIFF
--- a/crates/orbit-cli/src/command/workspace/source_remote.rs
+++ b/crates/orbit-cli/src/command/workspace/source_remote.rs
@@ -50,8 +50,8 @@ impl Execute for WorkspaceSourceRemoteShowArgs {
         let registry = workspace_registry::load_registry_from(
             &workspace_registry::registry_path_for(&runtime.global_root()),
         )?;
-        let workspace =
-            workspace_registry::find_workspace(&registry, &workspace_id)?.ok_or_else(|| {
+        let workspace = workspace_registry::find_workspace_by_id(&registry, &workspace_id)
+            .ok_or_else(|| {
                 OrbitError::WorkspaceError(format!("unknown workspace '{workspace_id}'"))
             })?;
 

--- a/crates/orbit-cli/src/command/workspace/sync.rs
+++ b/crates/orbit-cli/src/command/workspace/sync.rs
@@ -42,7 +42,7 @@ impl WorkspaceSyncArgs {
             })
             .max_by_key(|checkout| checkout.repo_root.components().count())
             .ok_or_else(workspace_init_required)?;
-        if workspace_registry::find_workspace(&registry, &checkout.workspace_id)?.is_none() {
+        if workspace_registry::find_workspace_by_id(&registry, &checkout.workspace_id).is_none() {
             return Err(workspace_init_required());
         }
         let host_id = match inspect_host_identity(&global_root)? {

--- a/crates/orbit-cli/tests/workspace_selector.rs
+++ b/crates/orbit-cli/tests/workspace_selector.rs
@@ -228,6 +228,120 @@ fn global_workspace_flag_fails_closed_on_unknown_selector() {
     );
 }
 
+/// A workspace whose ID equals another workspace's name must still be reachable
+/// from its checkout and by absolute path. The colliding token stays fail-closed
+/// only when the operator types it as an id-or-name selector [ORB-11805].
+#[test]
+fn checkout_path_and_cwd_resolve_an_id_that_collides_with_another_workspace_name() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let alpha_repo = temp.path().join("alpha");
+    let shadow_repo = temp.path().join("ws-alpha");
+    let elsewhere = temp.path().join("elsewhere");
+    fs::create_dir_all(&home).expect("home");
+    fs::create_dir_all(&elsewhere).expect("elsewhere");
+
+    init_git_repo(&alpha_repo);
+    init_git_repo(&shadow_repo);
+
+    run_orbit(
+        &alpha_repo,
+        &home,
+        &[
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "selector-host",
+            "--task-prefix",
+            "SEL",
+        ],
+    )
+    .success();
+    run_orbit(
+        &alpha_repo,
+        &home,
+        &["workspace", "init", "--name", "alpha"],
+    )
+    .success();
+    run_orbit(
+        &shadow_repo,
+        &home,
+        &["workspace", "init", "--name", "ws_alpha"],
+    )
+    .success();
+
+    let shown = run_orbit_json(
+        &alpha_repo,
+        &home,
+        &["--format", "json", "workspace", "show"],
+    );
+    assert_eq!(shown["workspace"]["id"], "ws_alpha");
+    assert_eq!(shown["workspace"]["name"], "alpha");
+
+    let listed = run_orbit_json(
+        &alpha_repo,
+        &home,
+        &["--format", "json", "task", "list", "--limit", "10"],
+    );
+    assert!(
+        listed.as_array().is_some() || listed.get("tasks").and_then(Value::as_array).is_some(),
+        "task list from the id-owning checkout must succeed: {listed}"
+    );
+
+    let by_path = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "--workspace",
+            alpha_repo.to_str().expect("utf8"),
+            "--format",
+            "json",
+            "workspace",
+            "show",
+        ],
+    );
+    assert_eq!(by_path["workspace"]["id"], "ws_alpha");
+    assert_eq!(by_path["workspace"]["name"], "alpha");
+
+    let path_list = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "--workspace",
+            alpha_repo.to_str().expect("utf8"),
+            "--format",
+            "json",
+            "task",
+            "list",
+            "--limit",
+            "10",
+        ],
+    );
+    assert!(
+        path_list.as_array().is_some()
+            || path_list.get("tasks").and_then(Value::as_array).is_some(),
+        "absolute checkout path must list the id-owning workspace: {path_list}"
+    );
+
+    for args in [
+        ["workspace", "remove", "ws_alpha"].as_slice(),
+        ["workspace", "role", "ws_alpha", "owner"].as_slice(),
+    ] {
+        let assert = run_orbit(&alpha_repo, &home, args).failure();
+        let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+        let combined = format!("{stdout}{stderr}");
+        assert!(
+            combined.contains("ws_alpha"),
+            "ambiguous selector must be named for {args:?}: {combined}"
+        );
+        assert!(
+            combined.contains("ambiguous workspace selector"),
+            "typed selector {args:?} must fail closed: {combined}"
+        );
+    }
+}
+
 /// `task show` is the one verb whose target is a machine-global primary key, so
 /// omitting `--workspace` follows the ID instead of the cwd [ORB-10797].
 #[test]

--- a/crates/orbit-cmd/src/registry_runtime.rs
+++ b/crates/orbit-cmd/src/registry_runtime.rs
@@ -475,7 +475,7 @@ fn resolve_cli_workspace_path<'a>(
     if let Some(checkout) = find_checkout_for_canonical_path(registry, &canonical)
         .or_else(|| find_checkout_for_git_common_dir(registry, &canonical))
     {
-        let workspace = workspace_registry::find_workspace(registry, &checkout.workspace_id)?
+        let workspace = workspace_registry::find_workspace_by_id(registry, &checkout.workspace_id)
             .ok_or_else(|| unsupported_cli_workspace(selector))?;
         return Ok(CliWorkspaceTarget::Checkout {
             workspace,
@@ -677,7 +677,7 @@ pub(crate) fn select_workspace_for_cwd_and_roots(
     if let Some(checkout) = workspace_registry::find_checkout_by_path(&registry, cwd)
         && canonical_or_original(&checkout.orbit_dir) == shared
         && let Some(workspace) =
-            workspace_registry::find_workspace(&registry, &checkout.workspace_id)?
+            workspace_registry::find_workspace_by_id(&registry, &checkout.workspace_id)
     {
         return Ok(Some(ResolvedWorkspaceSelection {
             workspace: workspace.clone(),

--- a/crates/orbit-cmd/src/tests/registry_runtime.rs
+++ b/crates/orbit-cmd/src/tests/registry_runtime.rs
@@ -1042,3 +1042,89 @@ fn unpinned_root_resolution_still_binds_the_registered_checkout() {
     assert_eq!(from_worktree.workspace.id, "ws_managed");
     assert_eq!(from_worktree.checkout.repo_root, fixture.repo_root);
 }
+
+struct CollidingIdNameFixture {
+    _root: tempfile::TempDir,
+    global: PathBuf,
+    alpha_repo: PathBuf,
+    alpha_orbit_dir: PathBuf,
+}
+
+fn colliding_id_name_fixture() -> CollidingIdNameFixture {
+    let root = tempfile::tempdir().expect("root");
+    let global = root.path().join("global");
+    std::fs::create_dir_all(&global).expect("global");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_collision\"\nhost_id = \"collision\"\ntask_prefix = \"ORB\"\n",
+    )
+    .expect("host identity");
+
+    let (ws_alpha, checkout_alpha) =
+        registered_workspace(root.path(), "ws_alpha", "alpha", "hm_collision");
+    let (ws_shadow, checkout_shadow) =
+        registered_workspace(root.path(), "ws_ws_alpha", "ws_alpha", "hm_collision");
+    save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![ws_alpha, ws_shadow],
+            checkouts: vec![checkout_alpha.clone(), checkout_shadow],
+            ..Default::default()
+        },
+        &registry_path_for(&global),
+    )
+    .expect("workspace registry");
+
+    CollidingIdNameFixture {
+        _root: root,
+        global,
+        alpha_repo: checkout_alpha.repo_root,
+        alpha_orbit_dir: checkout_alpha.orbit_dir,
+    }
+}
+
+#[test]
+fn cwd_and_absolute_path_select_a_workspace_whose_id_collides_with_another_name() {
+    let fixture = colliding_id_name_fixture();
+    let roots = OrbitRuntimeRoots {
+        global_root: fixture.global.clone(),
+        shared_root: fixture.alpha_orbit_dir.clone(),
+        local_root: fixture.alpha_orbit_dir.clone(),
+    };
+
+    let from_cwd = select_workspace_for_cwd_and_roots(&fixture.alpha_repo, &roots)
+        .expect("cwd selection must not treat the checkout id as an ambiguous selector")
+        .expect("alpha checkout must bind");
+    assert_eq!(from_cwd.workspace.id, "ws_alpha");
+    assert_eq!(from_cwd.workspace.name, "alpha");
+    assert_eq!(from_cwd.checkout.repo_root, fixture.alpha_repo);
+
+    let alpha_path = fixture.alpha_repo.to_str().expect("utf8 checkout path");
+    let from_path = RegisteredRuntimeFactory::initialize_with_overrides(
+        Some(&fixture.global),
+        Some(alpha_path),
+    )
+    .expect("absolute checkout path must bind alpha");
+    let binding = from_path
+        .workspace_runtime_binding()
+        .expect("path-selected runtime is bound");
+    assert_eq!(binding.logical_workspace_id, "ws_alpha");
+    assert_eq!(binding.repo_root, fixture.alpha_repo);
+
+    let ambiguous = match RegisteredRuntimeFactory::initialize_with_overrides(
+        Some(&fixture.global),
+        Some("ws_alpha"),
+    ) {
+        Ok(_) => panic!("a directly entered colliding selector must fail closed"),
+        Err(error) => error,
+    };
+    match ambiguous {
+        OrbitError::InvalidInput(message) => {
+            assert!(message.contains("ws_alpha"), "{message}");
+            assert!(
+                message.contains("ambiguous workspace selector"),
+                "{message}"
+            );
+        }
+        other => panic!("expected InvalidInput, got {other}"),
+    }
+}

--- a/crates/orbit-registry/src/tests/workspace_registry.rs
+++ b/crates/orbit-registry/src/tests/workspace_registry.rs
@@ -11,10 +11,10 @@ use serde_json::{Value, json};
 use tempfile::tempdir;
 
 use crate::workspace_registry::{
-    assign_checkout_role, find_checkout_by_path, find_workspace, find_workspace_by_path,
-    load_registry_from, load_registry_from_with_writer, register_checkout, remove_workspace,
-    rename_local_owner_host_id, resolve_logical_workspace, save_registry_to, set_path_override,
-    validate_workspaces,
+    assign_checkout_role, find_checkout_by_path, find_workspace, find_workspace_by_id,
+    find_workspace_by_path, load_registry_from, load_registry_from_with_writer, register_checkout,
+    remove_workspace, rename_local_owner_host_id, resolve_logical_workspace, save_registry_to,
+    set_path_override, validate_workspaces,
 };
 
 fn timestamp() -> chrono::DateTime<Utc> {
@@ -568,6 +568,78 @@ fn mutation_helpers_reject_a_name_that_matches_another_workspace_id() {
     let assigned = assign_checkout_role(
         &mut registry,
         "ws_1",
+        WorkspaceCheckoutRole::Owner,
+        None,
+        None,
+    )
+    .expect_err("role assignment must reject an ambiguous selector")
+    .to_string();
+    assert!(
+        assigned.contains("ambiguous workspace selector"),
+        "{assigned}"
+    );
+    assert_eq!(registry, before);
+}
+
+#[test]
+fn exact_id_lookup_survives_a_name_that_matches_another_workspace_id() {
+    let mut registry = WorkspaceRegistry {
+        workspaces: vec![
+            logical_workspace("ws_alpha", None),
+            logical_workspace("ws_ws_alpha", None),
+        ],
+        checkouts: vec![
+            WorkspaceCheckout::owner(
+                "ws_alpha".to_string(),
+                PathBuf::from("/repos/alpha"),
+                PathBuf::from("/repos/alpha/.orbit"),
+            ),
+            WorkspaceCheckout::owner(
+                "ws_ws_alpha".to_string(),
+                PathBuf::from("/repos/ws_alpha"),
+                PathBuf::from("/repos/ws_alpha/.orbit"),
+            ),
+        ],
+        ..Default::default()
+    };
+    registry.workspaces[0].name = "alpha".to_string();
+    registry.workspaces[1].name = "ws_alpha".to_string();
+    let before = registry.clone();
+
+    assert_eq!(
+        find_workspace_by_id(&registry, "ws_alpha").map(|workspace| workspace.name.as_str()),
+        Some("alpha")
+    );
+    assert_eq!(
+        find_workspace_by_id(&registry, "ws_ws_alpha").map(|workspace| workspace.name.as_str()),
+        Some("ws_alpha")
+    );
+    assert_eq!(
+        find_workspace_by_path(&registry, Path::new("/repos/alpha/src"))
+            .map(|workspace| workspace.id.as_str()),
+        Some("ws_alpha")
+    );
+
+    let ambiguous = find_workspace(&registry, "ws_alpha")
+        .expect_err("id-or-name selector must stay fail-closed")
+        .to_string();
+    assert!(
+        ambiguous.contains("ambiguous workspace selector"),
+        "{ambiguous}"
+    );
+
+    let removed = remove_workspace(&mut registry, "ws_alpha")
+        .expect_err("removal must reject an ambiguous selector")
+        .to_string();
+    assert!(
+        removed.contains("ambiguous workspace selector"),
+        "{removed}"
+    );
+    assert_eq!(registry, before);
+
+    let assigned = assign_checkout_role(
+        &mut registry,
+        "ws_alpha",
         WorkspaceCheckoutRole::Owner,
         None,
         None,

--- a/crates/orbit-registry/src/workspace_registry/catalog.rs
+++ b/crates/orbit-registry/src/workspace_registry/catalog.rs
@@ -353,6 +353,22 @@ pub fn find_workspace<'a>(
     }
 }
 
+/// Finds a workspace by its exact catalog ID.
+///
+/// Checkout bindings and other persisted relations already store
+/// `workspace_id`. Those lookups must not reuse [`find_workspace`], which
+/// treats the argument as an id-or-name selector and fails closed when one
+/// workspace's ID equals another's name.
+pub fn find_workspace_by_id<'a>(
+    registry: &'a WorkspaceRegistry,
+    workspace_id: &str,
+) -> Option<&'a Workspace> {
+    registry
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == workspace_id)
+}
+
 /// Resolve a logical selector (registered name or `ws_*` id) to exactly one workspace.
 ///
 /// The same fail-closed name/id grammar is used by the CLI `--workspace` flag
@@ -424,10 +440,7 @@ pub fn local_workspaces(
     registry: &WorkspaceRegistry,
 ) -> impl Iterator<Item = (&Workspace, &WorkspaceCheckout)> {
     registry.checkouts.iter().filter_map(|checkout| {
-        registry
-            .workspaces
-            .iter()
-            .find(|workspace| workspace.id == checkout.workspace_id)
+        find_workspace_by_id(registry, &checkout.workspace_id)
             .map(|workspace| (workspace, checkout))
     })
 }
@@ -462,10 +475,7 @@ pub fn find_workspace_by_path<'a>(
     cwd: &Path,
 ) -> Option<&'a Workspace> {
     let checkout = find_checkout_by_path(registry, cwd)?;
-    registry
-        .workspaces
-        .iter()
-        .find(|workspace| workspace.id == checkout.workspace_id)
+    find_workspace_by_id(registry, &checkout.workspace_id)
 }
 
 /// Sets a path override binding a directory to a workspace.

--- a/crates/orbit-registry/src/workspace_registry/mod.rs
+++ b/crates/orbit-registry/src/workspace_registry/mod.rs
@@ -6,8 +6,8 @@ mod publication;
 
 pub use catalog::{
     WorkspaceRegistryHostContext, WorkspaceSourceRemoteRebind, assign_checkout_role, find_checkout,
-    find_checkout_by_path, find_workspace, find_workspace_by_path, local_workspaces,
-    parse_workspace_registry, rebind_workspace_source_remote, register_checkout,
+    find_checkout_by_path, find_workspace, find_workspace_by_id, find_workspace_by_path,
+    local_workspaces, parse_workspace_registry, rebind_workspace_source_remote, register_checkout,
     register_workspace, remove_workspace, rename_local_owner_host_id, resolve_logical_workspace,
     set_path_override, validate_workspace_registry, validate_workspaces,
 };


### PR DESCRIPTION
## Task

[ORB-11805](https://orbit-cli.com/tasks/ORB-11805) — [qa-sweep] Workspace ID/name collision makes the ID-owning checkout unusable

### Description

## Problem
After ORB-11723 made `find_workspace` reject selectors that match one workspace ID and another workspace name, internal resolution of a checkout binding still passes the binding’s authoritative `workspace_id` through that ambiguous-selector function. A legitimate collision therefore makes the workspace whose ID is shadowed unusable even when Orbit resolves it from the current checkout or an absolute checkout path.

## Observed evidence
Built `target/debug/orbit` from `09b5fa6dcc1d036ce9b029d0383e10e63019b504`. In an isolated `/tmp` Orbit root, workspace A was registered as `{id: ws_alpha, name: alpha}` and workspace B as `{id: ws_ws_alpha, name: ws_alpha}`. From A’s checkout, `orbit --root <root> --format json workspace show`, `task list`, `task add`, and `doctor` all exit 1 with `{"code":"invalid_input","error":"invalid input: ambiguous workspace selector ws_alpha; it matches more than one registered workspace"}`. `--workspace <absolute-path-to-A> task list` fails identically. `workspace list --all` still shows both valid checkout bindings.

The regression path is `crates/orbit-cmd/src/registry_runtime.rs`: `resolve_cli_workspace_path` and `select_workspace_for_cwd_and_roots` resolve an exact checkout, then call `find_workspace(registry, &checkout.workspace_id)`, reinterpreting an authoritative ID as an external id-or-name selector. Several CLI call sites were changed to exact-ID iteration in ORB-11723, but these runtime paths were not.

## Exact reproduction
1. Build: `cargo build -p orbit-cli --bin orbit`.
2. Create `/tmp/qa/root`, two scratch Git repositories, and initialize the root with `target/debug/orbit --root /tmp/qa/root init --non-interactive --host-name qa-host --task-prefix QAQA`.
3. In repo A run `target/debug/orbit --root /tmp/qa/root workspace init --name alpha` (creates `ws_alpha`).
4. In repo B run `target/debug/orbit --root /tmp/qa/root workspace init --name ws_alpha` (creates `ws_ws_alpha`).
5. In repo A run `target/debug/orbit --root /tmp/qa/root --format json task list`; observe exit 1 and the ambiguity error. Also reproduce with global `--workspace /tmp/qa/repo-a`.

## Impact
Production impact: a valid ID/name collision can block essentially every command that resolves the current/path-selected checkout, despite the checkout binding already identifying one workspace exactly. Validation impact: the standard suites are not known to fail; this was found only through hands-on CLI use.

## Scope assessment
Keep fail-closed behavior for user-entered ambiguous id-or-name selectors such as `workspace remove ws_alpha`, but use exact-ID resolution after a checkout or other persisted relation already supplies `workspace_id`. Add user-facing regression coverage for current-directory and absolute-path selection.

### Acceptance Criteria

- With workspace A `{id: ws_alpha, name: alpha}` and B `{id: ws_ws_alpha, name: ws_alpha}`, commands run from A’s checkout resolve A and do not report selector ambiguity.
- Selecting A by its absolute checkout path resolves A despite the ID/name collision.
- A directly entered ambiguous selector `ws_alpha` still fails closed for operations such as workspace removal and role assignment.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `find_workspace_by_id` for exact catalog-ID lookup that never treats the argument as an id-or-name selector.
- `resolve_cli_workspace_path` and `select_workspace_for_cwd_and_roots` now resolve a matched checkout through that helper, so a checkout-backed `workspace_id` is not reinterpreted as an ambiguous selector.
- `workspace sync` and `workspace source-remote show` use the same exact-ID lookup after they already have a checkout or runtime ID.
- User-entered selectors (`workspace remove`, `workspace role`, `--workspace ws_alpha`) still go through `find_workspace` / `resolve_logical_workspace` and fail closed on collision.
- Regression coverage: catalog exact-ID vs fail-closed selectors; runtime cwd and absolute-path selection; CLI `workspace show` / `task list` from A's checkout, `--workspace <absolute-path>`, and typed `ws_alpha` remove/role.
Assessment: Small, targeted seam. Checkout identity and typed selectors now use different lookup grammars at the catalog boundary rather than a one-off runtime workaround.
Strategic decisions: Exact-ID lookup lives next to `find_workspace` so later persisted-ID call sites do not reintroduce the reinterpretation. Existing mutation helpers keep the fail-closed id-or-name grammar.
Design weaknesses / risks:
- Severity: low. `workspace source-remote rebind` and publication helpers still pass a resolved ID through `find_workspace` / `find_checkout` / `find_publication_binding`. After this fix, cwd and path bootstrap succeed; those later lookups can still fail closed on the same collision. Mitigation: they are outside the QA reproduction and acceptance criteria; a follow-up can switch remaining persisted-ID call sites to `find_workspace_by_id`.
Deviations from original plan: none.
Recommended follow-ups: Switch remaining persisted-ID lookups in publication and source-remote rebind off `find_workspace`.

Acceptance criteria:
1. Commands from A's checkout resolve A: passed. CLI test runs `workspace show --format json` and `task list` from `{id: ws_alpha, name: alpha}` with `{id: ws_ws_alpha, name: ws_alpha}` registered; both succeed and show `ws_alpha` / `alpha`. Runtime `select_workspace_for_cwd_and_roots` binds A.
2. Absolute checkout path selects A: passed. CLI `--workspace <abs-path-to-A> workspace show` / `task list` from a foreign cwd bind A. Runtime `initialize_with_overrides` with A's path binds `ws_alpha`.
3. Typed selector `ws_alpha` fails closed for remove and role: passed. Catalog `remove_workspace` / `assign_checkout_role` and CLI `workspace remove ws_alpha` / `workspace role ws_alpha owner` report `ambiguous workspace selector`. `--workspace ws_alpha` still fails closed at runtime init.

Validation:
- `cargo test -p orbit-registry --lib -- workspace_registry`: passed (22 tests)
- `cargo test -p orbit-cmd --lib -- registry_runtime`: passed (17 tests)
- `cargo test -p orbit-cli --test workspace_selector`: passed (5 tests)
- `cargo test -p orbit-cli --test workspace_source_remote`: passed (3 tests)
- `cargo test -p orbit-cli --test workspace_sync`: passed (2 tests)
- `make ci-fast`: passed (fmt-check + guardrails; compiler-cache namespace probe skipped for bwrap userns)
- `make ci-lint`: passed (`cargo clippy --workspace --all-targets -- -D warnings`)
- `git diff --check`: passed
- `make ci`: not run (PR merge gate, not per-task)

Remaining risks: publication bind/show/restore and source-remote rebind can still hit ambiguous-selector errors if they look up the resolved `ws_alpha` ID through `find_workspace`. Changes left uncommitted for the pipeline.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11805-6a9f9843`
- Behind base: 0
- Ahead of base: 1