### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/routines/clock.rs

### DIFF
--- a/crates/orbit-core/src/application/routines/clock.rs
+++ b/crates/orbit-core/src/application/routines/clock.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 const LAUNCHD_PLIST_TEMPLATE: &str = include_str!("../../../assets/clock/com.orbit.sweep.plist");
 const SYSTEMD_SERVICE_TEMPLATE: &str = include_str!("../../../assets/clock/orbit-sweep.service");
 const SYSTEMD_TIMER_TEMPLATE: &str = include_str!("../../../assets/clock/orbit-sweep.timer");
+const CLOCK_SETTINGS_FILE: &str = "clock.toml";
 
 /// launchd agent label (macOS).
 pub const LAUNCHD_LABEL: &str = "com.orbit.sweep";
@@ -55,14 +56,16 @@ impl ClockSettings {
 }
 
 pub fn clock_settings_path(global_root: &Path) -> PathBuf {
-    global_root.join("clock.toml")
+    global_root.join(CLOCK_SETTINGS_FILE)
 }
 
 pub fn load_clock_settings(global_root: &Path) -> Result<ClockSettings, OrbitError> {
-    let path = clock_settings_path(global_root);
-    if !path.exists() {
+    let requested_path = clock_settings_path(global_root);
+    if !requested_path.exists() {
         return Ok(ClockSettings::default());
     }
+
+    let path = validated_clock_settings_path(global_root)?;
     let raw = fs::read_to_string(&path)
         .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
     toml::from_str::<ClockSettings>(&raw)
@@ -80,8 +83,44 @@ pub fn save_clock_settings(global_root: &Path, settings: ClockSettings) -> Resul
     let rendered = toml::to_string(&settings).map_err(|error| {
         OrbitError::Execution(format!("serialize clock configuration: {error}"))
     })?;
-    atomic_write_text(&clock_settings_path(global_root), &rendered)
+    let path = validated_clock_settings_path(global_root)?;
+    atomic_write_text(&path, &rendered)
         .map_err(|error| OrbitError::Io(format!("write clock configuration: {error}")))
+}
+
+/// Resolve the clock settings file beneath the canonical global root.
+///
+/// The root may be selected through an explicit CLI override, but the clock
+/// settings path itself is fixed. Canonicalizing both components and requiring
+/// the exact expected file prevents a symlink or traversal from redirecting a
+/// settings read to another host file.
+fn validated_clock_settings_path(global_root: &Path) -> Result<PathBuf, OrbitError> {
+    let canonical_root = fs::canonicalize(global_root).map_err(|error| {
+        OrbitError::Io(format!(
+            "resolve clock configuration root {}: {error}",
+            global_root.display()
+        ))
+    })?;
+    let expected_path = canonical_root.join(CLOCK_SETTINGS_FILE);
+
+    if !expected_path.exists() {
+        return Ok(expected_path);
+    }
+
+    let canonical_path = fs::canonicalize(&expected_path).map_err(|error| {
+        OrbitError::Io(format!(
+            "resolve clock configuration {}: {error}",
+            expected_path.display()
+        ))
+    })?;
+    if canonical_path != expected_path || !canonical_path.is_file() {
+        return Err(OrbitError::InvalidInput(format!(
+            "clock configuration must be a regular {CLOCK_SETTINGS_FILE} directly under {}",
+            canonical_root.display()
+        )));
+    }
+
+    Ok(canonical_path)
 }
 
 /// Change cadence transactionally from the operator's perspective: the

--- a/crates/orbit-core/src/application/routines/tests/clock.rs
+++ b/crates/orbit-core/src/application/routines/tests/clock.rs
@@ -484,6 +484,37 @@ fn clock_cadence_rejects_subminute_and_out_of_range_values() {
 }
 
 #[test]
+fn missing_clock_settings_use_the_default() {
+    let root = tempdir().expect("create global root");
+
+    assert_eq!(
+        load_clock_settings(root.path()).expect("load default clock settings"),
+        ClockSettings::default()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn clock_settings_reject_symlink_escape() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempdir().expect("create global root");
+    let outside = tempdir().expect("create outside root");
+    let outside_settings = outside.path().join("clock.toml");
+    save_clock_settings(outside.path(), ClockSettings::default())
+        .expect("write outside clock settings");
+    symlink(&outside_settings, root.path().join("clock.toml")).expect("create settings symlink");
+
+    let error = load_clock_settings(root.path()).expect_err("reject escaped settings path");
+
+    assert!(
+        error
+            .to_string()
+            .contains("clock configuration must be a regular clock.toml directly under")
+    );
+}
+
+#[test]
 fn status_is_deterministic_for_each_manager_and_reports_configured_cadence() {
     let root = tempdir().expect("create global root");
     let launchd = MockRunner::new(vec![Ok(true)]);


### PR DESCRIPTION
## Task

[ORB-11846](https://orbit-cli.com/tasks/ORB-11846) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/routines/clock.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#89`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value.
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-core/src/application/routines/clock.rs` line 66
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/89

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-core/src/application/routines/clock.rs` line 66 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a canonical clock-settings path boundary in `crates/orbit-core/src/application/routines/clock.rs`. The fixed `clock.toml` target is resolved beneath the canonical global root and must be the exact regular file; symlink/path escape targets are rejected before reading or writing. Missing settings still return defaults.
- Added sibling tests for missing-file defaults and Unix symlink escape rejection in `crates/orbit-core/src/application/routines/tests/clock.rs`.
Assessment: The flagged direct read is now behind an owning validation boundary, with behavior-preserving default and normal settings flows covered by the focused suite. No suppressions, dismissals, exclusions, or unrelated files were changed.

Criteria evidence:
1. `rust/path-injection` at the flagged clock settings read is remediated in production code by canonical-root/exact-target validation; no CodeQL configuration suppression was added.
2. Existing cadence/status/install tests pass; the new tests verify missing-file compatibility and rejection of an escaped settings symlink.
3. Source review confirms the old direct `global_root.join(...)/read_to_string` flow is gone. CodeQL CLI was not available locally, so a live CodeQL result cannot be confirmed in this environment; the repository workflow remains the authoritative scan.

Validation:
- `cargo fmt --all -- --check` — passed.
- `cargo test -p orbit-core application::routines::tests::clock --lib` — passed; 19 tests.
- `make ci-fast` — passed. Its `test-compiler-cache-namespaces` smoke check was skipped because this kernel denies unprivileged mount namespaces; other fast guardrails passed.
- `make ci-lint` — passed; workspace all-target clippy with warnings denied.
- `make audit` — failed at the first attempt because cargo-deny could not obtain an exclusive lock on the read-only `~/.cargo/advisory-dbs/db.lock`.
- `cargo deny check --disable-fetch` with a temporary writable `CARGO_HOME` populated from the existing local advisory database — passed; advisories, bans, licenses, and sources OK (warnings only for unmatched allow-list entries and absent ignored advisories).
- `git diff --check` — passed.
- `GIT_OPTIONAL_LOCKS=0 git status --short` — passed; only the two scoped clock files are modified.

Remaining risks/deviations: CodeQL was not installed, so the exact hosted alert re-run is not available locally. The separate CodeQL alert for the launchd log path in this same module was not part of ORB-11846 and remains outside scope.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11846-6aa0f026`
- Behind base: 0
- Ahead of base: 1