### PR TITLE
[ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### DIFF
--- a/crates/orbit-web/src/api/tests/runs.rs
+++ b/crates/orbit-web/src/api/tests/runs.rs
@@ -1310,13 +1310,13 @@ async fn healthz_answers_within_one_second_while_sixteen_ships_wait_on_bundle_lo
         })
         .expect("seed task")
         .id;
-    let lock_path = find_bundle_lock(&runtime.data_root(), &task_id)
-        .or_else(|| find_bundle_lock(&runtime.shared_root(), &task_id))
+    let lock_path = find_bundle_lock(&runtime.global_root(), &task_id)
+        .or_else(|| find_bundle_lock(&runtime.data_root(), &task_id))
         .unwrap_or_else(|| {
             panic!(
                 "missing .{task_id}.bundle.lock under {} or {}",
-                runtime.data_root().display(),
-                runtime.shared_root().display()
+                runtime.global_root().display(),
+                runtime.data_root().display()
             )
         });
     let _guard = hold_exclusive_bundle_lock(&lock_path);

--- a/crates/orbit-web/src/api/tests/test_support.rs
+++ b/crates/orbit-web/src/api/tests/test_support.rs
@@ -16,7 +16,7 @@ pub(super) fn write_lines(path: &std::path::Path, lines: &[String]) {
 }
 
 pub(super) fn write_replay_job(runtime: &OrbitRuntime, name: &str) -> std::path::PathBuf {
-    write_replay_job_under(&runtime.data_root(), name)
+    write_replay_job_under(&runtime.global_root(), name)
 }
 
 /// Writes the stub sleep-workflow job asset into `<root>/resources/jobs`.


### PR DESCRIPTION
## Task

