### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/docs/config.rs

### DIFF
--- a/crates/orbit-core/src/application/docs/config.rs
+++ b/crates/orbit-core/src/application/docs/config.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::path::Path;
 
 use serde::Deserialize;
@@ -5,6 +6,7 @@ use serde::Deserialize;
 use orbit_common::OrbitError;
 
 const DEFAULT_DOC_ROOT: &str = "docs/";
+const CONFIG_FILE_NAME: &str = "config.toml";
 
 #[derive(Debug, Deserialize)]
 struct DocsConfigFile {
@@ -135,34 +137,67 @@ pub fn parse_docs_search_config_from_config_toml(
 }
 
 pub(super) fn read_docs_roots_from_config_path(path: &Path) -> Result<Vec<DocsRoot>, OrbitError> {
-    if !path.exists() {
+    let Some(raw) = read_config_contents(path)? else {
         return Ok(default_doc_roots());
-    }
-    let raw = std::fs::read_to_string(path)
-        .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
+    };
     parse_docs_roots_from_config_toml(&raw)
 }
 
 pub(super) fn read_docs_search_config_from_config_path(
     path: &Path,
 ) -> Result<DocsSearchConfig, OrbitError> {
-    if !path.exists() {
+    let Some(raw) = read_config_contents(path)? else {
         return Ok(DocsSearchConfig::default());
-    }
-    let raw = std::fs::read_to_string(path)
-        .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
+    };
     parse_docs_search_config_from_config_toml(&raw)
 }
 
 pub(super) fn read_task_context_docs_roots_from_config_path(
     path: &Path,
 ) -> Result<Vec<DocsRoot>, OrbitError> {
-    if !path.exists() {
+    let Some(raw) = read_config_contents(path)? else {
         return Ok(default_doc_roots());
-    }
-    let raw = std::fs::read_to_string(path)
-        .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
+    };
     parse_task_context_docs_roots_from_config_toml(&raw)
+}
+
+fn read_config_contents(path: &Path) -> Result<Option<String>, OrbitError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let parent = path.parent().ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "invalid config path without parent: {}",
+            path.display()
+        ))
+    })?;
+    let canonical_parent = parent.canonicalize().map_err(|error| {
+        OrbitError::Io(format!(
+            "canonicalize config directory {}: {error}",
+            parent.display()
+        ))
+    })?;
+    let canonical_path = path.canonicalize().map_err(|error| {
+        OrbitError::Io(format!(
+            "canonicalize config path {}: {error}",
+            path.display()
+        ))
+    })?;
+    if !canonical_path.starts_with(&canonical_parent)
+        || canonical_path.file_name() != Some(OsStr::new(CONFIG_FILE_NAME))
+        || !canonical_path.is_file()
+    {
+        return Err(OrbitError::InvalidInput(format!(
+            "docs config path must be a regular {CONFIG_FILE_NAME} file: {}",
+            path.display()
+        )));
+    }
+
+    let safe_path = canonical_parent.join(CONFIG_FILE_NAME);
+    let raw = std::fs::read_to_string(&safe_path)
+        .map_err(|error| OrbitError::Io(format!("read {}: {error}", safe_path.display())))?;
+    Ok(Some(raw))
 }
 
 /// Parse the task-context docs roots (used by related_docs_for_task and its tests).

