### PR TITLE
[ci-failure-sweep] Fix red CI: CI / Coverage (informational) / Collect workspace coverage

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
@@ -58,6 +58,7 @@ pub(super) const DEFAULT_WALL_CLOCK_TIMEOUT_SECONDS: u64 = 300;
 pub(super) type SpawnOutput = (CapturedOutput, CapturedOutput, Option<i32>, Duration, bool);
 
 const OUTPUT_READER_JOIN_TIMEOUT: Duration = Duration::from_millis(500);
+const PROCESS_GROUP_CLEANUP_TIMEOUT: Duration = Duration::from_secs(1);
 const CLI_RUNNER_OUTPUT_CAPTURE_LIMIT_ENV: &str = "ORBIT_CLI_RUNNER_OUTPUT_CAPTURE_LIMIT_BYTES";
 const DEFAULT_CLI_RUNNER_OUTPUT_CAPTURE_LIMIT_BYTES: usize = 1024 * 1024;
 const OUTPUT_LINE_EVENT_LIMIT_BYTES: usize = 64 * 1024;
@@ -682,10 +683,38 @@ fn set_nonblocking(fd: RawFd) -> io::Result<()> {
 fn kill_child_process_tree(child: &mut Child) {
     #[cfg(unix)]
     {
-        let _ = signal_child_process_group(child.id(), libc::SIGKILL);
+        let child_id = child.id();
+        let _ = signal_child_process_group(child_id, libc::SIGKILL);
+        let _ = child.kill();
+        let _ = child.wait();
+        wait_for_process_group_exit(child_id);
     }
-    let _ = child.kill();
-    let _ = child.wait();
+    #[cfg(not(unix))]
+    {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+#[cfg(unix)]
+fn wait_for_process_group_exit(child_id: u32) {
+    let deadline = Instant::now() + PROCESS_GROUP_CLEANUP_TIMEOUT;
+    while process_group_is_alive(child_id) {
+        let _ = signal_child_process_group(child_id, libc::SIGKILL);
+        if Instant::now() >= deadline {
+            break;
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+}
+
+#[cfg(unix)]
+fn process_group_is_alive(child_id: u32) -> bool {
+    if child_id == 0 || child_id > i32::MAX as u32 {
+        return false;
+    }
+    let rc = unsafe { libc::killpg(child_id as libc::pid_t, 0) };
+    rc == 0 || std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Task

[ORB-11857](https://orbit-cli.com/tasks/ORB-11857) — [ci-failure-sweep] Fix red CI: CI / Coverage (informational) / Collect workspace coverage

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `CI`
- Failing job: `Coverage (informational)`
- Failing step: `Collect workspace coverage`
- Commit the runner actually checked out: `f56bfda5297c3e856b22d815c263f8d21dc481c4`
- Normalized error signature (the dedupe identity, not a quote): `test activity_job::cli_runner::tests::supervisor::spawn_with_timeout_cleans_process_group_when_wait_fails ... failed`
- Repository: `constellation-works/orbit`
- Release branch as GitHub reports it: `main`
- Evidence collected at: 2026-09-09T06:01:11.946713712+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/constellation-works/orbit/actions/runs/34315095258 run `34315095258` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `aead96f2ab132be1659c8dc09a5779fdf6c112ee`
  - current head of that ref: `6727038735ac262099d41caa611cc8946e9dcf93`
  - commit actually checked out: `f56bfda5297c3e856b22d815c263f8d21dc481c4`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/usr/bin/git checkout --progress --force -B agent-main refs/remotes/origin/agent-main`
  - checkout evidence: `/usr/bin/git log -1 --format=%H`
  - failed job `Coverage (informational)` (id `102349537291`): https://github.com/constellation-works/orbit/actions/runs/34315095258/job/102349537291
  - failing step(s): `Collect workspace coverage`

## Failed-step log excerpt

_Failure regions from a completely scanned command; the full command was not retained. 691867 of 696621 source bytes omitted, including 0 assertion payload bytes. All 5 recognized failure anchors and bounded context are retained (64 KiB selection limit)._

```
Coverage (informational)	Collect workspace coverage	﻿2026-09-09T05:44:09.5750486Z ##[group]Run cargo llvm-cov --workspace --locked --no-report
Coverage (informational)	Collect workspace coverage	[... 593836 command bytes omitted ...]
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:08.0384557Z test activity_job::cli_runner::tests::supervisor::spawn_with_timeout_cleans_process_group_when_wait_fails ... FAILED
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:08.0656595Z test activity_job::cli_runner::tests::supervisor::spawn_with_timeout_emits_structured_stdout_and_stderr_events ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:08.1068022Z test activity_job::cli_runner::tests::rebase_recovery::recovery_cannot_report_success_when_completion_checkpoint_cannot_be_persisted ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:08.1835750Z test activity_job::cli_runner::tests::supervisor::spawn_with_timeout_kills_timed_out_process_and_keeps_partial_output ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:08.1929264Z test activity_job::cli_runner::tests::supervisor::spawn_with_timeout_redacts_tracing_line_without_redacting_raw_stdout ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:08.1943530Z test activity_job::cli_runner::tests::orchestrator::primary_escape_is_checked_after_nonzero_exit_and_timeout ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:08.2178421Z test activity_job::cli_runner::tests::supervisor::spawn_with_timeout_kills_grandchild_holding_output_pipes ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:08.3373218Z test activity_job::cli_runner::tests::trusted_host::a_cooperative_admission_is_audited_as_self_asserted_not_key_bound ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:08.3376805Z test activity_job::cli_runner::tests::trusted_host::a_declared_mode_without_an_admission_fails_closed ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:08.3380128Z test activity_job::cli_runner::tests::trusted_host::a_forged_admission_value_does_not_admit_the_mode ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:08.3507977Z test activity_job::cli_runner::tests::rebase_recovery::conflict_recovery_rejects_metadata_copy_redirection_and_poisoned_todo ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:08.4586064Z test activity_job::cli_runner::tests::trusted_host::an_admission_alone_does_not_remove_an_ordinary_activitys_sandbox ... ok
Coverage (informational)	Collect workspace coverage	[... 98031 command bytes omitted ...]
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:24.4944724Z thread 'activity_job::cli_runner::tests::supervisor::spawn_with_timeout_cleans_process_group_when_wait_fails' (92794) panicked at crates/orbit-engine/src/activity_job/cli_runner/tests/supervisor.rs:200:5:
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:24.4947402Z assertion `left == right` failed
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:24.4948102Z   left: 0
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:24.4948600Z  right: -1
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:24.4949507Z note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:24.4950319Z 
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:24.4950327Z 
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:24.4950542Z failures:
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:24.4951746Z     activity_job::cli_runner::tests::supervisor::spawn_with_timeout_cleans_process_group_when_wait_fails
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:24.4952786Z 
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:24.4953488Z test result: FAILED. 659 passed; 1 failed; 3 ignored; 0 measured; 0 filtered out; finished in 22.55s
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:24.4954448Z 
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:24.4976244Z [1m[91merror[0m: test failed, to rerun pass `-p orbit-engine --lib`
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:24.5001345Z error: process didn't exit successfully: `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo test --tests --manifest-path /home/runner/work/orbit/orbit/Cargo.toml --target-dir /home/runner/work/orbit/orbit/target/llvm-cov-target --workspace --locked` (exit status: 101)
Coverage (informational)	Collect workspace coverage	2026-09-09T05:52:24.5020220Z ##[error]Process completed with exit code 101.

```

_The collection display was truncated. Selected evidence is used for diagnosis; its retention limits are independent of that display._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `CI` run https://github.com/constellation-works/orbit/actions/runs/34314969130 — superseded_by_newer_workflow_run: newer relevant run 34315095258 at 2026-09-09T05:29:41Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34314457799 — superseded_by_newer_workflow_run: newer relevant run 34314944567 at 2026-09-09T05:27:25Z is completed with conclusion success
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34313940522 — superseded_by_newer_workflow_run: newer relevant run 34314944567 at 2026-09-09T05:27:25Z is completed with conclusion success
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34312573777 — superseded_by_newer_workflow_run: newer relevant run 34314944567 at 2026-09-09T05:27:25Z is completed with conclusion success
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34312391496 — ref_no_longer_exists: branch 'codeql-advanced-setup' has no head on origin: its pull request was merged or the branch was deleted, so this run describes code that is either already landed — where the landing branch's own runs are the current evidence — or abandoned
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34314511752 — ref_no_longer_exists: branch 'orbit/ORB-11824-6aa0eaf9' has no head on origin: its pull request was merged or the branch was deleted, so this run describes code that is either already landed — where the landing branch's own runs are the current evidence — or abandoned

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 1,
  "current_failures_discovered": 1,
  "current_failures_investigated": 1,
  "current_failures_investigation_attempted": 6,
  "inconclusive": 0,
  "investigation_cursor": 496926,
  "job_log_reads": 1,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_job_log_reads": 6,
  "max_pull_requests": 10,
  "max_retired_ref_probes": 20,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely",
    "17 of 23 current or mixed-state runs were listed but not investigated (max_investigated_runs=6); their run URLs are still present, and the rotating slot reaches a different overflow candidate on the next sweep"
  ],
  "pull_requests_scanned": 3,
  "refs_scanned": 5,
  "retired_refs": [
    "codeql-advanced-setup",
    "orbit/ORB-11824-6aa0eaf9",
    "orbit/ORB-11826-6aa0eaf9",
    "orbit/ORB-11831-6aa0eafa"
  ],
  "runs_listed": 100,
  "unverified_refs": []
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `CI` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Hardened Unix CLI subprocess cleanup in crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs.
- After killing and reaping the direct child, cleanup now rechecks the child process group for up to one second and repeats SIGKILL while descendants remain. This closes the race that left a shell-launched process group alive when the injected wait failure returned.
- No workflow, assertion, lint level, or blocking behavior was weakened.

Acceptance criteria:
- Root cause fixed: passed. The failing wait-error path now waits for the process group to disappear rather than assuming the first group signal plus direct-child reap is synchronous.
- Runner failure reproduced and fixed: passed. The narrowest faithful equivalent, cargo test -q -p orbit-engine --lib activity_job::cli_runner::tests::supervisor::spawn_with_timeout_cleans_process_group_when_wait_fails -- --exact --test-threads=1, failed before the change with left=0/right=-1 and passed 30 consecutive times after the change. The exact cargo llvm-cov command was not available locally because cargo-llvm-cov is not installed.
- Documented pre-handoff gate: passed. make ci-fast and make ci-lint both passed after the final change. ci-fast reported the existing environment-bounded namespace probe as skipped because unprivileged bubblewrap namespaces are unavailable; the gate itself exited successfully.
- Infrastructure assessment: not infrastructure-only; the repository test reproduced the runner signature locally before the fix.

Validation:
- cargo fmt --all -- --check: passed.
- cargo test -p orbit-engine --lib activity_job::cli_runner::tests::supervisor: passed (9 passed).
- git diff --check: passed.
- git status --short: only the scoped supervisor implementation is modified.

Assessment: Small, repository-owned fix preserves the process-group cleanup contract and keeps the existing strong test assertion intact.

Remaining risk: The one-second cleanup bound reports failure-path cleanup complete after the bound if an unusual process group remains externally unreapable; repeated SIGKILL is attempted throughout the bound.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11857-6aa0fb2d`
- Behind base: 0
- Ahead of base: 1