### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/job/pipeline.rs

### DIFF
--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -1370,8 +1370,13 @@ impl OrbitRuntime {
         run_id: &str,
         actor: Option<&str>,
         mut command: Command,
-        worker_log: PathBuf,
+        worker_log: PipelineWorkerLog,
     ) -> Result<u32, OrbitError> {
+        let PipelineWorkerLog {
+            path: worker_log,
+            reader: worker_log_reader,
+        } = worker_log;
+
         #[cfg(unix)]
         unsafe {
             command.pre_exec(|| {
@@ -1406,6 +1411,7 @@ impl OrbitRuntime {
                     child,
                     &workspace_for_observer,
                     &worker_log_for_observer,
+                    worker_log_reader,
                     actor_for_observer.as_deref(),
                 ) {
                     tracing::error!(
@@ -1436,6 +1442,7 @@ impl OrbitRuntime {
         mut child: Child,
         workspace: &Path,
         worker_log: &Path,
+        mut worker_log_reader: File,
         actor: Option<&str>,
     ) -> Result<(), OrbitError> {
         let child_pid = child.id();
@@ -1492,7 +1499,7 @@ impl OrbitRuntime {
                 let run = self.get_job_run_backend(run_id)?.ok_or_else(|| {
                     OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string())
                 })?;
-                let output = read_pipeline_worker_log_tail(worker_log);
+                let output = read_pipeline_worker_log_tail(&mut worker_log_reader);
                 let output_detail = output
                     .as_deref()
                     .filter(|value| !value.is_empty())
@@ -1911,7 +1918,7 @@ pub(crate) fn configure_pipeline_worker_stdio(
     command: &mut Command,
     logs_dir: &Path,
     run_id: &str,
-) -> Result<PathBuf, OrbitError> {
+) -> Result<PipelineWorkerLog, OrbitError> {
     std::fs::create_dir_all(logs_dir).map_err(|error| {
         OrbitError::Io(format!(
             "create pipeline worker log directory '{}': {error}",
@@ -1922,7 +1929,7 @@ pub(crate) fn configure_pipeline_worker_stdio(
 
     let log_path = pipeline_worker_log_path(logs_dir, run_id);
     let mut options = OpenOptions::new();
-    options.create(true).append(true);
+    options.create(true).append(true).read(true);
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
@@ -1943,6 +1950,12 @@ pub(crate) fn configure_pipeline_worker_stdio(
         command.env("LLVM_PROFILE_FILE", profile);
     }
     write_pipeline_worker_spawn_banner(&log_path, command);
+    let reader = log.try_clone().map_err(|error| {
+        OrbitError::Io(format!(
+            "clone pipeline worker log reader '{}': {error}",
+            log_path.display()
+        ))
+    })?;
     let stdout = log.try_clone().map_err(|error| {
         OrbitError::Io(format!(
             "clone pipeline worker log '{}': {error}",
@@ -1950,7 +1963,22 @@ pub(crate) fn configure_pipeline_worker_stdio(
         ))
     })?;
     command.stdout(Stdio::from(stdout)).stderr(Stdio::from(log));
-    Ok(log_path)
+    Ok(PipelineWorkerLog {
+        path: log_path,
+        reader,
+    })
+}
+
+pub(crate) struct PipelineWorkerLog {
+    path: PathBuf,
+    reader: File,
+}
+
+impl PipelineWorkerLog {
+    #[cfg(test)]
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
 }
 
 fn write_pipeline_worker_spawn_banner(log_path: &Path, command: &Command) {
@@ -1974,8 +2002,7 @@ fn write_pipeline_worker_spawn_banner(log_path: &Path, command: &Command) {
     );
 }
 
-fn read_pipeline_worker_log_tail(path: &Path) -> Option<String> {
-    let mut file = File::open(path).ok()?;
+fn read_pipeline_worker_log_tail(file: &mut File) -> Option<String> {
     let len = file.metadata().ok()?.len();
     let start = len.saturating_sub(PIPELINE_WORKER_LOG_TAIL_BYTES);
     file.seek(SeekFrom::Start(start)).ok()?;

--- a/crates/orbit-core/src/application/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/application/tests/job_pipeline.rs
@@ -204,12 +204,13 @@ fn worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic() {
          printf 'action registration missing: routine_dispatch\\n' >&2; \
          exit 23",
     ]);
-    let log_path =
+    let worker_log =
         configure_pipeline_worker_stdio(&mut command, &runtime.paths().logs_dir, &run.run_id)
             .expect("configure worker log");
+    let log_path = worker_log.path().to_owned();
 
     runtime
-        .spawn_pipeline_worker_process(&run.run_id, Some("test"), command, log_path.clone())
+        .spawn_pipeline_worker_process(&run.run_id, Some("test"), command, worker_log)
         .expect("spawn detached failing worker fixture");
 
     let stored = wait_for_worker_ownership_outcome(&runtime, &run.run_id);
@@ -270,18 +271,14 @@ fn routine_style_detached_worker_is_claimed_within_ownership_window() {
         .expect("insert routine-dispatched run");
     let mut command = Command::new("sh");
     command.args(["-c", "printf 'routine worker startup\\n' >&2; sleep 0.25"]);
-    let log_path =
+    let worker_log =
         configure_pipeline_worker_stdio(&mut command, &runtime.paths().logs_dir, &run.run_id)
             .expect("configure routine worker log");
+    let log_path = worker_log.path().to_owned();
 
     let started = Instant::now();
     let worker_pid = runtime
-        .spawn_pipeline_worker_process(
-            &run.run_id,
-            Some("routine-sweep"),
-            command,
-            log_path.clone(),
-        )
+        .spawn_pipeline_worker_process(&run.run_id, Some("routine-sweep"), command, worker_log)
         .expect("spawn detached routine worker fixture");
     runtime
         .stores()
@@ -363,12 +360,14 @@ fn claimed_sleeping_worker_does_not_keep_polling_the_run_store() {
         .insert_job_run("task_gate_pipeline", 1, Utc::now(), None, None)
         .expect("insert pending run");
     let observer_reads = worker_observer_read_counter::track(&runtime, &run.run_id);
-    let command = worker_command_override::command(&runtime.paths().repo_root, &run.run_id)
+    let mut command = worker_command_override::command(&runtime.paths().repo_root, &run.run_id)
         .expect("build sleeping worker command");
-    let log_path = pipeline_worker_log_path(&runtime.paths().logs_dir, &run.run_id);
+    let worker_log =
+        configure_pipeline_worker_stdio(&mut command, &runtime.paths().logs_dir, &run.run_id)
+            .expect("configure sleeping worker log");
 
     let worker_pid = runtime
-        .spawn_pipeline_worker_process(&run.run_id, Some("test"), command, log_path)
+        .spawn_pipeline_worker_process(&run.run_id, Some("test"), command, worker_log)
         .expect("spawn detached sleeping worker");
     runtime
         .stores()


### PR DESCRIPTION
## Task

[ORB-11852](https://orbit-cli.com/tasks/ORB-11852) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/job/pipeline.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#96`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value.
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-core/src/application/job/pipeline.rs` line 1978
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/96

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-core/src/application/job/pipeline.rs` line 1978 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced the startup observers reopening of a caller-provided worker-log path with a PipelineWorkerLog handoff containing the already-open read handle.
- Kept the log path only for diagnostics and preserved tail truncation/redaction behavior.
- Updated affected worker startup tests to use the new owned log handle.

Acceptance criteria:
- CodeQL rust/path-injection sink at pipeline.rs line 1978 is removed: read_pipeline_worker_log_tail now accepts File and performs no path open.
- Intended worker startup failure diagnostics and log output are preserved; all job-pipeline tests pass.
- Repository validation passed; the local static sink check confirms the affected path-open construct is absent. The CodeQL CLI is not installed and this task has no agent-side GitHub access, so the hosted CodeQL scan itself was not run locally.

Validation:
- cargo fmt --all -- --check — passed.
- cargo test -p orbit-core --lib application::tests::job_pipeline — passed (22 tests).
- make ci-fast — passed; its compiler-cache mount-namespace subcheck reported the documented environment skip because bwrap cannot create a namespace.
- make ci-lint — passed (workspace clippy, all targets, warnings denied).
- git diff --check — passed.
- rg static sink check for File::open(path) / read_pipeline_worker_log_tail(path) — passed.

Assessment: The observer now reads from the file descriptor opened during trusted worker-log setup, eliminating the flagged user-controlled path reopen while retaining existing diagnostics and coverage. Changes are limited to the implementation and its directly affected tests.

Remaining risk: Hosted CodeQL confirmation remains pending CI because the CodeQL CLI/GitHub security surface is unavailable in this executor.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11852-6aa0f319`
- Behind base: 0
- Ahead of base: 1