### PR TITLE
[code-scanning-sweep] Fix rust/cleartext-logging in crates/orbit-agent/src/providers/gemini_http/transport.rs

### DIFF
--- a/crates/orbit-agent/src/providers/gemini_http/tests/transport.rs
+++ b/crates/orbit-agent/src/providers/gemini_http/tests/transport.rs
@@ -89,11 +89,11 @@ fn endpoint_builders_do_not_include_api_key_query_params() {
 }
 
 #[test]
-fn api_key_header_value_is_marked_sensitive_for_diagnostics() {
+fn api_key_header_is_marked_sensitive_for_diagnostics() {
     let transport =
         GeminiHttpTransport::new(GEMINI_API_KEY, "gemini-test", None).expect("transport");
 
-    let header_value = transport.api_key_header_value().expect("header value");
+    let header_value = transport.api_key_header_for_test();
 
     assert!(header_value.is_sensitive());
     assert_eq!(format!("{header_value:?}"), "Sensitive");

--- a/crates/orbit-agent/src/providers/gemini_http/transport.rs
+++ b/crates/orbit-agent/src/providers/gemini_http/transport.rs
@@ -28,7 +28,7 @@ pub(super) const GEMINI_API_KEY_HEADER: &str = "x-goog-api-key";
 pub struct GeminiHttpTransport {
     client: Client,
     base_url: String,
-    api_key: String,
+    api_key_header: HeaderValue,
     model: String,
     cache_content_threshold_turns: Option<usize>,
     custom_headers: Vec<(HeaderName, HeaderValue)>,
@@ -41,10 +41,16 @@ impl GeminiHttpTransport {
         cache_content_threshold_turns: Option<usize>,
     ) -> Result<Self, TransportError> {
         let client = build_client(Duration::from_secs(120))?;
+        let api_key = api_key.into();
+        let mut api_key_header = HeaderValue::from_str(&api_key).map_err(|e| {
+            TransportError::Other(format!("invalid Gemini API key header value: {e}"))
+        })?;
+        api_key_header.set_sensitive(true);
+
         Ok(Self {
             client,
             base_url: DEFAULT_BASE_URL.to_string(),
-            api_key: api_key.into(),
+            api_key_header,
             model: model.into(),
             cache_content_threshold_turns,
             custom_headers: Vec::new(),
@@ -87,7 +93,7 @@ impl GeminiHttpTransport {
             .client
             .post(endpoint)
             .header(CONTENT_TYPE, "application/json")
-            .header(GEMINI_API_KEY_HEADER, self.api_key_header_value()?);
+            .header(GEMINI_API_KEY_HEADER, self.api_key_header.clone());
 
         for (name, value) in &self.custom_headers {
             request = request.header(name.clone(), value.clone());
@@ -96,17 +102,9 @@ impl GeminiHttpTransport {
         Ok(request)
     }
 
-    // `pub(super)` widened for sibling test access.
-    pub(super) fn api_key_header_value(&self) -> Result<HeaderValue, TransportError> {
-        let mut header_value = HeaderValue::from_str(&self.api_key).map_err(|e| {
-            TransportError::Other(format!("invalid Gemini API key header value: {e}"))
-        })?;
-
-        // RequestBuilder's debug output includes header values unless they are
-        // explicitly marked sensitive. Keep the key usable on the wire while
-        // preventing accidental cleartext disclosure in diagnostics.
-        header_value.set_sensitive(true);
-        Ok(header_value)
+    #[cfg(test)]
+    pub(super) fn api_key_header_for_test(&self) -> &HeaderValue {
+        &self.api_key_header
     }
 
     fn try_create_cached_content(


### PR DESCRIPTION
## Task

[ORB-11865](https://orbit-cli.com/tasks/ORB-11865) — [code-scanning-sweep] Fix rust/cleartext-logging in crates/orbit-agent/src/providers/gemini_http/transport.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#81`
- Rule: `rust/cleartext-logging` (rust/cleartext-logging)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This operation writes self.api_key_header_value() to a log file.
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-agent/src/providers/gemini_http/transport.rs` line 124
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/81

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/cleartext-logging` at `crates/orbit-agent/src/providers/gemini_http/transport.rs` line 124 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Stored the Gemini API key only as an HTTP HeaderValue marked sensitive at construction time; the request path now clones that redacted diagnostic representation instead of rebuilding a raw secret through api_key_header_value().
- Preserved the x-goog-api-key wire header and added a test-only accessor so the boundary test verifies reqwest renders the value as Sensitive.
- Retained the existing constant network-error translation so request-bound errors cannot stringify credentials.

Assessment: The affected cleartext-logging data flow is removed from production request construction. The API key remains available to Gemini on the wire, while request diagnostics and transport failures are secret-free.

Acceptance criteria:
- Code scanning remediation: satisfied by removing the raw api_key_header_value() request flow and storing a sensitive HeaderValue; no suppression, dismissal, or exclusion was added.
- Intended behavior: satisfied; the Gemini header is still sent, endpoint URLs remain key-free, and the transport's network errors remain secret-free. Targeted tests: 6 passed.
- Validation/security: repository gates passed. CodeQL CLI is unavailable in this checkout, so the hosted CodeQL confirmation is deferred to the repository PR workflow; static inspection confirms the reported helper/sink flow is absent. make audit could not acquire ~/.cargo/advisory-dbs/db.lock because the host path is read-only; the non-advisory cargo-deny checks passed.

Validation:
- cargo fmt --all -- --check — passed.
- cargo test -p orbit-agent gemini_http --lib — passed (6 tests).
- make ci-fast — passed; its compiler-cache namespace probe reported the documented bubblewrap permission skip.
- make ci-lint — passed (workspace all-target clippy with warnings denied).
- cargo deny check bans licenses sources — passed.
- make audit — failed before checks because cargo-deny could not lock the read-only advisory database; not a source failure.
- codeql version — not run; CodeQL CLI unavailable.
- git diff --check — passed.
- GIT_OPTIONAL_LOCKS=0 git status --short — only the two scoped Gemini transport files are modified.

Remaining risk: The exact GitHub CodeQL alert result must be verified by the hosted CodeQL workflow after delivery; local CodeQL execution was unavailable.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11865-6aa0f67d`
- Behind base: 0
- Ahead of base: 1