### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/job/pipeline.rs

### DIFF
--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -1971,7 +1971,7 @@ pub(crate) fn configure_pipeline_worker_stdio(
         use std::os::unix::fs::OpenOptionsExt;
         options.mode(0o600);
     }
-    let log = options.open(&log_path).map_err(|error| {
+    let mut log = options.open(&log_path).map_err(|error| {
         OrbitError::Io(format!(
             "open pipeline worker log '{}': {error}",
             log_path.display()
@@ -1985,7 +1985,7 @@ pub(crate) fn configure_pipeline_worker_stdio(
     )? {
         command.env("LLVM_PROFILE_FILE", profile);
     }
-    write_pipeline_worker_spawn_banner(&log_path, command);
+    write_pipeline_worker_spawn_banner(&mut log, command);
     let reader = log.try_clone().map_err(|error| {
         OrbitError::Io(format!(
             "clone pipeline worker log reader '{}': {error}",
@@ -2017,11 +2017,7 @@ impl PipelineWorkerLog {
     }
 }
 
-fn write_pipeline_worker_spawn_banner(log_path: &Path, command: &Command) {
-    let mut file = match OpenOptions::new().create(true).append(true).open(log_path) {
-        Ok(file) => file,
-        Err(_) => return,
-    };
+fn write_pipeline_worker_spawn_banner(file: &mut File, command: &Command) {
     let args = command
         .get_args()
         .map(|arg| arg.to_string_lossy())


### PR DESCRIPTION
## Task

[ORB-11854](https://orbit-cli.com/tasks/ORB-11854) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/job/pipeline.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#98`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value.
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-core/src/application/job/pipeline.rs` line 1957
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/98

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-core/src/application/job/pipeline.rs` line 1957 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Removed the spawn-banner helper's second path-based open of the worker log.
- The banner is now written through the already-open, validated `File` handle created by `configure_pipeline_worker_stdio`; stdout/stderr cloning and existing banner content remain unchanged.
- Scope is limited to `crates/orbit-core/src/application/job/pipeline.rs`.

Acceptance criteria:
- Code scanning remediation: satisfied by removing the flagged `OpenOptions::open(log_path)` sink at the alert location; no suppression, dismissal, or CodeQL exclusion was added.
- Intended behavior: satisfied; the worker log is opened once with the existing permissions and append/read settings, the spawn banner is preserved, and later reader/stdout/stderr clones use that handle.
- Validation/security: targeted tests, formatting, repository guardrails, clippy, dependency audit, and a static sink check passed. Hosted CodeQL was not run because the `codeql` executable is unavailable and the task explicitly does not require agent-side GitHub access; hosted workflow confirmation remains the final external check.

Validation:
- `cargo fmt --all -- --check`: passed.
- `cargo test -p orbit-core --lib application::tests::job_pipeline --no-fail-fast`: passed, 24 tests.
- `make ci-fast`: passed; documented compiler-cache namespace subcheck skipped because the environment disallows unprivileged mount namespaces.
- `make ci-lint`: passed; workspace clippy/all targets with warnings denied.
- Static sink check for path-based spawn-banner reopen: passed; no matching `open(log_path)` or path-based banner call remains.
- `cargo deny check`: default invocation blocked by the read-only advisory DB lock; isolated temporary `CARGO_HOME` retry passed with only existing unmatched-allowance/advisory warnings.
- `git diff --check`: passed.
- `GIT_OPTIONAL_LOCKS=0 git status --short`: only the scoped pipeline file is modified.
- CodeQL CLI: not run; executable unavailable locally.

Assessment: The fix is minimal and preserves observable worker logging while eliminating the exact user-influenced path reopen identified by CodeQL. Remaining risk is limited to hosted CodeQL confirmation after delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11854-6aa0fbfb`
- Behind base: 0
- Ahead of base: 1