### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs

### DIFF
--- a/crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs
+++ b/crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Duration, Utc};
 use orbit_common::OrbitError;
@@ -25,6 +25,7 @@ pub use highlights::{
 };
 
 const SUMMARY_FILENAME: &str = "summary.json";
+const PR_SCOREBOARD_FILENAME: &str = "pr.json";
 // v2 adds `task_review.threads`; v3 adds tasks_created/tasks_planned,
 // per-(role, surface) tool call counts, top-level workflows_run, and a
 // recent_7d window block. v5 adds per-agent `friction.reported`
@@ -447,7 +448,7 @@ pub fn generate_summary_with_inputs(
     // TODO(phase-3+): timestamped snapshot logs would unblock real
     // windowing of these columns.
     if !windowed {
-        let pr = read_model_scoreboard(scoreboard_dir, "pr.json")?;
+        let pr = read_model_scoreboard(scoreboard_dir)?;
         overlay_nested_metric(&mut agents, &pr, "pr-review-comments", |summary, value| {
             summary.pr.review_comments = summary.pr.review_comments.saturating_add(value);
         });
@@ -662,22 +663,60 @@ pub fn summary_path(scoreboard_dir: &Path) -> std::path::PathBuf {
     scoreboard_dir.join(SUMMARY_FILENAME)
 }
 
-fn read_model_scoreboard(
-    scoreboard_dir: &Path,
-    file_name: &str,
-) -> Result<FamilyScoreboard, OrbitError> {
-    let path = scoreboard_dir.join(file_name);
-    if !path.exists() {
+fn read_model_scoreboard(scoreboard_dir: &Path) -> Result<FamilyScoreboard, OrbitError> {
+    let Some(path) = validated_pr_scoreboard_path(scoreboard_dir)? else {
         return Ok(FamilyScoreboard::new());
-    }
-    let raw =
-        fs::read_to_string(&path).map_err(|e| OrbitError::Io(format!("read {file_name}: {e}")))?;
+    };
+    let raw = fs::read_to_string(&path)
+        .map_err(|e| OrbitError::Io(format!("read {PR_SCOREBOARD_FILENAME}: {e}")))?;
     if raw.trim().is_empty() {
         return Ok(FamilyScoreboard::new());
     }
     let parsed: Value = serde_json::from_str(&raw)
-        .map_err(|e| OrbitError::Io(format!("parse {file_name}: {e}")))?;
+        .map_err(|e| OrbitError::Io(format!("parse {PR_SCOREBOARD_FILENAME}: {e}")))?;
     normalize_model_scoreboard(parsed)
+}
+
+/// Resolve the fixed PR scoreboard file beneath the selected scoreboard root.
+///
+/// The root is selected by the workspace configuration, but the file read by
+/// this summary is fixed. Canonicalizing the root and rejecting a symlink or
+/// non-regular target prevents a path component from redirecting this read to
+/// an unrelated file.
+fn validated_pr_scoreboard_path(scoreboard_dir: &Path) -> Result<Option<PathBuf>, OrbitError> {
+    let canonical_dir = match fs::canonicalize(scoreboard_dir) {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "canonicalize scoreboard directory {}: {error}",
+                scoreboard_dir.display()
+            )));
+        }
+    };
+    if !canonical_dir.is_dir() {
+        return Err(OrbitError::InvalidInput(format!(
+            "scoreboard path must be a directory: {}",
+            scoreboard_dir.display()
+        )));
+    }
+
+    let path = canonical_dir.join(PR_SCOREBOARD_FILENAME);
+    match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(OrbitError::InvalidInput(
+            format!("scoreboard file must not be a symlink: {}", path.display()),
+        )),
+        Ok(metadata) if !metadata.is_file() => Err(OrbitError::InvalidInput(format!(
+            "scoreboard file must be a regular file: {}",
+            path.display()
+        ))),
+        Ok(_) => Ok(Some(path)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(OrbitError::Io(format!(
+            "inspect scoreboard file {}: {error}",
+            path.display()
+        ))),
+    }
 }
 
 fn read_token_agents(scoreboard_dir: &Path) -> Result<Vec<TokenAgentEntry>, OrbitError> {

--- a/crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/tests/scoreboard_summary.rs
+++ b/crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/tests/scoreboard_summary.rs
@@ -2,6 +2,9 @@
 use super::super::*;
 use orbit_common::test_fixtures::{TEST_CLAUDE_MODEL, TEST_CODEX_MODEL, TEST_GROK_MODEL};
 
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
+
 #[test]
 fn summary_overlays_audit_tool_call_counts_by_normalized_model() {
     let temp = tempfile::tempdir().expect("create tempdir");
@@ -158,6 +161,33 @@ fn summary_exposes_pr_comments() {
     assert_eq!(summary.schema_version, CURRENT_SCHEMA_VERSION);
     let reviewer = summary.agents.get("codex").expect("reviewer summary");
     assert_eq!(reviewer.pr.review_comments, 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn summary_rejects_a_symlinked_pr_scoreboard() {
+    let root = tempfile::tempdir().expect("create scoreboard dir");
+    let outside = tempfile::tempdir().expect("create outside dir");
+    let outside_scoreboard = outside.path().join(PR_SCOREBOARD_FILENAME);
+    fs::write(
+        &outside_scoreboard,
+        r#"{"pr-review-comments":{"gpt-reviewer":1}}"#,
+    )
+    .expect("write outside scoreboard");
+    symlink(
+        &outside_scoreboard,
+        root.path().join(PR_SCOREBOARD_FILENAME),
+    )
+    .expect("create scoreboard symlink");
+
+    let error = generate_summary(root.path(), &[]).expect_err("reject symlinked scoreboard");
+
+    assert!(
+        error
+            .to_string()
+            .contains("scoreboard file must not be a symlink"),
+        "unexpected error: {error}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11849](https://orbit-cli.com/tasks/ORB-11849) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#92`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value.
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs` line 674
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/92

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs` line 674 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced the user-controlled filename parameter in `read_model_scoreboard` with the fixed `pr.json` scoreboard name.
- Added `validated_pr_scoreboard_path`, which canonicalizes the selected scoreboard directory and rejects symlinked or non-regular `pr.json` targets before `fs::read_to_string`.
- Added a Unix regression test proving a symlink cannot redirect summary reads outside the scoreboard directory.
- Preserved the existing missing-file behavior and verified normal PR metric aggregation still returns the expected count.

Assessment: The flagged data flow is removed at the owning file-store boundary without suppressing CodeQL or changing the normal scoreboard contract. The task remains uncommitted for pipeline delivery.

Criteria:
1. Passed — `pr.json` is now a fixed internal filename and the read path is validated; no suppression, dismissal, or exclusion was added.
2. Passed — existing `summary_exposes_pr_comments` behavior test passes, while the new symlink test rejects redirection.
3. Passed for repository-local validation — targeted tests, formatting, `make ci-fast`, `make ci-lint`, and diff checks passed. The repository CodeQL workflow is configured in `.github/workflows/codeql.yml`, but the `codeql` executable is unavailable on this executor, so an actual post-change CodeQL alert result is deferred to CI; source inspection confirms the flagged filename data flow is absent at the reported location.

Validation:
- Passed: `cargo fmt --all && cargo test -p orbit-store scoreboard_summary --lib` (26 passed).
- Passed: `make ci-fast`.
- Passed with bounded environment skip: `make ci-fast`'s compiler-cache namespace probe reported Bubblewrap cannot create an unprivileged mount namespace; all guardrails completed successfully.
- Passed: `make ci-lint`.
- Passed: `cargo fmt --all -- --check`.
- Passed: `git diff --check`.
- Not run: local CodeQL scan; `command -v codeql` reported `codeql: unavailable on this executor`. CI CodeQL remains the authoritative security confirmation.

Remaining risks/deviations: The final CodeQL alert state cannot be observed from this agent executor because the task explicitly does not require agent-side GitHub access and no local CodeQL binary is installed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11849-6aa0f2b9`
- Behind base: 0
- Ahead of base: 1