### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/mcp-session-context/1_overview.md
+++ b/docs/design/mcp-session-context/1_overview.md
@@ -3,13 +3,13 @@ summary: "MCP Session Context — Overview"
 type: design
 title: "MCP Session Context — Overview"
 owner: codex
-last_updated: 2026-08-15
-last_validated: 2026-08-15
+last_updated: 2026-09-09
+last_validated: 2026-09-09
 status: Accepted
 feature: mcp-session-context
 doc_role: overview
 tags: ["mcp-session-context", "mcp", "workspace", "audit"]
-paths: ["crates/orbit-common/src/types/tool.rs", "crates/orbit-mcp/src/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-core/src/command/tool/**"]
+paths: ["crates/orbit-types/src/tool/**", "crates/orbit-mcp/src/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-core/src/adapter/tool_host/**"]
 related_features: ["mcp-session-context"]
 related_artifacts: []
 ---
@@ -36,8 +36,8 @@ The external workspace value is addressing input, not a trusted workspace identi
 - process_machine_id and process_host_id describe the machine accepting and executing the call.
 - transport is local or ssh-mcp.
 
-## V1 boundary
+## Current boundary
 
-MCP v1 has one authoritative server host and stdio framing, either local or carried byte-for-byte through SSH. Tool definitions carry only global-versus-workspace-required scope. V1 has no TCP listener, broker, remote placement routing, capability authorization, leases, or Orbit-authenticated caller identity.
+MCP v1 still has one authoritative server host and stdio framing, either local or carried byte-for-byte through SSH. The current surface also has an explicit TCP listener transport and an opt-in federated stdio mux that routes to configured SSH destinations. Tool definitions carry global-versus-workspace-required scope; the accepting server and Core resolve capabilities and authorization. Caller machine and network labels remain audit evidence rather than authenticated principals, except where destination-owned SSH acceptance supplies key-bound caller evidence.
 
 See [2_design.md](./2_design.md) for the concrete path, [3_vision.md](./3_vision.md) for evolution gates, and [4_decisions.md](./4_decisions.md) for current design choices.

--- a/docs/design/mcp-session-context/3_vision.md
+++ b/docs/design/mcp-session-context/3_vision.md
@@ -3,13 +3,13 @@ summary: "MCP Session Context — Vision"
 type: design
 title: "MCP Session Context — Vision"
 owner: codex
-last_updated: 2026-08-23
-last_validated: 2026-08-15
+last_updated: 2026-09-09
+last_validated: 2026-09-09
 status: Accepted
 feature: mcp-session-context
 doc_role: vision
 tags: ["mcp-session-context", "mcp", "workspace", "audit"]
-paths: ["crates/orbit-common/src/types/tool.rs", "crates/orbit-mcp/src/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-core/src/command/tool/**"]
+paths: ["crates/orbit-types/src/tool/**", "crates/orbit-mcp/src/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-core/src/adapter/tool_host/**"]
 related_features: ["mcp-session-context", "federated-mcp"]
 related_artifacts: [ORB-11009]
 ---
@@ -22,11 +22,11 @@ Session context should remain a small provenance and correlation envelope. Tool-
 
 ### Authorization
 
-Future authorization belongs behind Core dispatch. It needs an authenticated principal or grant source distinct from caller_machine_id, caller_ip, hostname, and SSH target. Existing audit labels must never silently become credentials.
+Authorization is enforced behind Core dispatch. Session capability policy comes from the accepting server and its local or destination-owned SSH policy; caller_machine_id, caller_ip, hostname, and SSH target remain audit evidence rather than credentials. Any future grant source must preserve that separation.
 
 ### Additional transports
 
-A new transport must construct process and transport facts at the accepting server, preserve raw MCP framing, isolate mutable session state, and create one trace per call. It must not reintroduce a shared unauthenticated TCP listener.
+The current TCP listener and federated SSH mux construct process and transport facts at their accepting boundaries, preserve MCP framing, isolate mutable session state, and create one trace per call. Any new transport must follow the same rules. Because the TCP listener authenticates no client, its safe default remains loopback-only; a non-loopback deployment must provide access control outside the listener.
 
 ### Additional context fields
 
@@ -39,17 +39,17 @@ Add a field only when all three are true:
 ## Stable principles
 
 - External workspace values address server state; they do not prove identity.
