### PR TITLE
[BLOCKED] [code-scanning-sweep] Fix rust/path-injection in crates/orbit-common/src/fs/io.rs

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -39,3 +39,9 @@ extensions:
           "path-injection",
           "manual",
         ]
+      - [
+          "orbit_common::fs::io::validated_atomic_target",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]

--- a/crates/orbit-common/src/fs/io.rs
+++ b/crates/orbit-common/src/fs/io.rs
@@ -149,7 +149,6 @@ impl StagedTextFile {
     where
         F: FnOnce(&mut File) -> io::Result<()>,
     {
-        let file_name = validated_atomic_file_name(target_path)?;
         let parent = target_path.parent().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -157,22 +156,10 @@ impl StagedTextFile {
             )
         })?;
         create_private_dir_all(parent)?;
-        let parent_for_resolution = if parent.as_os_str().is_empty() {
-            Path::new(".")
-        } else {
-            parent
-        };
-        let canonical_parent = fs::canonicalize(parent_for_resolution)?;
-        let canonical_target = canonical_parent.join(file_name);
-        if !canonical_target.starts_with(&canonical_parent) {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!(
-                    "atomic write target escapes its parent: {}",
-                    target_path.display()
-                ),
-            ));
-        }
+        let canonical_target = validated_atomic_target(target_path)?;
+        let canonical_parent = canonical_target.parent().ok_or_else(|| {
+            io::Error::other("validated atomic target is missing its parent directory")
+        })?;
 
         let temp_path = temp_path_for(&canonical_target);
         let mut file = create_new_private_file(&temp_path)?;
@@ -188,7 +175,7 @@ impl StagedTextFile {
         }
         drop(file);
 
-        let parent_dir = durable.then(|| File::open(&canonical_parent)).transpose()?;
+        let parent_dir = durable.then(|| File::open(canonical_parent)).transpose()?;
 
         cleanup.disarm();
 
@@ -224,13 +211,14 @@ impl StagedTextFile {
     }
 }
 
-/// Return the only component that an atomic write may replace.
+/// Resolve an atomic write target to a canonical parent and a single file
+/// component.
 ///
-/// The parent is resolved separately in [`StagedTextFile::stage_with`], where
-/// it becomes the containment root for the final rename. Rejecting the dot
-/// components before creating a staging file also prevents a path such as
-/// `parent/..` from being interpreted as the parent directory itself.
-fn validated_atomic_file_name(path: &Path) -> io::Result<&std::ffi::OsStr> {
+/// The resolved parent becomes the containment root for the final rename.
+/// Rejecting the dot components before creating a staging file also prevents a
+/// path such as `parent/..` from being interpreted as the parent directory
+/// itself.
+fn validated_atomic_target(path: &Path) -> io::Result<PathBuf> {
     let Some(file_name) = path.file_name() else {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -243,7 +231,27 @@ fn validated_atomic_file_name(path: &Path) -> io::Result<&std::ffi::OsStr> {
             format!("atomic write path must name a file: {}", path.display()),
         ));
     }
-    Ok(file_name)
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("no parent dir for {}", path.display()),
+        )
+    })?;
+    let parent_for_resolution = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
+    let canonical_parent = fs::canonicalize(parent_for_resolution)?;
+    let canonical_target = canonical_parent.join(file_name);
+    if !canonical_target.starts_with(&canonical_parent) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("atomic write target escapes its parent: {}", path.display()),
+        ));
+    }
+
+    Ok(canonical_target)
 }
 
 /// Removes a newly-created staging file if setup or writing fails before the


### PR DESCRIPTION
## Merge conflict handoff

Orbit preserved and pushed this task's candidate after a merge conflict stopped delivery. This PR is intentionally blocked; reconcile the named paths before retrying delivery.

- Task: `ORB-11890`
- Run: `jrun-20260909-0649-20`
- Failed step: `sync_base`
- Error code: `recoverable_vcs_conflict`
- Original base: `c700eb75cd61ac31d869b1732734b06559ddca31`
- Target base: `7e2a03fff5511a6198dddf76a648b2a4e7513eac`

## Conflicting paths

- `.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml`

## Failure

```text
recoverable VCS conflict during 'git_rebase': original base 'c700eb75cd61ac31d869b1732734b06559ddca31', target base '7e2a03fff5511a6198dddf76a648b2a4e7513eac'; rebase of 'orbit/ORB-11890-6aa10169' onto checkpoint '7e2a03fff5511a6198dddf76a648b2a4e7513eac' stopped with conflicts; conflicting paths: .github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
```