### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-registry/src/host_identity.rs

### DIFF
--- a/crates/orbit-registry/src/host_identity.rs
+++ b/crates/orbit-registry/src/host_identity.rs
@@ -12,6 +12,7 @@
 //! no silent fallback to the OS hostname. Routine `hosts:` pinning,
 //! the sweep, and status all resolve through [`HostIdentity::host_id`].
 
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -168,6 +169,38 @@ fn host_toml_path(global_root: &Path) -> PathBuf {
     global_root.join(HOST_TOML_FILE)
 }
 
+fn existing_host_toml_path(global_root: &Path) -> Result<Option<PathBuf>, OrbitError> {
+    let path = host_toml_path(global_root);
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let canonical_root = global_root.canonicalize().map_err(|error| {
+        OrbitError::Io(format!(
+            "failed to canonicalize host identity directory '{}': {error}",
+            global_root.display()
+        ))
+    })?;
+    let canonical_path = path.canonicalize().map_err(|error| {
+        OrbitError::Io(format!(
+            "failed to canonicalize host identity '{}': {error}",
+            path.display()
+        ))
+    })?;
+    if !canonical_path.starts_with(&canonical_root)
+        || canonical_path.file_name() != Some(OsStr::new(HOST_TOML_FILE))
+        || !canonical_path.is_file()
+    {
+        return Err(OrbitError::InvalidInput(format!(
+            "host identity path must be a regular {HOST_TOML_FILE} file inside '{}': {}",
+            global_root.display(),
+            path.display()
+        )));
+    }
+
+    Ok(Some(canonical_root.join(HOST_TOML_FILE)))
+}
+
 fn non_blank(value: &Option<String>) -> Option<String> {
     value
         .as_deref()
@@ -181,10 +214,9 @@ fn non_blank(value: &Option<String>) -> Option<String> {
 /// for malformed, incomplete, blank, or future-schema files (fail closed —
 /// never rewrites the file).
 pub fn inspect_host_identity(global_root: &Path) -> Result<HostIdentityState, OrbitError> {
-    let path = host_toml_path(global_root);
-    if !path.exists() {
+    let Some(path) = existing_host_toml_path(global_root)? else {
         return Ok(HostIdentityState::Absent);
-    }
+    };
     let raw_text = std::fs::read_to_string(&path)
         .map_err(|error| OrbitError::Io(format!("failed to read '{}': {error}", path.display())))?;
     let parsed: RawHostToml = toml::from_str(&raw_text).map_err(|error| {

--- a/crates/orbit-registry/src/tests/host_identity.rs
+++ b/crates/orbit-registry/src/tests/host_identity.rs
@@ -1,6 +1,9 @@
 use std::sync::Barrier;
 use std::thread;
 
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
+
 use crate::HOST_IDENTITY_SCHEMA_VERSION;
 
 use crate::host_identity::{
@@ -205,6 +208,24 @@ fn malformed_toml_is_an_error_not_a_fallback() {
     let dir = tempfile::tempdir().expect("tempdir");
     std::fs::write(dir.path().join("host.toml"), "host_id = [not toml").expect("write");
     inspect_host_identity(dir.path()).expect_err("invalid toml must fail closed");
+}
+
+#[cfg(unix)]
+#[test]
+fn host_identity_rejects_a_host_toml_symlink_outside_its_root() {
+    let root = tempfile::tempdir().expect("create root tempdir");
+    let outside = tempfile::tempdir().expect("create outside tempdir");
+    let outside_path = outside.path().join("host.toml");
+    std::fs::write(&outside_path, "host_id = \"outside\"\n").expect("write outside file");
+    symlink(&outside_path, root.path().join("host.toml")).expect("create host.toml symlink");
+
+    let error = inspect_host_identity(root.path())
+        .expect_err("host identity must reject a path escaping its root")
+        .to_string();
+    assert!(
+        error.contains("regular host.toml file"),
+        "unexpected: {error}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11847](https://orbit-cli.com/tasks/ORB-11847) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-registry/src/host_identity.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#90`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-registry/src/host_identity.rs` line 188
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/90

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-registry/src/host_identity.rs` line 188 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added canonical-root and canonical-file validation before reading an existing host.toml, then read only the validated root-local path. This rejects host.toml symlinks/path escapes without changing normal host identity loading, migration, or creation behavior.
- Added a Unix regression test proving an external host.toml symlink is rejected.
- No CodeQL configuration suppression or exclusion was added.

Acceptance criteria:
1. Met: the rust/path-injection data flow at host_identity.rs was remediated in production code with canonicalization, containment, fixed filename, and regular-file checks.
2. Met: normal identities continue to load and all existing orbit-registry tests pass; unsafe host.toml symlinks now fail closed.
3. Partially locally verified: repository gates and cargo-deny passed; the CodeQL CLI is not installed in this checkout and the task explicitly excludes agent-side GitHub access, so hosted CodeQL must provide the final alert-resolution confirmation.

Validation:
- Passed: cargo fmt --all
- Passed: cargo fmt --all -- --check
- Passed: cargo test -p orbit-registry --lib host_identity (18 passed)
- Passed: cargo test -p orbit-registry --lib (52 passed)
- Passed: make ci-fast. The guardrail's compiler-cache namespace subcheck reported an environment skip because bwrap could not create a mount namespace; the overall gate passed.
- Passed: make ci-lint
- Passed: CARGO_HOME=<temporary writable directory> cargo deny check; advisories, bans, licenses, and sources passed with existing unmatched-allowance warnings.
- Passed: git diff --check
- Initially blocked: make audit could not lock ~/.cargo/advisory-dbs/db.lock because the path was read-only; rerun with an isolated writable CARGO_HOME passed.
- Not run: CodeQL CLI scan, because codeql is unavailable locally; the GitHub CodeQL workflow remains the authoritative hosted security check.

Assessment: The change is scoped to the host identity boundary, preserves valid behavior, and adds regression coverage for the reported path-escape class. Remaining risk is limited to hosted CodeQL confirmation of alert #90.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11847-6aa0f15d`
- Behind base: 0
- Ahead of base: 1