### PR TITLE
chore: prepare v0.20.0 release [ORB-11809]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.20.0
+
+### Breaking Changes
+
+- **Task workspace flags clarified**: `task add --workspace` now selects the target workspace; use `--workspace-path` for task workspace-path metadata. ([ORB-11598])
+- **Tool-run flags removed**: `orbit tool run` no longer accepts `--timeout` or `--output`; remove those flags from existing invocations. ([ORB-11618])
+- **Operation grants upgraded**: operation-policy version 2 introduces independent review and repair controls; replace version-1 grants before delivery. ([ORB-11333])
+- **Task-registry schema upgraded**: task action keys require schema version 6; older binaries that only support version 5 cannot open an upgraded registry. ([ORB-11529])
+- **Semantic-index layout migrated**: semantic search now uses chunk storage with external-content FTS5; coordinate runtime upgrades because older index layouts are incompatible. ([ORB-11695], [ORB-11753])
+
+### Highlights
+
+- **Independent delivery review**: configure review timing and repair budgets separately from implementation, with direct repairs and explicit delivery admission. ([ORB-11333])
+- **Flexible task lifecycle**: reopen completed work and make other explicitly authorized status transitions while retaining the audit trail. ([ORB-11449])
+- **Shared-root workspace isolation**: multiple repositories sharing an Orbit root keep task writes and bundles in the selected workspace. ([ORB-11807])
+- **Usable dashboard operations**: authorized sessions can mint and toggle automation, with compact controls that work on narrow screens. ([ORB-11557], [ORB-11559])
+- **Filesystem policy for child processes**: Linux `proc.spawn` applies the declared filesystem policy to indirect child-process access. ([ORB-11514])
+
 ## 0.19.0
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,7 +2094,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbit-agent"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-automation"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cli"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cmd"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "chrono",
  "flate2",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-common"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-config"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "orbit-common",
  "orbit-types",
@@ -2229,7 +2229,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-core"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-engine"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-exec"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "libc",
  "orbit-common",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-mcp"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2319,7 +2319,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-policy"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-registry"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "chrono",
  "hostname",
@@ -2344,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-search"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-store"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-tools"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-types"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-web"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.19.2"
+version = "0.20.0"
 edition = "2024"
 license = "MIT"
 # MSRV [ORB-10010]: edition 2024 requires >= 1.85; the highest `rust-version`

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbit-tools/cli",
-  "version": "0.19.2",
+  "version": "0.20.0",
   "mcpName": "io.github.constellation-works/orbit",
   "description": "npm proxy for the Orbit CLI. Downloads the matching native binary from GitHub Releases on install and forwards all invocations.",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.19.2",
+  "version": "0.20.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface, skills, and orchestration subagents to Claude Code.",
   "author": {
     "name": "constellation-works",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.19.2",
+  "version": "0.20.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP task and knowledge surface plus workflow skills to Codex.",
   "author": {
     "name": "constellation-works",
@@ -20,7 +20,7 @@
   "mcpServers": {
     "orbit": {
       "command": "npx",
-      "args": ["-y", "@orbit-tools/cli@0.19.2", "mcp", "serve"]
+      "args": ["-y", "@orbit-tools/cli@0.20.0", "mcp", "serve"]
     }
   },
   "interface": {

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "orbit": {
       "command": "npx",
-      "args": ["-y", "@orbit-tools/cli@0.19.2", "mcp", "serve"]
+      "args": ["-y", "@orbit-tools/cli@0.20.0", "mcp", "serve"]
     }
   }
 }

--- a/plugin/mcp.json
+++ b/plugin/mcp.json
@@ -4,7 +4,7 @@
     "orbit": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@orbit-tools/cli@0.19.2", "mcp", "serve"]
+      "args": ["-y", "@orbit-tools/cli@0.20.0", "mcp", "serve"]
     }
   }
 }

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "orbit",
-  "version": "0.19.2",
+  "version": "0.20.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface and shared workflow skills to compatible clients.",
   "author": {
     "name": "constellation-works",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/constellation-works/orbit",
     "source": "github"
   },
-  "version": "0.19.2",
+  "version": "0.20.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@orbit-tools/cli",
-      "version": "0.19.2",
+      "version": "0.20.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Prepare v0.20.0 with the approved breaking changes and consumer-facing release highlights. Synchronize Cargo, npm, registry metadata, plugin versions, and MCP launch pins; refresh only the 17 Orbit workspace package versions in Cargo.lock.

Validation on Mac: build, ci-fast, full workspace Clippy, plugin install smoke, npm version-assertion check, and a fresh-home local v0.20.0 CLI/MCP smoke all passed. Lockfile comparison confirms no third-party drift. Release-check validates all local sources at 0.20.0 and reports only expected drift from the still-published npm/GitHub v0.19.2. Definitive npm download/signature verification follows publication.

Task: ORB-11809. This PR prepares the repository; tagging, publication, and release-branch promotion remain separate steps.