-  Addressing may later become host-qualified (`hm_…/ws_*`) under the proposed
-  federated MCP surface; v1 still resolves a local selector on the accepting
-  machine. See [federated-mcp](../federated-mcp/specs/federated-workspace-mcp.md).
+  Federated mode uses host-qualified (`hm_…/ws_*`) selectors, while v1 still
+  resolves a local selector on the accepting machine. See
+  [federated-mcp](../federated-mcp/specs/federated-workspace-mcp.md).
 - The accepting machine describes itself.
 - Caller machine and network labels are useful for audit correlation but remain fallible.
 - The MCP adapter owns call correlation.
 - Every tools/call, including an unknown raw name, crosses one Core audit boundary.
-- Core remains the execution, audit, and future authorization authority.
+- Core remains the execution, audit, and authorization authority.
 
 ## Task References
 
-- [ORB-11009] noted that addressing may become host-qualified under federated MCP without changing v1 overview claims
+- [ORB-11009] established the separation between v1 local addressing and the host-qualified federated selector.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/operations-as-data/2_design.md
+++ b/docs/design/operations-as-data/2_design.md
@@ -1,15 +1,15 @@
 ---
 title: Operations as Data — Design
 owner: claude
-last_updated: 2026-08-15
-last_validated: 2026-08-15
+last_updated: 2026-09-09
+last_validated: 2026-09-09
 status: Accepted
 feature: operations-as-data
 doc_role: design
 type: design
 summary: How the operation spec kernel, the split spec/handler table, and the MCP and CLI adapters work today on the friction noun.
 tags: [operations-as-data, architecture]
-paths: ["crates/orbit-common/src/operation.rs", "crates/orbit-common/src/friction/**", "crates/orbit-tools/src/builtin/orbit/operation.rs", "crates/orbit-cli/src/command/operation_args.rs"]
+paths: ["crates/orbit-common/src/governance/operation.rs", "crates/orbit-common/src/governance/friction/**", "crates/orbit-tools/src/builtin/orbit/operation.rs", "crates/orbit-cli/src/command/operation_args.rs"]
 related_features: [operations-as-data, orbit-core]
 related_artifacts: []
 ---
@@ -22,7 +22,7 @@ Forward-looking questions live in [3_vision.md](3_vision.md).
 
 ## 1. The kernel
 
-`orbit_common::operation` holds the vocabulary and nothing else — no clap types,
+`orbit_common::governance::operation` holds the vocabulary and nothing else — no clap types,
 no axum types, no `OrbitRuntime`. That is what lets it sit in the leaf crate
 every surface can already read, adding no dependency edge anywhere.
 

--- a/docs/design/orbit-docs/1_overview.md
+++ b/docs/design/orbit-docs/1_overview.md
@@ -1,7 +1,7 @@
 ---
 title: "Orbit Docs — Overview"
 owner: claude
-last_updated: 2026-08-15
+last_updated: 2026-09-09
 status: Draft
 feature: orbit-docs
 doc_role: overview
@@ -10,7 +10,7 @@ summary: "Orbit Docs — the human-authored workspace corpus and how operators a
 tags: [orbit-docs]
 related_features: [orbit-docs]
 related_artifacts: [ORB-00163, ORB-00206, ORB-10319]
-last_validated: 2026-08-15
+last_validated: 2026-09-09
 ---
 
 # Orbit Docs — Overview
@@ -113,19 +113,19 @@ repository's ordinary agent instructions.
 
 | Concern | File / surface | Task |
 |---------|----------------|------|
-| Frontmatter parsing, tolerant fallback, walker | [crates/orbit-core/src/command/docs/](../../../crates/orbit-core/src/command/docs/) | [ORB-00163] |
+| Frontmatter parsing, tolerant fallback, walker | [crates/orbit-core/src/application/docs/](../../../crates/orbit-core/src/application/docs/) | [ORB-00163] |
 | CLI verbs (`orbit docs list/show/add/index/migrate`) | [crates/orbit-cli/src/command/docs.rs](../../../crates/orbit-cli/src/command/docs.rs) | [ORB-00163] |
 | Generic doc tool schemas + inactive agent policy | [crates/orbit-tools/src/builtin/orbit/docs.rs](../../../crates/orbit-tools/src/builtin/orbit/docs.rs), [crates/orbit-tools/src/builtin/orbit/mod.rs](../../../crates/orbit-tools/src/builtin/orbit/mod.rs) | [ORB-00163], [ORB-10319] |
 | Agent MCP exposure and routing (`orbit.search`, `kind: "doc"`) | [crates/orbit-mcp/src/remote/surface.rs](../../../crates/orbit-mcp/src/remote/surface.rs), [crates/orbit-cli/src/command/mcp/server.rs](../../../crates/orbit-cli/src/command/mcp/server.rs) | [ORB-00202], [ORB-10319] |