[ORB-11824](https://orbit-cli.com/tasks/ORB-11824) — [ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `CI`
- Failing job: `Check / Clippy / Test`
- Failing step: `Run CI guardrails`
- Commit the runner actually checked out: `66a6179b539e0e80ae837f06a3b86d4735104202`
- Normalized error signature (the dedupe identity, not a quote): `fail [ <n>.<n>s] (<n>/<n>) orbit-web api::tests::runs::auto_drain::auto_endpoint_defaults_to_review_without_authorization`
- Repository: `constellation-works/orbit`
- Release branch as GitHub reports it: `main`
- Evidence collected at: 2026-09-09T05:05:45.051725519+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/constellation-works/orbit/actions/runs/34194149723 run `34194149723` (pull_request on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `66a6179b539e0e80ae837f06a3b86d4735104202`
  - current head of that ref: `be1ad8ceff2efc2deb80d535e5cbb93878e6d085`
  - commit actually checked out: `66a6179b539e0e80ae837f06a3b86d4735104202`
  - checkout evidence: `* branch            66a6179b539e0e80ae837f06a3b86d4735104202 -> FETCH_HEAD`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/usr/bin/git checkout --progress --force 66a6179b539e0e80ae837f06a3b86d4735104202`
  - failed job `Check / Clippy / Test` (id `101958129373`): https://github.com/constellation-works/orbit/actions/runs/34194149723/job/101958129373
  - failing step(s): `Run CI guardrails`

## Failed-step log excerpt

_Failure regions from a completely scanned command; the full command was not retained. 1144717 of 1153825 source bytes omitted, including 0 assertion payload bytes. All 15 recognized failure anchors and bounded context are retained (64 KiB selection limit)._

```
2026-09-08T06:22:56.4455879Z ##[group]Run ./scripts/ci-guardrails.sh
[... 682879 command bytes omitted ...]
2026-09-08T06:29:33.8711947Z [31;1m        FAIL[0m [   0.384s] (2948/5073) [35;1morbit-web[0m [36mapi::tests::runs::auto_drain[0m[36m::[0m[34;1mauto_endpoint_defaults_to_review_without_authorization[0m
2026-09-08T06:29:33.8735049Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-08T06:29:33.8756702Z 
2026-09-08T06:29:33.8786712Z     running 1 test
2026-09-08T06:29:33.8816970Z     test api::tests::runs::auto_drain::auto_endpoint_defaults_to_review_without_authorization ... FAILED
2026-09-08T06:29:33.8817988Z 
2026-09-08T06:29:33.8846675Z     failures:
2026-09-08T06:29:33.8876401Z 
2026-09-08T06:29:33.8900234Z     failures:
2026-09-08T06:29:33.8927162Z         api::tests::runs::auto_drain::auto_endpoint_defaults_to_review_without_authorization
2026-09-08T06:29:33.8956456Z 
2026-09-08T06:29:33.8986986Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 375 filtered out; finished in 0.37s
2026-09-08T06:29:33.8988344Z     [0m
2026-09-08T06:29:33.9017345Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-08T06:29:33.9046505Z 
2026-09-08T06:29:33.9078534Z     [0m[31;1mthread 'api::tests::runs::auto_drain::auto_endpoint_defaults_to_review_without_authorization' (77383) panicked at crates/orbit-web/src/api/tests/runs.rs:1125:13:[0m
2026-09-08T06:29:33.9080571Z     [31;1massertion `left == right` failed[0m
2026-09-08T06:29:33.9126941Z       left: 404
2026-09-08T06:29:33.9156541Z      right: 200
2026-09-08T06:29:33.9157475Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-08T06:29:33.9186371Z 
2026-09-08T06:29:33.9305506Z [32;1m        PASS[0m [   0.449s] (2949/5073) [35;1morbit-web[0m [36mapi::tests::runs[0m[36m::[0m[34;1ma_terminal_run_never_projects_an_unfinished_step_as_still_running[0m
2026-09-08T06:29:34.3078663Z [31;1m        FAIL[0m [   0.434s] (2950/5073) [35;1morbit-web[0m [36mapi::tests::runs::auto_drain[0m[36m::[0m[34;1mauto_endpoint_propagates_authorized_complete_opt_in[0m
2026-09-08T06:29:34.3097257Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-08T06:29:34.3166544Z 
2026-09-08T06:29:34.3197012Z     running 1 test
2026-09-08T06:29:34.3212230Z     test api::tests::runs::auto_drain::auto_endpoint_propagates_authorized_complete_opt_in ... FAILED
2026-09-08T06:29:34.3213252Z 
2026-09-08T06:29:34.3213531Z     failures:
2026-09-08T06:29:34.3213857Z 
2026-09-08T06:29:34.3214073Z     failures:
2026-09-08T06:29:34.3214780Z         api::tests::runs::auto_drain::auto_endpoint_propagates_authorized_complete_opt_in
2026-09-08T06:29:34.3215467Z 
2026-09-08T06:29:34.3216297Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 375 filtered out; finished in 0.41s
2026-09-08T06:29:34.3217583Z     [0m
2026-09-08T06:29:34.3218169Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-08T06:29:34.3218605Z 
2026-09-08T06:29:34.3220021Z     [0m[31;1mthread 'api::tests::runs::auto_drain::auto_endpoint_propagates_authorized_complete_opt_in' (77562) panicked at crates/orbit-web/src/api/tests/runs.rs:1176:13:[0m
2026-09-08T06:29:34.3221502Z     [31;1massertion `left == right` failed[0m
2026-09-08T06:29:34.3222104Z       left: 404
2026-09-08T06:29:34.3222514Z      right: 200
2026-09-08T06:29:34.3223330Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-08T06:29:34.3224026Z 
2026-09-08T06:29:34.3343208Z [32;1m        PASS[0m [   0.405s] (2951/5073) [35;1morbit-web[0m [36mapi::tests::runs::auto_drain[0m[36m::[0m[34;1mauto_endpoint_refuses_complete_opt_in_without_authorization[0m
2026-09-08T06:29:34.7216665Z [32;1m        PASS[0m [   0.387s] (2952/5073) [35;1morbit-web[0m [36mapi::tests::runs::auto_drain[0m[36m::[0m[34;1mauto_endpoint_rejects_missing_duration[0m
2026-09-08T06:29:34.7394257Z [32;1m        PASS[0m [   0.434s] (2953/5073) [35;1morbit-web[0m [36mapi::tests::runs::auto_drain[0m[36m::[0m[34;1mauto_endpoint_rejects_invalid_duration_format[0m
2026-09-08T06:29:35.1142683Z [32;1m        PASS[0m [   0.393s] (2954/5073) [35;1morbit-web[0m [36mapi::tests::runs::auto_drain[0m[36m::[0m[34;1mauto_endpoint_rejects_unknown_workspace_with_404_json[0m
2026-09-08T06:29:35.1795803Z [32;1m        PASS[0m [   0.437s] (2955/5073) [35;1morbit-web[0m [36mapi::tests::runs::auto_drain[0m[36m::[0m[34;1mauto_endpoint_rejects_zero_concurrency[0m
2026-09-08T06:29:35.3396788Z [32;1m        PASS[0m [   2.391s] (2956/5073) [35;1morbit-web[0m [36mapi::tests::routines[0m[36m::[0m[34;1mauthorized_routine_toggle_reads_back_and_rejects_stale_or_wrong_selection[0m
2026-09-08T06:29:35.4720571Z [32;1m        PASS[0m [   0.357s] (2957/5073) [35;1morbit-web[0m [36mapi::tests::runs::auto_drain[0m[36m::[0m[34;1mauto_endpoint_rejects_zero_length_window[0m
[... 807 command bytes omitted ...]
2026-09-08T06:29:36.2738716Z [31;1m        FAIL[0m [   0.502s] (2962/5073) [35;1morbit-web[0m [36mapi::tests::runs[0m[36m::[0m[34;1mhealthz_answers_within_one_second_while_sixteen_ships_wait_on_bundle_lock[0m
2026-09-08T06:29:36.2776827Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-08T06:29:36.2836466Z 
2026-09-08T06:29:36.2867000Z     running 1 test
2026-09-08T06:29:36.2868158Z     test api::tests::runs::healthz_answers_within_one_second_while_sixteen_ships_wait_on_bundle_lock ... FAILED
2026-09-08T06:29:36.2896523Z 
2026-09-08T06:29:36.2916780Z     failures:
2026-09-08T06:29:36.2926620Z 
2026-09-08T06:29:36.2926816Z     failures:
2026-09-08T06:29:36.2927532Z         api::tests::runs::healthz_answers_within_one_second_while_sixteen_ships_wait_on_bundle_lock
2026-09-08T06:29:36.2928210Z 
2026-09-08T06:29:36.2928735Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 375 filtered out; finished in 0.48s
2026-09-08T06:29:36.2929776Z     [0m
2026-09-08T06:29:36.2930255Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-08T06:29:36.2930599Z 
2026-09-08T06:29:36.2931990Z     [0m[31;1mthread 'api::tests::runs::healthz_answers_within_one_second_while_sixteen_ships_wait_on_bundle_lock' (78424) panicked at crates/orbit-web/src/api/tests/runs.rs:1316:13:[0m
2026-09-08T06:29:36.2933993Z     [31;1mmissing .ORB-00000.bundle.lock under /tmp/orbit-in-memory-yBMqXV/.orbit or /tmp/orbit-in-memory-yBMqXV/.orbit[0m
2026-09-08T06:29:36.2935360Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-08T06:29:36.2935938Z 
2026-09-08T06:29:36.3146402Z [32;1m        PASS[0m [   0.402s] (2963/5073) [35;1morbit-web[0m [36mapi::tests::runs[0m[36m::[0m[34;1mlist_run_events_accepts_valid_run_id[0m
2026-09-08T06:29:36.3484977Z [32;1m        PASS[0m [   0.428s] (2964/5073) [35;1morbit-web[0m [36mapi::tests::runs[0m[36m::[0m[34;1mlist_run_events_kind_filter_still_works_with_streaming[0m
2026-09-08T06:29:36.7450874Z [32;1m        PASS[0m [   0.430s] (2965/5073) [35;1morbit-web[0m [36mapi::tests::runs[0m[36m::[0m[34;1mlist_run_events_rejects_path_traversal_id[0m
2026-09-08T06:29:36.8690856Z [33;1m        SLOW[0m [> 60.000s] (─────────) [35;1morbit-cli::mcp_roundtrip[0m [34;1mprocess_metadata_does_not_supply_a_replayable_key_bound_identity[0m
2026-09-08T06:29:37.1348581Z [32;1m        PASS[0m [   0.385s] (2966/5073) [35;1morbit-web[0m [36mapi::tests::runs[0m[36m::[0m[34;1mlist_run_events_streams_small_page_from_oversized_fixture[0m
2026-09-08T06:29:37.7070508Z [32;1m        PASS[0m [   0.576s] (2967/5073) [35;1morbit-web[0m [36mapi::tests::runs[0m[36m::[0m[34;1mlist_run_logs_returns_bounded_redacted_step_records[0m
2026-09-08T06:29:37.7257951Z [32;1m        PASS[0m [   1.454s] (2968/5073) [35;1morbit-web[0m [36mapi::tests::runs[0m[36m::[0m[34;1mlist_run_events_rejects_id_with_slashes[0m
2026-09-08T06:29:38.0353565Z [32;1m        PASS[0m [   0.327s] (2969/5073) [35;1morbit-web[0m [36mapi::tests::runs[0m[36m::[0m[34;1mresume_job_run_endpoint_rejects_non_terminal_run_with_guard_reason[0m
[... 461031 command bytes omitted ...]
2026-09-08T06:38:08.5476980Z [31;1m     Summary[0m [ 628.394s] [1m5073[0m tests run: [1m5070[0m [32;1mpassed[0m ([1m1[0m [33;1mslow[0m), [1m3[0m [31;1mfailed[0m, [1m17[0m [33;1mskipped[0m
2026-09-08T06:38:08.5479181Z [31;1m        FAIL[0m [   0.384s] (2948/5073) [35;1morbit-web[0m [36mapi::tests::runs::auto_drain[0m[36m::[0m[34;1mauto_endpoint_defaults_to_review_without_authorization[0m
2026-09-08T06:38:08.5481454Z [31;1m        FAIL[0m [   0.434s] (2950/5073) [35;1morbit-web[0m [36mapi::tests::runs::auto_drain[0m[36m::[0m[34;1mauto_endpoint_propagates_authorized_complete_opt_in[0m
2026-09-08T06:38:08.5483592Z [31;1m        FAIL[0m [   0.502s] (2962/5073) [35;1morbit-web[0m [36mapi::tests::runs[0m[36m::[0m[34;1mhealthz_answers_within_one_second_while_sixteen_ships_wait_on_bundle_lock[0m
2026-09-08T06:38:08.5506466Z [31;1merror[0m: test run failed
2026-09-08T06:38:08.5535286Z ##[error]Process completed with exit code 100.

```

_The collection display was truncated. Selected evidence is used for diagnosis; its retention limits are independent of that display._

_The run-scoped failed-step log came back empty, so this excerpt is the evidence from job `Check / Clippy / Test` (id `101958129373`), read from the job log API._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `CI` run https://github.com/constellation-works/orbit/actions/runs/34193952153 — superseded_by_newer_workflow_run: newer relevant run 34194149723 at 2026-09-08T06:19:16Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34193296404 — superseded_by_newer_workflow_run: newer relevant run 34194149723 at 2026-09-08T06:19:16Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34191611587 — superseded_by_newer_workflow_run: newer relevant run 34194149723 at 2026-09-08T06:19:16Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34191460330 — superseded_by_newer_workflow_run: newer relevant run 34194149723 at 2026-09-08T06:19:16Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34190428557 — superseded_by_newer_workflow_run: newer relevant run 34190468578 at 2026-09-08T05:23:55Z is completed with conclusion success
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34190314680 — superseded_by_newer_workflow_run: newer relevant run 34190468578 at 2026-09-08T05:23:55Z is completed with conclusion success

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 1,
  "current_failures_discovered": 6,
  "current_failures_investigated": 5,
  "current_failures_investigation_attempted": 4,
  "inconclusive": 0,
  "investigation_cursor": 496925,
  "job_log_reads": 6,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_job_log_reads": 6,
  "max_pull_requests": 10,
  "max_retired_ref_probes": 20,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely"
  ],
  "pull_requests_scanned": 3,
  "refs_scanned": 5,
  "retired_refs": [
    "codeql-advanced-setup",
    "codex/prepare-v0.20.0",
    "orbit/ORB-11514-6a9f84aa",
    "orbit/ORB-11701-6a9f96cf",
    "orbit/ORB-11713-6a9f96cf",
    "orbit/ORB-11718-6a9f8f12",
    "orbit/ORB-11723-6a9f90d9",
    "orbit/ORB-11735-6a9f96ce",
    "orbit/ORB-11786-6a9f9119",
    "orbit/ORB-11801-6a9f9471",
    "orbit/ORB-11802-6a9f9845",
    "orbit/ORB-11805-6a9f9843",
    "orbit/ORB-11807-6a9f9c21",
    "orbit/ORB-11808-6a9f9c91"
  ],
  "runs_listed": 100,
  "unverified_refs": []
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `CI` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated the orbit-web test replay-job fixture to write default-named jobs under the runtime global root, matching production job-catalog lookup.
- Updated the healthz contention fixture to locate the canonical bundle lock under the runtime global task-registry root and kept the current .<task>.bundle.lock naming.
Assessment: The CI failures were repository-owned stale test paths after global job/task-registry separation. The fix changes test setup only; no assertion, workflow, or lint gate was weakened.

Acceptance criteria:
1. Fixed: auto-drain tests now resolve the replay job and the healthz test now acquires the same lock target used by production.
2. Reproduced the reported test failure locally before the fix (cargo test -p orbit-web api::tests::runs::auto_drain::auto_endpoint_defaults_to_review_without_authorization -- --exact --nocapture, exit 101 with 404 vs 200), then reran it successfully (exit 0). The focused auto-drain suite passed 9/9, and the runs API suite passed 31/31; the healthz contention test passed.
3. Passed: make ci-fast and make ci-lint. ci-fast reported the compiler-cache namespace probe as skipped because this environment disallows unprivileged bubblewrap namespaces; its supported fallback checks passed and the gate exited 0.
4. Repository-owned cause confirmed by deterministic local reproduction and source inspection; this was not treated as infrastructure-only.

Validation:
- cargo test -p orbit-web api::tests::runs::auto_drain:: -- --nocapture — passed, 9/9.
- cargo test -p orbit-web api::tests::runs::healthz_answers_within_one_second_while_sixteen_ships_wait_on_bundle_lock -- --exact --nocapture — passed.
- cargo test -p orbit-web --lib api::tests::runs:: -- --nocapture — passed, 31/31.
- make ci-fast — passed (with the documented environment-bounded namespace probe skipped).
- make ci-lint — passed.
- git diff --check — passed.
- git status --short — only the two scoped test files are modified.

Remaining risks / deviations: The full make ci merge gate was not run because workspace policy says it is the PR gate; CI on the task PR remains authoritative. Changes are intentionally uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11824-6aa0eaf9`
- Behind base: 0
- Ahead of base: 1