### PR TITLE
[auto-task] Remediate current GitHub Actions failures

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -149,7 +149,7 @@ jobs:
               homepage="$(curl --fail --silent --show-error --max-time 20 "$base_url/")" || true
               metadata="$(curl --fail --silent --show-error "$base_url/deployment.json")" || true
               if grep -Fq 'Run coding agents as tracked, reviewable tasks.' <<<"$homepage" \
-                && grep -Fq 'Choose a delivery mode' <<<"$homepage" \
+                && grep -Fq 'Other delivery modes' <<<"$homepage" \
                 && curl --fail --silent --show-error --max-time 20 \
                   "$base_url/getting-started/install/" >/dev/null \
                 && METADATA="$metadata" node --input-type=module --eval \


### PR DESCRIPTION
## Task

[ORB-11856](https://orbit-cli.com/tasks/ORB-11856) — [auto-task] Remediate current GitHub Actions failures

### Description

Investigate and remediate current GitHub Actions failures for this
repository. This task may legitimately finish with no diff: if no
current, reproducible, repository-owned failure remains, persist the
evidence described below and report a successful no-current-failure or
transient-only outcome.

## Discovery and duplicate safety

1. Enumerate this repository's workflows and recent runs with GitHub's API
   or `gh`, and enumerate open pull requests with their current head SHAs.
   Cover failures for the current heads of `agent-main`, `main`, and every
   open pull request, including informational jobs such as coverage rather
   than looking only at required checks or the main `ci` job.
2. The fail-open CI failure report in `.github/workflows/ci.yml` records
   runner provenance only; it never creates Orbit tasks. Durable filing is
   owned by the host-side `ci_failure_sweep_pipeline`. Search open Orbit
   tasks for the report's run URL, job, SHAs, and failure signature.
   Reference matching tasks in the execution summary; do not create
   another task for the same run or root cause. This remediation task owns
   the repair and must not fan a red-run cluster out into more failure
   tasks.
3. For every candidate run, record the run and job URLs, workflow, event,
   branch or PR, run-attempt number, reported head SHA, and the current
   branch/PR head SHA. Query the failed jobs and steps and inspect the
   exact failed-step logs.
4. Independently verify the commit that Actions actually checked out from
   the checkout step/log (`HEAD is now at`, checkout ref/SHA, or equivalent
   unambiguous evidence). Keep the event's reported head SHA, the current
   ref head, and the tested checkout commit distinct; PR merge SHAs are not
   interchangeable with PR head SHAs.
5. Ignore a failed run as stale when its branch or PR has advanced and the
   failure does not reproduce at the current head, or when a newer
   successful run of the same workflow/check at the relevant current
   commit supersedes it. Cite the advancing or superseding run and SHAs;
   age alone is not evidence that a failure is stale.

## Diagnosis and remediation

Cluster repeated runs by root cause before editing. Use the failing
command, job/step, exact error signature, tested commit, and causal
dependency between failures to distinguish one regression repeated across
push/PR runs from independent failures. Repair each current root cause
once, while retaining a mapping from every affected run/job to that
cluster.

Reproduce every current candidate at the current repository head using
the exact command or the narrowest faithful local equivalent. A
deterministic repository-owned failure is in scope and must be fixed in
this task's worktree. Classify a GitHub service, network, hosted-runner, or
other infrastructure failure as transient only with concrete evidence,
such as a successful retry at the same SHA plus logs showing the
infrastructure fault. Do not call a failure transient merely because it
fails to reproduce once.

Fix the underlying repository-owned cause. Do not disable a workflow,
weaken an assertion or lint level, add a broad allow/ignore rule, mark a
failing gate `continue-on-error`, remove an affected target from coverage,
or otherwise obtain green CI by hiding the failure. Informational checks
remain informational, but they must execute successfully.

## Validation and handoff

For each fixed root cause, rerun the exact command that formerly failed.
Then run the repository pre-handoff gate, `make ci-fast`. After the
candidate commit is published through the repository's normal workflow,
inspect its GitHub Actions runs and require a green rerun for every
affected workflow/check. This includes affected informational jobs even
though they remain non-required. Do not declare a repair validated while
an affected run is missing, queued, in progress, cancelled, or red.

Persist an `execution_summary` that maps every investigated run/job URL,
reported head SHA, actual checkout commit, and current ref head to its
root-cause cluster, disposition (fixed, stale, superseded, or transient),
change, local reproduction, exact formerly failing validation, pre-handoff
result, and green GitHub rerun URL. Also map any matching PR-hook-created
Orbit task. For a successful no-diff pass, list the queries, current heads,
superseding successes or transient evidence, and why no repository-owned
failure remained.

## Historical validation fixture

Use run 30232696219 as the calibration example for the evidence model, not
as proof of a current failure:

- `Check / Clippy / Test` → `Run CI guardrails` reported Clippy's needless
  borrow at
  `crates/orbit-store/src/file/task_store/v2_bundle/bundle_io/mod.rs:172`,
  `sync_parent_dir(&staging_dir)`.
- `Coverage (informational)` reported that
  `command::skill::tests::plugin_skill_symlinks_resolve_to_assets` found
  `plugin/skills/orbit-task/SKILL.md` different from
  `crates/orbit-core/assets/skills/orbit-task/SKILL.md`.
- The run metadata reported head
  `49a2871a480b927bb31dc7a315f5ff5d130d15d0`, while the checkout log showed
  `5cec12c53211fad3f4ca940a0565bef87787958d`. A valid investigation preserves
  that discrepancy, clusters adjacent runs by the two root causes, and
  tests whether either failure still exists at the relevant current head
  before editing.


### Acceptance Criteria

- Current-head failures across agent-main, main, and open pull requests were enumerated for every repository workflow, including informational jobs.
- Every investigated run records its reported SHA, actual checkout commit, current ref head, failed job/step, exact log evidence, and stale or superseding evidence where applicable.
- Repeated red runs are clustered by root cause, and every current repository-owned failure is reproduced and fixed without weakening or bypassing a check.
- Transient-only classifications cite infrastructure evidence and a successful same-SHA retry; a single non-reproduction is not treated as sufficient evidence.
- Each fixed cause passes the exact formerly failing validation and make ci-fast, and every affected required or informational GitHub Actions check executes successfully on the candidate commit.
- The persisted execution_summary maps each run/job URL and SHA to its root cause, disposition, change, validations, green rerun, and any matching PR-hook task.
- A no-current-failure or transient-only investigation is a successful no-diff outcome when its current-head queries and superseding or transient evidence are persisted.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Fixed the current repository-owned Website failure in .github/workflows/website.yml. The deployment verifier required the removed homepage text "Choose a delivery mode"; the current homepage renders "Other delivery modes". The check still requires the homepage headline, delivery-mode section, install route, deployment revision metadata, security.txt, HSTS, and redirect.
- No duplicate CI fixture patch was created. The CI and coverage root cause was already fixed by covering commit 50656429646fe436ba8da69fd288a59a9371d858 (ORB-11824), which is an ancestor of this worktree HEAD 0869bcf0af2b36b3b6a1cacacd1667b3d0b62d50 and of the investigated agent-main line.
- Declared scope was extended through orbit.task.update to file:.github/workflows/website.yml because that file had to change to satisfy the current Website failure.

Run and head evidence:
- Repository workflows enumerated: CI, macOS Platform, CodeQL, Website, release, publish-mcp-registry, smoke-npm-install, and their configured push, pull_request, tag, schedule, and dispatch filters. Current heads at final query: main=5c4245aeb9e34251e2170a6508b4d898e9ae24ee; agent-main=575da16facd37df9bb970798682f9dd206478fe3. Open PR heads: #1482=80acce4b618837fbb4c4c45cca1a3dadea564e8b, #1481=88f0a27b6536221b62b7f068df1c9dd4f8e33530, #1478=569b125df4995ac24a7a844cc02b5d3da56bc82d.
- Main CI run https://github.com/constellation-works/orbit/actions/runs/34195398023, push, attempt 1, reported/current/tested SHA 5c4245aeb9e34251e2170a6508b4d898e9ae24ee. Failed jobs: Coverage (informational), https://github.com/constellation-works/orbit/actions/runs/34195398023/job/101961884055, step Collect workspace coverage; and Check / Clippy / Test, https://github.com/constellation-works/orbit/actions/runs/34195398023/job/101961884083, step Run CI guardrails. Exact evidence: three orbit-web tests failed, the two auto-drain tests returned left 404/right 200, and healthz reported missing .ORB-00000.bundle.lock; the workspace test command exited 101 and nextest reported 5070 passed, 3 failed, 17 skipped. Checkout log used ref main and the runner tested SHA 5c4245aeb9e34251e2170a6508b4d898e9ae24ee.
- Main Website run https://github.com/constellation-works/orbit/actions/runs/34195398040, push, attempt 1, reported/current/tested SHA 5c4245aeb9e34251e2170a6508b4d898e9ae24ee. Failed job https://github.com/constellation-works/orbit/actions/runs/34195398040/job/101962006802, step Verify deployment and custom domain. Exact evidence: after the configured curl/grep loop, the log said expected homepage, setup explorer, install route, and source revision did not reach https://19def95c.orbit-website-3zi.pages.dev. Checkout log fetched and checked out 5c4245aeb9e34251e2170a6508b4d898e9ae24ee. Matching task: ORB-11825.
- Main macOS Platform run https://github.com/constellation-works/orbit/actions/runs/34195398017 and CodeQL run https://github.com/constellation-works/orbit/actions/runs/34195398758 both completed successfully at the same main SHA; their jobs were successful.
- Final current agent-main SHA 575da16facd37df9bb970798682f9dd206478fe3 has CI run https://github.com/constellation-works/orbit/actions/runs/34318397222, CodeQL run https://github.com/constellation-works/orbit/actions/runs/34318397260, and macOS Platform run https://github.com/constellation-works/orbit/actions/runs/34318397418. All were queued at the final query; no runner checkout or failed step existed yet. Earlier queued runs for 89fe87b3853a74e58ed4576ccd20a0b743bbb238 and 21f15ded65e31481021f434acb32160a5ea77761 were superseded when agent-main advanced. They were not treated as failures.
- Open PR #1482 had CodeQL Advanced Security check https://github.com/constellation-works/orbit/runs/101619373142 at reported/current/tested SHA 80acce4b618837fbb4c4c45cca1a3dadea564e8b, with actual checkout evidence HEAD is now at 80acce4. Exact evidence: 1 new critical alert, rust/hard-coded-cryptographic-value at crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs:176. The same-SHA GitHub Actions CodeQL workflow run https://github.com/constellation-works/orbit/actions/runs/34081471765 completed all four language jobs successfully, but the Advanced Security alert remains on the PR. Matching repair tasks are ORB-11477 and ORB-11479; their recorded recovery is blocked on ORB-11506. No duplicate task was created.
- Open PR #1481 SHA 88f0a27b6536221b62b7f068df1c9dd4f8e33530 had successful CodeQL workflow run https://github.com/constellation-works/orbit/actions/runs/34081444468; the rust job log checked out HEAD 88f0a27. Its Advanced Security CodeQL check https://github.com/constellation-works/orbit/runs/101620012051 was also successful.
- Open PR #1478 SHA 569b125df4995ac24a7a844cc02b5d3da56bc82d had successful CI run https://github.com/constellation-works/orbit/actions/runs/34081397256 and CodeQL workflow run https://github.com/constellation-works/orbit/actions/runs/34081395248. CI jobs including Coverage (informational), Check / Clippy / Test, MSRV, and Linux Sandbox were successful; the CI checkout log recorded HEAD 569b125. Its Advanced Security check https://github.com/constellation-works/orbit/runs/101617752443 was successful. Matching task: ORB-11472.
- Historical calibration run 30232696219 was retained as historical only: reported SHA 49a2871a480b927bb31dc7a315f5ff5d130d15d0 versus checkout 5cec12c53211fad3f4ca940a0565bef87787958d, with CI jobs 89874419549 and 89874419524 exhibiting the documented clippy and coverage failures. It was not used as current-failure evidence.

Root-cause and disposition:
- Cluster CI/coverage: stale test fixtures still wrote default jobs under runtime.data_root and searched for bundle locks outside runtime.global_root. Disposition fixed before this task by ORB-11824; exact source diff is present in current HEAD ancestry. Matching task ORB-11823 covers the informational coverage job; ORB-11824 covers the CI job.
- Cluster Website: repository-owned workflow contract drift, not classified as transient. The source homepage contains "Other delivery modes" and the generated site now contains the required headline, section heading, and install route; the workflow assertion was updated to the current contract. Matching task ORB-11825 was referenced, not duplicated.
- Cluster PR #1482 Advanced Security: current PR head still has the critical alert; it is owned by the existing code-scanning repair/recovery tasks ORB-11477/ORB-11479 and is blocked by their recorded ORB-11506 dependency. This task did not manufacture a duplicate or falsely classify it as transient. No transient-only classification was made; no single non-reproduction was used as evidence.

Validation:
- PASS: cargo test -p orbit-web api::tests::runs::auto_drain:: -- --nocapture (9 passed, 0 failed).
- PASS: cargo test -p orbit-web api::tests::runs::healthz_answers_within_one_second_while_sixteen_ships_wait_on_bundle_lock -- --exact --nocapture (1 passed).
- PASS: npm ci --cache /tmp/orbit-npm-cache.* followed by npm run check and npm run build; Astro check reported 0 errors, 0 warnings, 0 hints and the static build produced 30 pages. The first canonical npm ci attempt failed with EROFS on ~/.npm; the task-local cache workaround passed.
- PASS: generated website equivalent assertion checked the headline, "Other delivery modes", and getting-started/install/index.html.
- PASS: make ci-fast. The documented compiler-cache-namespaces subcheck was skipped because this host cannot create an unprivileged bubblewrap mount namespace; all remaining guardrails passed and the command exited 0.
- PASS: make ci-lint (workspace clippy with -D warnings).
- PASS: git diff --check and GIT_OPTIONAL_LOCKS=0 git status --short; only .github/workflows/website.yml is modified.
- NOT RUN: candidate-commit GitHub green reruns for the one-line Website workflow repair. The worktree is intentionally uncommitted and the managed pipeline owns commit/push/PR publication; final current agent-main checks were still queued at the last query. This is the remaining handoff risk, not claimed as passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11856-6aa0f640`
- Behind base: 0
- Ahead of base: 1