### PR TITLE
[ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### DIFF
--- a/crates/orbit-registry/src/tests/workspace_registry.rs
+++ b/crates/orbit-registry/src/tests/workspace_registry.rs
@@ -14,7 +14,7 @@ use crate::workspace_registry::{
     assign_checkout_role, find_checkout_by_path, find_workspace, find_workspace_by_id,
     find_workspace_by_path, load_registry_from, load_registry_from_with_writer, register_checkout,
     remove_workspace, rename_local_owner_host_id, resolve_logical_workspace, save_registry_to,
-    set_path_override, validate_workspaces,
+    set_path_override, validate_workspaces, with_registry_lock,
 };
 
 fn timestamp() -> chrono::DateTime<Utc> {
@@ -706,6 +706,17 @@ fn registry_io_rejects_a_symlinked_registry_file() {
         error.to_string().contains("must not be a symlink"),
         "unexpected: {error}"
     );
+}
+
+#[test]
+fn registry_lock_creates_a_missing_parent_directory() {
+    let root = tempdir().expect("tempdir");
+    let registry_dir = root.path().join("custom-orbit");
+    let path = registry_dir.join("workspaces.json");
+
+    with_registry_lock(&path, || Ok(())).expect("lock registry in a new root");
+
+    assert!(registry_dir.is_dir());
 }
 
 #[test]

--- a/crates/orbit-registry/src/workspace_registry/io.rs
+++ b/crates/orbit-registry/src/workspace_registry/io.rs
@@ -37,6 +37,14 @@ pub fn with_registry_lock<T>(
     path: &Path,
     op: impl FnOnce() -> Result<T, OrbitError>,
 ) -> Result<T, OrbitError> {
+    let parent = registry_parent(path)?;
+    std::fs::create_dir_all(parent).map_err(|error| {
+        OrbitError::Io(format!(
+            "create workspace registry directory {}: {error}",
+            parent.display()
+        ))
+    })?;
+
     let path = validated_registry_path(path)?;
     with_exclusive_file_lock(&path, "workspace registry", op)
 }
@@ -85,19 +93,7 @@ pub fn save_registry_to(registry: &WorkspaceRegistry, path: &Path) -> Result<(),
 /// and inspecting the final component without following it rejects a registry
 /// symlink that would redirect reads or writes outside the selected root.
 fn validated_registry_path(path: &Path) -> Result<PathBuf, OrbitError> {
-    if path.file_name() != Some(OsStr::new(REGISTRY_FILE_NAME)) {
-        return Err(OrbitError::WorkspaceError(format!(
-            "workspace registry path must name '{REGISTRY_FILE_NAME}': {}",
-            path.display()
-        )));
-    }
-
-    let parent = path.parent().ok_or_else(|| {
-        OrbitError::WorkspaceError(format!(
-            "workspace registry path '{}' has no parent directory",
-            path.display()
-        ))
-    })?;
+    let parent = registry_parent(path)?;
     let canonical_parent = parent
         .canonicalize()
         .map_err(|error| OrbitError::Io(format!("canonicalize {}: {error}", parent.display())))?;
@@ -127,6 +123,24 @@ fn validated_registry_path(path: &Path) -> Result<PathBuf, OrbitError> {
     }
 
     Ok(canonical_path)
+}
+
+fn registry_parent(path: &Path) -> Result<&Path, OrbitError> {
+    if path.file_name() != Some(OsStr::new(REGISTRY_FILE_NAME)) {
+        return Err(OrbitError::WorkspaceError(format!(
+            "workspace registry path must name '{REGISTRY_FILE_NAME}': {}",
+            path.display()
+        )));
+    }
+
+    let parent = path.parent().ok_or_else(|| {
+        OrbitError::WorkspaceError(format!(
+            "workspace registry path '{}' has no parent directory",
+            path.display()
+        ))
+    })?;
+
+    Ok(parent)
 }
 
 fn registry_host_context(path: &Path) -> Result<WorkspaceRegistryHostContext, OrbitError> {


### PR DESCRIPTION
## Task

[ORB-11892](https://orbit-cli.com/tasks/ORB-11892) — [ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `CI`
- Failing job: `Check / Clippy / Test`
- Failing step: `Run CI guardrails`
- Commit the runner actually checked out: `339cda534d05ff3409e8a0877d8b432c1cd3f87b`
- Normalized error signature (the dedupe identity, not a quote): `fail [ <n>.<n>s] (<n>/<n>) orbit-cli::worktree_resolution run_job_with_explicit_root_completes_instead_of_staying_pending`
- Repository: `constellation-works/orbit`
- Release branch as GitHub reports it: `agent-main`
- Evidence collected at: 2026-09-09T06:21:35.083196265+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/constellation-works/orbit/actions/runs/34315471615 run `34315471615` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `f7df863910d4bb0421b04d6e2bda5be263a79bfd`
  - current head of that ref: `575da16facd37df9bb970798682f9dd206478fe3`
  - commit actually checked out: `339cda534d05ff3409e8a0877d8b432c1cd3f87b`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/usr/bin/git checkout --progress --force -B agent-main refs/remotes/origin/agent-main`
  - checkout evidence: `/usr/bin/git log -1 --format=%H`
  - failed job `Check / Clippy / Test` (id `102350646262`): https://github.com/constellation-works/orbit/actions/runs/34315471615/job/102350646262
  - failing step(s): `Run CI guardrails`

## Failed-step log excerpt

_Failure regions from a completely scanned command; the full command was not retained. 1105910 of 1140236 source bytes omitted, including 0 assertion payload bytes. All 57 recognized failure anchors and bounded context are retained (64 KiB selection limit)._

```
2026-09-09T06:06:22.5227622Z ##[group]Run ./scripts/ci-guardrails.sh
[... 715334 command bytes omitted ...]
2026-09-09T06:13:46.4077674Z [31;1m        FAIL[0m [   0.037s] (3293/5088) [35;1morbit-cli::worktree_resolution[0m [34;1mrun_job_with_explicit_root_completes_instead_of_staying_pending[0m
2026-09-09T06:13:46.4079351Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-09T06:13:46.4079741Z 
2026-09-09T06:13:46.4079924Z     running 1 test
2026-09-09T06:13:46.4080578Z     test run_job_with_explicit_root_completes_instead_of_staying_pending ... FAILED
2026-09-09T06:13:46.4081292Z 
2026-09-09T06:13:46.4081453Z     failures:
2026-09-09T06:13:46.4081668Z 
2026-09-09T06:13:46.4081809Z     failures:
2026-09-09T06:13:46.4082315Z         run_job_with_explicit_root_completes_instead_of_staying_pending
2026-09-09T06:13:46.4082808Z 
2026-09-09T06:13:46.4083263Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.03s
2026-09-09T06:13:46.4084139Z     [0m
2026-09-09T06:13:46.4084601Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-09T06:13:46.4085299Z 
2026-09-09T06:13:46.4086671Z     [0m[31;1mthread 'run_job_with_explicit_root_completes_instead_of_staying_pending' (99535) panicked at /rustc/48a229ceaefd4985c50990b14116b6d856af0985/library/core/src/ops/function.rs:250:5:[0m
2026-09-09T06:13:46.4088186Z     [31;1mUnexpected failure.[0m
2026-09-09T06:13:46.4088628Z     code=1
2026-09-09T06:13:46.4089933Z     stderr=```"error: io error: canonicalize /tmp/.tmpuiaJ1F/custom-orbit: No such file or directory (os error 2)\n"```
2026-09-09T06:13:46.4096385Z     command=`cd "/tmp/.tmpuiaJ1F/repo" && env -u LLVM_PROFILE_FILE -u ORBIT_ACTIVE_TASK_ID -u ORBIT_ACTIVITY_DIR -u ORBIT_ACTIVITY_FS_PROFILE -u ORBIT_ACTIVITY_ID -u ORBIT_ACTIVITY_TOOLS -u ORBIT_AGENT_MODEL -u ORBIT_AGENT_NAME -u ORBIT_BIN -u ORBIT_JOB_DIR -u ORBIT_MANAGED_RUN_CONTEXT -u ORBIT_OPERATOR -u ORBIT_PROC_ALLOWED_PROGRAMS -u ORBIT_REGISTRY_ROOT -u ORBIT_ROOT -u ORBIT_RUN_ID -u ORBIT_SESSION_ID -u ORBIT_STEP_INDEX -u ORBIT_TASK_ACTOR_KIND -u ORBIT_TASK_ID -u ORBIT_WORKSPACE -u ORBIT_WORKSPACE_CLAIM_TOKEN -u ORBIT_WORKTREE_ROOT HOME="/tmp/.tmpuiaJ1F/home" PATH="/tmp/.tmpuiaJ1F/home/stub-bin:/snap/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin" USERPROFILE="/tmp/.tmpuiaJ1F/home" "/home/runner/work/orbit/orbit/target/debug/orbit" "--root" "/tmp/.tmpuiaJ1F/custom-orbit" "workspace" "init"`
2026-09-09T06:13:46.4102748Z     code=1
2026-09-09T06:13:46.4103091Z     stdout=""
2026-09-09T06:13:46.4103846Z     stderr="error: io error: canonicalize /tmp/.tmpuiaJ1F/custom-orbit: No such file or directory (os error 2)\n"
2026-09-09T06:13:46.4104580Z 
2026-09-09T06:13:46.4105158Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-09T06:13:46.4105722Z 
2026-09-09T06:13:47.4053547Z [32;1m        PASS[0m [   0.998s] (3294/5088) [35;1morbit-cli::worktree_resolution[0m [34;1mworkspace_init_force_rebinds_synthetic_data_dir_checkout[0m
[... 80350 command bytes omitted ...]
2026-09-09T06:14:05.9541741Z [31;1m        FAIL[0m [   0.014s] (3668/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mnameless_tmp_workspace_registers_only_in_isolated_registry[0m
2026-09-09T06:14:05.9543350Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-09T06:14:05.9543747Z 
2026-09-09T06:14:05.9543876Z     running 1 test
2026-09-09T06:14:05.9544530Z     test command::workspace::tests::init::nameless_tmp_workspace_registers_only_in_isolated_registry ... FAILED
2026-09-09T06:14:05.9545169Z 
2026-09-09T06:14:05.9545281Z     failures:
2026-09-09T06:14:05.9545445Z 
2026-09-09T06:14:05.9545557Z     failures:
2026-09-09T06:14:05.9546093Z         command::workspace::tests::init::nameless_tmp_workspace_registers_only_in_isolated_registry
2026-09-09T06:14:05.9546629Z 
2026-09-09T06:14:05.9547031Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 489 filtered out; finished in 0.01s
2026-09-09T06:14:05.9547713Z     [0m
2026-09-09T06:14:05.9548081Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-09T06:14:05.9548356Z 
2026-09-09T06:14:05.9549835Z     [0m[31;1mthread 'command::workspace::tests::init::nameless_tmp_workspace_registers_only_in_isolated_registry' (100436) panicked at crates/orbit-cli/src/command/workspace/tests/init.rs:1868:10:[0m
2026-09-09T06:14:05.9551522Z     [31;1mnameless workspace init: Io("canonicalize /tmp/.tmpTCiB4s/.orbit: No such file or directory (os error 2)")[0m
2026-09-09T06:14:05.9552374Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-09T06:14:05.9552704Z 
2026-09-09T06:14:05.9618023Z [32;1m        PASS[0m [   0.008s] (3669/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mtask_id_start_uses_the_host_task_prefix[0m
2026-09-09T06:14:05.9758689Z [31;1m        FAIL[0m [   0.014s] (3670/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_appends_orbit_to_existing_gitignore[0m
2026-09-09T06:14:05.9760664Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-09T06:14:05.9761025Z 
2026-09-09T06:14:05.9761145Z     running 1 test
2026-09-09T06:14:05.9761756Z     test command::workspace::tests::init::workspace_init_appends_orbit_to_existing_gitignore ... FAILED
2026-09-09T06:14:05.9762309Z 
2026-09-09T06:14:05.9762417Z     failures:
2026-09-09T06:14:05.9762564Z 
2026-09-09T06:14:05.9762664Z     failures:
2026-09-09T06:14:05.9763141Z         command::workspace::tests::init::workspace_init_appends_orbit_to_existing_gitignore
2026-09-09T06:14:05.9763591Z 
2026-09-09T06:14:05.9763947Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 489 filtered out; finished in 0.01s
2026-09-09T06:14:05.9764568Z     [0m
2026-09-09T06:14:05.9764879Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-09T06:14:05.9765132Z 
2026-09-09T06:14:05.9766138Z     [0m[31;1mthread 'command::workspace::tests::init::workspace_init_appends_orbit_to_existing_gitignore' (100444) panicked at crates/orbit-cli/src/command/workspace/tests/init.rs:1349:12:[0m
2026-09-09T06:14:05.9767562Z     [31;1mworkspace init: Io("canonicalize /tmp/.tmpydNHRS/.orbit: No such file or directory (os error 2)")[0m
2026-09-09T06:14:05.9768463Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-09T06:14:05.9768893Z 
2026-09-09T06:14:06.1653130Z [32;1m        PASS[0m [   0.189s] (3671/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_can_atomically_declare_a_remote_owner_replica[0m
2026-09-09T06:14:06.1797600Z [31;1m        FAIL[0m [   0.014s] (3672/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_does_not_create_orbitignore[0m
2026-09-09T06:14:06.1799479Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-09T06:14:06.1800289Z 
2026-09-09T06:14:06.1800444Z     running 1 test
2026-09-09T06:14:06.1800976Z     test command::workspace::tests::init::workspace_init_does_not_create_orbitignore ... FAILED
2026-09-09T06:14:06.1801463Z 
2026-09-09T06:14:06.1801565Z     failures:
2026-09-09T06:14:06.1801714Z 
2026-09-09T06:14:06.1801815Z     failures:
2026-09-09T06:14:06.1802236Z         command::workspace::tests::init::workspace_init_does_not_create_orbitignore
2026-09-09T06:14:06.1802656Z 
2026-09-09T06:14:06.1803009Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 489 filtered out; finished in 0.01s
2026-09-09T06:14:06.1803655Z     [0m
2026-09-09T06:14:06.1803979Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-09T06:14:06.1804232Z 
2026-09-09T06:14:06.1805178Z     [0m[31;1mthread 'command::workspace::tests::init::workspace_init_does_not_create_orbitignore' (100456) panicked at crates/orbit-cli/src/command/workspace/tests/init.rs:1730:12:[0m
2026-09-09T06:14:06.1806482Z     [31;1mworkspace init: Io("canonicalize /tmp/.tmpO4UZUr/.orbit: No such file or directory (os error 2)")[0m
2026-09-09T06:14:06.1807254Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-09T06:14:06.1807609Z 
2026-09-09T06:14:06.1940933Z [31;1m        FAIL[0m [   0.014s] (3673/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_from_git_subdir_gitignores_repo_orbit_dir[0m
2026-09-09T06:14:06.1942489Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-09T06:14:06.1942771Z 
2026-09-09T06:14:06.1942913Z     running 1 test
2026-09-09T06:14:06.1943499Z     test command::workspace::tests::init::workspace_init_from_git_subdir_gitignores_repo_orbit_dir ... FAILED
2026-09-09T06:14:06.1944039Z 
2026-09-09T06:14:06.1944138Z     failures:
2026-09-09T06:14:06.1944284Z 
2026-09-09T06:14:06.1944387Z     failures:
2026-09-09T06:14:06.1944860Z         command::workspace::tests::init::workspace_init_from_git_subdir_gitignores_repo_orbit_dir
2026-09-09T06:14:06.1945343Z 
2026-09-09T06:14:06.1945695Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 489 filtered out; finished in 0.01s
2026-09-09T06:14:06.1946298Z     [0m
2026-09-09T06:14:06.1946620Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-09T06:14:06.1946875Z 
2026-09-09T06:14:06.1947907Z     [0m[31;1mthread 'command::workspace::tests::init::workspace_init_from_git_subdir_gitignores_repo_orbit_dir' (100462) panicked at crates/orbit-cli/src/command/workspace/tests/init.rs:1500:12:[0m
2026-09-09T06:14:06.1949641Z     [31;1mworkspace init: Io("canonicalize /tmp/.tmpYaiCzK/.orbit: No such file or directory (os error 2)")[0m
2026-09-09T06:14:06.1950571Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-09T06:14:06.1950990Z 
2026-09-09T06:14:06.3935668Z [32;1m        PASS[0m [   0.199s] (3674/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_guidance_and_generated_onboarding_files_lifecycle[0m
2026-09-09T06:14:06.9642339Z [32;1m        PASS[0m [   0.571s] (3675/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_in_independent_nested_git_repo_preserves_parent_binding[0m
2026-09-09T06:14:06.9788336Z [31;1m        FAIL[0m [   0.015s] (3676/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_preserves_existing_orbitignore[0m
2026-09-09T06:14:06.9789799Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-09T06:14:06.9790408Z 
2026-09-09T06:14:06.9790524Z     running 1 test
2026-09-09T06:14:06.9791047Z     test command::workspace::tests::init::workspace_init_preserves_existing_orbitignore ... FAILED
2026-09-09T06:14:06.9791550Z 
2026-09-09T06:14:06.9791652Z     failures:
2026-09-09T06:14:06.9791798Z 
2026-09-09T06:14:06.9791896Z     failures:
2026-09-09T06:14:06.9792482Z         command::workspace::tests::init::workspace_init_preserves_existing_orbitignore
2026-09-09T06:14:06.9792912Z 
2026-09-09T06:14:06.9793275Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 489 filtered out; finished in 0.01s
2026-09-09T06:14:06.9793892Z     [0m
2026-09-09T06:14:06.9795630Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-09T06:14:06.9795971Z 
2026-09-09T06:14:06.9797355Z     [0m[31;1mthread 'command::workspace::tests::init::workspace_init_preserves_existing_orbitignore' (100495) panicked at crates/orbit-cli/src/command/workspace/tests/init.rs:1763:12:[0m
2026-09-09T06:14:06.9799849Z     [31;1mworkspace init: Io("canonicalize /tmp/.tmpkTmWN1/.orbit: No such file or directory (os error 2)")[0m
2026-09-09T06:14:06.9801504Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-09T06:14:06.9802115Z 
2026-09-09T06:14:07.1711781Z [32;1m        PASS[0m [   0.192s] (3677/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_rejects_existing_checkout_path_with_different_id_without_force[0m
2026-09-09T06:14:07.3672641Z [32;1m        PASS[0m [   0.196s] (3678/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_rejects_existing_durable_id_without_force[0m
2026-09-09T06:14:07.3814066Z [31;1m        FAIL[0m [   0.014s] (3679/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_replaces_legacy_bare_orbit_gitignore_line_with_managed_block[0m
2026-09-09T06:14:07.3815423Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-09T06:14:07.3815756Z 
2026-09-09T06:14:07.3815877Z     running 1 test
2026-09-09T06:14:07.3816623Z     test command::workspace::tests::init::workspace_init_replaces_legacy_bare_orbit_gitignore_line_with_managed_block ... FAILED
2026-09-09T06:14:07.3817307Z 
2026-09-09T06:14:07.3817423Z     failures:
2026-09-09T06:14:07.3817586Z 
2026-09-09T06:14:07.3817693Z     failures:
2026-09-09T06:14:07.3818330Z         command::workspace::tests::init::workspace_init_replaces_legacy_bare_orbit_gitignore_line_with_managed_block
2026-09-09T06:14:07.3818952Z 
2026-09-09T06:14:07.3819707Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 489 filtered out; finished in 0.01s
2026-09-09T06:14:07.3820396Z     [0m
2026-09-09T06:14:07.3820763Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-09T06:14:07.3821044Z 
2026-09-09T06:14:07.3822285Z     [0m[31;1mthread 'command::workspace::tests::init::workspace_init_replaces_legacy_bare_orbit_gitignore_line_with_managed_block' (100521) panicked at crates/orbit-cli/src/command/workspace/tests/init.rs:1384:10:[0m
2026-09-09T06:14:07.3823994Z     [31;1mworkspace init: Io("canonicalize /tmp/.tmp9bwdoP/.orbit: No such file or directory (os error 2)")[0m
2026-09-09T06:14:07.3824991Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-09T06:14:07.3825463Z 
2026-09-09T06:14:07.3956348Z [31;1m        FAIL[0m [   0.014s] (3680/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_retires_adr_store_gitignore_lines[0m
2026-09-09T06:14:07.3957534Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-09T06:14:07.3958097Z 
2026-09-09T06:14:07.3958236Z     running 1 test
2026-09-09T06:14:07.3958984Z     test command::workspace::tests::init::workspace_init_retires_adr_store_gitignore_lines ... FAILED
2026-09-09T06:14:07.3960044Z 
2026-09-09T06:14:07.3960197Z     failures:
2026-09-09T06:14:07.3960416Z 
2026-09-09T06:14:07.3960554Z     failures:
2026-09-09T06:14:07.3961592Z         command::workspace::tests::init::workspace_init_retires_adr_store_gitignore_lines
2026-09-09T06:14:07.3962316Z 
2026-09-09T06:14:07.3962948Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 489 filtered out; finished in 0.01s
2026-09-09T06:14:07.3964084Z     [0m
2026-09-09T06:14:07.3964756Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-09T06:14:07.3965266Z 
2026-09-09T06:14:07.3967192Z     [0m[31;1mthread 'command::workspace::tests::init::workspace_init_retires_adr_store_gitignore_lines' (100527) panicked at crates/orbit-cli/src/command/workspace/tests/init.rs:1443:10:[0m
2026-09-09T06:14:07.3969926Z     [31;1mworkspace init: Io("canonicalize /tmp/.tmpp4KFTw/.orbit: No such file or directory (os error 2)")[0m
2026-09-09T06:14:07.3970658Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-09T06:14:07.3971012Z 
2026-09-09T06:14:07.4101599Z [31;1m        FAIL[0m [   0.014s] (3681/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_seeds_auto_detected_mcp_configs[0m
2026-09-09T06:14:07.4102787Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-09T06:14:07.4103108Z 
2026-09-09T06:14:07.4103231Z     running 1 test
2026-09-09T06:14:07.4103803Z     test command::workspace::tests::init::workspace_init_seeds_auto_detected_mcp_configs ... FAILED
2026-09-09T06:14:07.4104347Z 
2026-09-09T06:14:07.4104467Z     failures:
2026-09-09T06:14:07.4104632Z 
2026-09-09T06:14:07.4104745Z     failures:
2026-09-09T06:14:07.4105218Z         command::workspace::tests::init::workspace_init_seeds_auto_detected_mcp_configs
2026-09-09T06:14:07.4105693Z 
2026-09-09T06:14:07.4106081Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 489 filtered out; finished in 0.01s
2026-09-09T06:14:07.4106754Z     [0m
2026-09-09T06:14:07.4107113Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-09T06:14:07.4107393Z 
2026-09-09T06:14:07.4108440Z     [0m[31;1mthread 'command::workspace::tests::init::workspace_init_seeds_auto_detected_mcp_configs' (100533) panicked at crates/orbit-cli/src/command/workspace/tests/init.rs:1057:12:[0m
2026-09-09T06:14:07.4110214Z     [31;1mworkspace init: Io("canonicalize /tmp/.tmpU2IrfY/.orbit: No such file or directory (os error 2)")[0m
2026-09-09T06:14:07.4111116Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-09T06:14:07.4111546Z 
2026-09-09T06:14:07.7794859Z [32;1m        PASS[0m [   0.369s] (3682/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_seeds_disabled_routines_and_reinit_preserves_authored_files[0m
2026-09-09T06:14:07.7937997Z [31;1m        FAIL[0m [   0.014s] (3683/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_skips_mcp_by_default[0m
2026-09-09T06:14:07.7938896Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-09T06:14:07.7939414Z 
2026-09-09T06:14:07.7939612Z     running 1 test
2026-09-09T06:14:07.7940314Z     test command::workspace::tests::init::workspace_init_skips_mcp_by_default ... FAILED
2026-09-09T06:14:07.7940752Z 
2026-09-09T06:14:07.7940837Z     failures:
2026-09-09T06:14:07.7940958Z 
2026-09-09T06:14:07.7941042Z     failures:
2026-09-09T06:14:07.7941357Z         command::workspace::tests::init::workspace_init_skips_mcp_by_default
2026-09-09T06:14:07.7941667Z 
2026-09-09T06:14:07.7941966Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 489 filtered out; finished in 0.01s
2026-09-09T06:14:07.7942503Z     [0m
2026-09-09T06:14:07.7942779Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-09T06:14:07.7942981Z 
2026-09-09T06:14:07.7943768Z     [0m[31;1mthread 'command::workspace::tests::init::workspace_init_skips_mcp_by_default' (100548) panicked at crates/orbit-cli/src/command/workspace/tests/init.rs:1228:12:[0m
2026-09-09T06:14:07.7944857Z     [31;1mworkspace init: Io("canonicalize /tmp/.tmpzjpi9J/.orbit: No such file or directory (os error 2)")[0m
2026-09-09T06:14:07.7945928Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-09T06:14:07.7946268Z 
2026-09-09T06:14:07.9784381Z [32;1m        PASS[0m [   0.185s] (3684/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_under_home_with_global_orbit_creates_repo_orbit[0m
2026-09-09T06:14:08.1799363Z [32;1m        PASS[0m [   0.201s] (3685/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_uses_the_checked_out_branch_when_base_branch_is_omitted[0m
2026-09-09T06:14:08.1915606Z [31;1m        FAIL[0m [   0.012s] (3686/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_with_root_override_does_not_modify_repo_gitignore[0m
2026-09-09T06:14:08.1917238Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-09T06:14:08.1917586Z 
2026-09-09T06:14:08.1917736Z     running 1 test
2026-09-09T06:14:08.1918427Z     test command::workspace::tests::init::workspace_init_with_root_override_does_not_modify_repo_gitignore ... FAILED
2026-09-09T06:14:08.1919340Z 
2026-09-09T06:14:08.1919461Z     failures:
2026-09-09T06:14:08.1919636Z 
2026-09-09T06:14:08.1919745Z     failures:
2026-09-09T06:14:08.1920347Z         command::workspace::tests::init::workspace_init_with_root_override_does_not_modify_repo_gitignore
2026-09-09T06:14:08.1920915Z 
2026-09-09T06:14:08.1921310Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 489 filtered out; finished in 0.00s
2026-09-09T06:14:08.1921988Z     [0m
2026-09-09T06:14:08.1922351Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-09T06:14:08.1922642Z 
2026-09-09T06:14:08.1923815Z     [0m[31;1mthread 'command::workspace::tests::init::workspace_init_with_root_override_does_not_modify_repo_gitignore' (100571) panicked at crates/orbit-cli/src/command/workspace/tests/init.rs:1797:12:[0m
2026-09-09T06:14:08.1925263Z     [31;1mworkspace init with root override in a git repo: Io("canonicalize /tmp/.tmpzwcXe0/custom-orbit: No such file or directory (os error 2)")[0m
2026-09-09T06:14:08.1926177Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-09T06:14:08.1926540Z 
2026-09-09T06:14:08.2029657Z [31;1m        FAIL[0m [   0.011s] (3687/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_with_root_override_uses_custom_registry[0m
2026-09-09T06:14:08.2031079Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-09T06:14:08.2031557Z 
2026-09-09T06:14:08.2031683Z     running 1 test
2026-09-09T06:14:08.2032319Z     test command::workspace::tests::init::workspace_init_with_root_override_uses_custom_registry ... FAILED
2026-09-09T06:14:08.2032900Z 
2026-09-09T06:14:08.2033017Z     failures:
2026-09-09T06:14:08.2033180Z 
2026-09-09T06:14:08.2033287Z     failures:
2026-09-09T06:14:08.2033810Z         command::workspace::tests::init::workspace_init_with_root_override_uses_custom_registry
2026-09-09T06:14:08.2034337Z 
2026-09-09T06:14:08.2034727Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 489 filtered out; finished in 0.00s
2026-09-09T06:14:08.2035402Z     [0m
2026-09-09T06:14:08.2035762Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-09T06:14:08.2036042Z 
2026-09-09T06:14:08.2037178Z     [0m[31;1mthread 'command::workspace::tests::init::workspace_init_with_root_override_uses_custom_registry' (100575) panicked at crates/orbit-cli/src/command/workspace/tests/init.rs:1678:12:[0m
2026-09-09T06:14:08.2038888Z     [31;1mworkspace init with root override: Io("canonicalize /tmp/.tmpVQ0fzF/custom-orbit: No such file or directory (os error 2)")[0m
2026-09-09T06:14:08.2040328Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-09T06:14:08.2040799Z 
2026-09-09T06:14:08.2108178Z [32;1m        PASS[0m [   0.008s] (3688/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_list_and_show_report_effective_ship_mode[0m
2026-09-09T06:14:08.2189653Z [32;1m        PASS[0m [   0.008s] (3689/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_list_hides_replicas_unless_all_and_marks_their_owner[0m
2026-09-09T06:14:09.1250771Z [32;1m        PASS[0m [   0.906s] (3690/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_reinit_requires_force_and_force_reconciles_matching_registration[0m
2026-09-09T06:14:09.1392956Z [31;1m        FAIL[0m [   0.014s] (3691/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_reinit_with_force_mcp_refreshes_operator_argv_without_duplicating_it[0m
2026-09-09T06:14:09.1394724Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-09T06:14:09.1395026Z 
2026-09-09T06:14:09.1395151Z     running 1 test
2026-09-09T06:14:09.1395953Z     test command::workspace::tests::init::workspace_reinit_with_force_mcp_refreshes_operator_argv_without_duplicating_it ... FAILED
2026-09-09T06:14:09.1396684Z 
2026-09-09T06:14:09.1396802Z     failures:
2026-09-09T06:14:09.1396962Z 
2026-09-09T06:14:09.1397077Z     failures:
2026-09-09T06:14:09.1397721Z         command::workspace::tests::init::workspace_reinit_with_force_mcp_refreshes_operator_argv_without_duplicating_it
2026-09-09T06:14:09.1398367Z 
2026-09-09T06:14:09.1398760Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 489 filtered out; finished in 0.01s
2026-09-09T06:14:09.1399760Z     [0m
2026-09-09T06:14:09.1400119Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-09T06:14:09.1400442Z 
2026-09-09T06:14:09.1401746Z     [0m[31;1mthread 'command::workspace::tests::init::workspace_reinit_with_force_mcp_refreshes_operator_argv_without_duplicating_it' (100605) panicked at crates/orbit-cli/src/command/workspace/tests/init.rs:1175:10:[0m
2026-09-09T06:14:09.1403051Z     [31;1mworkspace init with --mcp: Io("canonicalize /tmp/.tmp04XVuf/.orbit: No such file or directory (os error 2)")[0m
2026-09-09T06:14:09.1403862Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-09T06:14:09.1404206Z 
2026-09-09T06:14:09.7482143Z [32;1m        PASS[0m [   0.609s] (3692/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init_report[0m[36m::[0m[34;1mcustom_prefix_without_task_id_start_still_mints_tasks[0m
2026-09-09T06:14:09.9373710Z [32;1m        PASS[0m [   0.189s] (3693/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init_report[0m[36m::[0m[34;1mforce_init_json_is_one_object_with_identity_and_explicit_mcp[0m
2026-09-09T06:14:10.1281564Z [32;1m        PASS[0m [   0.191s] (3694/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init_report[0m[36m::[0m[34;1mpayload_detail_uses_the_existing_renderer_contract[0m
2026-09-09T06:14:10.4961023Z [32;1m        PASS[0m [   0.368s] (3695/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init_report[0m[36m::[0m[34;1mrequested_allocator_uses_the_host_task_prefix_and_records_unchanged_reseeds[0m
2026-09-09T06:14:10.6896877Z [32;1m        PASS[0m [   0.193s] (3696/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init_report[0m[36m::[0m[34;1mrequested_mcp_records_configured_providers[0m
2026-09-09T06:14:10.8797009Z [32;1m        PASS[0m [   0.190s] (3697/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init_report[0m[36m::[0m[34;1mrequested_mcp_records_none_detected_when_no_providers_exist[0m
2026-09-09T06:14:11.0712389Z [32;1m        PASS[0m [   0.191s] (3698/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init_report[0m[36m::[0m[34;1mrequested_rule_injection_records_created_files[0m
2026-09-09T06:14:11.2599662Z [32;1m        PASS[0m [   0.189s] (3699/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init_report[0m[36m::[0m[34;1mskipped_optional_actions_are_explicit_in_the_payload[0m
[... 710 command bytes omitted ...]
2026-09-09T06:14:11.9131704Z [31;1m        FAIL[0m [   0.012s] (3703/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::shared_root[0m[36m::[0m[34;1mshared_root_registers_each_checkout_and_show_resolves_by_repo_root[0m
2026-09-09T06:14:11.9132845Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-09T06:14:11.9134693Z 
2026-09-09T06:14:11.9134839Z     running 1 test
2026-09-09T06:14:11.9135663Z     test command::workspace::tests::shared_root::shared_root_registers_each_checkout_and_show_resolves_by_repo_root ... FAILED
2026-09-09T06:14:11.9136586Z 
2026-09-09T06:14:11.9136743Z     failures:
2026-09-09T06:14:11.9136957Z 
2026-09-09T06:14:11.9137138Z     failures:
2026-09-09T06:14:11.9138142Z         command::workspace::tests::shared_root::shared_root_registers_each_checkout_and_show_resolves_by_repo_root
2026-09-09T06:14:11.9139379Z 
2026-09-09T06:14:11.9140265Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 489 filtered out; finished in 0.00s
2026-09-09T06:14:11.9141477Z     [0m
2026-09-09T06:14:11.9142008Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-09T06:14:11.9142437Z 
2026-09-09T06:14:11.9144334Z     [0m[31;1mthread 'command::workspace::tests::shared_root::shared_root_registers_each_checkout_and_show_resolves_by_repo_root' (100668) panicked at crates/orbit-cli/src/command/workspace/tests/shared_root.rs:44:10:[0m
2026-09-09T06:14:11.9146529Z     [31;1mfirst shared-root workspace init: Io("canonicalize /tmp/.tmpG8DYeW/shared-orbit: No such file or directory (os error 2)")[0m
2026-09-09T06:14:11.9147896Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-09T06:14:11.9148490Z 
2026-09-09T06:14:11.9237230Z [32;1m        PASS[0m [   0.010s] (3704/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::source_remote[0m[36m::[0m[34;1minjected_persistence_failure_leaves_registry_file_unchanged[0m
2026-09-09T06:14:11.9314150Z [32;1m        PASS[0m [   0.008s] (3705/5088) [35;1morbit-cli::bin/orbit[0m [36moutput::pipe::tests[0m[36m::[0m[34;1ma_broken_pipe_io_error_is_recognized[0m
2026-09-09T06:14:11.9392866Z [32;1m        PASS[0m [   0.008s] (3706/5088) [35;1morbit-cli::bin/orbit[0m [36moutput::pipe::tests[0m[36m::[0m[34;1man_unwritable_stdout_still_panics[0m
2026-09-09T06:14:11.9470674Z [32;1m        PASS[0m [   0.008s] (3707/5088) [35;1morbit-cli::bin/orbit[0m [36moutput::pipe::tests[0m[36m::[0m[34;1mthe_panic_std_raises_for_a_closed_stdout_is_recognized[0m
2026-09-09T06:14:11.9549444Z [32;1m        PASS[0m [   0.008s] (3708/5088) [35;1morbit-cli::bin/orbit[0m [36moutput::tests::color[0m[36m::[0m[34;1mbacklog_is_no_longer_inconsistent_between_forms[0m
2026-09-09T06:14:11.9627614Z [32;1m        PASS[0m [   0.008s] (3709/5088) [35;1morbit-cli::bin/orbit[0m [36moutput::tests::color[0m[36m::[0m[34;1mcell_and_text_forms_agree_for_every_mapped_value[0m
2026-09-09T06:14:11.9703678Z [32;1m        PASS[0m [   0.008s] (3710/5088) [35;1morbit-cli::bin/orbit[0m [36moutput::tests::color[0m[36m::[0m[34;1mmapping_matches_expected_role[0m
2026-09-09T06:14:11.9778303Z [32;1m        PASS[0m [   0.007s] (3711/5088) [35;1morbit-cli::bin/orbit[0m [36moutput::tests::color[0m[36m::[0m[34;1mtagging_with_a_role_directly_bypasses_the_domain_table[0m
[... 309516 command bytes omitted ...]
2026-09-09T06:20:10.3167935Z [31;1m     Summary[0m [ 629.251s] [1m5088[0m tests run: [1m5074[0m [32;1mpassed[0m ([1m1[0m [33;1mslow[0m), [1m14[0m [31;1mfailed[0m, [1m17[0m [33;1mskipped[0m
2026-09-09T06:20:10.3169468Z [31;1m        FAIL[0m [   0.037s] (3293/5088) [35;1morbit-cli::worktree_resolution[0m [34;1mrun_job_with_explicit_root_completes_instead_of_staying_pending[0m
2026-09-09T06:20:10.3170880Z [31;1m        FAIL[0m [   0.014s] (3668/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mnameless_tmp_workspace_registers_only_in_isolated_registry[0m
2026-09-09T06:20:10.3172250Z [31;1m        FAIL[0m [   0.014s] (3670/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_appends_orbit_to_existing_gitignore[0m
2026-09-09T06:20:10.3173579Z [31;1m        FAIL[0m [   0.014s] (3672/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_does_not_create_orbitignore[0m
2026-09-09T06:20:10.3174948Z [31;1m        FAIL[0m [   0.014s] (3673/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_from_git_subdir_gitignores_repo_orbit_dir[0m
2026-09-09T06:20:10.3176262Z [31;1m        FAIL[0m [   0.015s] (3676/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_preserves_existing_orbitignore[0m
2026-09-09T06:20:10.3177678Z [31;1m        FAIL[0m [   0.014s] (3679/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_replaces_legacy_bare_orbit_gitignore_line_with_managed_block[0m
2026-09-09T06:20:10.3179726Z [31;1m        FAIL[0m [   0.014s] (3680/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_retires_adr_store_gitignore_lines[0m
2026-09-09T06:20:10.3181254Z [31;1m        FAIL[0m [   0.014s] (3681/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_seeds_auto_detected_mcp_configs[0m
2026-09-09T06:20:10.3182437Z [31;1m        FAIL[0m [   0.014s] (3683/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_skips_mcp_by_default[0m
2026-09-09T06:20:10.3183677Z [31;1m        FAIL[0m [   0.012s] (3686/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_with_root_override_does_not_modify_repo_gitignore[0m
2026-09-09T06:20:10.3184960Z [31;1m        FAIL[0m [   0.011s] (3687/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_with_root_override_uses_custom_registry[0m
2026-09-09T06:20:10.3186323Z [31;1m        FAIL[0m [   0.014s] (3691/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_reinit_with_force_mcp_refreshes_operator_argv_without_duplicating_it[0m
2026-09-09T06:20:10.3187756Z [31;1m        FAIL[0m [   0.012s] (3703/5088) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::shared_root[0m[36m::[0m[34;1mshared_root_registers_each_checkout_and_show_resolves_by_repo_root[0m
2026-09-09T06:20:10.3197161Z [31;1merror[0m: test run failed
2026-09-09T06:20:10.3228394Z ##[error]Process completed with exit code 100.

```

_The collection display was truncated. Selected evidence is used for diagnosis; its retention limits are independent of that display._

_The run-scoped failed-step log came back empty, so this excerpt is the evidence from job `Check / Clippy / Test` (id `102350646262`), read from the job log API._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `CI` run https://github.com/constellation-works/orbit/actions/runs/34315263123 — superseded_by_newer_workflow_run: newer relevant run 34315471615 at 2026-09-09T05:35:07Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34315095258 — superseded_by_newer_workflow_run: newer relevant run 34315471615 at 2026-09-09T05:35:07Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34316488340 — ref_no_longer_exists: branch 'orbit/ORB-11834-6aa0f1af' has no head on origin: its pull request was merged or the branch was deleted, so this run describes code that is either already landed — where the landing branch's own runs are the current evidence — or abandoned
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34316320363 — ref_no_longer_exists: branch 'orbit/ORB-11845-6aa0f007' has no head on origin: its pull request was merged or the branch was deleted, so this run describes code that is either already landed — where the landing branch's own runs are the current evidence — or abandoned
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34316451112 — ref_no_longer_exists: branch 'orbit/ORB-11847-6aa0f15d' has no head on origin: its pull request was merged or the branch was deleted, so this run describes code that is either already landed — where the landing branch's own runs are the current evidence — or abandoned

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 1,
  "current_failures_discovered": 2,
  "current_failures_investigated": 2,
  "current_failures_investigation_attempted": 6,
  "inconclusive": 0,
  "investigation_cursor": 496926,
  "job_log_reads": 2,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_job_log_reads": 6,
  "max_pull_requests": 10,
  "max_retired_ref_probes": 20,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely",
    "14 of 20 current or mixed-state runs were listed but not investigated (max_investigated_runs=6); their run URLs are still present, and the rotating slot reaches a different overflow candidate on the next sweep"
  ],
  "pull_requests_scanned": 3,
  "refs_scanned": 4,
  "retired_refs": [
    "orbit/ORB-11834-6aa0f1af",
    "orbit/ORB-11845-6aa0f007",
    "orbit/ORB-11847-6aa0f15d"
  ],
  "runs_listed": 100,
  "unverified_refs": []
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `CI` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Fixed workspace-registry locking for first-use custom roots by creating the registry parent before canonicalization, preserving the fixed `workspaces.json` filename and registry-symlink rejection checks.
- Added a registry-boundary regression test proving a missing custom registry parent is created by `with_registry_lock`.

Assessment: The failure was repository-owned: the runner-reported root-override test reproduced locally before the change with `canonicalize .../custom-orbit: No such file or directory`, and the same test passes after the change. The patch is limited to the registry I/O boundary and its sibling tests; no workflow, assertion, or lint level was weakened.

Acceptance criteria:
1. Fixed: registry locking now supports first-use custom Orbit roots without disabling the existing path-safety validation.
2. Passed: before-fix reproduction `cargo test -p orbit-cli --test worktree_resolution run_job_with_explicit_root_completes_instead_of_staying_pending -- --exact --nocapture` failed with the recorded canonicalization error; after-fix it passed (1 passed).
3. Passed: documented gates `make ci-fast` and `make ci-lint` both passed. `make ci-fast` reported one environment-limited sandbox subcheck skipped because bubblewrap could not create a mount namespace; the gate itself completed successfully.
4. Not applicable as an infrastructure explanation: the repository-owned failure was reproduced locally and fixed; no same-commit retry or runner fault evidence is needed.

Validation:
- Passed: `cargo fmt --all -- --check`
- Passed: `cargo test -p orbit-registry` (55 unit tests, dependency-boundary test, and doc tests)
- Passed: `cargo test -p orbit-cli --test worktree_resolution run_job_with_explicit_root_completes_instead_of_staying_pending -- --exact --nocapture`
- Passed: `cargo test -p orbit-cli --bin orbit command::workspace::tests::init::workspace_init_with_root_override -- --nocapture` (2 tests)
- Passed: `cargo test -p orbit-cli --bin orbit command::workspace::tests::shared_root::shared_root_registers_each_checkout_and_show_resolves_by_repo_root -- --exact --nocapture`
- Passed: `make ci-fast`
- Passed: `make ci-lint`
- Passed: `git diff --check`
- Passed: `git status --short` reviewed; only the two task-scoped registry files are modified.

Remaining risk: CI runner coverage may differ from this Linux execution lane; the affected behavior is filesystem root creation and was exercised through the CLI integration test plus registry unit tests.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11892-6aa10169`
- Behind base: 0
- Ahead of base: 1