### PR TITLE
[code-review] Activity-scoped external tools inherit Landlock confinement and fail outright off Linux

### DIFF
--- a/crates/orbit-tools/src/builtin/proc/spawn.rs
+++ b/crates/orbit-tools/src/builtin/proc/spawn.rs
@@ -116,7 +116,11 @@ fn spawn_request(
     }
 }
 
-/// Filesystem confinement for an activity-scoped subprocess.
+/// Filesystem confinement for activity-scoped `proc.spawn`.
+///
+/// This type is the `proc.spawn` sandbox, not a generic activity subprocess
+/// wrapper. Registered external tools share the program allowlist but stay on
+/// the unconfined `NoSandbox` path; see `crates/orbit-tools/src/external.rs`.
 ///
 /// Two layers, doing two different jobs. Explicit path arguments (including
 /// `--key=path`) are resolved symlink-safely by the same policy engine the

--- a/crates/orbit-tools/src/external.rs
+++ b/crates/orbit-tools/src/external.rs
@@ -2,11 +2,11 @@ use std::env;
 
 use orbit_common::OrbitError;
 use orbit_common::security::child_env::allowlisted_child_env;
-use orbit_exec::{EnvironmentMode, ExecRequest, StdinMode, run_process};
+use orbit_exec::{EnvironmentMode, ExecRequest, NoSandbox, StdinMode, run_process};
 use orbit_types::tool::{ToolParam, ToolSchema};
 use serde_json::Value;
 
-use crate::builtin::proc::spawn::{ActivityFsSandbox, enforce_program_allowlist};
+use crate::builtin::proc::spawn::enforce_program_allowlist;
 use crate::{TIMEOUT_DEFAULT_MS, Tool, ToolContext};
 
 const EXTERNAL_TOOL_TIMEOUT_OVERRIDE_ENV: &str = "ORBIT_EXTERNAL_TOOL_TIMEOUT_MS";
@@ -49,6 +49,14 @@ impl Tool for ExternalTool {
         let environment_mode =
             EnvironmentMode::ClearAndSet(runtime_environment(ctx, &self.name, &cwd));
 
+        // External tools stay unconfined at the process boundary. Landlock is a
+        // `proc.spawn` rule (`ActivityFsSandbox::spawn`): it fails closed off
+        // Linux and compiles grants from the workspace read profile plus a host
+        // table curated for `proc.spawn`. An external tool is already gated by
+        // the program allowlist above; it runs with `current_dir = ctx.cwd`,
+        // which need not equal `workspace_root`. Inheriting that override would
+        // either refuse the child outright (macOS / Linux below Landlock ABI 2)
+        // or confine it to a ruleset it was not designed for.
         let output = run_process(
             &ExecRequest {
                 program: self.path.clone(),
@@ -59,7 +67,7 @@ impl Tool for ExternalTool {
                 environment_mode,
                 debug: false,
             },
-            &ActivityFsSandbox::new(ctx)?,
+            &NoSandbox,
         )?;
 
         if !output.success {

--- a/crates/orbit-tools/tests/external_tool_lockdown.rs
+++ b/crates/orbit-tools/tests/external_tool_lockdown.rs
@@ -86,4 +86,34 @@ printf '{"gh_token_present":%s,"name_present":%s,"cwd_present":%s,"root_present"
 
         assert!(matches!(error, OrbitError::PolicyDenied(_)));
     }
+
+    #[test]
+    fn activity_scoped_allowlisted_external_tool_runs() {
+        let directory = tempdir().expect("temporary directory");
+        let script_path = directory.path().join("print-ok.sh");
+        fs::write(
+            &script_path,
+            r##"#!/bin/sh
+cat >/dev/null
+printf '{"ok":true}'
+"##,
+        )
+        .expect("write activity-scoped script");
+        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o700))
+            .expect("make activity-scoped script executable");
+
+        let program = script_path.to_string_lossy().into_owned();
+        let context = ToolContext {
+            cwd: Some(directory.path().to_string_lossy().into_owned()),
+            proc_allowed_programs: vec![program.clone()],
+            proc_spawn_activity_scoped: true,
+            ..ToolContext::default()
+        };
+
+        let output = external_tool(&program)
+            .execute(&context, json!({}))
+            .expect("allowlisted activity-scoped external tool must run");
+
+        assert_eq!(output["ok"], true);
+    }
 }


### PR DESCRIPTION
## Task

