### PR TITLE
[code-scanning-sweep] Fix rust/cleartext-logging in crates/orbit-agent/src/providers/gemini_http/transport.rs

### DIFF
--- a/crates/orbit-agent/src/providers/gemini_http/tests/transport.rs
+++ b/crates/orbit-agent/src/providers/gemini_http/tests/transport.rs
@@ -48,6 +48,33 @@ fn send_turn_sends_api_key_header_without_key_query_param() {
 }
 
 #[test]
+fn send_turn_network_failures_use_a_secret_free_message() {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind listener");
+    let addr = listener.local_addr().expect("listener address");
+    drop(listener);
+
+    let transport = GeminiHttpTransport::new(GEMINI_API_KEY, "gemini-test", None)
+        .expect("transport")
+        .with_base_url(format!("http://{addr}"));
+    let messages = [Message::user_text("hello")];
+    let req = TurnRequest {
+        system: None,
+        messages: &messages,
+        tools: &[],
+        cache_hint: CacheHint::None,
+        max_response_tokens: 0,
+    };
+
+    let TransportError::Network(message) = transport.send_turn(&req).expect_err("request fails")
+    else {
+        panic!("expected network error");
+    };
+
+    assert_eq!(message, "Gemini request failed");
+    assert!(!message.contains(GEMINI_API_KEY));
+}
+
+#[test]
 fn endpoint_builders_do_not_include_api_key_query_params() {
     let transport =
         GeminiHttpTransport::new(GEMINI_API_KEY, "gemini-test", None).expect("transport");

--- a/crates/orbit-agent/src/providers/gemini_http/transport.rs
+++ b/crates/orbit-agent/src/providers/gemini_http/transport.rs
@@ -129,7 +129,10 @@ impl GeminiHttpTransport {
         let endpoint = self.cached_contents_endpoint();
         let request = self.post_json_request(&endpoint)?;
 
-        let response = request.body(body_bytes).send().map_err(network_error)?;
+        let response = request
+            .body(body_bytes)
+            .send()
+            .map_err(network_request_error)?;
 
         let http_status = response.status().as_u16();
         let response_bytes = response
@@ -232,7 +235,7 @@ impl LoopTransport for GeminiHttpTransport {
         let response = request
             .body(body_bytes.clone())
             .send()
-            .map_err(network_error)?;
+            .map_err(network_request_error)?;
 
         let http_status = response.status().as_u16();
         let response_bytes = response
@@ -388,7 +391,15 @@ fn build_client(timeout: Duration) -> Result<Client, TransportError> {
         .map_err(|e| TransportError::Other(format!("reqwest build: {e}")))
 }
 
-// `pub(super)` widened for sibling test access.
+fn network_request_error(_: reqwest::Error) -> TransportError {
+    // Do not format the request-bound error: reqwest may retain request data,
+    // including the API-key header, in an error's diagnostic representation.
+    TransportError::Network("Gemini request failed".to_string())
+}
+
+// `pub(super)` widened for sibling test access; it is not part of production
+// error translation because request-bound errors may contain sensitive data.
+#[cfg(test)]
 pub(super) fn network_error(error: reqwest::Error) -> TransportError {
     TransportError::Network(reqwest_error_message(error))
 }


### PR DESCRIPTION
## Task

[ORB-11841](https://orbit-cli.com/tasks/ORB-11841) — [code-scanning-sweep] Fix rust/cleartext-logging in crates/orbit-agent/src/providers/gemini_http/transport.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#81`
- Rule: `rust/cleartext-logging` (rust/cleartext-logging)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This operation writes self.api_key_header_value() to a log file.
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-agent/src/providers/gemini_http/transport.rs` line 124
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/81

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/cleartext-logging` at `crates/orbit-agent/src/providers/gemini_http/transport.rs` line 124 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced both production Gemini request-send error mappings with a fixed, secret-free `TransportError::Network("Gemini request failed")` translation so request-bound `reqwest::Error` values cannot flow from the API-key header into diagnostic stringification.
- Kept the existing detailed network formatter test-only and added a regression test covering the send-failure boundary.
Assessment: The API-key header remains marked sensitive and is still sent in the request; successful request, caching, response parsing, and error-category behavior are unchanged. Only request-send diagnostics are intentionally generalized to remove the sensitive data flow.

Acceptance criteria:
- CodeQL cleartext-logging remediation: met in `crates/orbit-agent/src/providers/gemini_http/transport.rs`; both request `.send()` paths now discard the request-bound error before constructing the transport error, with no suppression or exclusion.
- Intended behavior: met; successful Gemini requests retain the same header and endpoint behavior, while request failures remain `TransportError::Network` and are now guaranteed not to expose request data. The focused regression test passed.
- Validation and security checks: repository validation passed below; local CodeQL confirmation was not run because the `codeql` CLI is unavailable in this checkout. The configured GitHub CodeQL workflow remains the authoritative security-scan confirmation.

Validation:
- PASSED — `cargo fmt --all -- --check`
- PASSED — `cargo test -p orbit-agent providers::gemini_http::tests::transport` (6 passed)
- PASSED — `make ci-fast` (the documented compiler-cache namespace probe reported its known unprivileged-user-namespace skip)
- PASSED — `make ci-lint`
- PASSED — `git diff --check`
- NOT RUN — CodeQL CLI scan; `codeql` unavailable locally, so the affected alert can only be confirmed by CI.
Risks / deviations: Request-send error messages no longer include reqwest diagnostic detail by design; preserving those details would retain the request-bound sensitive-data flow flagged by CodeQL. No commits or delivery transitions were made.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11841-6aa0f152`
- Behind base: 0
- Ahead of base: 1