-| Tool host dispatch | [crates/orbit-core/src/runtime/orbit_tool_host/docs_tools.rs](../../../crates/orbit-core/src/runtime/orbit_tool_host/docs_tools.rs) | [ORB-00163] |
-| Skill (agent-facing entry point) | [crates/orbit-core/assets/skills/orbit-search/SKILL.md](../../../crates/orbit-core/assets/skills/orbit-search/SKILL.md) | [ORB-00163] |
+| Tool host dispatch | [crates/orbit-core/src/adapter/tool_host/docs_tools.rs](../../../crates/orbit-core/src/adapter/tool_host/docs_tools.rs) | [ORB-00163] |
+| Skill (agent-facing entry point) | [crates/orbit-core/assets/skills/orbit/SKILL.md](../../../crates/orbit-core/assets/skills/orbit/SKILL.md) | [ORB-00163] |
 | Config root | `[docs].roots` in [.orbit/config.toml](../../../.orbit/config.toml) | [ORB-00163] |
 | Backfill migrator | `orbit docs migrate` | [ORB-00163] |
-| Internal hardening (real diff, robust YAML edit, batched gitignore) | [crates/orbit-core/src/command/docs/](../../../crates/orbit-core/src/command/docs/) | [ORB-00164] |
-| Retire `orbit-design` skill | [crates/orbit-core/assets/skills/orbit-design/](../../../crates/orbit-core/assets/skills/orbit-design/) | [ORB-00165] |
+| Internal hardening (real diff, robust YAML edit, batched gitignore) | [crates/orbit-core/src/application/docs/](../../../crates/orbit-core/src/application/docs/) | [ORB-00164] |
+| Retire `orbit-design` skill | Retired; no current asset | [ORB-00165] |
 | Inject into `task show --with-context` | [crates/orbit-cli/src/command/task/](../../../crates/orbit-cli/src/command/task/) | [ORB-00166] (shipped) |
 | Extend PreToolUse hook to surface docs | Not implemented; no current code owner | [ORB-00167] |
-| Doc semantic embeddings and hybrid ranker | [crates/orbit-core/src/command/semantic.rs](../../../crates/orbit-core/src/command/semantic.rs) | [ORB-00206] (shipped) |
+| Doc semantic embeddings and hybrid ranker | [crates/orbit-core/src/application/semantic.rs](../../../crates/orbit-core/src/application/semantic.rs) | [ORB-00206] (shipped) |
 
 ---
 

--- a/docs/design/orbit-docs/2_design.md
+++ b/docs/design/orbit-docs/2_design.md
@@ -1,24 +1,24 @@
 ---
 title: "Orbit Docs — Design"
 owner: claude
-last_updated: 2026-08-15
+last_updated: 2026-09-09
 status: Draft
 feature: orbit-docs
 doc_role: design
 type: design
 summary: "Orbit Docs — frontmatter schema, walker, doc embeddings index, hybrid search, and the `.orbit/` exclusion invariant."
 tags: [orbit-docs]
-paths: ["crates/orbit-core/src/command/docs/**", "crates/orbit-core/src/runtime/orbit_tool_host/docs_tools.rs", "crates/orbit-tools/src/builtin/orbit/docs.rs", "crates/orbit-mcp/src/remote/surface.rs", "crates/orbit-cli/src/command/mcp/server.rs", "crates/orbit-cli/src/command/docs.rs"]
+paths: ["crates/orbit-core/src/application/docs/**", "crates/orbit-core/src/adapter/tool_host/docs_tools.rs", "crates/orbit-tools/src/builtin/orbit/docs.rs", "crates/orbit-mcp/src/remote/surface.rs", "crates/orbit-cli/src/command/mcp/server.rs", "crates/orbit-cli/src/command/docs.rs"]
 related_features: [orbit-docs]
 related_artifacts: [ORB-00163, ORB-00206, ORB-10319]
-last_validated: 2026-08-15
+last_validated: 2026-09-09
 ---
 
 # Orbit Docs — Design
 
 This document specifies what [ORB-00163] and [ORB-00206] ship: the locked frontmatter schema, the strict-then-tolerant parser, the walker (including the `.orbit/` exclusion invariant), the CLI/admin doc verbs, unified agent MCP retrieval, doc-corpus embeddings, hybrid doc search, and the migration verb that backfills legacy docs. It also names the remaining limitations the follow-ups ([ORB-00164] through [ORB-00169]) address.
 