[ORB-11878](https://orbit-cli.com/tasks/ORB-11878) — [code-review] Activity-scoped external tools inherit Landlock confinement and fail outright off Linux

### Description

## Problem

ORB-11514 gave `ActivityFsSandbox` a `Sandbox::spawn` override that routes an
activity-scoped child through `spawn_under_linux_landlock`. `ProcSpawnTool` is
the intended consumer, but `ExternalTool` shares the same sandbox type, so it
silently inherited process-boundary confinement — including the deliberate
non-Linux hard refusal that was designed for `proc.spawn` alone.

- `crates/orbit-tools/src/builtin/proc/spawn.rs:212-219` — `fn spawn` returns
  `spawn_under_linux_landlock(request, scope.workspace_root, &scope.profile)`
  whenever a scope is present.
- `crates/orbit-tools/src/external.rs:62` — `ExternalTool::execute` passes
  `&ActivityFsSandbox::new(ctx)?` to `run_process`, so it takes that override.
  The ORB-11514 diff only added `?` here to absorb the new `Result` signature;
  nothing in that change discusses external tools.
- `crates/orbit-exec/src/linux_landlock/mod.rs:174-180` —
  `spawn_under_linux_landlock` returns `OrbitError::PolicyDenied` when the probe
  is unavailable. On non-Linux, `landlock_abi()` is `-1`
  (`mod.rs:224-227`), so the probe is always unavailable.
- `crates/orbit-core/src/adapter/engine_host/runtime_host.rs:652` — every v2
  activity `ToolContext` sets `proc_spawn_activity_scoped = true`
  unconditionally; `crates/orbit-core/src/adapter/command/dispatch.rs:262` sets
  it from `managed_run_context()`.

## Impact

In any managed activity run:

- On macOS, or on Linux below Landlock ABI 2, **every external tool invocation
  now fails** with
  `activity-scoped proc.spawn cannot run here: enforcing the filesystem profile
  at the process boundary requires Linux Landlock ABI 2 or later (...)`
  (`crates/orbit-exec/src/linux_landlock/mod.rs:143-150`). The caller invoked an
  external tool, not `proc.spawn`, so the message misidentifies the surface.
- On supported Linux, an external tool is now confined to a ruleset compiled
  from the workspace read profile plus the curated host table in
  `crates/orbit-exec/src/linux_landlock/host.rs`. `ExternalTool` runs with
  `current_dir: ctx.cwd` (`external.rs:56`), which is
  `std::env::current_dir()` for `runtime_host` contexts and need not equal
  `scope.workspace_root`; any host resource the tool needs outside that table is
  denied.

The non-Linux refusal is a documented, tested decision **for `proc.spawn`**
(`crates/orbit-exec/src/linux_landlock/tests/platform.rs:59-70`). No equivalent
decision was recorded for external tools.

## Missing coverage

`crates/orbit-tools/tests/external_tool_lockdown.rs` has no activity-scoped
success path. The success test builds a `ToolContext` with
`proc_spawn_activity_scoped` at its `false` default, so it takes `NoSandbox`;
`activity_scoped_external_tool_must_be_allowlisted` (line 74) asserts a denial
from `enforce_program_allowlist` and never reaches the spawn. The widening is
therefore entirely untested.

## Expected

Decide the external-tool boundary explicitly rather than inheriting it. Either
confine external tools deliberately — with their own documentation, a message
that names the external-tool surface, and coverage for a successfully
allowlisted tool under activity scope — or keep `ExternalTool` on the
unconfined spawn path and scope the Landlock override to `proc.spawn`.

### Acceptance Criteria

- An external tool that is allowlisted and invoked from an activity-scoped ToolContext has a documented, intentional spawn path, and the choice between confining it and leaving it unconfined is stated next to the code.
- On a host without Landlock ABI 2 (macOS, or Linux below 5.19), invoking an allowlisted external tool from a managed activity either succeeds or fails with an error that names the external-tool surface rather than `proc.spawn`.
- crates/orbit-tools/tests/external_tool_lockdown.rs covers an allowlisted external tool executing under `proc_spawn_activity_scoped: true`, asserting the intended outcome on the current host.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `ExternalTool::execute` now spawns through `NoSandbox` instead of `ActivityFsSandbox`. The confine-vs-unconfine choice is stated next to that call: Landlock remains a `proc.spawn` rule; external tools keep the program allowlist and credential-free environment as their gates.
- `ActivityFsSandbox` docs now name it as the `proc.spawn` sandbox, not a generic activity subprocess wrapper.
- `activity_scoped_allowlisted_external_tool_runs` in `crates/orbit-tools/tests/external_tool_lockdown.rs` executes an allowlisted tool with `proc_spawn_activity_scoped: true` (no resolved fs profile, which would fail closed if the Landlock sandbox were still inherited).
Assessment: Small, explicit boundary split. `proc.spawn` confinement is unchanged.
Strategic decisions: Left external tools unconfined rather than giving them their own Landlock path. The current grant table and non-Linux hard refusal were designed for `proc.spawn`; `ExternalTool` uses `current_dir = ctx.cwd`, which need not equal `workspace_root`.
Design weaknesses / risks:
- Severity: medium. An allowlisted external tool in a managed activity can still read host paths Landlock would block for `proc.spawn`. Mitigation: program allowlist plus credential-free child env remain enforced; a future confinement design would need its own grant table and surface-named errors.
Criteria:
1. Documented intentional spawn path with the confine/unconfine choice next to the code — passed (`external.rs` comment; `ActivityFsSandbox` ownership comment).
2. Host without Landlock ABI 2 succeeds or fails naming the external-tool surface rather than `proc.spawn` — passed by construction: `NoSandbox` is used, so the Landlock `proc.spawn` refusal cannot fire. This host is Linux; the new test succeeded here without applying Landlock. Not executed on macOS.
3. `external_tool_lockdown.rs` covers an allowlisted tool under `proc_spawn_activity_scoped: true` — passed (`activity_scoped_allowlisted_external_tool_runs`).
Validation:
- `CARGO_TARGET_DIR=/tmp/orbit-jrun-20260909-0627-3-target cargo test -p orbit-tools --test external_tool_lockdown -- --nocapture` — passed (3 tests).
- `make ci-fast` — passed (`test-compiler-cache-namespaces` skipped: bwrap user-namespace EPERM in this runner; not evidence of this change).
- `make ci-lint` — passed.
- `git diff --check` — passed.
Remaining risks: unconfined host-path reads by allowlisted external tools, as above. No scope deviations. Changes left uncommitted.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11878-6aa0fc4f`
- Behind base: 0
- Ahead of base: 1