### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/job/pipeline.rs

### DIFF
--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -868,7 +868,7 @@ impl OrbitRuntime {
             if (action_key.is_none() || run.state == JobRunState::Pending)
                 && let Err(error) = self.spawn_pipeline_worker(&run.run_id, actor)
             {
-                let worker_log = pipeline_worker_log_path(&self.paths().logs_dir, &run.run_id);
+                let worker_log = pipeline_worker_log_path(&self.paths().logs_dir, &run.run_id)?;
                 let message = format!(
                     "pipeline worker for run '{}' could not start from registered workspace '{}': \
                      {error}; worker log: '{}'",
@@ -915,7 +915,7 @@ impl OrbitRuntime {
     /// Durably pin a submitted run's job definition next to the run record.
     fn write_run_definition_snapshot(&self, run_id: &str, yaml: &str) -> Result<(), OrbitError> {
         let dir = self.paths().job_runs_dir.clone();
-        let path = run_definition_snapshot_path(&dir, run_id);
+        let path = run_definition_snapshot_path(&dir, run_id)?;
         atomic_write_text(&path, yaml).map_err(|error| {
             OrbitError::Io(format!(
                 "write job run definition snapshot '{}': {error}",
@@ -930,7 +930,7 @@ impl OrbitRuntime {
         &self,
         run: &JobRun,
     ) -> Result<(PathBuf, JobV2), OrbitError> {
-        let snapshot = run_definition_snapshot_path(&self.paths().job_runs_dir, &run.run_id);
+        let snapshot = run_definition_snapshot_path(&self.paths().job_runs_dir, &run.run_id)?;
         if !snapshot.is_file() {
             return self.load_v2_job_asset_by_name(&run.job_id);
         }
@@ -1663,6 +1663,7 @@ impl OrbitRuntime {
                 state: state.to_string(),
             })?;
         }
+        let worker_log = pipeline_worker_log_path(&self.paths().logs_dir, &current.run_id)?;
         self.record_pipeline_audit(
             audit_name,
             Some(&current.run_id),
@@ -1671,7 +1672,7 @@ impl OrbitRuntime {
             json!({
                 "run_id": current.run_id,
                 "workspace": self.paths().repo_root,
-                "worker_log": pipeline_worker_log_path(&self.paths().logs_dir, &current.run_id),
+                "worker_log": worker_log,
             }),
             Some(message.to_string()),
         )
@@ -1714,6 +1715,7 @@ impl OrbitRuntime {
                 state: JobRunState::Interrupted.to_string(),
             })?;
         }
+        let worker_log = pipeline_worker_log_path(&self.paths().logs_dir, &run.run_id)?;
         self.record_pipeline_audit(
             "pipeline.worker.startup",
             Some(&run.run_id),
@@ -1722,7 +1724,7 @@ impl OrbitRuntime {
             json!({
                 "run_id": run.run_id,
                 "workspace": self.paths().repo_root,
-                "worker_log": pipeline_worker_log_path(&self.paths().logs_dir, &run.run_id),
+                "worker_log": worker_log,
             }),
             Some(message.to_string()),
         )
@@ -1899,19 +1901,52 @@ pub(crate) fn pipeline_worker_profile_file(
     logs_dir: &Path,
     run_id: &str,
     inherited: Option<&OsStr>,
-) -> Option<PathBuf> {
-    inherited
-        .filter(|value| !value.is_empty())
-        .map(|_| logs_dir.join(format!("{run_id}.%p.profraw")))
+) -> Result<Option<PathBuf>, OrbitError> {
+    let Some(_) = inherited.filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+
+    Ok(Some(
+        logs_dir.join(pipeline_worker_file_name(run_id, ".%p.profraw")?),
+    ))
 }
 
 /// Where a submitted run's pinned job definition lives.
-pub(crate) fn run_definition_snapshot_path(job_runs_dir: &Path, run_id: &str) -> PathBuf {
-    job_runs_dir.join(format!("{run_id}.job.yaml"))
+pub(crate) fn run_definition_snapshot_path(
+    job_runs_dir: &Path,
+    run_id: &str,
+) -> Result<PathBuf, OrbitError> {
+    Ok(job_runs_dir.join(pipeline_worker_file_name(run_id, ".job.yaml")?))
 }
 
-pub(crate) fn pipeline_worker_log_path(logs_dir: &Path, run_id: &str) -> PathBuf {
-    logs_dir.join(format!("{run_id}.worker.log"))
+pub(crate) fn pipeline_worker_log_path(
+    logs_dir: &Path,
+    run_id: &str,
+) -> Result<PathBuf, OrbitError> {
+    Ok(logs_dir.join(pipeline_worker_file_name(run_id, ".worker.log")?))
+}
+
+/// Turn a persisted run ID into a filename only after rejecting path syntax.
+///
+/// Run IDs normally come from the store, but worker entry points also accept
+/// an ID from a process argument. Keeping this check at the shared filename
+/// boundary prevents either source from steering pipeline artifacts outside
+/// their owning directory.
+fn pipeline_worker_file_name(run_id: &str, suffix: &str) -> Result<String, OrbitError> {
+    let safe = !run_id.is_empty()
+        && run_id != "."
+        && run_id != ".."
+        && !run_id.contains(['/', '\\'])
+        && run_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'));
+    if !safe {
+        return Err(OrbitError::InvalidInput(format!(
+            "job run id must be a safe filename stem: {run_id}"
+        )));
+    }
+
+    Ok(format!("{run_id}{suffix}"))
 }
 
 pub(crate) fn configure_pipeline_worker_stdio(
@@ -1919,6 +1954,8 @@ pub(crate) fn configure_pipeline_worker_stdio(
     logs_dir: &Path,
     run_id: &str,
 ) -> Result<PipelineWorkerLog, OrbitError> {
+    let log_path = pipeline_worker_log_path(logs_dir, run_id)?;
+
     std::fs::create_dir_all(logs_dir).map_err(|error| {
         OrbitError::Io(format!(
             "create pipeline worker log directory '{}': {error}",
@@ -1927,7 +1964,6 @@ pub(crate) fn configure_pipeline_worker_stdio(
     })?;
     restrict_pipeline_worker_log_directory(logs_dir)?;
 
-    let log_path = pipeline_worker_log_path(logs_dir, run_id);
     let mut options = OpenOptions::new();
     options.create(true).append(true).read(true);
     #[cfg(unix)]
@@ -1946,7 +1982,7 @@ pub(crate) fn configure_pipeline_worker_stdio(
         logs_dir,
         run_id,
         std::env::var_os("LLVM_PROFILE_FILE").as_deref(),
-    ) {
+    )? {
         command.env("LLVM_PROFILE_FILE", profile);
     }
     write_pipeline_worker_spawn_banner(&log_path, command);

--- a/crates/orbit-core/src/application/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/application/tests/job_pipeline.rs
@@ -18,7 +18,8 @@ use crate::application::job::JobRunListParams;
 use crate::application::job::pipeline::{
     configure_pipeline_worker_command, configure_pipeline_worker_stdio, pipeline_worker_log_path,
     pipeline_worker_profile_file, pipeline_worker_root_override,
-    resolve_pipeline_worker_executable, worker_command_override, worker_observer_read_counter,
+    resolve_pipeline_worker_executable, run_definition_snapshot_path, worker_command_override,
+    worker_observer_read_counter,
 };
 use crate::application::task::TaskAddParams;
 use crate::application::workflow::{CompletionPolicy, ShipMode};
@@ -144,11 +145,13 @@ fn pipeline_worker_command_forwards_explicit_root_to_the_detached_worker() {
 #[test]
 fn pipeline_worker_profile_file_is_none_without_inherited_coverage_env() {
     assert_eq!(
-        pipeline_worker_profile_file(Path::new("/tmp/logs"), "jrun-child", None),
+        pipeline_worker_profile_file(Path::new("/tmp/logs"), "jrun-child", None)
+            .expect("profile path validation"),
         None
     );
     assert_eq!(
-        pipeline_worker_profile_file(Path::new("/tmp/logs"), "jrun-child", Some(OsStr::new(""))),
+        pipeline_worker_profile_file(Path::new("/tmp/logs"), "jrun-child", Some(OsStr::new("")))
+            .expect("profile path validation"),
         None
     );
 }
@@ -160,8 +163,41 @@ fn pipeline_worker_profile_file_rewrites_inherited_coverage_dump_under_the_worke
             Path::new("/tmp/logs"),
             "jrun-child",
             Some(OsStr::new("target/llvm-cov-target/orbit-%p-%m.profraw")),
-        ),
+        )
+        .expect("profile path validation"),
         Some(PathBuf::from("/tmp/logs/jrun-child.%p.profraw"))
+    );
+}
+
+#[test]
+fn pipeline_worker_paths_reject_run_id_path_syntax() {
+    for run_id in ["../outside", r"nested\outside", ".", ""] {
+        assert!(
+            pipeline_worker_log_path(Path::new("/tmp/logs"), run_id).is_err(),
+            "run ID {run_id:?} must not become a worker-log path"
+        );
+        assert!(
+            pipeline_worker_profile_file(
+                Path::new("/tmp/logs"),
+                run_id,
+                Some(OsStr::new("coverage.profraw")),
+            )
+            .is_err(),
+            "run ID {run_id:?} must not become a profile path"
+        );
+        assert!(
+            run_definition_snapshot_path(Path::new("/tmp/job-runs"), run_id).is_err(),
+            "run ID {run_id:?} must not become a snapshot path"
+        );
+    }
+}
+
+#[test]
+fn pipeline_worker_paths_preserve_safe_run_id_stems() {
+    assert_eq!(
+        pipeline_worker_log_path(Path::new("/tmp/logs"), "jrun-child.1")
+            .expect("worker log path validation"),
+        PathBuf::from("/tmp/logs/jrun-child.1.worker.log")
     );
 }
 
@@ -240,6 +276,7 @@ fn worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic() {
     assert_eq!(
         log_path,
         pipeline_worker_log_path(&runtime.paths().logs_dir, &run.run_id)
+            .expect("worker log path validation")
     );
     let durable_output = std::fs::read_to_string(&log_path).expect("read durable worker log");
     assert!(durable_output.contains("worker stdout context"));
@@ -302,6 +339,7 @@ fn routine_style_detached_worker_is_claimed_within_ownership_window() {
     assert_eq!(
         log_path,
         pipeline_worker_log_path(&runtime.paths().logs_dir, &run.run_id)
+            .expect("worker log path validation")
     );
     let durable_output = wait_for_log_contains(&log_path, "routine worker startup");
     assert!(durable_output.contains("routine worker startup"));

--- a/crates/orbit-core/src/application/tests/job_submission.rs
+++ b/crates/orbit-core/src/application/tests/job_submission.rs
@@ -249,7 +249,8 @@ fn direct_path_submission_pins_the_validated_definition_against_later_edits() {
         )
         .expect("direct-path submission succeeds");
 
-    let snapshot = run_definition_snapshot_path(&runtime.paths().job_runs_dir, &invoke.run_id);
+    let snapshot = run_definition_snapshot_path(&runtime.paths().job_runs_dir, &invoke.run_id)
+        .expect("snapshot path validation");
     let pinned = std::fs::read_to_string(&snapshot).expect("definition snapshot is durable");
     assert_eq!(pinned, job_yaml("qa_direct", 1));
 


### PR DESCRIPTION
## Task

[ORB-11855](https://orbit-cli.com/tasks/ORB-11855) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/job/pipeline.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#101`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value.
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-core/src/application/job/pipeline.rs` line 1931
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/101

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-core/src/application/job/pipeline.rs` line 1931 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Made pipeline run-ID filename derivation fallible and reject empty, dot, traversal, separator, and non-safe-character inputs before any log directory creation or file open.
- Applied the same boundary to worker logs, coverage profiles, and direct-submission job-definition snapshots.
- Added regression coverage for rejected path syntax and preserved safe dot-containing run-ID stems.

Acceptance criteria:
- Code scanning remediation: satisfied by the real validation boundary in crates/orbit-core/src/application/job/pipeline.rs; no suppression, dismissal, or exclusion was added.
- Intended behavior: satisfied; canonical jrun-* paths remain unchanged, including dot-containing safe stems, while unsafe IDs fail before filesystem use.
- Validation/security: targeted tests, workspace guardrails, clippy, formatting, and cargo-deny passed. The local CodeQL executable is unavailable, so the GitHub CodeQL workflow was not run here; static review and regression tests show the affected OpenOptions::open path is now derived only from the validated filename helper. CI CodeQL remains the authoritative report confirmation.

Validation:
- cargo test -p orbit-core application::tests::job_pipeline --no-fail-fast: passed, 24 tests.
- cargo test -p orbit-core application::tests::job_submission --no-fail-fast: passed, 10 tests.
- make ci-fast: passed; its documented compiler-cache namespace probe skipped because unprivileged namespaces are unavailable.
- make ci-lint: passed with workspace clippy and -D warnings.
- cargo fmt --all -- --check: passed.
- git diff --check: passed.
- cargo deny check: passed in an isolated temporary Cargo home. The repository-default make audit encountered a read-only advisory-db lock before the isolated rerun.
- codeql: not run; executable unavailable locally and no agent-side GitHub access is required by the task.

Assessment: The fix is scoped, fail-closed at the shared filename boundary, preserves valid pipeline artifact naming, and has focused behavioral coverage.

Remaining risk: Final CodeQL confirmation must come from the repository workflow after delivery; no local CodeQL database or extractor was available.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11855-6aa0f67e`
- Behind base: 0
- Ahead of base: 1