### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/routines/clock.rs

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -21,3 +21,9 @@ extensions:
           "path-injection",
           "manual",
         ]
+      - [
+          "orbit_core::application::routines::clock::validated_sweep_log_path",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]

--- a/crates/orbit-core/src/application/routines/clock.rs
+++ b/crates/orbit-core/src/application/routines/clock.rs
@@ -303,6 +303,63 @@ pub fn sweep_log_path(global_root: &Path) -> PathBuf {
     global_root.join("logs").join("sweep.log")
 }
 
+/// Resolve the launchd log beneath the canonical global root.
+///
+/// The root can come from an explicit runtime override, but the launchd log
+/// location is fixed. Requiring the existing `logs` directory and log file to
+/// resolve to their expected locations prevents a symlink from redirecting
+/// launchd output outside the selected Orbit root.
+pub(super) fn validated_sweep_log_path(global_root: &Path) -> Result<PathBuf, OrbitError> {
+    let canonical_root = fs::canonicalize(global_root).map_err(|error| {
+        OrbitError::Io(format!(
+            "resolve sweep log root {}: {error}",
+            global_root.display()
+        ))
+    })?;
+    let expected_parent = canonical_root.join("logs");
+    let expected_path = expected_parent.join("sweep.log");
+
+    let canonical_parent = match fs::canonicalize(&expected_parent) {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(expected_path);
+        }
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "resolve sweep log directory {}: {error}",
+                expected_parent.display()
+            )));
+        }
+    };
+    if canonical_parent != expected_parent || !canonical_parent.is_dir() {
+        return Err(OrbitError::InvalidInput(format!(
+            "sweep log directory must be a regular directory directly under {}",
+            canonical_root.display()
+        )));
+    }
+
+    let canonical_path = match fs::canonicalize(&expected_path) {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(expected_path);
+        }
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "resolve sweep log {}: {error}",
+                expected_path.display()
+            )));
+        }
+    };
+    if canonical_path != expected_path || !canonical_path.is_file() {
+        return Err(OrbitError::InvalidInput(format!(
+            "sweep log must be a regular file directly under {}",
+            expected_parent.display()
+        )));
+    }
+
+    Ok(canonical_path)
+}
+
 /// What an installation attempt did: files written, plus either a successful
 /// activation or the commands the user must run themselves.
 #[derive(Debug)]
@@ -358,10 +415,14 @@ fn install_launchd(
     runner: &dyn ClockCommandRunner,
     home: &Path,
 ) -> Result<ClockInstallReport, OrbitError> {
-    let log_path = sweep_log_path(global_root);
-    if let Some(parent) = log_path.parent() {
-        fs::create_dir_all(parent).map_err(|error| OrbitError::Io(error.to_string()))?;
-    }
+    let log_path = validated_sweep_log_path(global_root)?;
+    let log_parent = log_path.parent().ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "sweep log path has no parent directory: {}",
+            log_path.display()
+        ))
+    })?;
+    fs::create_dir_all(log_parent).map_err(|error| OrbitError::Io(error.to_string()))?;
     let plist = LAUNCHD_PLIST_TEMPLATE
         .replace("{{ORBIT_BIN}}", orbit_bin)
         .replace("{{CADENCE_SECONDS}}", &settings.cadence_seconds.to_string())

--- a/crates/orbit-core/src/application/routines/tests/clock.rs
+++ b/crates/orbit-core/src/application/routines/tests/clock.rs
@@ -9,7 +9,7 @@ use orbit_common::OrbitError;
 use super::super::clock::{
     ClockCommandRunner, ClockPlatform, ClockSettings, ManagerCommand, clock_status_with,
     install_clock_with, load_clock_settings, render_systemd_service, render_systemd_timer,
-    save_clock_settings, set_clock_cadence_with, set_clock_enabled_with,
+    save_clock_settings, set_clock_cadence_with, set_clock_enabled_with, validated_sweep_log_path,
 };
 
 struct MockRunner {
@@ -511,6 +511,45 @@ fn clock_settings_reject_symlink_escape() {
         error
             .to_string()
             .contains("clock configuration must be a regular clock.toml directly under")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn sweep_log_path_rejects_symlinked_directory() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempdir().expect("create global root");
+    let outside = tempdir().expect("create outside root");
+    symlink(outside.path(), root.path().join("logs")).expect("create logs symlink");
+
+    let error = validated_sweep_log_path(root.path()).expect_err("reject escaped log directory");
+
+    assert!(
+        error
+            .to_string()
+            .contains("sweep log directory must be a regular directory directly under")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn sweep_log_path_rejects_symlinked_file() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempdir().expect("create global root");
+    let outside = tempdir().expect("create outside root");
+    fs::create_dir(root.path().join("logs")).expect("create log directory");
+    let outside_log = outside.path().join("sweep.log");
+    fs::write(&outside_log, "redirected").expect("write outside log");
+    symlink(&outside_log, root.path().join("logs/sweep.log")).expect("create log symlink");
+
+    let error = validated_sweep_log_path(root.path()).expect_err("reject escaped log file");
+
+    assert!(
+        error
+            .to_string()
+            .contains("sweep log must be a regular file directly under")
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-11900](https://orbit-cli.com/tasks/ORB-11900) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/routines/clock.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#109`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `f56bfda5297c3e856b22d815c263f8d21dc481c4`
- Location: `crates/orbit-core/src/application/routines/clock.rs` line 320
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:48:41Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/109

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-core/src/application/routines/clock.rs` line 320 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `validated_sweep_log_path`, which canonicalizes the selected global root and rejects symlinked/non-regular `logs` directories or `sweep.log` files before launchd creates the log parent.
- Updated launchd installation to create the parent from the validated path, preserving the existing `logs/sweep.log` location and activation flow.
- Added Unix symlink regression tests for the log directory and file, plus a CodeQL Rust barrier model for the validator.
Acceptance criteria:
- `rust/path-injection`: satisfied by the real path-validation code and the matching CodeQL barrier configuration; no suppression, dismissal, or exclusion was added.
- Intended behavior: existing clock tests pass, and valid installs still render/activate normally; symlink redirection is rejected.
- Security confirmation: the affected sink now receives only the validator result, and the CodeQL extension models that validator as a path-injection barrier. The CodeQL CLI/GitHub analysis is not available in this executor, so final alert confirmation is deferred to CI.
Validation:
- Passed: `cargo fmt --all -- --check`.
- Passed: `cargo test -p orbit-core application::routines::tests::clock --lib` (21 passed).
- Passed: `make ci-fast` (the repository's compiler-cache namespace subcheck reported the environment's expected bubblewrap permission skip while the guardrail target exited successfully).
- Passed: `make ci-lint`.
- Passed: `git diff --check` and final `git status --short` review.
- Passed: CodeQL extension YAML parse via PyYAML.
- Not run: CodeQL CLI scan; `codeql` is not installed locally and this task has no agent-side GitHub access.
Assessment: Scoped implementation with explicit canonical-location checks, focused regression coverage, and the repository's existing CodeQL extension mechanism. Remaining risk is CI-only CodeQL behavior confirmation.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11900-6aa104fb`
- Behind base: 0
- Ahead of base: 1