### PR TITLE
[dependabot-sweep] Update js-yaml in website/package-lock.json

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -246,6 +246,28 @@
         "unified": "^11.0.5"
       }
     },
+    "node_modules/@astrojs/internal-helpers/node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@astrojs/language-server": {
       "version": "2.16.6",
       "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.6.tgz",
@@ -427,6 +449,28 @@
         "@astrojs/markdown-remark": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -3045,6 +3089,28 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/astro/node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/astro/node_modules/jsonc-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
@@ -4540,28 +4606,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/json-schema-traverse": {

--- a/website/package.json
+++ b/website/package.json
@@ -25,7 +25,7 @@
   "overrides": {
     "yaml": "2.8.3",
     "esbuild": "0.28.1",
-    "js-yaml": ">=4.3.1",
+    "js-yaml": "4.3.2",
     "fast-uri": ">=4.1.3"
   }
 }


### PR DESCRIPTION
## Task

[ORB-11882](https://orbit-cli.com/tasks/ORB-11882) — [dependabot-sweep] Update js-yaml in website/package-lock.json

### Description

This task was filed from a bounded, redacted Dependabot snapshot collected on the host before the task existed. The implementing agent does not need GitHub credentials.

## Dependency bump

- Repository: `constellation-works/orbit`
- Ecosystem: `npm`
- Package: `js-yaml`
- Manifest path: `website/package-lock.json`
- First patched version: `4.3.2`

## Open alerts

- **GHSA-2883-xcg3-v3hh / CVE-2026-84375** — severity `high`; js-yaml: maxTotalMergeKeys does not limit CPU use for empty merge sources; vulnerable range `>= 4.0.0, < 4.3.2`; first patched version `4.3.2`; https://github.com/constellation-works/orbit/security/dependabot/46

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": [],
  "pull_requests_at_cap": false,
  "pull_requests_limit": 100
}
```

Update the dependency and regenerate the lockfile through the repository's normal package-manager workflow. Verify that the manifest and lockfile agree and run the documented pre-handoff checks.


### Acceptance Criteria

- Bump `js-yaml` to a non-vulnerable version that resolves every alert listed in the task description.
- `website/package-lock.json` and the repository lockfile agree on the resolved `js-yaml` version.
- The repository's documented pre-handoff checks pass without weakening security checks or suppressing the advisories.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated website/package.json override from js-yaml >=4.3.1 to the first patched release, 4.3.2.
- Regenerated website/package-lock.json through npm; all three resolved js-yaml package entries are 4.3.2 with the matching registry integrity.

Assessment: The scoped Dependabot advisory is resolved without suppressing npm audit output or weakening any security check. The exact 4.3.2 pin avoids an unrelated major-version upgrade while satisfying the first patched version requirement.

Criteria evidence:
1. Satisfied: website/package.json requires js-yaml 4.3.2, and a lockfile consistency script confirmed every resolved js-yaml entry is 4.3.2, outside the vulnerable range <4.3.2.
2. Satisfied: website/package-lock.json is the repository's npm lockfile; its three js-yaml resolutions all agree on 4.3.2 and match the manifest override.
3. Satisfied for documented pre-handoff checks: npm ci, npm run check, npm run build, source and dist security.txt validation, make ci-fast, make ci-lint, and git diff --check all passed. Build emitted two pre-existing content warnings (missing i18n collection and docs/404 entry) but no errors.

Validation:
- Passed: NPM_CONFIG_CACHE=/tmp/... npm --prefix website install --package-lock-only --ignore-scripts (the normal command was retried with a writable temporary cache after the default cache failed with EROFS).
- Passed: NPM_CONFIG_CACHE=/tmp/... npm --prefix website ci --ignore-scripts.
- Passed: npm --prefix website run check.
- Passed: npm --prefix website run build (2 existing content warnings, 0 build errors).
- Passed: npm --prefix website run validate:security-txt -- public/.well-known/security.txt.
- Passed: npm --prefix website run validate:security-txt -- dist/.well-known/security.txt.
- Passed: make ci-fast.
- Passed: make ci-lint.
- Passed: lockfile consistency script, git diff --check, and final git status.
- Failed but not required by the documented website runbook: npm audit --json exited 1 for an unrelated existing transitive svgo 4.0.2 advisory (GHSA-w27v-7q3p-w38r); no js-yaml advisory was reported, and the svgo finding was not suppressed or changed.

Handoff:
- Worktree contains only the intended modifications: website/package.json and website/package-lock.json.
- Generated website/.astro, website/dist, and website/node_modules directories were removed after validation. A bounded temporary npm cache remained under /tmp/orbit-npm-cache.7J49Uh because cache cleanup left files after npm cache clean; it is outside the worktree and not part of the patch.
- Changes are intentionally uncommitted for the pipeline.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11882-6aa0fc6d`
- Behind base: 0
- Ahead of base: 1