### PR TITLE
[code-scanning-sweep] Fix rust/cleartext-logging in crates/orbit-core/src/bootstrap/activity.rs

### DIFF
--- a/crates/orbit-core/src/bootstrap/activity.rs
+++ b/crates/orbit-core/src/bootstrap/activity.rs
@@ -633,7 +633,7 @@ backend = "cli"
                     )
                 );
             }
-            other => panic!("expected agent_loop epic_orchestrator, got {other:?}"),
+            _ => panic!("expected agent_loop epic_orchestrator"),
         }
     }
 }


### PR DESCRIPTION
## Task

[ORB-11840](https://orbit-cli.com/tasks/ORB-11840) — [code-scanning-sweep] Fix rust/cleartext-logging in crates/orbit-core/src/bootstrap/activity.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#38`
- Rule: `rust/cleartext-logging` (rust/cleartext-logging)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This operation writes validate_trusted_host_activity(...) to a log file.
- Ref: `refs/heads/main`
- Commit: `5c4245aeb9e34251e2170a6508b4d898e9ae24ee`
- Location: `crates/orbit-core/src/bootstrap/activity.rs` line 637
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/38

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/cleartext-logging` at `crates/orbit-core/src/bootstrap/activity.rs` line 637 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `crates/orbit-core/src/bootstrap/activity.rs:636` to match the unexpected activity variant with `_` and emit only the stable message `expected agent_loop epic_orchestrator`.
- Removed the `{other:?}` interpolation that could send embedded activity/validation data to the panic/log sink; no suppression, dismissal, or CodeQL exclusion was added.

Acceptance criteria:
- rust/cleartext-logging remediation: satisfied by removing the cleartext data flow at the reported sink.
- Intended behavior: satisfied; the test still panics on an unexpected variant, but no longer exposes its contents.
- Validation/security: `cargo test -p orbit-core bootstrap::activity::tests` passed (12/12); `make ci-fast` passed; `make ci-lint` passed; `git diff --check` passed. `make audit` was attempted but failed before analysis because Cargo's advisory DB lock at `~/.cargo/advisory-dbs/db.lock` is read-only in this environment. The local CodeQL CLI is unavailable, so CodeQL confirmation is deferred to the repository workflow.

Assessment: Minimal, behavior-preserving fix with no unrelated file changes.

Validation:
- PASS — `cargo test -p orbit-core bootstrap::activity::tests`
- PASS — `make ci-fast`
- PASS — `make ci-lint`
- PASS — `git diff --check`
- NOT RUN / BLOCKED — `make audit`: read-only advisory DB lock
- NOT RUN — local CodeQL CLI unavailable; source inspection confirms the interpolated sink is gone

Remaining risk: CodeQL must rerun in CI to provide the platform-specific alert result.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11840-6aa0fe32`
- Behind base: 0
- Ahead of base: 1