### PR TITLE
Resolve Homebrew Codex launcher for Mac scheduled drains with minimal PATH

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -28,6 +28,14 @@ const DEFAULT_MACOS_CA_CERTIFICATE: &str = "/etc/ssl/cert.pem";
 /// and child-env construction cannot drift. [ORB-10909]
 const CONVENTIONAL_HOME_BIN_DIRS: &[&str] = &[".local/bin", ".orbit/bin", ".cargo/bin", "bin"];
 
+/// Portable supported-launcher prefixes searched after `PATH` and `$HOME`
+/// bins, and backfilled into the spawned agent `PATH`. These are OS package
+/// prefixes, not user directories: Apple Silicon Homebrew, then the Intel
+/// Homebrew / `/usr/local` prefix. launchd's default `PATH` omits both, which
+/// is why a scheduled Mac drain cannot find `/opt/homebrew/bin/codex` while
+/// an interactive shell can. [ORB-11808]
+pub(crate) const SUPPORTED_SYSTEM_BIN_DIRS: &[&str] = &["/opt/homebrew/bin", "/usr/local/bin"];
+
 /// Typed spawn failure with a retryability classification (ORB-10006).
 ///
 /// `permanent: true` marks failures that retrying cannot fix — the step
@@ -262,14 +270,20 @@ pub(crate) fn orbit_tool_env_with(
         }
     }
     // Service/routine dispatch often inherits a PATH that omits cargo and
-    // other login-shell bins. Backfill the same conventional home dirs
-    // `resolve_provider_launcher_with` already searches so `cargo test`
-    // inside the spawned agent is not "command not found". [ORB-10909]
+    // other login-shell bins. Backfill the same conventional home dirs and
+    // supported system prefixes `resolve_provider_launcher_with` already
+    // searches so `cargo test` and Homebrew-installed tools inside the
+    // spawned agent are not "command not found". [ORB-10909] [ORB-11808]
     if let Some(home) = home {
         for dir in conventional_home_bin_dirs(home) {
             if seen.insert(dir.clone()) {
                 path_entries.push(dir);
             }
+        }
+    }
+    for dir in supported_system_bin_dirs() {
+        if seen.insert(dir.clone()) {
+            path_entries.push(dir);
         }
     }
     let pinned_path = std::env::join_paths(path_entries)
@@ -299,6 +313,28 @@ fn conventional_home_bin_dirs(home: &Path) -> impl Iterator<Item = PathBuf> + '_
         .map(|relative| home.join(relative))
 }
 