--- a/crates/orbit-core/src/application/docs/tests/config.rs
+++ b/crates/orbit-core/src/application/docs/tests/config.rs
@@ -1,8 +1,14 @@
 //! Config parsing (roots + search weights) tests migrated for ORB-00250.
 
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
+
+use tempfile::tempdir;
+
 use super::super::config::{
     DocsRoot, parse_docs_roots_from_config_toml, parse_docs_search_config_from_config_toml,
-    parse_task_context_docs_roots_from_config_toml,
+    parse_task_context_docs_roots_from_config_toml, read_docs_roots_from_config_path,
 };
 
 fn root_paths(roots: &[DocsRoot]) -> Vec<&str> {
@@ -87,4 +93,40 @@ fn task_context_docs_roots_skip_explicit_empty_or_unset_roots() {
         root_paths(&parse_task_context_docs_roots_from_config_toml("").unwrap()),
         vec!["docs/"]
     );
+}
+
+#[test]
+fn config_reader_accepts_the_workspace_config_file() {
+    let root = tempdir().expect("create tempdir");
+    let path = root.path().join("config.toml");
+    fs::write(&path, "[docs]\nroots = [\"guides/\"]\n").expect("write config");
+
+    let roots = read_docs_roots_from_config_path(&path).expect("read config");
+
+    assert_eq!(root_paths(&roots), vec!["guides/"]);
+}
+
+#[test]
+fn config_reader_rejects_an_existing_non_config_file() {
+    let root = tempdir().expect("create tempdir");
+    let path = root.path().join("secrets.txt");
+    fs::write(&path, "[docs]\nroots = [\"guides/\"]\n").expect("write fixture");
+
+    let error = read_docs_roots_from_config_path(&path).expect_err("reject non-config path");
+
+    assert!(error.to_string().contains("config.toml"));
+}
+
+#[cfg(unix)]
+#[test]
+fn config_reader_rejects_a_config_symlink_to_another_file() {
+    let root = tempdir().expect("create tempdir");
+    let target = root.path().join("secrets.toml");
+    let path = root.path().join("config.toml");
+    fs::write(&target, "[docs]\nroots = [\"guides/\"]\n").expect("write fixture");
+    symlink(&target, &path).expect("create config symlink");
+
+    let error = read_docs_roots_from_config_path(&path).expect_err("reject config symlink");
+
+    assert!(error.to_string().contains("config.toml"));
 }


### PR DESCRIPTION
## Task

[ORB-11843](https://orbit-cli.com/tasks/ORB-11843) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/docs/config.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#83`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value.
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-core/src/application/docs/config.rs` line 141
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/83

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-core/src/application/docs/config.rs` line 141 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a shared validated config-file reader in `crates/orbit-core/src/application/docs/config.rs` that canonicalizes the parent and target, requires containment, requires the fixed `config.toml` basename and a regular file, then reads only the reconstructed safe path. Missing config files still return the existing defaults; symlinked/non-config files are rejected.
- Added focused acceptance and rejection tests, including a Unix symlink traversal case, in `crates/orbit-core/src/application/docs/tests/config.rs`.
Assessment: The CodeQL sink is now behind canonicalization, containment, fixed-name validation, and regular-file validation; the original direct read of the supplied path is gone. The implementation preserves normal config parsing and missing-file behavior.

Acceptance criteria:
- rust/path-injection remediation: satisfied by the validated fixed-name read boundary; no suppression, dismissal, or exclusion was added.
- Intended behavior: satisfied by passing docs config and full docs test suites plus explicit missing-file/default-preserving control flow.
- Validation/security checks: repository checks passed. Local CodeQL execution was not available (`codeql` is not installed and the task explicitly does not require agent-side GitHub access); the source sink check found no direct `read_to_string(path)` or `read_to_string(&canonical_path)`, and the external CodeQL workflow remains the final scanner confirmation.

Validation:
- `cargo fmt --all -- --check`: passed.
- `cargo test -p orbit-core application::docs::tests::config`: passed, 8 tests.
- `cargo test -p orbit-core application::docs::tests`: passed, 27 tests.
- `make ci-fast`: passed; the compiler-cache namespace subcheck was skipped because bubblewrap cannot create an unprivileged mount namespace in this environment.
- `make ci-lint`: passed with workspace clippy and warnings denied.
- `git diff --check`: passed.
- Final worktree contains only the two task-scoped source/test files; changes remain uncommitted for pipeline delivery.

Remaining risk: the hosted CodeQL scan was not runnable locally and should re-evaluate the changed path on delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11843-6aa0ef6d`
- Behind base: 0
- Ahead of base: 1