-The design lives in [crates/orbit-core/src/command/docs/](../../../crates/orbit-core/src/command/docs/) (parser + walker + verb implementations + tests) and [crates/orbit-cli/src/command/docs.rs](../../../crates/orbit-cli/src/command/docs.rs) (~250 lines, clap argument shapes + table rendering). The MCP twin lives in [crates/orbit-core/src/runtime/orbit_tool_host/docs_tools.rs](../../../crates/orbit-core/src/runtime/orbit_tool_host/docs_tools.rs).
+The design lives in [crates/orbit-core/src/application/docs/](../../../crates/orbit-core/src/application/docs/) (parser + walker + verb implementations + tests) and [crates/orbit-cli/src/command/docs.rs](../../../crates/orbit-cli/src/command/docs.rs) (clap argument shapes + table rendering). The MCP twin lives in [crates/orbit-core/src/adapter/tool_host/docs_tools.rs](../../../crates/orbit-core/src/adapter/tool_host/docs_tools.rs).
 
 ---
 
@@ -82,7 +82,7 @@ The parser hard-errors on unknown prefixes. This is intentional: silent acceptan
 
 ## 2. Strict Parser
 
-Strict-mode parsing is the contract the `migrate` verb backfills toward, and the contract `orbit docs add`-ed roots are expected to honor. Strict mode is invoked by `parse_doc_frontmatter_strict` and is the inner workhorse of the tolerant `parse_doc_tolerant`.
+Strict-mode parsing is the contract the `migrate` verb backfills toward, and the contract `orbit docs add`-ed roots are expected to honor. Strict mode is invoked by `parse_doc_strict` and is the inner workhorse of the tolerant `parse_doc_tolerant`.
 
 ### 2.1 Frontmatter delimiter
 
@@ -107,7 +107,7 @@ A `DocFrontmatter` struct with the six fields, ready to serialize as JSON for th
 
 ## 3. Tolerant Indexer
 
-Strict mode is the canonical contract. Tolerant mode is what makes the corpus queryable on day one without a flag-day migration. It is the path most reads go through ([crates/orbit-core/src/command/docs/](../../../crates/orbit-core/src/command/docs/)).
+Strict mode is the canonical contract. Tolerant mode is what makes the corpus queryable on day one without a flag-day migration. It is the path most reads go through ([crates/orbit-core/src/application/docs/](../../../crates/orbit-core/src/application/docs/)).
 
 ### 3.1 Algorithm
 
@@ -159,7 +159,7 @@ A unit test (`walker_skips_dot_orbit_even_when_root_points_above_it`) pins the c
 ### 4.3 Other skips
 
 - `.git`, `node_modules`, `target` — hard-listed in `should_skip_dir`.
-- `.gitignore`-matched paths — `is_git_ignored` shells out to `git check-ignore -q` per file. This is slow at scale; [ORB-00164] tracks the fix (batched stdin or the `ignore` crate).
+- `.gitignore`-matched paths — the walker batches candidates into one `git check-ignore -z --stdin` call. If that check cannot run, candidates are left unfiltered.
 
 ### 4.4 Deterministic output
 
@@ -229,11 +229,11 @@ Walks configured docs roots, reads each Markdown body through the tolerant parse
 Scans `docs/design/<feature>/*.md` (relative depth 2) and `docs/design-patterns/*.md` (relative depth 1) for files that don't pass strict parsing. For each, runs tolerant inference and either:
 
 - If the file has no frontmatter: prepends a fresh `---` block with `type`, `summary`, and `tags`.
-- If the file has frontmatter that's missing locked fields: `upsert_yaml_scalar` line-edits in `type` and `summary`, and appends `tags` if absent.
+- If the file has frontmatter that's missing locked fields: the migrator parses the YAML mapping, inserts inferred `type` and `summary`, adds inferred `tags` when absent, and round-trips the block through `serde_yaml` while preserving other metadata.
 
 Idempotent: a second run reports `No docs need migration.` `--dry-run` prints planned diffs without writing. Never touches `.orbit/`.
 
-The line-based YAML editing is fragile against multi-line / quoted values — [ORB-00164] tracks the round-trip-through-`serde_yaml` fix.
+The migrator compares the complete before/after documents and round-trips frontmatter through `serde_yaml`, so migration reports are reviewable and existing metadata is retained.
 
 ---
 

--- a/docs/design/remote-access/specs/ssh-tunnel.md
+++ b/docs/design/remote-access/specs/ssh-tunnel.md
@@ -1,7 +1,7 @@
 ---
 type: design
 summary: "Spec: Orbit Web SSH Local Forward"
-last_validated: 2026-08-15
+last_validated: 2026-09-09
 tags: [remote-access]
 ---
 


