### PR TITLE
[code-scanning-sweep] Fix rust/cleartext-logging in crates/orbit-agent/src/providers/antigravity/antigravity_cli.rs

### DIFF
--- a/crates/orbit-engine/src/activity_job/tests/asset_loader.rs
+++ b/crates/orbit-engine/src/activity_job/tests/asset_loader.rs
@@ -157,7 +157,8 @@ fn load_activity_asset_rejects_trusted_host_execution_on_any_other_activity() {
         matches!(error, AssetLoadError::TrustedHostActivity(_)),
         "expected a trusted-host refusal, got {error:?}"
     );
-    assert!(error.to_string().contains("agent_implement"));
+    assert!(error.to_string().contains("an activity declares"));
+    assert!(!error.to_string().contains("agent_implement"));
 }
 
 #[test]

--- a/crates/orbit-types/src/workflow/activity_job/tests/trusted_host.rs
+++ b/crates/orbit-types/src/workflow/activity_job/tests/trusted_host.rs
@@ -21,12 +21,17 @@ fn admission() -> TrustedHostAdmission {
 #[test]
 fn only_the_builtin_activity_may_declare_trusted_host_execution() {
     assert!(validate_trusted_host_activity(TRUSTED_HOST_ACTIVITY, true).is_ok());
-    let error = validate_trusted_host_activity("agent_implement", true)
+    let error = validate_trusted_host_activity("operator-controlled-name", true)
         .expect_err("a second activity must not be able to claim the mode");
-    assert_eq!(error.activity, "agent_implement");
+    assert_eq!(error.activity, "<redacted>");
+    assert_eq!(
+        error.to_string(),
+        "an activity declares `trustedHostExecution: true`, which only the built-in `agent_invoke` activity may declare; an unsandboxed provider subprocess is admitted per invocation by an operator, never by an asset"
+    );
+    assert!(!format!("{error:?}").contains("operator-controlled-name"));
     assert!(
         error.to_string().contains("admitted per invocation"),
-        "the refusal must say where the mode actually comes from: {error}"
+        "the refusal must say where the mode actually comes from"
     );
 }
 

--- a/crates/orbit-types/src/workflow/activity_job/trusted_host.rs
+++ b/crates/orbit-types/src/workflow/activity_job/trusted_host.rs
@@ -112,14 +112,19 @@ pub fn strip_trusted_host_admission(input: &mut Value) -> bool {
 }
 
 /// Refusal to load an asset that claims trusted-host execution it may not have.
+///
+/// The offending asset name is replaced with a constant marker. Asset metadata
+/// is operator-controlled input and this error can cross logging boundaries;
+/// the stable diagnostic preserves the validation reason without copying that
+/// input into a value that may be formatted later.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error(
-    "activity `{activity}` declares `trustedHostExecution: true`, which only the built-in \
+    "an activity declares `trustedHostExecution: true`, which only the built-in \
      `{TRUSTED_HOST_ACTIVITY}` activity may declare; an unsandboxed provider subprocess is \
      admitted per invocation by an operator, never by an asset"
 )]
 pub struct TrustedHostActivityError {
-    /// Name of the offending activity asset.
+    /// Redacted marker retained for source compatibility with error consumers.
     pub activity: String,
 }
 
@@ -133,7 +138,7 @@ pub fn validate_trusted_host_activity(
 ) -> Result<(), TrustedHostActivityError> {
     if declares_trusted_host && activity != TRUSTED_HOST_ACTIVITY {
         return Err(TrustedHostActivityError {
-            activity: activity.to_string(),
+            activity: "<redacted>".to_string(),
         });
     }
     Ok(())


### PR DESCRIPTION
## Task

[ORB-11826](https://orbit-cli.com/tasks/ORB-11826) — [code-scanning-sweep] Fix rust/cleartext-logging in crates/orbit-agent/src/providers/antigravity/antigravity_cli.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#13`
- Rule: `rust/cleartext-logging` (rust/cleartext-logging)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This operation writes validate_trusted_host_activity(...) to a log file.
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-agent/src/providers/antigravity/antigravity_cli.rs` line 170
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/13

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/cleartext-logging` at `crates/orbit-agent/src/providers/antigravity/antigravity_cli.rs` line 170 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Removed the operator-controlled activity name from TrustedHostActivityError's Display and retained only a constant `<redacted>` marker in its compatibility field, eliminating the cleartext data flow identified by the CodeQL source link while preserving fail-closed trusted-host validation.
- Updated the direct trusted-host and asset-loader tests to assert the stable diagnostic and that the supplied activity name is absent.
- No suppression, dismissal, exclusion, or CodeQL configuration change was added.

Assessment: The validation decision and error category remain unchanged; only untrusted metadata retention and rendering were removed. The alert's reported antigravity_cli.rs sink is unchanged because GitHub's alert message identifies validate_trusted_host_activity in the asset loader as the tainted source; removing that source data is the smallest real remediation.

Criteria:
1. Remediated by removing the arbitrary activity string from TrustedHostActivityError before it can reach downstream logging, including the reported path.
2. Fail-closed rejection of every non-built-in trusted-host activity remains intact; focused tests cover the behavior and redaction.
3. Local formatting, focused tests, `make ci-fast`, and `make ci-lint` passed. The repository CodeQL CLI is unavailable locally; the GitHub CodeQL workflow must provide the post-change confirmation on the delivery revision. The pre-change GitHub API instance for alert #13 remains open on main and is not evidence about this unpushed work.

Validation:
- PASSED: `cargo fmt --all -- --check`.
- PASSED: `cargo test -p orbit-types trusted_host --lib` (6 tests).
- PASSED: `cargo test -p orbit-agent antigravity_cli --lib` (10 tests).
- PASSED: `cargo test -p orbit-engine asset_loader --lib` (10 tests).
- PASSED: `make ci-fast`; its compiler-cache namespace subcheck reported an environment skip because unprivileged bubblewrap namespaces are unavailable.
- PASSED: `make ci-lint` (workspace all-target clippy with warnings denied).
- PASSED: `git diff --check`.
- PASSED: `GIT_OPTIONAL_LOCKS=0 git status --short`; only the three task-scoped source/test files are modified.
- NOT RUN: local CodeQL analysis; `codeql` is not installed and the repo documents CodeQL in GitHub Actions.

Remaining risks/deviations:
- The affected GitHub CodeQL alert cannot be marked/rechecked from this executor before the pipeline analyzes the resulting revision; CI CodeQL confirmation remains required.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11826-6aa0eaf9`
- Behind base: 0
- Ahead of base: 1