### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-common/src/storage/sqlite.rs

### DIFF
--- a/crates/orbit-common/src/storage/sqlite.rs
+++ b/crates/orbit-common/src/storage/sqlite.rs
@@ -10,7 +10,7 @@
 
 use std::fs;
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use rusqlite::{Connection, OpenFlags};
 
@@ -39,38 +39,44 @@ pub struct OpenedConnection {
 /// is opened immutable. A database on a read-only filesystem is opened
 /// immutable before any directory creation or permission change is attempted.
 pub fn open_private(path: &Path) -> Result<OpenedConnection, OrbitError> {
-    match fs::metadata(path) {
+    let path = validated_sqlite_path(path)?;
+
+    match fs::metadata(&path) {
         Ok(metadata) => {
-            let filesystem_read_only = filesystem_is_read_only(path)?;
+            let filesystem_read_only = filesystem_is_read_only(&path)?;
             if filesystem_read_only || metadata.permissions().readonly() {
-                return open_private_read_only(path, filesystem_read_only);
+                return open_private_read_only(&path, filesystem_read_only);
             }
-            harden_sqlite_files(path)?;
+            harden_sqlite_files(&path)?;
         }
         Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-        Err(error) => return Err(sqlite_path_error("inspect", path, error)),
+        Err(error) => return Err(sqlite_path_error("inspect", &path, error)),
     }
 
-    if let Some(parent) = path.parent() {
-        create_private_dir_all(parent)?;
-    }
-    prepare_private_database_file(path)?;
+    prepare_private_database_file(&path)?;
 
-    let connection = Connection::open(path).map_err(|error| {
+    let connection = Connection::open_with_flags(
+        &path,
+        OpenFlags::SQLITE_OPEN_READ_WRITE
+            | OpenFlags::SQLITE_OPEN_CREATE
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX
+            | OpenFlags::SQLITE_OPEN_NOFOLLOW,
+    )
+    .map_err(|error| {
         OrbitError::Store(format!(
             "cannot open SQLite database '{}': {error}",
             path.display()
         ))
     })?;
     let pragmas = apply_default_pragmas(&connection)?;
-    if pragmas.write_denied || filesystem_is_read_only(path)? {
+    if pragmas.write_denied || filesystem_is_read_only(&path)? {
         drop(connection);
         return Ok(OpenedConnection {
-            connection: open_immutable(path)?,
+            connection: open_immutable(&path)?,
             read_only: true,
         });
     }
-    harden_sqlite_files(path)?;
+    harden_sqlite_files(&path)?;
 
     Ok(OpenedConnection {
         connection,
@@ -82,13 +88,81 @@ pub(super) fn open_private_read_only(
     path: &Path,
     filesystem_read_only: bool,
 ) -> Result<OpenedConnection, OrbitError> {
+    let path = validated_sqlite_path(path)?;
+
     if !filesystem_read_only {
-        harden_read_only_sqlite_files(path)?;
+        harden_read_only_sqlite_files(&path)?;
     }
     Ok(OpenedConnection {
-        connection: open_immutable(path)?,
+        connection: open_immutable(&path)?,
         read_only: true,
     })
+}
+
+/// Resolve a SQLite file path through its existing parent and reject traversal
+/// and final-component symlinks before any SQLite or database-file permission
+/// operation.
+///
+/// Orbit callers provide complete paths because the database may live in a
+/// caller-selected state root. The root remains caller-owned, but path
+/// traversal and symlink redirection are not part of that contract. Creating
+/// missing parents preserves the existing first-open behavior; once they exist,
+/// all subsequent operations use the canonical parent path.
+fn validated_sqlite_path(path: &Path) -> Result<PathBuf, OrbitError> {
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(OrbitError::InvalidInput(format!(
+            "SQLite path '{}' must not contain parent-directory traversal",
+            path.display()
+        )));
+    }
+
+    let file_name = path.file_name().ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "SQLite path '{}' must name a database file",
+            path.display()
+        ))
+    })?;
+    let parent = path.parent().ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "SQLite path '{}' must have a parent directory",
+            path.display()
+        ))
+    })?;
+
+    create_private_dir_all(parent)?;
+    let canonical_parent = fs::canonicalize(parent)
+        .map_err(|error| sqlite_path_error("resolve parent for", parent, error))?;
+    let canonical_path = canonical_parent.join(file_name);
+
+    if !canonical_path.starts_with(&canonical_parent) {
+        return Err(OrbitError::InvalidInput(format!(
+            "SQLite path '{}' escapes its parent directory",
+            path.display()
+        )));
+    }
+
+    match fs::symlink_metadata(&canonical_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(OrbitError::InvalidInput(format!(
+                "SQLite path must not be a symlink: {}",
+                path.display()
+            )));
+        }
+        Ok(metadata) if !metadata.is_file() => {
+            return Err(OrbitError::InvalidInput(format!(
+                "SQLite path must be a regular file: {}",
+                path.display()
+            )));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(sqlite_path_error("inspect", &canonical_path, error)),
+    }
+
+    Ok(canonical_path)
 }
 
 /// Create a sensitive SQLite-adjacent state directory.
