### PR TITLE
[qa-sweep] Shared-root runtime routes second workspace task writes into the first workspace store

### DIFF
--- a/crates/orbit-cli/tests/shared_root_task_isolation.rs
+++ b/crates/orbit-cli/tests/shared_root_task_isolation.rs
@@ -1,0 +1,253 @@
+#![allow(missing_docs)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::fs;
+use std::path::Path;
+use std::process::Command as StdCommand;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
+use serde_json::Value;
+use tempfile::tempdir;
+
+#[test]
+fn shared_explicit_root_keeps_task_bundles_isolated_by_selected_workspace() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let root = temp.path().join("shared-root");
+    let alpha_repo = temp.path().join("alpha");
+    let beta_repo = temp.path().join("beta");
+    let elsewhere = temp.path().join("elsewhere");
+    for directory in [&home, &elsewhere] {
+        fs::create_dir_all(directory).expect("fixture directory");
+    }
+    init_git_repo(&alpha_repo);
+    init_git_repo(&beta_repo);
+    let root_arg = root.to_str().expect("utf8 root");
+
+    run_orbit(
+        &alpha_repo,
+        &home,
+        &[
+            "--root",
+            root_arg,
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "shared-root-host",
+            "--task-prefix",
+            "SHR",
+        ],
+    )
+    .success();
+    run_orbit(
+        &alpha_repo,
+        &home,
+        &["--root", root_arg, "workspace", "init", "--name", "alpha"],
+    )
+    .success();
+    run_orbit(
+        &beta_repo,
+        &home,
+        &["--root", root_arg, "workspace", "init", "--name", "beta"],
+    )
+    .success();
+
+    let alpha = run_orbit_json(
+        &alpha_repo,
+        &home,
+        &[
+            "--root",
+            root_arg,
+            "task",
+            "add",
+            "--title",
+            "Alpha task",
+            "--complexity",
+            "low",
+            "--json",
+        ],
+    );
+    let alpha_id = alpha["id"].as_str().expect("alpha task id");
+    let beta_from_cwd = run_orbit_json(
+        &beta_repo,
+        &home,
+        &[
+            "--root",
+            root_arg,
+            "task",
+            "add",
+            "--title",
+            "Beta cwd task",
+            "--complexity",
+            "low",
+            "--json",
+        ],
+    );
+    let beta_cwd_id = beta_from_cwd["id"].as_str().expect("beta cwd task id");
+    let beta_from_path = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "--root",
+            root_arg,
+            "--workspace",
+            beta_repo.to_str().expect("utf8 beta repo"),
+            "task",
+            "add",
+            "--title",
+            "Beta path task",
+            "--complexity",
+            "low",
+            "--json",
+        ],
+    );
+    let beta_path_id = beta_from_path["id"].as_str().expect("beta path task id");
+
+    assert!(
+        root.join("tasks/workspaces/ws_alpha")
+            .join(alpha_id)
+            .join("task.yaml")
+            .is_file()
+    );
+    for task_id in [beta_cwd_id, beta_path_id] {
+        assert!(
+            root.join("tasks/workspaces/ws_beta")
+                .join(task_id)
+                .join("task.yaml")
+                .is_file(),
+            "beta bundle must be owned by the selected beta partition"
+        );
+        assert!(
+            !root
+                .join("tasks/workspaces/ws_alpha")
+                .join(task_id)
+                .exists(),
+            "beta bundle must not leak into the alpha partition"
+        );
+    }
+
+    let alpha_list = run_orbit_json(
+        &alpha_repo,
+        &home,
+        &[
+            "--root", root_arg, "task", "list", "--limit", "10", "--json",
+        ],
+    );
+    assert_eq!(task_ids(&alpha_list), vec![alpha_id.to_string()]);
+
+    let beta_list = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "--root",
+            root_arg,
+            "--workspace",
+            beta_repo.to_str().expect("utf8 beta repo"),
+            "task",
+            "list",
+            "--limit",
+            "10",
+            "--json",
+        ],
+    );
+    let beta_ids = task_ids(&beta_list);
+    assert_eq!(beta_ids.len(), 2);
+    assert!(beta_ids.contains(&beta_cwd_id.to_string()));
+    assert!(beta_ids.contains(&beta_path_id.to_string()));
+    assert!(!beta_ids.contains(&alpha_id.to_string()));
+
+    for (repo, task_id, workspace_id, workspace_name) in [
+        (&alpha_repo, alpha_id, "ws_alpha", "alpha"),
+        (&beta_repo, beta_cwd_id, "ws_beta", "beta"),
+        (&beta_repo, beta_path_id, "ws_beta", "beta"),
+    ] {
+        let shown = run_orbit_json(
+            repo,
+            &home,
+            &["--root", root_arg, "task", "show", task_id, "--json"],
+        );
+        assert_eq!(shown["workspace"]["id"], workspace_id);
+        assert_eq!(shown["workspace"]["name"], workspace_name);
+    }
+
+    for (workspace, foreign_task_id) in [(&alpha_repo, beta_path_id), (&beta_repo, alpha_id)] {
+        run_orbit(
+            &elsewhere,
+            &home,
+            &[
+                "--root",
+                root_arg,
+                "--workspace",
+                workspace.to_str().expect("utf8 workspace path"),
+                "task",
+                "show",
+                foreign_task_id,
+                "--json",
+            ],
+        )
+        .failure();
+    }
+}
+
+fn task_ids(value: &Value) -> Vec<String> {
+    let items = value
+        .as_array()
+        .cloned()
+        .or_else(|| value.get("tasks").and_then(Value::as_array).cloned())
+        .unwrap_or_default();
+    items
+        .iter()
+        .filter_map(|task| {
+            task.get("id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+        .collect()
+}
+
+fn run_orbit(cwd: &Path, home: &Path, args: &[&str]) -> assert_cmd::assert::Assert {
+    let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .args(args);
+    command.assert()
+}
+
+fn run_orbit_json(cwd: &Path, home: &Path, args: &[&str]) -> Value {
+    let assert = run_orbit(cwd, home, args).success();
+    serde_json::from_slice(&assert.get_output().stdout).expect("orbit json output")
+}
+
+fn init_git_repo(repo: &Path) {
+    fs::create_dir_all(repo).expect("create repo");
+    run_git(repo, &["init"]);
+    run_git(repo, &["config", "user.name", "Orbit Test"]);
+    run_git(repo, &["config", "user.email", "orbit-test@example.com"]);
+    run_git(repo, &["config", "commit.gpgsign", "false"]);
+    fs::write(repo.join("README.md"), "# repo\n").expect("write readme");
+    run_git(repo, &["add", "README.md"]);
+    run_git(repo, &["commit", "-m", "initial"]);
+}
+
+fn run_git(cwd: &Path, args: &[&str]) {
+    let output = StdCommand::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git -C {} {} failed\nstdout:\n{}\nstderr:\n{}",
+        cwd.display(),
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/orbit-cmd/src/task_owner.rs
+++ b/crates/orbit-cmd/src/task_owner.rs
@@ -97,8 +97,9 @@ pub fn resolve_task_owner(
     let registry = workspace_registry::load_registry_from(&workspace_registry::registry_path_for(
         global_root,
     ))?;
-    let owner = workspace_registry::local_workspaces(&registry).find(|(_, checkout)| {
+    let owner = workspace_registry::local_workspaces(&registry).find(|(workspace, checkout)| {
         checkout_identity(&checkout.orbit_dir).is_some_and(|identity| identity == partition)
+            || (checkout.orbit_dir == global_root && workspace.id == partition)
     });
     let Some((workspace, checkout)) = owner else {
         // The task registry keeps the partition's slug even when no checkout

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -69,16 +69,22 @@ pub(crate) fn build_context_from_roots(
         global_root.to_path_buf(),
     );
 
-    let task_backends = build_v2_task_backends(
-        global_root,
-        &paths,
-        binding.map(|binding| binding.workspace_id.as_str()),
-    )?;
+    let task_backends = build_v2_task_backends(global_root, &paths, binding)?;
     let configured = read_workspace_config_optional(&paths.orbit_dir)?;
-    let workspace_id = configured
-        .as_ref()
-        .map(|config| config.workspace_id.clone())
-        .unwrap_or_else(|| UNBOUND_DATA_DIR_WORKSPACE_ID.to_string());
+    let workspace_id = if is_explicit_data_dir(global_root, &paths.orbit_dir) {
+        binding
+            .map(|binding| binding.logical_workspace_id.clone())
+            .or_else(|| {
+                configured
+                    .as_ref()
+                    .map(|config| config.workspace_id.clone())
+            })
+    } else {
+        configured
+            .as_ref()
+            .map(|config| config.workspace_id.clone())
+    }
+    .unwrap_or_else(|| UNBOUND_DATA_DIR_WORKSPACE_ID.to_string());
     let import_report = if configured.is_none() {
         orbit_store::workflow::legacy_state::ImportReport::skipped()
     } else {
@@ -219,10 +225,25 @@ pub(crate) fn build_context_from_roots(
 fn build_v2_task_backends(
     global_root: &Path,
     paths: &WorkspacePaths,
-    workspace_id_hint: Option<&str>,
+    runtime_binding: Option<&WorkspaceRuntimeBinding>,
 ) -> Result<WorkspaceTaskBackends, OrbitError> {
     let registry = TaskRegistryStore::open(&task_registry_path(global_root))?;
     let config = read_workspace_config_optional(&paths.orbit_dir)?;
+    // Several registered repositories may intentionally share one explicit
+    // Orbit root. That root has only one compatibility config.yaml and cannot
+    // represent every selected workspace. Workspace init has already created
+    // each logical task-registry partition, so route directly by the selected
+    // registry identity and omit a checkout-local projection that would itself
+    // be shared by every repository.
+    if is_explicit_data_dir(global_root, &paths.orbit_dir)
+        && let Some(binding) = runtime_binding
+    {
+        return Ok(coordination_task_backends(
+            registry,
+            binding.logical_workspace_id.clone(),
+        ));
+    }
+    let workspace_id_hint = runtime_binding.map(|binding| binding.workspace_id.as_str());
     // An explicit `--root` data directory is not a checkout. Binding
     // `parent(data-dir)` as `repo_root` mints a synthetic workspace (e.g.
     // `tmp-XXXXXX` for `/tmp`) that later `workspace init --force` cannot


### PR DESCRIPTION
## Task

[ORB-11807](https://orbit-cli.com/tasks/ORB-11807) — [qa-sweep] Shared-root runtime routes second workspace task writes into the first workspace store

### Description

## Problem
With two registered workspaces sharing one explicit Orbit root, CLI runtime selection can project the second workspace identity while its task store still reads and writes the first workspace’s bundle directory. This silently crosses workspace boundaries. It remains present after ORB-10846’s shared-root routing fix and was exposed while validating current HEAD `09b5fa6dcc1d036ce9b029d0383e10e63019b504`.

## Observed evidence
An isolated root `/tmp/orbit-qa-11803.BAjPvu/root` registered A `{id: ws_alpha, repo-a}` and B `{id: ws_ws_alpha, repo-b}`. From repo-b, `workspace show` reports B correctly. Yet `task add` created QAQA-00001 under `root/tasks/workspaces/ws_alpha/QAQA-00001`, not `ws_ws_alpha`. Even an explicit top-level `--workspace /tmp/orbit-qa-11803.BAjPvu/repo-b task add` created QAQA-00002 under `ws_alpha`. Reading with `--workspace repo-b task show QAQA-00002` misleadingly attached `{workspace:{id:ws_ws_alpha,name:ws_alpha}}` although the only on-disk bundle was under A. `task list` selected as A by name and as B by absolute path returned the same three A tasks. Clearing inherited `ORBIT_WORKSPACE` did not change the result.

## Exact reproduction
1. `cargo build -p orbit-cli --bin orbit`.
2. Initialize `/tmp/qa/root` with `target/debug/orbit --root /tmp/qa/root init --non-interactive --host-name qa-host --task-prefix QAQA`.
3. Initialize Git repo A with `target/debug/orbit --root /tmp/qa/root workspace init --name alpha`.
4. Initialize Git repo B under the same root with `target/debug/orbit --root /tmp/qa/root workspace init --name beta`.
5. Run `env -u ORBIT_WORKSPACE target/debug/orbit --root /tmp/qa/root --workspace /tmp/qa/repo-b --format json task add --title probe --complexity low --status proposed`.
6. Observe the response projects B, but `find /tmp/qa/root/tasks/workspaces -name task.yaml` locates the new bundle under `ws_alpha`, and task lists for A and B return the same row.

## Impact
Production impact: task reads/writes intended for a non-default workspace silently operate on another workspace’s data while responses advertise the selected workspace. This is a data-integrity and isolation defect. Validation impact: `make ci-fast`, `make ci-lint`, and current targeted tests pass; the defect needs multi-workspace shared-root end-to-end coverage.

## Scope assessment
Trace how `RegisteredRuntimeFactory` passes `WorkspaceRuntimeBinding` into `OrbitRuntime` and how the task bundle root is derived. The authoritative selected workspace ID must control both response projection and store paths for reads and writes. Preserve explicit-root isolation and fail-closed selector behavior.

### Acceptance Criteria

- With two workspaces sharing one explicit root, `task add` selected by the second checkout path persists only under the second workspace’s task-bundle directory.
- `task list` and `task show` for each workspace return only that workspace’s bundles, and the projected workspace identity matches the physical store owner.
- The behavior is covered end-to-end for both cwd-derived and explicit `--workspace` selection under a shared root.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Shared explicit-root runtimes now use the selected logical workspace ID for task and job-run partitioning instead of the root's single compatibility config.yaml identity.
- Shared-root task stores use coordination-only canonical bundles, avoiding a checkout-local projection shared by multiple repositories.
- Global task-show owner resolution recognizes logical workspace ownership for checkouts sharing the explicit root.
- Added a dedicated CLI integration test covering two registered workspaces, physical bundle ownership, isolated list/show behavior, cwd-derived selection, and explicit absolute-path --workspace selection.
Acceptance criteria:
1. Passed: beta tasks created from its cwd and explicit checkout path exist only under tasks/workspaces/ws_beta; alpha owns only its bundle.
2. Passed: alpha/beta lists are disjoint, task show projects ws_alpha/alpha and ws_beta/beta from the physical owners, and explicit foreign-workspace show filters fail.
3. Passed: the end-to-end test exercises both cwd-derived and explicit absolute-path selection for shared-root task creation and reads.
Validation:
- cargo test -p orbit-cli --test shared_root_task_isolation -- --nocapture: passed (1 test).
- cargo test -p orbit-cli --test workspace_selector -- --nocapture: passed (6 tests, before extracting the new dedicated test target).
- cargo test -p orbit-cmd registry_runtime -- --nocapture: passed (17 tests).
- cargo test -p orbit-cmd task_owner -- --nocapture: passed (5 tests).
- make ci-fast: passed; its optional compiler-cache namespace probe reported the environment cannot create an unprivileged bwrap namespace and was skipped by the guardrail.
- make ci-lint: passed.
- cargo fmt --all -- --check: passed.
- git diff --check: passed.
Assessment: Selected registry identity and physical task-store ownership now agree without changing legacy non-shared checkout/config drift semantics.
Deviations from original plan:
- Added task_owner.rs after tracing unqualified task show, because shared-root logical partitions do not have distinct task-registry checkout rows.
Remaining risks: None identified within task scope; full make ci is intentionally reserved for the merge gate by workspace policy.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11807-6a9f9c21`
- Behind base: 0
- Ahead of base: 1