### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-common/src/fs/io.rs

### DIFF
--- a/crates/orbit-common/src/fs/io.rs
+++ b/crates/orbit-common/src/fs/io.rs
@@ -149,6 +149,7 @@ impl StagedTextFile {
     where
         F: FnOnce(&mut File) -> io::Result<()>,
     {
+        let file_name = validated_atomic_file_name(target_path)?;
         let parent = target_path.parent().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -156,12 +157,28 @@ impl StagedTextFile {
             )
         })?;
         create_private_dir_all(parent)?;
+        let parent_for_resolution = if parent.as_os_str().is_empty() {
+            Path::new(".")
+        } else {
+            parent
+        };
+        let canonical_parent = fs::canonicalize(parent_for_resolution)?;
+        let canonical_target = canonical_parent.join(file_name);
+        if !canonical_target.starts_with(&canonical_parent) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "atomic write target escapes its parent: {}",
+                    target_path.display()
+                ),
+            ));
+        }
 
-        let temp_path = temp_path_for(target_path);
+        let temp_path = temp_path_for(&canonical_target);
         let mut file = create_new_private_file(&temp_path)?;
         let mut cleanup = TempFileCleanup::new(temp_path.clone());
 
-        if preserve_existing_permissions && let Ok(metadata) = fs::metadata(target_path) {
+        if preserve_existing_permissions && let Ok(metadata) = fs::metadata(&canonical_target) {
             fs::set_permissions(&temp_path, metadata.permissions())?;
         }
 
@@ -171,12 +188,12 @@ impl StagedTextFile {
         }
         drop(file);
 
-        let parent_dir = durable.then(|| File::open(parent)).transpose()?;
+        let parent_dir = durable.then(|| File::open(&canonical_parent)).transpose()?;
 
         cleanup.disarm();
 
         Ok(Self {
-            target_path: target_path.to_path_buf(),
+            target_path: canonical_target,
             temp_path,
             parent_dir,
             sync_parent: durable,
@@ -205,6 +222,28 @@ impl StagedTextFile {
         }
         Ok(())
     }
+}
+
+/// Return the only component that an atomic write may replace.
+///
+/// The parent is resolved separately in [`StagedTextFile::stage_with`], where
+/// it becomes the containment root for the final rename. Rejecting the dot
+/// components before creating a staging file also prevents a path such as
+/// `parent/..` from being interpreted as the parent directory itself.
+fn validated_atomic_file_name(path: &Path) -> io::Result<&std::ffi::OsStr> {
+    let Some(file_name) = path.file_name() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("atomic write path has no file name: {}", path.display()),
+        ));
+    };
+    if file_name == "." || file_name == ".." {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("atomic write path must name a file: {}", path.display()),
+        ));
+    }
+    Ok(file_name)
 }
 
 /// Removes a newly-created staging file if setup or writing fails before the

--- a/crates/orbit-common/src/fs/tests/io.rs
+++ b/crates/orbit-common/src/fs/tests/io.rs
@@ -317,6 +317,38 @@ fn atomic_write_bytes_removes_its_temp_file_when_the_rename_fails() {
 }
 
 #[test]
+fn atomic_write_rejects_a_dot_component_as_the_target() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let parent = dir.path().join("parent");
+    std::fs::create_dir(&parent).expect("parent directory");
+
+    let error = super::super::io::atomic_write_text(&parent.join(".."), "payload")
+        .expect_err("atomic write must not replace a directory");
+
+    assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    assert!(parent.is_dir(), "the parent directory must remain intact");
+}
+
+#[cfg(unix)]
+#[test]
+fn atomic_write_preserves_a_symlinked_parent_route() {
+    let root = tempfile::tempdir().expect("root tempdir");
+    let real_dir = root.path().join("real");
+    std::fs::create_dir(&real_dir).expect("real directory");
+    let linked_dir = root.path().join("linked");
+    std::os::unix::fs::symlink(&real_dir, &linked_dir).expect("parent symlink");
+
+    let path = linked_dir.join("config");
+    super::super::io::atomic_write_text(&path, "payload").expect("write through parent link");
+
+    assert_eq!(
+        std::fs::read_to_string(real_dir.join("config")).expect("read config"),
+        "payload"
+    );
+    assert!(!path.is_symlink(), "the final file must be a regular file");
+}
+
+#[test]
 fn staged_write_removes_partial_temp_file_when_writing_fails() {
     use std::io::Write;
 


### PR DESCRIPTION
## Task

[ORB-11877](https://orbit-cli.com/tasks/ORB-11877) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-common/src/fs/io.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#105`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-common/src/fs/io.rs` line 192
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/105

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-common/src/fs/io.rs` line 192 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Hardened `StagedTextFile::stage_with` by validating the final filename, canonicalizing the existing parent, checking the canonical target remains within that parent, and storing the canonical target for the atomic rename and parent fsync.
- Preserved writes through symlinked parent directories and added regression coverage for that behavior.
- Rejected dot-component targets before staging so a path such as `parent/..` cannot be treated as a directory replacement.

Acceptance criteria:
- CodeQL `rust/path-injection`: addressed at the atomic rename boundary with real path validation and canonicalization; no suppression, dismissal, or exclusion was added.
- Intended behavior: atomic writes, permission preservation, durable parent syncing, and symlinked-parent routes remain covered and passing.
- Validation: repository formatting, fast guardrails, focused and full orbit-common library tests, workspace clippy, and supply-chain checks passed. The CodeQL CLI is not installed in this executor and the repository runs CodeQL in GitHub Actions; workflow confirmation remains an external post-delivery check.

Assessment: The rename now receives a canonical path whose parent is resolved and whose final component is restricted to a file name, removing the previously unchecked path flow while retaining atomic replacement semantics.

Validation:
- `cargo fmt --all -- --check`: passed.
- `cargo test -p orbit-common --lib fs::tests::io`: passed (16 tests).
- `cargo test -p orbit-common --lib`: passed (247 tests).
- `make ci-fast`: passed; the compiler-cache namespace subcheck reported an environment-limited skip because unprivileged user namespaces are unavailable.
- `make ci-lint`: passed.
- `cargo deny check` with task-local `CARGO_HOME`: passed.
- `git diff --check`: passed.
- CodeQL CLI: not run; `codeql` is unavailable locally, so GitHub Actions must provide the affected-rule confirmation.

Remaining risk: direct CodeQL alert re-analysis is unavailable in this host-only execution environment; no other known deviations.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11877-6aa0fd2e`
- Behind base: 0
- Ahead of base: 1