### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/docs/config.rs

### DIFF
--- a/crates/orbit-core/src/application/docs/config.rs
+++ b/crates/orbit-core/src/application/docs/config.rs
@@ -194,9 +194,11 @@ fn read_config_contents(path: &Path) -> Result<Option<String>, OrbitError> {
         )));
     }
 
-    let safe_path = canonical_parent.join(CONFIG_FILE_NAME);
-    let raw = std::fs::read_to_string(&safe_path)
-        .map_err(|error| OrbitError::Io(format!("read {}: {error}", safe_path.display())))?;
+    // Read the path that passed the canonical-location and regular-file checks.
+    // Reconstructing the path from the untrusted parent after validation would
+    // reintroduce a symlink race between the check and the read.
+    let raw = std::fs::read_to_string(&canonical_path)
+        .map_err(|error| OrbitError::Io(format!("read {}: {error}", canonical_path.display())))?;
     Ok(Some(raw))
 }
 


### PR DESCRIPTION
## Task

[ORB-11886](https://orbit-cli.com/tasks/ORB-11886) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/docs/config.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#83`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `f7df863910d4bb0421b04d6e2bda5be263a79bfd`
- Location: `crates/orbit-core/src/application/docs/config.rs` line 141
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:48:41Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/83

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-core/src/application/docs/config.rs` line 141 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `crates/orbit-core/src/application/docs/config.rs` so the config reader reads the canonical path that passed the location, filename, and regular-file checks instead of reconstructing a path from the caller-derived parent. This preserves config loading while avoiding a post-validation symlink race and removes the direct user-derived path flow at the file-read sink.
- No files outside the declared task scope were changed.

Assessment: The scoped security remediation is small, readable, and preserves existing missing-file, validation-error, and TOML parsing behavior.

Criteria evidence:
1. Remediated the `rust/path-injection` sink in `config.rs`: no `read_to_string(path)` or `read_to_string(&path)` remains; the read uses `canonical_path` after the existing canonical-location and regular-file checks. No suppression, dismissal, or exclusion was added.
2. Existing focused tests pass for accepting the workspace config, rejecting an existing non-config file, and rejecting a config symlink; the implementation keeps the same parsed contents and default behavior for valid config paths.
3. Repository gates and security checks were exercised. The local source check finds only `read_to_string(&canonical_path)`. CodeQL CLI is not installed in this runner and the task explicitly does not require agent-side GitHub access, so the hosted CodeQL alert result could not be queried locally; the source-level sink check and all available Rust/security gates pass.

Validation:
- `cargo fmt --all -- --check`: passed.
- `cargo test -p orbit-core application::docs::tests::config`: passed, 8 passed, 0 failed.
- `make ci-fast`: passed; the repository's compiler-cache namespace subcheck reported an environment skip because this runner lacks unprivileged mount namespaces.
- `make ci-lint`: passed.
- `make audit`: failed because the shared cargo-deny advisory database lock was on a read-only path.
- `CARGO_HOME=/tmp/orbit-audit-cargo-home.Opeve1 cargo deny check --disable-fetch`: passed; advisories, bans, licenses, and sources all passed using the existing advisory database copied into the isolated temporary cache.
- `rg -n "read_to_string\\(path\\)|read_to_string\\(&path\\)|read_to_string\\(&canonical_path\\)" crates/orbit-core/src/application/docs/config.rs`: passed source check; only the canonical-path read remains.
- `git diff --check`: passed.
- `git status --short`: only the intended config file is modified.

Remaining risk: hosted CodeQL must perform its normal CI analysis to close/confirm alert #83; it was not runnable in this environment because the CodeQL CLI is unavailable.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11886-6aa0fe73`
- Behind base: 0
- Ahead of base: 1