### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/workspace_binding.rs

### DIFF
--- a/crates/orbit-store/src/driver/file/workspace_binding.rs
+++ b/crates/orbit-store/src/driver/file/workspace_binding.rs
@@ -10,6 +10,7 @@ use crate::fs::yaml::{parse_yaml_with, write_yaml_atomic_with};
 use crate::contracts::WorkspaceConfig;
 
 const CONFIG_SCHEMA_VERSION: u32 = 1;
+const CONFIG_FILE_NAME: &str = "config.yaml";
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -19,7 +20,7 @@ struct WorkspaceConfigDoc {
 }
 
 pub fn workspace_config_path(orbit_dir: &Path) -> PathBuf {
-    orbit_dir.join("config.yaml")
+    orbit_dir.join(CONFIG_FILE_NAME)
 }
 
 pub fn read_workspace_config(orbit_dir: &Path) -> Result<WorkspaceConfig, OrbitError> {
@@ -44,19 +45,48 @@ pub fn workspace_id_for_orbit_dir(orbit_dir: &Path) -> Result<String, OrbitError
 pub fn read_workspace_config_optional(
     orbit_dir: &Path,
 ) -> Result<Option<WorkspaceConfig>, OrbitError> {
-    let path = workspace_config_path(orbit_dir);
+    let display_path = workspace_config_path(orbit_dir);
+    let Some(path) = validated_workspace_config_path(orbit_dir)? else {
+        return Ok(None);
+    };
+
     let raw = match fs::read_to_string(&path) {
         Ok(raw) => raw,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(err) => return Err(OrbitError::Io(err.to_string())),
     };
-    let doc: WorkspaceConfigDoc = parse_yaml_with(&raw, &path, |_, e| {
+    let doc: WorkspaceConfigDoc = parse_yaml_with(&raw, &display_path, |_, e| {
         OrbitError::InvalidInput(format!(
             "invalid workspace config '{}': {e}",
-            path.display()
+            display_path.display()
         ))
     })?;
     validate_workspace_config_doc(doc).map(Some)
+}
+
+/// Resolve the config path before reading it and require the resolved file to
+/// remain below the resolved orbit directory. This removes traversal and
+/// symlink components from the path presented to the filesystem read.
+fn validated_workspace_config_path(orbit_dir: &Path) -> Result<Option<PathBuf>, OrbitError> {
+    let canonical_orbit_dir = match orbit_dir.canonicalize() {
+        Ok(path) => path,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(OrbitError::Io(err.to_string())),
+    };
+    let candidate = canonical_orbit_dir.join(CONFIG_FILE_NAME);
+    let canonical_config_path = match candidate.canonicalize() {
+        Ok(path) => path,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(OrbitError::Io(err.to_string())),
+    };
+
+    if !canonical_config_path.starts_with(&canonical_orbit_dir) {
+        return Err(OrbitError::InvalidInput(
+            "workspace config must remain within the orbit directory".to_string(),
+        ));
+    }
+
+    Ok(Some(canonical_config_path))
 }
 
 pub fn write_workspace_config(

--- a/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
@@ -1284,6 +1284,46 @@ fn workspace_config_optional_distinguishes_missing_file() {
 }
 
 #[test]
+fn workspace_config_reads_from_a_normalized_orbit_directory() {
+    let temp = TempDir::new().expect("tempdir");
+    let orbit_dir = temp.path().join(".orbit");
+    write_workspace_config(
+        &orbit_dir,
+        &WorkspaceConfig {
+            schema_version: 1,
+            workspace_id: "ws-test-abcdef".into(),
+        },
+    )
+    .expect("write config");
+
+    let normalized_alias = orbit_dir.join("..").join(".orbit");
+    let config = read_workspace_config(&normalized_alias).expect("read config through alias");
+
+    assert_eq!(config.workspace_id, "ws-test-abcdef");
+}
+
+#[cfg(unix)]
+#[test]
+fn workspace_config_rejects_a_symlink_outside_the_orbit_directory() {
+    let temp = TempDir::new().expect("tempdir");
+    let orbit_dir = temp.path().join(".orbit");
+    fs::create_dir_all(&orbit_dir).expect("create orbit dir");
+    let outside_config = temp.path().join("outside.yaml");
+    atomic_write_text(
+        &outside_config,
+        "schema_version: 1\nworkspace_id: ws-test-abcdef\n",
+    )
+    .expect("write outside config");
+    std::os::unix::fs::symlink(&outside_config, workspace_config_path(&orbit_dir))
+        .expect("link outside config");
+
+    assert!(matches!(
+        read_workspace_config_optional(&orbit_dir),
+        Err(OrbitError::InvalidInput(_))
+    ));
+}
+
+#[test]
 fn workspace_id_for_orbit_dir_returns_id_from_config() {
     let temp = TempDir::new().expect("tempdir");
     let orbit_dir = temp.path().join(".orbit");


### PR DESCRIPTION
## Task

[ORB-11848](https://orbit-cli.com/tasks/ORB-11848) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/workspace_binding.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#91`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-store/src/driver/file/workspace_binding.rs` line 48
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/91

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-store/src/driver/file/workspace_binding.rs` line 48 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `read_workspace_config_optional` to canonicalize the orbit directory and resolved `config.yaml` before reading.
- Added a canonical-prefix check that rejects config symlinks escaping the orbit directory, while preserving missing-file behavior and original diagnostic paths.
- Added regression coverage for normalized orbit-directory aliases and external config symlinks.

Acceptance criteria:
- Criterion 1: satisfied. The affected `fs::read_to_string` now receives only a canonicalized config path guarded by `canonical_config_path.starts_with(&canonical_orbit_dir)`; no suppression, dismissal, or exclusion was added.
- Criterion 2: satisfied. Existing config round-trip and missing-file behavior pass, and the new normalized-alias test confirms valid workspace binding remains readable.
- Criterion 3: satisfied for repository-local validation. Formatting, targeted tests, the full orbit-store library tests, `make ci-fast`, `make ci-lint`, and isolated `make audit` passed. The repository CodeQL workflow is GitHub-hosted; no local CodeQL CLI is installed, so an actual CodeQL database scan was not run. Static review against the CodeQL Rust path-injection model confirms the flow is normalized and prefix-checked before the read; CI remains the authoritative scan confirmation.

Validation:
- `cargo fmt --all -- --check`: passed.
- `cargo test -p orbit-store workspace_config --lib`: passed, 4 tests.
- `cargo test -p orbit-store --lib`: passed, 487 passed, 7 ignored.
- `make ci-fast`: passed. Its compiler-cache namespace probe reported the documented environment skip.
- `make ci-lint`: passed with warnings denied.
- `CARGO_HOME=$(mktemp -d /tmp/orbit-cargo-home.XXXXXX) make audit`: passed; cargo-deny reported only existing unmatched-allowance warnings.
- `git diff --check`: passed.
- `GIT_OPTIONAL_LOCKS=0 git status --short`: expected two scoped modified files.

Assessment: The fix establishes an explicit filesystem safety boundary for the flagged read, rejects symlink escape, preserves supported path aliases and missing-config semantics, and is covered by focused plus full crate tests.

Remaining risk: The GitHub-hosted CodeQL workflow must rerun after delivery to provide the authoritative alert result.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11848-6aa0f1bb`
- Behind base: 0
- Ahead of base: 1