### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/skill_store/mod.rs

### DIFF
--- a/crates/orbit-store/src/driver/file/skill_store/mod.rs
+++ b/crates/orbit-store/src/driver/file/skill_store/mod.rs
@@ -107,9 +107,9 @@ impl SkillCatalog {
         if self.global_root.is_none() {
             fs::create_dir_all(&self.root).map_err(|e| OrbitError::Io(e.to_string()))?;
         }
-        if let Some(ref global_root) = self.global_root {
-            fs::create_dir_all(global_root).map_err(|e| OrbitError::Io(e.to_string()))?;
-        }
+
+        // Layered catalogs read shipped global skills that bootstrap owns. Do
+        // not create a caller-selected global path while opening the catalog.
         Ok(())
     }
 

--- a/crates/orbit-store/src/driver/file/skill_store/tests/skill_store.rs
+++ b/crates/orbit-store/src/driver/file/skill_store/tests/skill_store.rs
@@ -51,6 +51,22 @@ fn layered_catalog_uses_merge_by_key_precedence() {
 }
 
 #[test]
+fn layered_catalog_does_not_create_missing_global_root() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let global = workspace.path().join("global-skills");
+    let catalog = SkillCatalog::layered(workspace.path().to_path_buf(), global.clone());
+
+    catalog
+        .ensure_layout()
+        .expect("ensure layered catalog layout");
+
+    assert!(
+        !global.exists(),
+        "catalog opening must not create global root"
+    );
+}
+
+#[test]
 fn doctor_reports_skill_directories_without_skill_markdown() {
     let root = tempdir().expect("catalog tempdir");
     write_skill(root.path(), "orbit", "healthy skill");


### PR DESCRIPTION
## Task

[ORB-11901](https://orbit-cli.com/tasks/ORB-11901) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/skill_store/mod.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#110`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `f56bfda5297c3e856b22d815c263f8d21dc481c4`
- Location: `crates/orbit-store/src/driver/file/skill_store/mod.rs` line 111
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:48:41Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/110

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-store/src/driver/file/skill_store/mod.rs` line 111 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Removed the layered SkillCatalog write of caller-selected global_root from ensure_layout; bootstrap remains responsible for creating the global shipped-skills root, and layered catalogs continue to read existing global skills.
- Added a regression test proving a missing global root is not created.
- Context boundary expanded to include the directly affected sibling test file.

Acceptance criteria:
1. CodeQL rust/path-injection sink at the reported create_dir_all(global_root) location is removed by code change; no suppression, dismissal, or exclusion was added.
2. Existing layered merge behavior and runtime/bootstrap skill behavior remain covered: orbit-store layered catalog tests and orbit-core skill/runtime tests pass; traversal validation remains passing.
3. Repository validation passed. The local CodeQL CLI is unavailable (codeql: command not found), so a scanner rerun could not be performed here; static verification found no remaining create_dir_all(global_root) call in the affected file. CI's documented .github/workflows/codeql.yml remains the scanner confirmation point.

Validation:
- PASS: cargo fmt --all -- --check
- PASS: cargo test -p orbit-store --locked skill_store (4 passed)
- PASS: cargo test -p orbit-core --locked skill --lib (13 passed)
- PASS: make ci-fast; its compiler-cache namespace sub-check was boundedly skipped because bubblewrap could not create a mount namespace under this host's permissions.
- PASS: make ci-lint (workspace clippy, -D warnings)
- PASS: git diff --check
- NOT RUN: CodeQL CLI database/analyze; unavailable on this execution lane (codeql: command not found).

Assessment: The change removes the flagged filesystem write at the owning boundary, keeps existing global skill loading intact, and is limited to the store plus its regression test.

Remaining risk: The exact CodeQL alert recheck must occur in the repository's GitHub CodeQL workflow because the CLI is not installed locally.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11901-6aa10438`
- Behind base: 0
- Ahead of base: 1