### PR TITLE
[ci-failure-sweep] Fix red CI: CI / Coverage (informational) / Collect workspace coverage

### DIFF
--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -95,6 +95,17 @@ impl WorkspaceInitArgs {
         let roots = RegisteredRuntimeFactory::resolve_bootstrap_roots_for_cwd(&cwd, root_override)?;
         let orbit_dir = roots.shared_root;
         let global_root = roots.global_root;
+
+        // Registry path validation canonicalizes its parent before reading or
+        // locking the registry. Create a fresh global root here so first-time
+        // workspace initialization can reach that validation step.
+        std::fs::create_dir_all(&global_root).map_err(|error| {
+            OrbitError::Io(format!(
+                "create global Orbit root '{}': {error}",
+                global_root.display()
+            ))
+        })?;
+
         let registry_path = workspace_registry::registry_path_for(&global_root);
         let mcp = self.mcp;
         let inject_rules = self.inject_agent_rules;


### PR DESCRIPTION
## Task

[ORB-11891](https://orbit-cli.com/tasks/ORB-11891) — [ci-failure-sweep] Fix red CI: CI / Coverage (informational) / Collect workspace coverage

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `CI`
- Failing job: `Coverage (informational)`
- Failing step: `Collect workspace coverage`
- Commit the runner actually checked out: `89fe87b3853a74e58ed4576ccd20a0b743bbb238`
- Normalized error signature (the dedupe identity, not a quote): `test command::workspace::tests::init::nameless_tmp_workspace_registers_only_in_isolated_registry ... failed`
- Repository: `constellation-works/orbit`
- Release branch as GitHub reports it: `agent-main`
- Evidence collected at: 2026-09-09T06:21:35.083196265+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/constellation-works/orbit/actions/runs/34315471615 run `34315471615` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `f7df863910d4bb0421b04d6e2bda5be263a79bfd`
  - current head of that ref: `575da16facd37df9bb970798682f9dd206478fe3`
  - commit actually checked out: `89fe87b3853a74e58ed4576ccd20a0b743bbb238`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/usr/bin/git checkout --progress --force -B agent-main refs/remotes/origin/agent-main`
  - checkout evidence: `/usr/bin/git log -1 --format=%H`
  - failed job `Coverage (informational)` (id `102350646040`): https://github.com/constellation-works/orbit/actions/runs/34315471615/job/102350646040
  - failing step(s): `Collect workspace coverage`

## Failed-step log excerpt

```
[...]
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:07.8669417Z test command::workspace::tests::init::force_refuses_to_replace_a_checkout_identity_a_registration_still_claims ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:08.1318361Z test command::workspace::tests::init::force_replaces_a_checkout_identity_that_no_registration_claims ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:08.3097668Z test command::workspace::tests::init::forced_workspace_reconciliation_preserves_registry_and_identity_on_validation_failure ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:08.5748692Z test command::workspace::tests::init::multi_host_workspace_init_persists_an_explicit_local_owner ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:08.5750284Z test command::workspace::tests::init::task_id_start_uses_the_host_task_prefix ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:08.5757708Z test command::workspace::tests::init::invalid_replica_init_fails_before_workspace_artifacts_or_registry_mutation ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:08.5818136Z test command::workspace::tests::init::nameless_tmp_workspace_registers_only_in_isolated_registry ... FAILED
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:08.6786968Z test command::workspace::tests::init::workspace_init_appends_orbit_to_existing_gitignore ... FAILED
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:08.8540947Z test command::workspace::tests::init::workspace_init_can_atomically_declare_a_remote_owner_replica ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:08.8580892Z test command::workspace::tests::init::workspace_init_does_not_create_orbitignore ... FAILED
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:08.9662427Z test command::workspace::tests::init::workspace_init_from_git_subdir_gitignores_repo_orbit_dir ... FAILED
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:09.1549732Z test command::workspace::tests::init::workspace_init_guidance_and_generated_onboarding_files_lifecycle ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:09.7180155Z test command::workspace::tests::init::workspace_init_in_independent_nested_git_repo_preserves_parent_binding ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:09.8131487Z test command::tests::init::invalid_task_prefixes_fail_closed ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:09.8159974Z test command::workspace::tests::init::workspace_init_preserves_existing_orbitignore ... FAILED
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:10.0058508Z test command::workspace::tests::init::workspace_init_rejects_existing_checkout_path_with_different_id_without_force ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:10.1816885Z test command::workspace::tests::init::workspace_init_rejects_existing_durable_id_without_force ... ok
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:10.1848068Z test command::workspace::tests::init::workspace_init_replaces_legacy_bare_orbit_gitignore_line_with_managed_block ... FAILED
Coverage (informational)	Collect workspace coverage	2026-09-09T06:08:10.1910118Z test command::workspace::tests::init::workspace_init_retires_adr_store_gitignore_lines ... FAILED
```

_The collection display was truncated. Selected evidence is used for diagnosis; its retention limits are independent of that display._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `CI` run https://github.com/constellation-works/orbit/actions/runs/34315263123 — superseded_by_newer_workflow_run: newer relevant run 34315471615 at 2026-09-09T05:35:07Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34315095258 — superseded_by_newer_workflow_run: newer relevant run 34315471615 at 2026-09-09T05:35:07Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34316488340 — ref_no_longer_exists: branch 'orbit/ORB-11834-6aa0f1af' has no head on origin: its pull request was merged or the branch was deleted, so this run describes code that is either already landed — where the landing branch's own runs are the current evidence — or abandoned
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34316320363 — ref_no_longer_exists: branch 'orbit/ORB-11845-6aa0f007' has no head on origin: its pull request was merged or the branch was deleted, so this run describes code that is either already landed — where the landing branch's own runs are the current evidence — or abandoned
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34316451112 — ref_no_longer_exists: branch 'orbit/ORB-11847-6aa0f15d' has no head on origin: its pull request was merged or the branch was deleted, so this run describes code that is either already landed — where the landing branch's own runs are the current evidence — or abandoned

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 1,
  "current_failures_discovered": 2,
  "current_failures_investigated": 2,
  "current_failures_investigation_attempted": 6,
  "inconclusive": 0,
  "investigation_cursor": 496926,
  "job_log_reads": 2,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_job_log_reads": 6,
  "max_pull_requests": 10,
  "max_retired_ref_probes": 20,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely",
    "14 of 20 current or mixed-state runs were listed but not investigated (max_investigated_runs=6); their run URLs are still present, and the rotating slot reaches a different overflow candidate on the next sweep"
  ],
  "pull_requests_scanned": 3,
  "refs_scanned": 4,
  "retired_refs": [
    "orbit/ORB-11834-6aa0f1af",
    "orbit/ORB-11845-6aa0f007",
    "orbit/ORB-11847-6aa0f15d"
  ],
  "runs_listed": 100,
  "unverified_refs": []
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `CI` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Fixed first-time workspace initialization in crates/orbit-cli/src/command/workspace/init.rs by creating the resolved global Orbit root before workspace-registry validation. The validator canonicalizes the registry parent, so fresh HOME/custom-root initialization previously failed before bootstrap could create it.
- No workflow, assertion, lint level, or coverage behavior was weakened.

Criteria evidence:
1. Root cause fixed: reproduced repository-owned `Io("canonicalize .../.orbit: No such file or directory")` on the reported nameless temporary workspace test; the minimal init-boundary fix preserves registry path validation and all existing assertions.
2. Runner failure reproduced and passing: `cargo test -p orbit-cli command::workspace::tests::init::nameless_tmp_workspace_registers_only_in_isolated_registry --locked -- --nocapture` failed before the fix and passed afterward; the full focused init module also passed (31/31).
3. Documented pre-handoff gate: `make ci-fast` passed and `make ci-lint` passed with `-D warnings`.
4. Infrastructure assessment: not an infrastructure failure; local reproduction produced the same repository error shape, and the fix made the test pass. No same-commit retry evidence was needed.

Validation:
- PASSED: `cargo test -p orbit-cli command::workspace::tests::init::nameless_tmp_workspace_registers_only_in_isolated_registry --locked -- --nocapture` (1/1).
- PASSED: `cargo test -p orbit-cli command::workspace::tests::init:: --locked -- --test-threads=1` (31/31).
- PASSED: `make ci-fast` (guardrails passed; compiler-cache namespace probe reported its documented environment skip because unprivileged bubblewrap namespaces are unavailable).
- PASSED: `make ci-lint` (workspace all-target clippy, warnings denied).
- PASSED: `git diff --check`.
- PASSED: `git status --short` reviewed; only the scoped init.rs change is present.
- NOT RUN: exact `cargo llvm-cov --workspace --locked --no-report`; the focused test command and full focused init-module command are the narrow faithful local equivalents used here, while CI coverage itself runs on the task PR.

Assessment: Small, scoped fix for fresh registry roots; friction F2026-09-099 records the validation-order gotcha.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11891-6aa0ff97`
- Behind base: 0
- Ahead of base: 1