### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-common/src/fs/io.rs

### DIFF
--- a/crates/orbit-common/src/fs/io.rs
+++ b/crates/orbit-common/src/fs/io.rs
@@ -513,10 +513,87 @@ fn lock_path_for(path: &Path) -> io::Result<PathBuf> {
 }
 
 pub(crate) fn open_private_file(path: &Path, options: &mut OpenOptions) -> io::Result<File> {
+    let path = validated_private_file_path(path)?;
     apply_private_file_mode(options);
-    let file = options.open(path)?;
-    set_private_file_permissions(path)?;
+    apply_no_follow_final_component(options);
+    let file = options.open(&path)?;
+    set_private_file_permissions_for_open_file(&file)?;
     Ok(file)
+}
+
+/// Resolve a private file's parent before opening it and reject a final
+/// component that would redirect the operation through a symlink.
+///
+/// Callers intentionally use symlinked parent directories for checkout
+/// projections, so the parent is canonicalized rather than rejected. The
+/// final component is checked without following it, and the open below also
+/// uses `O_NOFOLLOW` on Unix so the check and open cannot be raced into a
+/// different file.
+fn validated_private_file_path(path: &Path) -> io::Result<PathBuf> {
+    let file_name = path.file_name().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("path '{}' has no file name", path.display()),
+        )
+    })?;
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("path '{}' has no parent directory", path.display()),
+        )
+    })?;
+    let canonical_parent = fs::canonicalize(parent)?;
+    let canonical_path = canonical_parent.join(file_name);
+
+    match fs::symlink_metadata(&canonical_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "private file path must not be a symlink: {}",
+                    path.display()
+                ),
+            ));
+        }
+        Ok(metadata) if !metadata.is_file() => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "private file path must be a regular file: {}",
+                    path.display()
+                ),
+            ));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+
+    Ok(canonical_path)
+}
+
+#[cfg(unix)]
+fn apply_no_follow_final_component(options: &mut OpenOptions) {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    options.custom_flags(libc::O_NOFOLLOW);
+}
+
+#[cfg(not(unix))]
+fn apply_no_follow_final_component(_options: &mut OpenOptions) {}
+
+fn set_private_file_permissions_for_open_file(file: &File) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        file.set_permissions(fs::Permissions::from_mode(PRIVATE_FILE_MODE))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = file;
+        Ok(())
+    }
 }
 
 #[cfg(unix)]
@@ -576,14 +653,14 @@ fn apply_private_file_mode(options: &mut OpenOptions) {
 #[cfg(not(unix))]
 fn apply_private_file_mode(_options: &mut OpenOptions) {}
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "sqlite"))]
 pub(crate) fn set_private_file_permissions(path: &Path) -> io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
     fs::set_permissions(path, fs::Permissions::from_mode(PRIVATE_FILE_MODE))
 }
 
-#[cfg(not(unix))]
+#[cfg(all(not(unix), feature = "sqlite"))]
 pub(crate) fn set_private_file_permissions(_path: &Path) -> io::Result<()> {
     Ok(())
 }

--- a/crates/orbit-common/src/fs/tests/io.rs
+++ b/crates/orbit-common/src/fs/tests/io.rs
@@ -101,6 +101,43 @@ fn exclusive_lock_open_on_readonly_dir_names_path_and_hints_sandbox() {
 
 #[cfg(unix)]
 #[test]
+fn private_append_rejects_a_final_symlink() {
+    let root = tempfile::tempdir().expect("root tempdir");
+    let outside = tempfile::tempdir().expect("outside tempdir");
+    let outside_file = outside.path().join("outside.log");
+    std::fs::write(&outside_file, b"unchanged").expect("outside file");
+    let link = root.path().join("log");
+    std::os::unix::fs::symlink(&outside_file, &link).expect("symlink");
+
+    let error = super::super::io::append_private_file(&link)
+        .expect_err("private append must reject a symlink target");
+
+    assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(
+        std::fs::read(&outside_file).expect("outside file remains"),
+        b"unchanged"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn private_append_preserves_a_symlinked_parent_route() {
+    let root = tempfile::tempdir().expect("root tempdir");
+    let real_dir = root.path().join("real");
+    std::fs::create_dir(&real_dir).expect("real directory");
+    let linked_dir = root.path().join("linked");
+    std::os::unix::fs::symlink(&real_dir, &linked_dir).expect("parent symlink");
+
+    let path = linked_dir.join("log");
+    let file = super::super::io::append_private_file(&path).expect("append through parent link");
+    drop(file);
+
+    assert!(real_dir.join("log").is_file());
+    assert!(!path.is_symlink(), "the final file must be a regular file");
+}
+
+#[cfg(unix)]
+#[test]
 fn remove_path_if_exists_unlinks_a_dangling_symlink() {
     let temp = TempDir::new().expect("tempdir");
     let link = temp.path().join("link");


### PR DESCRIPTION
## Task

[ORB-11853](https://orbit-cli.com/tasks/ORB-11853) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-common/src/fs/io.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#97`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-common/src/fs/io.rs` line 512
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/97

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-common/src/fs/io.rs` line 512 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `crates/orbit-common/src/fs/io.rs` so private-file opens canonicalize the existing parent, reject final symlink/non-regular targets, use Unix `O_NOFOLLOW`, and apply permissions through the opened file handle.
- Added Unix regression tests in `crates/orbit-common/src/fs/tests/io.rs` covering final-symlink rejection, preservation of symlinked-parent routes, and unchanged outside content.
- Criterion 1: remediated the shared `rust/path-injection` sink with a real filesystem-boundary fix; no suppression, dismissal, or exclusion was added.
- Criterion 2: normal private file, atomic write, SQLite, logging, and lock behavior remains covered; full feature-enabled `orbit-common` tests passed.
- Criterion 3: the direct `options.open(path)` sink is absent; the source-level check confirms the validated canonical path and `O_NOFOLLOW` path are used. A CodeQL executable is not installed in this worker, so the hosted CodeQL alert itself was not re-run here.

Validation:
- PASSED: `cargo fmt --all -- --check`.
- PASSED: `cargo test -p orbit-common fs::tests::io --locked` (14 tests).
- PASSED: `cargo test -p orbit-common --features sqlite fs::tests::io --locked` (14 tests).
- PASSED: `cargo test -p orbit-common --all-features --locked` (251 unit tests, 1 integration test; one documented doctest ignored).
- PASSED: `make ci-fast` (the guardrail's namespace-dependent case reported an explicit environment skip).
- PASSED: `make ci-lint` after correcting one initial needless-return lint failure.
- PASSED: `env CARGO_HOME="$(mktemp -d /tmp/orbit-audit-home.XXXXXX)" cargo deny check` (advisories, bans, licenses, and sources all okay; warnings only for unused allowances/ignored advisories).
- PASSED: `git diff --check` and final `git status --short`.

Assessment: The shared private-file boundary now rejects final-component redirection and closes the Unix check/open race without breaking Orbit's existing symlinked-parent projection behavior. Remaining limitation is hosted CodeQL confirmation, which requires the CI/GitHub environment.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11853-6aa0f641`
- Behind base: 0
- Ahead of base: 1