### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs

### DIFF
--- a/crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs
+++ b/crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs
@@ -26,6 +26,7 @@ pub use highlights::{
 
 const SUMMARY_FILENAME: &str = "summary.json";
 const PR_SCOREBOARD_FILENAME: &str = "pr.json";
+const TOKEN_SCOREBOARD_FILENAME: &str = "tokens.json";
 // v2 adds `task_review.threads`; v3 adds tasks_created/tasks_planned,
 // per-(role, surface) tool call counts, top-level workflows_run, and a
 // recent_7d window block. v5 adds per-agent `friction.reported`
@@ -664,7 +665,7 @@ pub fn summary_path(scoreboard_dir: &Path) -> std::path::PathBuf {
 }
 
 fn read_model_scoreboard(scoreboard_dir: &Path) -> Result<FamilyScoreboard, OrbitError> {
-    let Some(path) = validated_pr_scoreboard_path(scoreboard_dir)? else {
+    let Some(path) = validated_scoreboard_file_path(scoreboard_dir, ScoreboardFile::Pr)? else {
         return Ok(FamilyScoreboard::new());
     };
     let raw = fs::read_to_string(&path)
@@ -677,13 +678,32 @@ fn read_model_scoreboard(scoreboard_dir: &Path) -> Result<FamilyScoreboard, Orbi
     normalize_model_scoreboard(parsed)
 }
 
-/// Resolve the fixed PR scoreboard file beneath the selected scoreboard root.
+/// The fixed snapshot files are selected by the store, never by a caller.
+#[derive(Clone, Copy)]
+enum ScoreboardFile {
+    Pr,
+    Tokens,
+}
+
+impl ScoreboardFile {
+    fn filename(self) -> &'static str {
+        match self {
+            Self::Pr => PR_SCOREBOARD_FILENAME,
+            Self::Tokens => TOKEN_SCOREBOARD_FILENAME,
+        }
+    }
+}
+
+/// Resolve a fixed scoreboard file beneath the selected scoreboard root.
 ///
 /// The root is selected by the workspace configuration, but the file read by
-/// this summary is fixed. Canonicalizing the root and rejecting a symlink or
-/// non-regular target prevents a path component from redirecting this read to
-/// an unrelated file.
-fn validated_pr_scoreboard_path(scoreboard_dir: &Path) -> Result<Option<PathBuf>, OrbitError> {
+/// this summary is fixed. Canonicalizing the root, checking containment, and
+/// rejecting a symlink or non-regular target prevents a path component from
+/// redirecting this read to an unrelated file.
+fn validated_scoreboard_file_path(
+    scoreboard_dir: &Path,
+    file: ScoreboardFile,
+) -> Result<Option<PathBuf>, OrbitError> {
     let canonical_dir = match fs::canonicalize(scoreboard_dir) {
         Ok(path) => path,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -701,7 +721,14 @@ fn validated_pr_scoreboard_path(scoreboard_dir: &Path) -> Result<Option<PathBuf>
         )));
     }
 
-    let path = canonical_dir.join(PR_SCOREBOARD_FILENAME);
+    let path = canonical_dir.join(file.filename());
+    if !path.starts_with(&canonical_dir) {
+        return Err(OrbitError::InvalidInput(format!(
+            "scoreboard file must remain within the scoreboard directory: {}",
+            path.display()
+        )));
+    }
+
     match fs::symlink_metadata(&path) {
         Ok(metadata) if metadata.file_type().is_symlink() => Err(OrbitError::InvalidInput(
             format!("scoreboard file must not be a symlink: {}", path.display()),
@@ -720,10 +747,9 @@ fn validated_pr_scoreboard_path(scoreboard_dir: &Path) -> Result<Option<PathBuf>
 }
 
 fn read_token_agents(scoreboard_dir: &Path) -> Result<Vec<TokenAgentEntry>, OrbitError> {
-    let path = scoreboard_dir.join("tokens.json");
-    if !path.exists() {
+    let Some(path) = validated_scoreboard_file_path(scoreboard_dir, ScoreboardFile::Tokens)? else {
         return Ok(Vec::new());
-    }
+    };
     let raw =
         fs::read_to_string(&path).map_err(|e| OrbitError::Io(format!("read tokens.json: {e}")))?;
     if raw.trim().is_empty() {

--- a/crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/tests/scoreboard_summary.rs
+++ b/crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/tests/scoreboard_summary.rs
@@ -190,6 +190,33 @@ fn summary_rejects_a_symlinked_pr_scoreboard() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn summary_rejects_a_symlinked_token_scoreboard() {
+    let root = tempfile::tempdir().expect("create scoreboard dir");
+    let outside = tempfile::tempdir().expect("create outside dir");
+    let outside_scoreboard = outside.path().join(TOKEN_SCOREBOARD_FILENAME);
+    fs::write(
+        &outside_scoreboard,
+        r#"{"agents":[{"agent":"codex","model":"gpt-5","total_tokens":1}]}"#,
+    )
+    .expect("write outside scoreboard");
+    symlink(
+        &outside_scoreboard,
+        root.path().join(TOKEN_SCOREBOARD_FILENAME),
+    )
+    .expect("create scoreboard symlink");
+
+    let error = generate_summary(root.path(), &[]).expect_err("reject symlinked scoreboard");
+
+    assert!(
+        error
+            .to_string()
+            .contains("scoreboard file must not be a symlink"),
+        "unexpected error: {error}"
+    );
+}
+
 #[test]
 fn summary_counts_tasks_created_and_planned_across_all_statuses() {
     let temp = tempfile::tempdir().expect("create tempdir");


### PR DESCRIPTION
## Task

[ORB-11850](https://orbit-cli.com/tasks/ORB-11850) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#93`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value.
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs` line 689
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/93

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs` line 689 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced the unvalidated fixed-file path handling for both `pr.json` and `tokens.json` with a shared scoreboard-file validator.
- The validator canonicalizes the configured scoreboard directory, verifies the fixed file remains beneath that directory, and rejects symlinked or non-regular files before reading.
- Added a Unix regression test proving a symlinked `tokens.json` cannot redirect the summary read.

Assessment: The affected path data flow is bounded at the scoreboard reader and preserves the existing optional-file behavior and PR symlink protection.

Criteria:
- AC1: Passed by the real code change in `crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs`; no suppression, dismissal, or exclusion was added.
- AC2: Passed by retaining fixed `pr.json`/`tokens.json` selection, empty/missing-file handling, JSON parsing, and rejecting redirection through symlinks; focused tests passed.
- AC3: Repository validation passed below. Hosted CodeQL was not runnable locally (`codeql: unavailable`), so final alert closure remains to be confirmed by the repository's CodeQL workflow.

Validation:
- `cargo fmt --check`: passed.
- `cargo test -p orbit-store scoreboard_summary --lib`: passed, 27 passed, 0 failed.
- `make ci-fast`: passed. Its compiler-cache namespace probe reported the documented environment limitation (unprivileged namespace creation unavailable) and skipped only that probe.
- `make ci-lint`: passed, workspace all-target clippy with `-D warnings`.
- `git diff --check`: passed.
- `git status --short`: expected task-scoped modifications only in the two declared context files.
- CodeQL CLI scan: not run; `codeql` is unavailable in this checkout, and no local CodeQL database/runner is provided.

Risks / deviations:
- The final CodeQL alert result cannot be independently observed from this managed checkout; CI must confirm the `rust/path-injection` alert is cleared. The code now uses CodeQL's normalization-plus-containment pattern before filesystem access.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11850-6aa0f510`
- Behind base: 0
- Ahead of base: 1