### PR TITLE
[dependabot-sweep] Update svgo in website/package-lock.json

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -3391,16 +3391,16 @@
       }
     },
     "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-6.0.0.tgz",
+      "integrity": "sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
+        "css-what": "^7.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "nth-check": "^2.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
@@ -3436,9 +3436,9 @@
       }
     },
     "node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-7.0.0.tgz",
+      "integrity": "sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
@@ -6908,9 +6908,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -7129,18 +7129,18 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
-      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.1.0.tgz",
+      "integrity": "sha512-bkxnTg1kSU0guhIBmibA6UUhrQmPVA1XsQLN+ylCd+UWzbnLkySOcXpyk1mrl05f+pcaCx2eHb+sp6BgMZWX+Q==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
-        "css-select": "^5.1.0",
+        "css-select": "^6.0.0",
         "css-tree": "^3.0.1",
-        "css-what": "^6.1.0",
+        "css-what": "^7.0.0",
         "csso": "^5.0.5",
         "picocolors": "^1.1.1",
-        "sax": "^1.5.0"
+        "sax": "1.6.1"
       },
       "bin": {
         "svgo": "bin/svgo.js"


### PR DESCRIPTION
## Task

[ORB-11884](https://orbit-cli.com/tasks/ORB-11884) — [dependabot-sweep] Update svgo in website/package-lock.json

### Description

This task was filed from a bounded, redacted Dependabot snapshot collected on the host before the task existed. The implementing agent does not need GitHub credentials.

## Dependency bump

- Repository: `constellation-works/orbit`
- Ecosystem: `npm`
- Package: `svgo`
- Manifest path: `website/package-lock.json`
- First patched version: `4.1.0`

## Open alerts

- **GHSA-w27v-7q3p-w38r / CVE-2026-84370** — severity `high`; SVGO: removeScripts allows executable links through namespace and control-character bypasses; vulnerable range `>= 4.0.0, < 4.1.0`; first patched version `4.1.0`; https://github.com/constellation-works/orbit/security/dependabot/45

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": [],
  "pull_requests_at_cap": false,
  "pull_requests_limit": 100
}
```

Update the dependency and regenerate the lockfile through the repository's normal package-manager workflow. Verify that the manifest and lockfile agree and run the documented pre-handoff checks.


### Acceptance Criteria

- Bump `svgo` to a non-vulnerable version that resolves every alert listed in the task description.
- `website/package-lock.json` and the repository lockfile agree on the resolved `svgo` version.
- The repository's documented pre-handoff checks pass without weakening security checks or suppressing the advisories.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Regenerated `website/package-lock.json` with the repository npm workflow using `npm update svgo --package-lock-only --ignore-scripts`.
- Updated transitive `svgo` from 4.0.2 to patched 4.1.0, with its required `css-select` 6.0.0, `css-what` 7.0.0, and `sax` 1.6.1 resolutions.
- No files outside the scoped lockfile changed; changes remain uncommitted for the pipeline.

Acceptance criteria:
1. Passed — `npm ls svgo --all` resolves `astro@7.3.2 -> svgo@4.1.0`; the audit report contains no svgo vulnerability.
2. Passed — the repository has one npm lockfile, `website/package-lock.json`; `npm ci` succeeded against it and the lock entry resolves svgo 4.1.0.
3. Passed for documented pre-handoff checks — `npm ci`, `npm run check`, `npm run build`, both source/dist `validate:security-txt` checks, `make ci-fast`, `make ci-lint`, `git diff --check`, and `git status --short` completed as recorded below. No security advisory was suppressed or checks weakened.

Validation:
- Passed: `npm update svgo --package-lock-only --ignore-scripts` with a temporary npm cache. The initial default-cache attempt failed with EROFS because `~/.npm` is read-only; the safe workspace-independent cache retry passed.
- Passed: `npm ci` (432 packages installed; npm reported an unrelated existing high-severity js-yaml advisory).
- Passed: `npm ls svgo --all`.
- Passed: `npm run check` (0 errors, 0 warnings, 0 hints).
- Passed: `npm run build` (30 pages built); Astro emitted existing content warnings for the absent i18n collection and docs/404 entry.
- Passed: `npm run validate:security-txt -- public/.well-known/security.txt` and the corresponding dist check.
- Passed: `make ci-fast`; its environment-aware compiler-cache namespace subcheck reported skip because unprivileged bubblewrap namespaces are unavailable, while the make target exited 0.
- Passed: `make ci-lint` (workspace clippy with `-D warnings`).
- Failed, non-blocking to this task's listed alert: `npm audit --json` exits 1 for the unrelated js-yaml advisory GHSA-2883-xcg3-v3hh; it reports no svgo advisory and no available fix. This remains a dependency-health risk outside the scoped svgo bump.
- Passed: `git diff --check`; status contains only `M website/package-lock.json`.

Assessment: The requested security bump is complete, narrowly scoped, reproducible through npm, and validated at the website and repository gates. Remaining risk is the pre-existing unrelated js-yaml audit finding.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11884-6aa0fdf4`
- Behind base: 0
- Ahead of base: 1