+fn supported_system_bin_dirs() -> impl Iterator<Item = PathBuf> {
+    SUPPORTED_SYSTEM_BIN_DIRS.iter().map(PathBuf::from)
+}
+
+fn is_launchable_file(path: &Path) -> bool {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        metadata.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
 // pub(crate) widened for sibling tests under the repository's enforced test layout.
 pub(crate) fn resolve_provider_launcher_with(
     provider: &str,
@@ -306,6 +342,28 @@ pub(crate) fn resolve_provider_launcher_with(
     path: Option<&OsStr>,
     home: Option<&Path>,
     cwd: Option<&Path>,
+) -> Result<String, SpawnError> {
+    resolve_provider_launcher_with_extra_dirs(
+        provider,
+        program,
+        path,
+        home,
+        cwd,
+        supported_system_bin_dirs(),
+    )
+}
+
+/// Test-injectable resolver: production calls
+/// [`resolve_provider_launcher_with`], which supplies the supported system
+/// prefixes. Tests pass a temporary Homebrew-style prefix rather than
+/// writing into `/opt/homebrew/bin`.
+pub(crate) fn resolve_provider_launcher_with_extra_dirs(
+    provider: &str,
+    program: &str,
+    path: Option<&OsStr>,
+    home: Option<&Path>,
+    cwd: Option<&Path>,
+    extra_bin_dirs: impl IntoIterator<Item = PathBuf>,
 ) -> Result<String, SpawnError> {
     let configured = Path::new(program);
     if configured.components().count() > 1 {
@@ -333,12 +391,17 @@ pub(crate) fn resolve_provider_launcher_with(
             }
         }
     }
+    for dir in extra_bin_dirs {
+        if seen.insert(dir.clone()) {
+            search_dirs.push(dir);
+        }
+    }
 
     let mut searched = Vec::with_capacity(search_dirs.len());
     for dir in search_dirs {
         let candidate = dir.join(program);
         searched.push(candidate.clone());
-        if candidate.is_file() {
+        if is_launchable_file(&candidate) {
             return Ok(candidate.to_string_lossy().into_owned());
         }
         #[cfg(windows)]
@@ -346,7 +409,7 @@ pub(crate) fn resolve_provider_launcher_with(
             for extension in windows_executable_extensions() {
                 let candidate = dir.join(format!("{program}{extension}"));
                 searched.push(candidate.clone());
-                if candidate.is_file() {
+                if is_launchable_file(&candidate) {
                     return Ok(candidate.to_string_lossy().into_owned());
                 }
             }

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
@@ -8,13 +8,13 @@ use tempfile::tempdir;
 
 use super::super::super::dispatcher::ResolvedSandbox;
 use super::super::spawn::{
-    SpawnError, SpawnedChild, linux_bwrap_failed_write_diagnostic,
+    SUPPORTED_SYSTEM_BIN_DIRS, SpawnError, SpawnedChild, linux_bwrap_failed_write_diagnostic,
     macos_keychain_auth_diagnostic_with, orbit_tool_env_with,
     prepare_linux_sandbox_for_dispatch_with_probe, prepare_macos_codex_ca_environment_with,
-    reject_unsatisfiable_managed_grants, resolve_provider_launcher_with, spawn_bare,
-    spawn_macos_sandboxed_with,
+    reject_unsatisfiable_managed_grants, resolve_provider_launcher_with,
+    resolve_provider_launcher_with_extra_dirs, spawn_bare, spawn_macos_sandboxed_with,
 };
-use super::test_support::{sandbox_for_test, sh_args};
+use super::test_support::{sandbox_for_test, sh_args, write_executable};
 
 /// A profile shaped like a managed-worktree implementer: the worktree is
 /// writable, its `.orbit` store is not.
@@ -611,7 +611,7 @@ fn provider_launcher_resolution_falls_back_to_temp_home_with_scrubbed_path() {
     std::fs::create_dir_all(&fake_path).expect("create fake PATH");
     std::fs::create_dir_all(&provider_bin).expect("create provider bin");
     let launcher = provider_bin.join("claude");
-    std::fs::write(&launcher, "#!/bin/sh\nexit 0\n").expect("write fake provider launcher");
+    write_executable(&launcher, "#!/bin/sh\nexit 0\n");
 
     let resolved = resolve_provider_launcher_with(
         "claude",
@@ -654,6 +654,8 @@ fn missing_provider_launcher_error_names_provider_and_searched_locations() {
         home.join(".orbit/bin/claude"),
         home.join(".cargo/bin/claude"),
         home.join("bin/claude"),
+        std::path::PathBuf::from("/opt/homebrew/bin/claude"),
+        std::path::PathBuf::from("/usr/local/bin/claude"),
     ] {
         assert!(
             error.message.contains(&searched.display().to_string()),
@@ -662,6 +664,10 @@ fn missing_provider_launcher_error_names_provider_and_searched_locations() {
             error.message
         );
     }
+    assert_eq!(
+        SUPPORTED_SYSTEM_BIN_DIRS,
+        &["/opt/homebrew/bin", "/usr/local/bin"]
+    );
 }
 
 #[test]
@@ -694,6 +700,8 @@ fn agent_tool_environment_prefers_dispatching_orbit_over_stale_path_entry() {
             std::path::PathBuf::from("/home/test/.orbit/bin"),
             std::path::PathBuf::from("/home/test/.cargo/bin"),
             std::path::PathBuf::from("/usr/bin"),
+            std::path::PathBuf::from("/opt/homebrew/bin"),
+            std::path::PathBuf::from("/usr/local/bin"),
         ]
     );
 }
@@ -721,6 +729,8 @@ fn configured_orbit_bin_wins_and_its_path_entry_is_deduplicated() {
             std::path::PathBuf::from("/opt/orbit/bin"),
             std::path::PathBuf::from("/home/test/.cargo/bin"),
             std::path::PathBuf::from("/usr/bin"),
+            std::path::PathBuf::from("/opt/homebrew/bin"),
+            std::path::PathBuf::from("/usr/local/bin"),
         ]
     );
 }
@@ -750,7 +760,186 @@ fn agent_tool_environment_backfills_conventional_home_bin_dirs_missing_from_path
             std::path::PathBuf::from("/home/test/.local/bin"),
             std::path::PathBuf::from("/home/test/.cargo/bin"),
             std::path::PathBuf::from("/home/test/bin"),
+            std::path::PathBuf::from("/opt/homebrew/bin"),
+            std::path::PathBuf::from("/usr/local/bin"),
         ]
+    );
+}
+
+/// launchd's default PATH on macOS. Drain, pilot, and shipment share
+/// `resolve_provider_launcher`; this is the scheduled-worker environment
+/// that failed to find `/opt/homebrew/bin/codex` on the live Mac cargo
+/// binary `/Users/daniel/.cargo/bin/orbit` (0.19.2). Source HEAD at
+/// pickup: `bca1cddc99987506c96e0ea626902f537d53572b`. [ORB-11808]
+const MACOS_LAUNCHD_PATH: &str = "/usr/bin:/bin:/usr/sbin:/sbin";
+
+fn homebrew_style_prefix(root: &std::path::Path) -> std::path::PathBuf {
+    root.join("opt").join("homebrew").join("bin")
+}
+
+fn launch_resolved_provider(program: &str) -> String {
+    let spawned = spawn_bare(
+        program,
+        &[],
+        &[("PATH".to_string(), MACOS_LAUNCHD_PATH.to_string())],
+        None,
+    )
+    .expect("spawn resolved provider launcher");
+    let output = spawned
+        .child
+        .wait_with_output()
+        .expect("wait for resolved provider");
+    assert!(
+        output.status.success(),
+        "resolved launcher must exit 0: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[cfg(unix)]
+#[test]
+fn minimal_macos_path_resolves_homebrew_style_provider_for_scheduled_and_interactive_launch() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let prefix = homebrew_style_prefix(temp.path());
+    std::fs::create_dir_all(&home).expect("create fake HOME");
+    std::fs::create_dir_all(&prefix).expect("create Homebrew-style prefix");
+    let launcher = prefix.join("codex");
+    write_executable(&launcher, "#!/bin/sh\nprintf 'codex-fixture-0.153.4\\n'\n");
+
+    let scheduled = resolve_provider_launcher_with_extra_dirs(
+        "codex",
+        "codex",
+        Some(std::ffi::OsStr::new(MACOS_LAUNCHD_PATH)),
+        Some(&home),
+        None,
+        [prefix.clone()],
+    )
+    .expect("scheduled drain PATH must resolve Homebrew-style launcher");
+    let interactive_path = format!("{MACOS_LAUNCHD_PATH}:{}", prefix.display());
+    let interactive = resolve_provider_launcher_with_extra_dirs(
+        "codex",
+        "codex",
+        Some(std::ffi::OsStr::new(&interactive_path)),
+        Some(&home),
+        None,
+        [prefix.clone()],
+    )
+    .expect("interactive PATH must resolve Homebrew-style launcher");
+    let pilot = resolve_provider_launcher_with_extra_dirs(
+        "codex",
+        "codex",
+        Some(std::ffi::OsStr::new(MACOS_LAUNCHD_PATH)),
+        Some(&home),
+        None,
+        [prefix],
+    )
+    .expect("pilot PATH must resolve Homebrew-style launcher");
+
+    assert_eq!(scheduled, launcher.to_string_lossy());
+    assert_eq!(interactive, scheduled);
+    assert_eq!(pilot, scheduled);
+
+    let scheduled_out = launch_resolved_provider(&scheduled);
+    let interactive_out = launch_resolved_provider(&interactive);
+    assert_eq!(scheduled_out, "codex-fixture-0.153.4\n");
+    assert_eq!(interactive_out, scheduled_out);
+}
+
+#[cfg(unix)]
+#[test]
+fn explicit_launcher_path_wins_over_homebrew_style_prefix() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let prefix = homebrew_style_prefix(temp.path());
+    let override_dir = temp.path().join("override");
+    std::fs::create_dir_all(&home).expect("create fake HOME");
+    std::fs::create_dir_all(&prefix).expect("create Homebrew-style prefix");
+    std::fs::create_dir_all(&override_dir).expect("create override dir");
+    write_executable(&prefix.join("codex"), "#!/bin/sh\nprintf 'homebrew\\n'\n");
+    let override_launcher = override_dir.join("codex");
+    write_executable(&override_launcher, "#!/bin/sh\nprintf 'override\\n'\n");
+
+    let resolved = resolve_provider_launcher_with_extra_dirs(
+        "codex",
+        override_launcher.to_str().expect("utf-8 override path"),
+        Some(std::ffi::OsStr::new(MACOS_LAUNCHD_PATH)),
+        Some(&home),
+        None,
+        [prefix],
+    )
+    .expect("explicit path must be preserved");
+
+    assert_eq!(resolved, override_launcher.to_string_lossy());
+    assert_eq!(launch_resolved_provider(&resolved), "override\n");
+}
+
+#[cfg(unix)]
+#[test]
+fn path_executable_wins_over_homebrew_style_fallback() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let prefix = homebrew_style_prefix(temp.path());
+    let path_dir = temp.path().join("path-bin");
+    std::fs::create_dir_all(&home).expect("create fake HOME");
+    std::fs::create_dir_all(&prefix).expect("create Homebrew-style prefix");
+    std::fs::create_dir_all(&path_dir).expect("create PATH dir");
+    write_executable(&prefix.join("codex"), "#!/bin/sh\nprintf 'homebrew\\n'\n");
+    let path_launcher = path_dir.join("codex");
+    write_executable(&path_launcher, "#!/bin/sh\nprintf 'path\\n'\n");
+
+    let resolved = resolve_provider_launcher_with_extra_dirs(
+        "codex",
+        "codex",
+        Some(path_dir.as_os_str()),
+        Some(&home),
+        None,
+        [prefix],
+    )
+    .expect("PATH must beat Homebrew-style fallback");
+
+    assert_eq!(resolved, path_launcher.to_string_lossy());
+    assert_eq!(launch_resolved_provider(&resolved), "path\n");
+}
+
+#[cfg(unix)]
+#[test]
+fn non_executable_homebrew_style_file_is_skipped_and_absent_launcher_stays_permanent() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let prefix = homebrew_style_prefix(temp.path());
+    std::fs::create_dir_all(&home).expect("create fake HOME");
+    std::fs::create_dir_all(&prefix).expect("create Homebrew-style prefix");
+    let stub = prefix.join("codex");
+    std::fs::write(&stub, "#!/bin/sh\nprintf 'not-executable\\n'\n")
+        .expect("write non-executable stub");
+
+    let error = resolve_provider_launcher_with_extra_dirs(
+        "codex",
+        "codex",
+        Some(std::ffi::OsStr::new(MACOS_LAUNCHD_PATH)),
+        Some(&home),
+        None,
+        [prefix.clone()],
+    )
+    .expect_err("non-executable stub must not resolve");
+
+    assert!(error.permanent, "missing launcher must remain permanent");
+    assert!(
+        error.message.contains("provider `codex`"),
+        "error should name the provider: {}",
+        error.message
+    );
+    assert!(
+        error.message.contains(&stub.display().to_string()),
+        "error should name the non-executable candidate: {}",
+        error.message
+    );
+    assert!(
+        error.message.contains("was not found"),
+        "error should stay a missing-launcher diagnostic: {}",
+        error.message
     );
 }
 

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -589,11 +589,15 @@ After [ORB-10456], every bare provider launcher is resolved before audit and
 spawn at the shared `orbit-engine` CLI boundary ([Provider launchers resolve at the shared CLI spawn boundary](./4_decisions.md#provider-launchers-resolve-at-the-shared-cli-spawn-boundary)). Lookup preserves
 configured paths verbatim; bare names search the process `PATH` first, then
 portable user-local directories derived from `HOME` (`.local/bin`,
-`.orbit/bin`, `.cargo/bin`, and `bin`). Dashboard Ship, routine sweep,
-`orbit run ship`, and direct job execution all converge on this boundary, so
-none depends solely on the environment inherited by its entry process. A
-missing launcher remains a permanent failure, but the diagnostic names the
-provider and every path Orbit searched.
+`.orbit/bin`, `.cargo/bin`, and `bin`), then portable supported system
+prefixes (`/opt/homebrew/bin`, `/usr/local/bin`) so a launchd-minimal Mac
+`PATH` still finds Homebrew-installed provider CLIs ([ORB-11808]). Searched
+candidates must be regular files with execute permission on Unix; explicit
+overrides skip that search. Dashboard Ship, routine sweep, `orbit run ship`,
+and direct job execution all converge on this boundary, so none depends solely
+on the environment inherited by its entry process. A missing launcher remains
+a permanent failure, but the diagnostic names the provider and every path
+Orbit searched.
 
 After [T20260430-15], the CLI stdin envelope carries rendered activity input and durable `run_id` beside instruction, prompt, tools, and model. [ORB-11069] defines `tools` there as the computed effective list and adds the task's requested `required_tools`; the child also receives the effective list in `ORBIT_ACTIVITY_TOOLS`. When input identifies one task, orbit-core embeds a canonical task snapshot with `input.workspace_path` / `input.repo_root` taking precedence over stored paths. After [T20260508-8], agent dispatch also uses a shared workspace resolver for subprocess cwd: `input.workspace_path`, then `task.workspace_path`, then best-effort `ToolContext.workspace_root`. Declared input/task paths must already be directories; stale worktrees fail as `CliInvocationFailed` before `CliInvocationStarted` is emitted. After [T20260505-10], Orbit-managed CLI subprocesses receive `ORBIT_RUN_ID` plus an Orbit-managed run-context marker; `orbit tool run` requires both before it populates `ToolContext` reservation ownership. Direct manual CLI tool calls, including calls with only `ORBIT_RUN_ID`, remain unowned.
 
@@ -1021,6 +1025,7 @@ Read-only history does not need the same dependencies as live execution. [T20260
 - **[ORB-10414]** — Make HTTP replay an explicit default-off cargo feature and keep replay environment variables inert in default builds.
 - **[ORB-10434]** — Extend the replay opt-in to orbit-core (`orbit-core/replay`) so its fixture-backed v2_host test keeps running hermetically instead of demanding a live credential.
 - **[ORB-10456]** — Resolve provider launchers at the shared CLI spawn boundary and report provider-aware searched-location diagnostics.
+- **[ORB-11808]** — Search portable Homebrew `/opt/homebrew/bin` and `/usr/local/bin` prefixes after `PATH` and `$HOME` bins so scheduled Mac drains resolve the same launcher as interactive launches.
 - **[ORB-10461]** — Persist detached pipeline-worker output by run id and terminalize pre-claim exits with the captured startup diagnostic.
 - **[ORB-10464]** — Verify that done dependencies are delivered into the pinned base before a worktree is created.
 - **[ORB-10499]** — Identify the bounded post-recovery attempt as the duplicate implement invocation, and let a re-dispatched attempt exit on a write-gated task.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -1231,16 +1231,16 @@ Recognition is the entire change: no safety gate moved. Non-terminal run, `--old
 
 ## Provider launchers resolve at the shared CLI spawn boundary
 
-**Recorded:** 2026-08-01 19:17:24.893725Z · [ORB-10456], [ORB-10479]
+**Recorded:** 2026-08-01 19:17:24.893725Z · [ORB-10456], [ORB-10479], [ORB-11808]
 
-**Context.** Dashboard shipment reproduced the same provider-launcher ENOENT previously seen in routine sweeps: independent process entry points inherited different `PATH` values even though every `backend: cli` provider invocation converges on one engine spawn boundary. The alternatives were to keep pinning `PATH` in each service/entry point or resolve configured launcher names once at that shared boundary.
+**Context.** Dashboard shipment reproduced the same provider-launcher ENOENT previously seen in routine sweeps: independent process entry points inherited different `PATH` values even though every `backend: cli` provider invocation converges on one engine spawn boundary. The alternatives were to keep pinning `PATH` in each service/entry point or resolve configured launcher names once at that shared boundary. [ORB-11808] then showed the same seam still missed Apple Silicon Homebrew: launchd's default `PATH` is `/usr/bin:/bin:/usr/sbin:/sbin`, and the `$HOME` fallback list does not include `/opt/homebrew/bin`. Interactive MCP and login-shell pilot inherit that prefix; scheduled drain does not. Pinning Homebrew into the launchd unit would have been a scheduler change; hardcoding a user home would have broken isolation.
 
-**Decision.** Resolve every bare provider launcher at the orbit-engine CLI spawn boundary. Search the process `PATH` first, then portable per-user fallback directories derived from `HOME`; preserve explicitly pathed commands unchanged. Missing-launcher failures remain permanent and name the provider plus every searched path.
+**Decision.** Resolve every bare provider launcher at the orbit-engine CLI spawn boundary. Search the process `PATH` first, then portable per-user fallback directories derived from `HOME`, then portable supported system prefixes (`/opt/homebrew/bin`, `/usr/local/bin`). Preserve explicitly pathed commands unchanged. Searched candidates must be regular executable files; missing-launcher failures remain permanent and name the provider plus every searched path.
 
 **Consequences.**
 - Dashboard, routine, CLI ship, and direct job dispatch share one provider-launcher resolution mechanism rather than depending on each parent environment being curated.
-- Explicit command paths and `PATH` precedence remain authoritative, while common user-local installations work from scrubbed service environments.
-- Cost: Orbit now recognizes a small ordered set of conventional user-local bin directories outside `PATH`, so moving a launcher into a new convention requires extending and testing that list.
+- Explicit command paths and `PATH` precedence remain authoritative, while common user-local installations and Homebrew prefixes work from scrubbed service environments, including macOS launchd.
+- Cost: Orbit now recognizes a small ordered set of conventional user-local and supported-system bin directories outside `PATH`, so moving a launcher into a new convention requires extending and testing that list.
 
 ## Resume is a durable submission scoped by explicit retry lineage
 
@@ -1611,6 +1611,7 @@ Retrying setup while the stale leftover remains keeps refusing. Recovery is oper
 - **[ORB-10471]** — Scope the worktree boundary guard's primary dirt check to paths the run touched, so unrelated primary dirt no longer defeats a benign fast-forward ([Primary fast-forward acceptance is decided by interference with the run, not primary dirty-state byte-identity](#primary-fast-forward-acceptance-is-decided-by-interference-with-the-run-not-primary-dirty-state-byte-identity)).
 - **[ORB-10470]** — Make resume submit a detached run that starts at the failed checkpoint, and reconcile blocked/re-stamped tasks against the run's retry lineage ([Resume is a durable submission scoped by explicit retry lineage](#resume-is-a-durable-submission-scoped-by-explicit-retry-lineage)).
 - **[ORB-10456]** — Resolve provider launchers at the shared CLI spawn boundary and add provider-aware missing-launcher diagnostics ([Provider launchers resolve at the shared CLI spawn boundary](#provider-launchers-resolve-at-the-shared-cli-spawn-boundary)).
+- **[ORB-11808]** — Search `/opt/homebrew/bin` and `/usr/local/bin` after `PATH` and `$HOME` bins so launchd-minimal Mac drains resolve Homebrew provider CLIs at the same seam.
 - **[ORB-10454]** — Allocate [Step completion is a separate contract from response content](#step-completion-is-a-separate-contract-from-response-content) for the step-completion / response-content split and retire the IOU in [CLI response envelopes are optional for artifact-backed activities](#cli-response-envelopes-are-optional-for-artifact-backed-activities)'s amendment block.
 - **[ORB-10427]** — Share one worktree-path derivation between `setup_worktree` and gc; collect bundles only when every member has settled.
 - **[ORB-10393]** — Port planning-duel planner and arbiter legs to seeded v2


### PR DESCRIPTION
## Task

[ORB-11808](https://orbit-cli.com/tasks/ORB-11808) — Resolve Homebrew Codex launcher for Mac scheduled drains with minimal PATH

### Description

Live Mac workflow matrix on ws_dsearch 2026-09-08: existing workspace_auto_pipeline jrun-20260908-0514-3 admitted DANI-10316 (low/luna) and DANI-10317 (medium/terra), correctly preserving task.crew. Leaves jrun-20260908-0523 and jrun-20260908-0523-2 failed after 1114/1540 ms before provider launch: provider launcher codex was not found; searched /usr/bin, /bin, /usr/sbin, /sbin, ~/.local/bin, ~/.orbit/bin, ~/.cargo/bin, ~/bin. /opt/homebrew/bin is absent. /opt/homebrew/bin/codex --version independently succeeds (codex-cli 0.153.4). Both tasks became blocked. The same tasks resumed through authoritative MCP as jrun-20260908-0524 and jrun-20260908-0524-2 start successfully with their original crews, indicating an entry-point/environment-dependent launcher resolution failure. Targeted task-pilot jrun-20260908-0521 also successfully uses /opt/homebrew/bin/codex.

Earlier ORB-10456 fixed shared provider resolution for dashboard/Linux and ORB-10214 addressed systemd PATH. No active Mac/Homebrew coverage found. Mac MCP is still Homebrew Orbit 0.19.0 despite restart; installed cargo binary is newer 0.19.2. Establish exact scheduled worker binary/config/PATH before attributing this to the current source; do not conflate versions. Trace current shared resolver and introducing source/task before setting source_task_id. Provide portable Mac supported-launcher resolution or explicit durable configuration at the owning seam so scheduled and interactive launches agree. Preserve explicit overrides, executable validation, fail-fast missing launcher errors and sandbox boundaries; avoid hardcoded user directories or weakening env isolation. No global installs, release, merge or scheduler changes authorized.

### Acceptance Criteria

- Reproduce with minimal macOS-style PATH and an installed Homebrew-style provider; resolve it consistently for scheduled drain, pilot and explicit shipment.
- Preserve explicit launcher override precedence, executable checks and actionable errors for truly absent providers.
- Use deterministic temporary executable fixtures and verify live Mac scheduled-equivalent launch plus interactive launch at an identified binary revision.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Extended the shared CLI spawn resolver (`resolve_provider_launcher` / `orbit_tool_env` in `crates/orbit-engine/src/activity_job/cli_runner/spawn.rs`) so bare provider names search PATH, then `$HOME` conventional bins, then portable supported system prefixes `/opt/homebrew/bin` and `/usr/local/bin`. Drain, pilot, and shipment already share this seam; launchd/systemd units were not changed.
- Searched candidates must now be regular files with Unix execute permission. Explicit pathed commands remain verbatim. Missing launchers stay permanent and name every searched path, including the Homebrew prefixes.
- Added deterministic temp executable fixtures covering launchd-minimal PATH vs interactive PATH, explicit override precedence, PATH-over-Homebrew precedence, non-executable skip, and live spawn of the resolved fixture.
- Updated activity-job design prose and the shared-resolver decision to record the supported prefixes.

Assessment: The owning seam is the ORB-10456 resolver, not the scheduler. The live Mac failure (`/opt/homebrew/bin` absent from launchd PATH `/usr/bin:/bin:/usr/sbin:/sbin` plus `$HOME` bins) is the exact gap this list closes. Checkout at pickup: `bca1cddc99987506c96e0ea626902f537d53572b`. Live incident parent was `/Users/daniel/.cargo/bin/orbit` 0.19.2, not Homebrew Orbit 0.19.0. `source_task_id` belongs to ORB-10456; `orbit.task.update` cannot set it after creation.

Strategic decisions:
- Search OS package prefixes at the shared resolver rather than pinning PATH in launchd (scheduler changes not authorized).
- Inject Homebrew-style prefixes in tests instead of writing `/opt/homebrew/bin`.

Criteria:
1. Minimal macOS-style PATH + Homebrew-style provider resolves the same launcher for scheduled, interactive, and a third same-seam call (stand-in for drain/pilot/shipment): passed via `minimal_macos_path_resolves_homebrew_style_provider_for_scheduled_and_interactive_launch`.
2. Explicit path wins; PATH executable wins over Homebrew fallback; non-executable stub is skipped; absent launcher is permanent and names provider plus searched paths including `/opt/homebrew/bin` and `/usr/local/bin`: passed.
3. Temp executable fixtures actually spawned (scheduled-equivalent and interactive) and printed `codex-fixture-0.153.4`. Identified revisions: source HEAD `bca1cddc99987506c96e0ea626902f537d53572b`; live Mac parent `/Users/daniel/.cargo/bin/orbit` 0.19.2. Live Apple Silicon launchd was not exercised from this Linux worktree.

Validation:
- `CARGO_TARGET_DIR=/tmp/orbit-orb-11808-target cargo test -p orbit-engine --lib cli_runner::tests::spawn`: passed (32 tests).
- `make ci-fast`: passed.
- `CARGO_TARGET_DIR=/tmp/orbit-orb-11808-target make ci-lint`: passed.
- `git diff --check`: passed (no whitespace errors).
- Live Mac launchd drain: not run (this host is Linux). Remaining risk: real `/opt/homebrew/bin/codex` under launchd is proven only by the PATH-shape fixture plus production prefix list, not by a live `com.orbit.sweep` spawn.

No scheduler, release, merge, or global-install changes. Cargo outputs were written under `/tmp/orbit-orb-11808-target`, not the worktree.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11808-6a9f9c91`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra