### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-registry/src/workspace_registry/io.rs

### DIFF
--- a/crates/orbit-registry/src/tests/workspace_registry.rs
+++ b/crates/orbit-registry/src/tests/workspace_registry.rs
@@ -655,11 +655,9 @@ fn exact_id_lookup_survives_a_name_that_matches_another_workspace_id() {
 
 #[test]
 fn malformed_and_future_registries_fail_without_rewriting() {
-    let root = tempdir().expect("tempdir");
-    for (name, bytes, expected) in [
-        ("malformed", b"{ not json".to_vec(), "malformed JSON"),
+    for (bytes, expected) in [
+        (b"{ not json".to_vec(), "malformed JSON"),
         (
-            "future",
             serde_json::to_vec_pretty(&json!({
                 "schema_version": WORKSPACE_REGISTRY_SCHEMA_VERSION + 1,
                 "workspaces": [],
@@ -669,12 +667,45 @@ fn malformed_and_future_registries_fail_without_rewriting() {
             "unsupported schema_version",
         ),
     ] {
-        let path = root.path().join(format!("{name}.json"));
+        let root = tempdir().expect("tempdir");
+        let path = root.path().join("workspaces.json");
         fs::write(&path, &bytes).expect("write invalid fixture");
         let error = load_registry_from(&path).expect_err("invalid registry must fail");
         assert!(error.to_string().contains(expected), "{error}");
         assert_eq!(fs::read(&path).expect("read unchanged fixture"), bytes);
     }
+}
+
+#[test]
+fn registry_io_rejects_a_non_registry_file_name() {
+    let root = tempdir().expect("tempdir");
+    let path = root.path().join("other.json");
+    fs::write(&path, b"not a registry").expect("write fixture");
+
+    let error = load_registry_from(&path).expect_err("alternate registry file must fail");
+
+    assert!(
+        error.to_string().contains("must name 'workspaces.json'"),
+        "unexpected: {error}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn registry_io_rejects_a_symlinked_registry_file() {
+    let root = tempdir().expect("tempdir");
+    let outside = tempdir().expect("tempdir");
+    let target = outside.path().join("workspaces.json");
+    fs::write(&target, b"not a registry").expect("write target");
+    let path = root.path().join("workspaces.json");
+    std::os::unix::fs::symlink(&target, &path).expect("create registry symlink");
+
+    let error = load_registry_from(&path).expect_err("symlinked registry must fail");
+
+    assert!(
+        error.to_string().contains("must not be a symlink"),
+        "unexpected: {error}"
+    );
 }
 
 #[test]

--- a/crates/orbit-registry/src/workspace_registry/io.rs
+++ b/crates/orbit-registry/src/workspace_registry/io.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 use orbit_common::OrbitError;
@@ -8,6 +9,8 @@ use orbit_types::workspace::WorkspaceRegistry;
 use super::{WorkspaceRegistryHostContext, parse_workspace_registry, validate_workspace_registry};
 use crate::{HostIdentityState, inspect_host_identity};
 
+const REGISTRY_FILE_NAME: &str = "workspaces.json";
+
 /// Return the path to the machine-global workspace registry.
 pub fn registry_path() -> Result<PathBuf, OrbitError> {
     Ok(registry_path_for(&global_orbit_dir()?))
@@ -15,7 +18,7 @@ pub fn registry_path() -> Result<PathBuf, OrbitError> {
 
 /// Return the workspace registry path under an already-resolved global root.
 pub fn registry_path_for(global_root: &Path) -> PathBuf {
-    global_root.join("workspaces.json")
+    global_root.join(REGISTRY_FILE_NAME)
 }
 
 /// Load the machine-global workspace registry.
@@ -34,7 +37,8 @@ pub fn with_registry_lock<T>(
     path: &Path,
     op: impl FnOnce() -> Result<T, OrbitError>,
 ) -> Result<T, OrbitError> {
-    with_exclusive_file_lock(path, "workspace registry", op)
+    let path = validated_registry_path(path)?;
+    with_exclusive_file_lock(&path, "workspace registry", op)
 }
 
 /// Load, migrate, and validate a registry from an explicit path.
@@ -46,15 +50,16 @@ pub(crate) fn load_registry_from_with_writer(
     path: &Path,
     writer: impl FnOnce(&WorkspaceRegistry, &Path) -> Result<(), OrbitError>,
 ) -> Result<WorkspaceRegistry, OrbitError> {
+    let path = validated_registry_path(path)?;
     if !path.exists() {
         return Ok(WorkspaceRegistry::default());
     }
     let content =
-        std::fs::read_to_string(path).map_err(|error| OrbitError::Io(error.to_string()))?;
-    let context = registry_host_context(path)?;
+        std::fs::read_to_string(&path).map_err(|error| OrbitError::Io(error.to_string()))?;
+    let context = registry_host_context(&path)?;
     let (registry, migrated) = parse_workspace_registry(&content, &context)?;
     if migrated {
-        writer(&registry, path)?;
+        writer(&registry, &path)?;
     }
     Ok(registry)
 }
@@ -66,10 +71,62 @@ pub fn save_registry(registry: &WorkspaceRegistry) -> Result<(), OrbitError> {
 
 /// Validate and atomically save a registry to an explicit path.
 pub fn save_registry_to(registry: &WorkspaceRegistry, path: &Path) -> Result<(), OrbitError> {
-    let context = registry_host_context(path)?;
+    let path = validated_registry_path(path)?;
+    let context = registry_host_context(&path)?;
     let mut canonical = registry.clone();
     validate_workspace_registry(&mut canonical, &context)?;
-    write_registry(&canonical, path)
+    write_registry(&canonical, &path)
+}
+
+/// Resolve the registry path before it reaches a filesystem operation.
+///
+/// Registry callers may select a custom Orbit data root, but the file inside
+/// that root is fixed. Canonicalizing the parent also removes `..` components,
+/// and inspecting the final component without following it rejects a registry
+/// symlink that would redirect reads or writes outside the selected root.
+fn validated_registry_path(path: &Path) -> Result<PathBuf, OrbitError> {
+    if path.file_name() != Some(OsStr::new(REGISTRY_FILE_NAME)) {
+        return Err(OrbitError::WorkspaceError(format!(
+            "workspace registry path must name '{REGISTRY_FILE_NAME}': {}",
+            path.display()
+        )));
+    }
+
+    let parent = path.parent().ok_or_else(|| {
+        OrbitError::WorkspaceError(format!(
+            "workspace registry path '{}' has no parent directory",
+            path.display()
+        ))
+    })?;
+    let canonical_parent = parent
+        .canonicalize()
+        .map_err(|error| OrbitError::Io(format!("canonicalize {}: {error}", parent.display())))?;
+    let canonical_path = canonical_parent.join(REGISTRY_FILE_NAME);
+    if !canonical_path.starts_with(&canonical_parent) {
+        return Err(OrbitError::WorkspaceError(format!(
+            "workspace registry path '{}' resolves outside its selected root",
+            path.display()
+        )));
+    }
+
+    match std::fs::symlink_metadata(&canonical_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(OrbitError::WorkspaceError(format!(
+                "workspace registry path '{}' must not be a symlink",
+                path.display()
+            )));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "inspect {}: {error}",
+                canonical_path.display()
+            )));
+        }
+    }
+
+    Ok(canonical_path)
 }
 
 fn registry_host_context(path: &Path) -> Result<WorkspaceRegistryHostContext, OrbitError> {


### PR DESCRIPTION
## Task

[ORB-11845](https://orbit-cli.com/tasks/ORB-11845) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-registry/src/workspace_registry/io.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#85`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-registry/src/workspace_registry/io.rs` line 53
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/85

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-registry/src/workspace_registry/io.rs` line 53 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a registry-path validation boundary in `crates/orbit-registry/src/workspace_registry/io.rs`.
- Registry I/O now accepts only the fixed `workspaces.json` leaf, canonicalizes the selected root, checks the final component without following symlinks, and rejects redirected registry files before reads, writes, or locks.
- Added regression tests for alternate filenames and symlinked registry files; existing malformed/future fixtures now use the canonical filename.
Assessment: The affected filesystem read consumes only the validated canonical path, preserving explicit custom Orbit roots while removing the uncontrolled path expression and unsafe symlink redirect.
Acceptance criteria:
- `rust/path-injection`: remediated with executable filename, normalization, containment, and symlink checks; no suppression, dismissal, or exclusion added.
- Intended behavior: custom registry roots and migration behavior remain supported; invalid filenames and redirected registry symlinks fail closed.
- Validation: focused tests and repository gates passed; source inspection confirms the affected read is downstream of `validated_registry_path`. Local CodeQL is unavailable, so hosted CodeQL must confirm alert #85.
Validation commands:
- `cargo fmt --all -- --check`: passed.
- `cargo test -p orbit-registry`: passed (53 unit tests, 1 dependency-boundary test, 0 doc tests).
- `make ci-fast`: passed; its compiler-cache namespace subcheck was skipped because unprivileged bubblewrap namespaces are unavailable.
- `make ci-lint`: passed (`cargo clippy --workspace --all-targets -- -D warnings`).
- `make audit`: failed because `cargo-deny` could not acquire the advisory database lock on a read-only path; a task-local `CARGO_HOME` retry with offline mode resolved the same host advisory database and failed identically.
- `git diff --check`: passed.
- `git status --short`: only the two task-scoped source/test files are modified.
Remaining risks or deviations: CodeQL and cargo-deny advisory scanning could not run to completion in this executor environment; CI/hosted scanning remains the confirmation point for alert #85.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11845-6aa0f007`
- Behind base: 0
- Ahead of base: 1