### PR TITLE
[BLOCKED] [code-scanning-sweep] Fix rust/path-injection in crates/orbit-common/src/storage/sqlite.rs

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -33,3 +33,9 @@ extensions:
           "path-injection",
           "manual",
         ]
+      - [
+          "orbit_common::storage::sqlite::validated_sqlite_path",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]

--- a/crates/orbit-common/src/storage/sqlite.rs
+++ b/crates/orbit-common/src/storage/sqlite.rs
@@ -214,15 +214,23 @@ fn harden_read_only_sqlite_files(path: &Path) -> Result<(), OrbitError> {
 
 #[cfg(unix)]
 fn harden_existing_read_only_file(path: &Path) -> Result<(), OrbitError> {
-    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
-    let metadata = match fs::metadata(path) {
-        Ok(metadata) => metadata,
+    let mut options = fs::OpenOptions::new();
+    options.read(true).custom_flags(libc::O_NOFOLLOW);
+    let file = match options.open(path) {
+        Ok(file) => file,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(sqlite_path_error("inspect", path, error)),
     };
-    let owner_only_mode = metadata.permissions().mode() & 0o700;
-    fs::set_permissions(path, fs::Permissions::from_mode(owner_only_mode))
+
+    let owner_only_mode = file
+        .metadata()
+        .map_err(|error| sqlite_path_error("inspect", path, error))?
+        .permissions()
+        .mode()
+        & 0o700;
+    file.set_permissions(fs::Permissions::from_mode(owner_only_mode))
         .map_err(|error| sqlite_path_error("harden", path, error))
 }
 


### PR DESCRIPTION
## Merge conflict handoff

Orbit preserved and pushed this task's candidate after a merge conflict stopped delivery. This PR is intentionally blocked; reconcile the named paths before retrying delivery.

- Task: `ORB-11876`
- Run: `jrun-20260909-0649-18`
- Failed step: `sync_base`
- Error code: `recoverable_vcs_conflict`
- Original base: `c700eb75cd61ac31d869b1732734b06559ddca31`
- Target base: `7e2a03fff5511a6198dddf76a648b2a4e7513eac`

## Conflicting paths

- `.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml`

## Failure

```text
recoverable VCS conflict during 'git_rebase': original base 'c700eb75cd61ac31d869b1732734b06559ddca31', target base '7e2a03fff5511a6198dddf76a648b2a4e7513eac'; rebase of 'orbit/ORB-11876-6aa10168' onto checkpoint '7e2a03fff5511a6198dddf76a648b2a4e7513eac' stopped with conflicts; conflicting paths: .github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
```