### PR TITLE
[code-scanning-sweep] Fix rust/cleartext-logging in crates/orbit-agent/src/providers/gemini_http/transport.rs

### DIFF
--- a/crates/orbit-agent/src/providers/gemini_http/tests/transport.rs
+++ b/crates/orbit-agent/src/providers/gemini_http/tests/transport.rs
@@ -62,6 +62,18 @@ fn endpoint_builders_do_not_include_api_key_query_params() {
 }
 
 #[test]
+fn api_key_header_value_is_marked_sensitive_for_diagnostics() {
+    let transport =
+        GeminiHttpTransport::new(GEMINI_API_KEY, "gemini-test", None).expect("transport");
+
+    let header_value = transport.api_key_header_value().expect("header value");
+
+    assert!(header_value.is_sensitive());
+    assert_eq!(format!("{header_value:?}"), "Sensitive");
+    assert_eq!(header_value, GEMINI_API_KEY);
+}
+
+#[test]
 fn reqwest_transport_errors_strip_url_before_stringifying() {
     let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind listener");
     let addr = listener.local_addr().expect("listener address");

--- a/crates/orbit-agent/src/providers/gemini_http/transport.rs
+++ b/crates/orbit-agent/src/providers/gemini_http/transport.rs
@@ -96,9 +96,17 @@ impl GeminiHttpTransport {
         Ok(request)
     }
 
-    fn api_key_header_value(&self) -> Result<HeaderValue, TransportError> {
-        HeaderValue::from_str(&self.api_key)
-            .map_err(|e| TransportError::Other(format!("invalid Gemini API key header value: {e}")))
+    // `pub(super)` widened for sibling test access.
+    pub(super) fn api_key_header_value(&self) -> Result<HeaderValue, TransportError> {
+        let mut header_value = HeaderValue::from_str(&self.api_key).map_err(|e| {
+            TransportError::Other(format!("invalid Gemini API key header value: {e}"))
+        })?;
+
+        // RequestBuilder's debug output includes header values unless they are
+        // explicitly marked sensitive. Keep the key usable on the wire while
+        // preventing accidental cleartext disclosure in diagnostics.
+        header_value.set_sensitive(true);
+        Ok(header_value)
     }
 
     fn try_create_cached_content(


### PR DESCRIPTION
## Task

[ORB-11842](https://orbit-cli.com/tasks/ORB-11842) — [code-scanning-sweep] Fix rust/cleartext-logging in crates/orbit-agent/src/providers/gemini_http/transport.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#82`
- Rule: `rust/cleartext-logging` (rust/cleartext-logging)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This operation writes self.api_key_header_value() to a log file.
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-agent/src/providers/gemini_http/transport.rs` lines 224-225
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/82

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/cleartext-logging` at `crates/orbit-agent/src/providers/gemini_http/transport.rs` lines 224-225 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Marked the Gemini API-key `HeaderValue` sensitive with `set_sensitive(true)` before it is used by reqwest, preserving the cleartext value only for the authenticated wire request while making diagnostics render `Sensitive`.
- Added a focused transport test proving the header remains usable on the wire and is masked in debug output.

Assessment: The finding's unsafe diagnostic data flow is removed at the owning transport boundary without changing endpoint construction, authentication, request bodies, or response handling.

Acceptance criteria:
1. Pass — `crates/orbit-agent/src/providers/gemini_http/transport.rs` now applies a real runtime sensitivity marker; no suppression, dismissal, or exclusion was added.
2. Pass — the existing request test still observes the exact API-key header on the wire, and the new test verifies debug masking.
3. Pass with hosted-scan handoff — local focused source inspection found no logging macro consuming the API key, and the repository's required checks passed. The GitHub CodeQL CLI is not installed in this executor and the task explicitly bounds out agent-side GitHub access; the configured `.github/workflows/codeql.yml` remains the authoritative confirmation for the alert's disappearance.

Validation:
- Passed: `cargo fmt --all -- --check`.
- Passed: `cargo test -p orbit-agent gemini_http` (5 passed).
- Passed: `make ci-fast`; its compiler-cache mount-namespace subcheck was explicitly skipped because this kernel denies unprivileged bubblewrap namespaces.
- Passed: `make ci-lint`.
- Passed: `CARGO_HOME=/tmp/orbit-audit-cargo.yOpkfY cargo deny check` (advisories, bans, licenses, and sources accepted; existing unmatched-allowance warnings only).
- Not run: local CodeQL scan, because `codeql` is unavailable and no agent-side GitHub access is required by the task.
- Passed: focused logging scan, `git diff --check`, and final `GIT_OPTIONAL_LOCKS=0 git status --short`.

Deviations from original plan:
- Added the existing sibling transport test file to `context_files` to cover the security property at the boundary.

Remaining risk: hosted CodeQL must rerun on the delivered revision to provide the platform-level alert closure evidence; local Rust, guardrail, lint, and supply-chain checks are clean. Changes remain uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11842-6aa0ef2d`
- Behind base: 0
- Ahead of base: 1