### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/workspace_binding.rs

### DIFF
--- a/crates/orbit-store/src/driver/file/workspace_binding.rs
+++ b/crates/orbit-store/src/driver/file/workspace_binding.rs
@@ -45,29 +45,9 @@ pub fn workspace_id_for_orbit_dir(orbit_dir: &Path) -> Result<String, OrbitError
 pub fn read_workspace_config_optional(
     orbit_dir: &Path,
 ) -> Result<Option<WorkspaceConfig>, OrbitError> {
-    let display_path = workspace_config_path(orbit_dir);
-    let Some(path) = validated_workspace_config_path(orbit_dir)? else {
-        return Ok(None);
-    };
-
-    let raw = match fs::read_to_string(&path) {
-        Ok(raw) => raw,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(err) => return Err(OrbitError::Io(err.to_string())),
-    };
-    let doc: WorkspaceConfigDoc = parse_yaml_with(&raw, &display_path, |_, e| {
-        OrbitError::InvalidInput(format!(
-            "invalid workspace config '{}': {e}",
-            display_path.display()
-        ))
-    })?;
-    validate_workspace_config_doc(doc).map(Some)
-}
-
-/// Resolve the config path before reading it and require the resolved file to
-/// remain below the resolved orbit directory. This removes traversal and
-/// symlink components from the path presented to the filesystem read.
-fn validated_workspace_config_path(orbit_dir: &Path) -> Result<Option<PathBuf>, OrbitError> {
+    // Workspace paths may contain aliases and symlinks, so resolve the fixed
+    // config filename before reading and reject any path that escapes the
+    // resolved orbit directory.
     let canonical_orbit_dir = match orbit_dir.canonicalize() {
         Ok(path) => path,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -86,7 +66,18 @@ fn validated_workspace_config_path(orbit_dir: &Path) -> Result<Option<PathBuf>, 
         ));
     }
 
-    Ok(Some(canonical_config_path))
+    let raw = match fs::read_to_string(&canonical_config_path) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(OrbitError::Io(err.to_string())),
+    };
+    let doc: WorkspaceConfigDoc = parse_yaml_with(&raw, &canonical_config_path, |_, e| {
+        OrbitError::InvalidInput(format!(
+            "invalid workspace config '{}': {e}",
+            canonical_config_path.display()
+        ))
+    })?;
+    validate_workspace_config_doc(doc).map(Some)
 }
 
 pub fn write_workspace_config(


### PR DESCRIPTION
## Task

[ORB-11872](https://orbit-cli.com/tasks/ORB-11872) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/workspace_binding.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#91`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-store/src/driver/file/workspace_binding.rs` line 48
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/91

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-store/src/driver/file/workspace_binding.rs` line 48 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Reworked read_workspace_config_optional so the fixed config filename is canonicalized and checked with starts_with against the canonical orbit directory before fs::read_to_string.
- Removed the pre-validation user-derived path from the read flow; valid aliases remain supported and symlink escapes remain rejected.
- No suppressions, dismissals, exclusions, or unrelated files were changed.

Acceptance criteria:
- Criterion 1: satisfied. The flagged read now consumes only the canonicalized, orbit-directory-contained config path; this is a real code remediation in workspace_binding.rs.
- Criterion 2: satisfied. The workspace config round-trip, missing-file behavior, normalized-directory alias, and external-symlink rejection tests all pass.
- Criterion 3: satisfied for available repository checks. Formatting, focused tests, ci-fast, ci-lint, and isolated cargo-deny security audit passed. The local CodeQL CLI is unavailable, so the GitHub-hosted CodeQL workflow could not be run here; the inlined canonicalize/prefix-check pattern matches the repository's CodeQL remediation guidance and CI remains the authoritative alert confirmation.

Validation:
- cargo fmt --all -- --check: passed.
- cargo test -p orbit-store workspace_config --lib: passed, 4 passed.
- make ci-fast: passed; its documented compiler-cache namespace probe skipped because unprivileged bubblewrap namespaces are unavailable.
- make ci-lint: passed with warnings denied.
- make audit: initially blocked by a read-only shared cargo advisory-db lock; rerun with an isolated temporary CARGO_HOME: passed (advisories, bans, licenses, sources; existing unmatched-allowance warnings only).
- git diff --check: passed.
- GIT_OPTIONAL_LOCKS=0 git status --short: one intended modified file, crates/orbit-store/src/driver/file/workspace_binding.rs.

Assessment: The diff is scoped to the flagged persistence boundary, preserves supported behavior, and makes the filesystem safety check visible at the read sink for static analysis.

Remaining risk: A fresh GitHub CodeQL run is still required to confirm alert #91 is cleared after delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11872-6aa0fb2e`
- Behind base: 0
- Ahead of base: 1