@@ -253,6 +327,7 @@ pub fn open_immutable(path: &Path) -> Result<Connection, OrbitError> {
         uri.as_str(),
         OpenFlags::SQLITE_OPEN_READ_ONLY
             | OpenFlags::SQLITE_OPEN_NO_MUTEX
+            | OpenFlags::SQLITE_OPEN_NOFOLLOW
             | OpenFlags::SQLITE_OPEN_URI,
     )
     .map_err(|error| {

--- a/crates/orbit-common/src/storage/tests/sqlite.rs
+++ b/crates/orbit-common/src/storage/tests/sqlite.rs
@@ -60,6 +60,38 @@ fn defaults_are_idempotent() {
     assert!(outcome.wal_active());
 }
 
+#[test]
+fn private_open_rejects_parent_directory_traversal() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("nested").join("..").join("escape.db");
+
+    let error = match super::super::sqlite::open_private(&path) {
+        Ok(_) => panic!("reject traversal"),
+        Err(error) => error,
+    };
+
+    assert!(error.to_string().contains("parent-directory traversal"));
+    assert!(!dir.path().join("nested").exists());
+    assert!(!dir.path().join("escape.db").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn private_open_rejects_symlink_database() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let target = dir.path().join("target.db");
+    Connection::open(&target).expect("create target");
+    let link = dir.path().join("link.db");
+    std::os::unix::fs::symlink(&target, &link).expect("create symlink");
+
+    let error = match super::super::sqlite::open_private(&link) {
+        Ok(_) => panic!("reject symlink database"),
+        Err(error) => error,
+    };
+
+    assert!(error.to_string().contains("must not be a symlink"));
+}
+
 #[cfg(unix)]
 #[test]
 fn private_open_repairs_existing_database_and_sidecars() {


### PR DESCRIPTION
## Task

[ORB-11875](https://orbit-cli.com/tasks/ORB-11875) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-common/src/storage/sqlite.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#103`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value.
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-common/src/storage/sqlite.rs` line 42
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/103

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-common/src/storage/sqlite.rs` line 42 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `validated_sqlite_path` in `crates/orbit-common/src/storage/sqlite.rs` to reject `..` traversal, canonicalize the parent, enforce containment, and reject final-component symlinks before SQLite metadata, permission, or connection operations.
- Open writable and immutable connections with SQLite `SQLITE_OPEN_NOFOLLOW` and use the validated canonical path throughout, preserving first-open parent creation and read-only fallback behavior.
- Added regression tests for parent traversal and symlink database paths in `crates/orbit-common/src/storage/tests/sqlite.rs`.
Assessment: The remediation is confined to the shared SQLite storage boundary, directly addresses the tainted path flow, and keeps existing private-permission and read-only behavior covered by the existing tests.
Acceptance criteria:
- `rust/path-injection` at the reported metadata access is remediated by validating and canonicalizing the path before filesystem access; no suppression or exclusion was added.
- Existing SQLite behavior remains covered: all prior storage tests pass, and the new tests prove traversal and symlink redirection are rejected.
- Repository validation passed. The local CodeQL CLI is unavailable, so the GitHub CodeQL workflow was not run locally; source inspection confirms the affected access now receives the validated canonical path and the final connection uses `SQLITE_OPEN_NOFOLLOW`.
Validation:
- `cargo fmt --all -- --check` — passed.
- `cargo test -p orbit-common --features sqlite storage::tests::sqlite` — passed, 8 tests.
- `make ci-fast` — passed. Its compiler-cache mount-namespace sub-check reported the environment denial `bwrap: No permissions to create new namespace`; the guardrail recorded that check as skipped.
- `make ci-lint` — passed (`cargo clippy --workspace --all-targets -- -D warnings`).
- `git diff --check` — passed.
- `GIT_OPTIONAL_LOCKS=0 git status --short` — only the two task-scoped SQLite source/test files are modified.
Risks / deviations: A hosted CodeQL run remains required to provide scanner-result confirmation because CodeQL is not installed in this environment. Changes are intentionally left uncommitted for the delivery pipeline.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11875-6aa0fc0b`
- Behind base: 0
- Ahead of base: 1