### PR TITLE
[code-scanning-sweep] Fix rust/cleartext-logging in crates/orbit-core/src/bootstrap/activity.rs

### DIFF
--- a/crates/orbit-core/src/bootstrap/activity.rs
+++ b/crates/orbit-core/src/bootstrap/activity.rs
@@ -235,8 +235,7 @@ backend = "cli"
             spec.tools
                 .iter()
                 .all(|tool| !tool.starts_with("github.") && !tool.contains("ceiling")),
-            "agent_implement must not widen to GitHub reads or grow a task ceiling: {:?}",
-            spec.tools
+            "agent_implement tool allowlist must not widen to GitHub reads or grow a task ceiling"
         );
     }
 


### PR DESCRIPTION
## Task

[ORB-11832](https://orbit-cli.com/tasks/ORB-11832) — [code-scanning-sweep] Fix rust/cleartext-logging in crates/orbit-core/src/bootstrap/activity.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#33`
- Rule: `rust/cleartext-logging` (rust/cleartext-logging)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This operation writes validate_trusted_host_activity(...) to a log file.
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-core/src/bootstrap/activity.rs` lines 238-239
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/33

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/cleartext-logging` at `crates/orbit-core/src/bootstrap/activity.rs` lines 238-239 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Removed the \`spec.tools\` debug formatting from the affected assertion failure in \`crates/orbit-core/src/bootstrap/activity.rs\`. The allowlist predicate and intended test behavior are unchanged; failures now emit only a fixed diagnostic.
- No suppression, dismissal, exclusion, configuration bypass, or unrelated file change was added.

Acceptance criteria:
- Code scanning sink remediated at the reported lines: passed. Parsed activity data is no longer interpolated into the assertion panic/log output.
- Intended behavior preserved: passed. The assertion still checks that the implementation activity has no GitHub or ceiling tool.
- Validation/security evidence: local checks passed below; hosted CodeQL re-analysis was not run because the task explicitly states there is no agent-side GitHub access. The source-level diff removes the reported data flow at the affected location.

Validation:
- \`cargo test -p orbit-core bootstrap::activity\`: passed (12 targeted tests).
- \`make ci-fast\`: passed. Its compiler-cache namespace subcheck reported the documented environment limitation (bubblewrap could not create a user namespace) and skipped only that subcheck; the overall guardrail exited 0.
- \`make ci-lint\`: passed (workspace all-target clippy with warnings denied).
- \`git diff --check\`: passed.
- \`cargo deny check\`: not completed; cargo-deny could not acquire \`~/.cargo/advisory-dbs/db.lock\` because the path is read-only in this runner. The normal \`make ci\` supply-chain gate remains for CI/PR validation; \`make ci\` was not run per workspace policy.
- CodeQL hosted scan: not run; GitHub access is outside this activity's bounds.

Assessment: Minimal, behavior-preserving remediation with one scoped file changed. Remaining risk is limited to hosted CodeQL confirmation and the runner's read-only cargo advisory database; no local code or formatting issues remain.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11832-6aa0f01d`
- Behind base: 0
- Ahead of base: 1