### PR DESCRIPTION
## Task

[ORB-11821](https://orbit-cli.com/tasks/ORB-11821) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Selected exactly the six oldest in-scope docs from the starting HEAD by missing-then-oldest `last_validated`, with path tie-break: `docs/design/mcp-session-context/1_overview.md`, `docs/design/mcp-session-context/3_vision.md`, `docs/design/operations-as-data/2_design.md`, `docs/design/orbit-docs/1_overview.md`, `docs/design/orbit-docs/2_design.md`, and `docs/design/remote-access/specs/ssh-tunnel.md`. The selection was reproduced with `git ls-tree` + `git show HEAD:<path>` and all six started at `2026-08-15`.
- `mcp-session-context/1_overview.md`: updated stale implementation paths and the V1/current-boundary description for the TCP listener, federated stdio mux, and server/Core capability resolution. Verified against `crates/orbit-types/src/tool/definition.rs`, `crates/orbit-mcp/src/adapter/dispatch.rs`, `crates/orbit-mcp/src/listener.rs`, `crates/orbit-mcp/src/remote/identity.rs`, and `crates/orbit-cli/src/command/mcp/server.rs`.
- `mcp-session-context/3_vision.md`: updated authorization, transport, federated-selector, and Core-authority claims. Verified with the same MCP identity/listener/server source inspection and the current transport/capability definitions.
- `operations-as-data/2_design.md`: corrected the moved `orbit_common::governance` namespace and frontmatter paths. Verified against `crates/orbit-common/src/governance/operation.rs`, `crates/orbit-common/src/governance/friction/operations.rs`, `crates/orbit-tools/src/builtin/orbit/{operation,friction}/`, `crates/orbit-cli/src/command/{operation_args,friction}.rs`, and `crates/orbit-web/src/api/frictions.rs`.
- `orbit-docs/1_overview.md`: corrected stale source/skill links and implementation paths. Verified every referenced local link and code path; the current agent entry point is `crates/orbit-core/assets/skills/orbit/SKILL.md`.
- `orbit-docs/2_design.md`: corrected moved module paths and parser function name, documented the current batched `git check-ignore -z --stdin` walker, and documented the current serde_yaml migration implementation. Verified against `crates/orbit-core/src/application/docs/**`, `crates/orbit-core/src/adapter/tool_host/docs_tools.rs`, `crates/orbit-cli/src/command/docs.rs`, and `crates/orbit-core/src/application/semantic.rs`.
- `remote-access/specs/ssh-tunnel.md`: all source claims remained current; stamped after verifying `crates/orbit-web/src/connect.rs`, `crates/orbit-web/src/ssh_tunnel.rs`, and the connect/SSH tunnel tests.
- All six selected docs had existing valid frontmatter with confidently derived `type` and `summary`; no frontmatter migration was needed. Each was stamped `last_validated: 2026-09-09`. No selected claims were left unvalidated or selected docs left unchanged.

Assessment: The six selected docs now match current repository structure and behavior without introducing metadata, documents, or new sections. Relative-link validation passed, and the final diff contains only the six selected docs.

Criteria:
- Batch selection and stable tie-break: passed; reproduced from starting HEAD.
- Verification before stamping: passed; source inspections plus `cargo test -p orbit-core application::docs --lib` (24 passed).
- Unverifiable claims: none in the selected batch; external SSH/network execution was not required and remains an environment-dependent risk.
- Forbidden/generated paths: passed; final changed paths are only the six selected docs.
- Frontmatter-less eligibility/migration: passed; none of the six selected docs was frontmatter-less, and no metadata migration was performed.
- Schema/classification and validation marker rules: passed; existing schema fields only, no sidecar/new marker system.
- No new document/section and no prose reflow: passed.
- `make ci-fast`: passed (exit 0). Its compiler-cache namespace probe reported an environment skip because Bubblewrap cannot create an unprivileged mount namespace; this is the only validation limitation.

Validation:
- passed: `cargo test -p orbit-core application::docs --lib` — 24 passed.
- passed: `make ci-fast` — exit 0.
- passed: selected-doc frontmatter and relative-link checker — all six stamped today and all local links resolved.
- passed: selected referenced-code-path existence and stale-path/name scan.
- passed: `git diff --check`.
- passed: forbidden-path check and final `git status --short` review.
- not run: `make ci-lint` — not required by this documentation task; workspace instructions require it before review but the task acceptance requires `make ci-fast` only.

Remaining risk: SSH/network behavior was verified against current implementation and tests, not a live remote host.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11821-6aa0ec69`
- Behind base: 0
- Ahead of base: 1