### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs

### DIFF
--- a/crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs
+++ b/crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs
@@ -721,7 +721,42 @@ fn validated_scoreboard_file_path(
         )));
     }
 
-    let path = canonical_dir.join(file.filename());
+    let candidate = canonical_dir.join(file.filename());
+    let metadata = match fs::symlink_metadata(&candidate) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "inspect scoreboard file {}: {error}",
+                candidate.display()
+            )));
+        }
+    };
+    if metadata.file_type().is_symlink() {
+        return Err(OrbitError::InvalidInput(format!(
+            "scoreboard file must not be a symlink: {}",
+            candidate.display()
+        )));
+    }
+    if !metadata.is_file() {
+        return Err(OrbitError::InvalidInput(format!(
+            "scoreboard file must be a regular file: {}",
+            candidate.display()
+        )));
+    }
+
+    // Read only the canonical file path. This removes aliases and symlink
+    // components from the path passed to the filesystem read.
+    let path = match fs::canonicalize(&candidate) {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "canonicalize scoreboard file {}: {error}",
+                candidate.display()
+            )));
+        }
+    };
     if !path.starts_with(&canonical_dir) {
         return Err(OrbitError::InvalidInput(format!(
             "scoreboard file must remain within the scoreboard directory: {}",
@@ -729,21 +764,7 @@ fn validated_scoreboard_file_path(
         )));
     }
 
-    match fs::symlink_metadata(&path) {
-        Ok(metadata) if metadata.file_type().is_symlink() => Err(OrbitError::InvalidInput(
-            format!("scoreboard file must not be a symlink: {}", path.display()),
-        )),
-        Ok(metadata) if !metadata.is_file() => Err(OrbitError::InvalidInput(format!(
-            "scoreboard file must be a regular file: {}",
-            path.display()
-        ))),
-        Ok(_) => Ok(Some(path)),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(OrbitError::Io(format!(
-            "inspect scoreboard file {}: {error}",
-            path.display()
-        ))),
-    }
+    Ok(Some(path))
 }
 
 fn read_token_agents(scoreboard_dir: &Path) -> Result<Vec<TokenAgentEntry>, OrbitError> {


### PR DESCRIPTION
## Task

[ORB-11888](https://orbit-cli.com/tasks/ORB-11888) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#93`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `f7df863910d4bb0421b04d6e2bda5be263a79bfd`
- Location: `crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs` line 689
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:48:41Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/93

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs` line 689 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `validated_scoreboard_file_path` so each fixed scoreboard file is checked for symlinks and regular-file type, canonicalized as a concrete file path, verified to remain beneath the canonical scoreboard directory, and only then passed to `fs::read_to_string`.
- Preserved missing-file behavior and existing symlink rejection for both `pr.json` and `tokens.json`.
- Scope remained limited to `crates/orbit-store/src/driver/file/scoreboard/scoreboard_summary/mod.rs`.

Acceptance criteria:
- rust/path-injection remediation: satisfied by removing the direct read of the path assembled from the configured directory; the read now consumes the canonicalized file path.
- Intended behavior: focused tests passed, including normal PR/token aggregation and symlink rejection.
- Security confirmation: local CodeQL executable/database is unavailable. The repository's hosted CodeQL workflow remains the definitive scan; local static evidence shows the affected read is now behind concrete-file canonicalization, with no suppression or exclusion added.

Validation:
- `cargo fmt --all -- --check`: passed.
- `cargo test -p orbit-store scoreboard_summary`: passed, 27 tests.
- `make ci-fast`: passed (exit 0; compiler-cache namespace sub-check reported an expected environment skip because unprivileged user namespaces are unavailable).
- `make ci-lint`: passed, workspace all-target clippy with `-D warnings`.
- `git diff --check`: passed.
- `GIT_OPTIONAL_LOCKS=0 git status --short`: one intended modified source file.
- CodeQL hosted scan: not run locally; no `codeql` executable is installed.

Assessment: The path is normalized and containment-checked at the file boundary before reading, while fixed filenames and existing error behavior remain intact.

Remaining risk: definitive alert closure requires the hosted CodeQL scan after delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11888-6aa0fef5`
- Behind base: 0
- Ahead of base: 1