### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/routines/clock.rs

### DIFF
--- a/crates/orbit-core/src/application/routines/clock.rs
+++ b/crates/orbit-core/src/application/routines/clock.rs
@@ -60,14 +60,16 @@ pub fn clock_settings_path(global_root: &Path) -> PathBuf {
 }
 
 pub fn load_clock_settings(global_root: &Path) -> Result<ClockSettings, OrbitError> {
-    let requested_path = clock_settings_path(global_root);
-    if !requested_path.exists() {
-        return Ok(ClockSettings::default());
-    }
-
     let path = validated_clock_settings_path(global_root)?;
-    let raw = fs::read_to_string(&path)
-        .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
+    let raw = match fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(ClockSettings::default());
+        }
+        Err(error) => {
+            return Err(OrbitError::Io(format!("read {}: {error}", path.display())));
+        }
+    };
     toml::from_str::<ClockSettings>(&raw)
         .map_err(|error| {
             OrbitError::InvalidInput(format!(
@@ -103,16 +105,18 @@ fn validated_clock_settings_path(global_root: &Path) -> Result<PathBuf, OrbitErr
     })?;
     let expected_path = canonical_root.join(CLOCK_SETTINGS_FILE);
 
-    if !expected_path.exists() {
-        return Ok(expected_path);
-    }
-
-    let canonical_path = fs::canonicalize(&expected_path).map_err(|error| {
-        OrbitError::Io(format!(
-            "resolve clock configuration {}: {error}",
-            expected_path.display()
-        ))
-    })?;
+    let canonical_path = match fs::canonicalize(&expected_path) {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(expected_path);
+        }
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "resolve clock configuration {}: {error}",
+                expected_path.display()
+            )));
+        }
+    };
     if canonical_path != expected_path || !canonical_path.is_file() {
         return Err(OrbitError::InvalidInput(format!(
             "clock configuration must be a regular {CLOCK_SETTINGS_FILE} directly under {}",


### PR DESCRIPTION
## Task

[ORB-11870](https://orbit-cli.com/tasks/ORB-11870) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/routines/clock.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#89`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value.
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-core/src/application/routines/clock.rs` line 66
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/89

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-core/src/application/routines/clock.rs` line 66 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Kept the existing canonical-root and exact-target validation for host-local `clock.toml`.
- Removed the pre-validation `exists()` probe from `load_clock_settings`; it now resolves the validated fixed target first and treats a `NotFound` read as the existing default-settings behavior.
- Replaced the validation helper's pre-check `exists()` call with `canonicalize` error handling, preserving missing-file behavior while avoiding an unsafe filesystem probe on the user-selected path.
- Preserved the public `clock_settings_path` helper for compatibility; no suppressions, dismissals, exclusions, or unrelated files were changed.

Assessment: The production data flow at the reported clock-settings read now passes through canonical-root/exact-target validation before filesystem access, and the existing missing-file and symlink-escape tests remain green. This run reconciles the stale duplicate alert already covered by ORB-11846 while adding the targeted pre-validation probe fix.

Criteria evidence:
1. `rust/path-injection`: the flagged direct read/probe flow was replaced with validated-path resolution; no CodeQL configuration suppression was added.
2. Intended behavior: `missing_clock_settings_use_the_default` and `clock_settings_reject_symlink_escape` pass, along with the remaining 17 focused clock tests.
3. Validation/security: repository guardrails, clippy, and cargo-deny pass; source review shows no `requested_path.exists()` flow remains. The local CodeQL CLI is unavailable, so a live hosted alert re-run cannot be performed here; `.github/workflows/codeql.yml` is unchanged and remains the authoritative check.

Validation:
- `cargo fmt --all -- --check` — passed after formatting the changed match expression.
- `cargo test -p orbit-core application::routines::tests::clock --lib` — passed; 19 tests.
- `make ci-fast` — passed; the documented compiler-cache mount-namespace smoke check was skipped because this kernel denies unprivileged mount namespaces.
- `make ci-lint` — passed; workspace all-target clippy with warnings denied.
- `make audit` — not completed: cargo-deny could not acquire the exclusive lock at `~/.cargo/advisory-dbs/db.lock` because the host path is read-only.
- `CARGO_HOME=<temporary writable cache> cargo deny check --disable-fetch` — passed; advisories, bans, licenses, and sources OK, with existing unmatched-allow warnings.
- `codeql version` — not run: CodeQL CLI unavailable locally.
- `git diff --check` — passed.
- `GIT_OPTIONAL_LOCKS=0 git status --short` — passed; only `crates/orbit-core/src/application/routines/clock.rs` is modified.

Remaining risks/deviations: Hosted CodeQL confirmation is unavailable in this environment. The task's prior covering implementation landed under ORB-11846; this run made the additional in-scope path-probe hardening and validated the resulting checkout.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11870-6aa0f8f1`
- Behind base: 0
- Ahead of base: 1