### PR TITLE
[BLOCKED] [code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/job/pipeline.rs

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -16,6 +16,12 @@ extensions:
           "manual",
         ]
       - [
+          "orbit_core::application::job::pipeline::validated_pipeline_worker_log_directory",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]
+      - [
           "orbit_core::application::routines::clock::validated_clock_settings_path",
           "ReturnValue.Field[core::result::Result::Ok(0)]",
           "path-injection",

--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsStr;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc;
 use std::thread;
@@ -1949,20 +1949,108 @@ fn pipeline_worker_file_name(run_id: &str, suffix: &str) -> Result<String, Orbit
     Ok(format!("{run_id}{suffix}"))
 }
 
+/// Resolve the worker-log directory before using it for any file operation.
+/// Runtime initialization normally owns this directory, but a missing final
+/// component is created only after its existing parent has passed the same
+/// checks. Symlinked paths and traversal syntax fail closed.
+fn validated_pipeline_worker_log_directory(path: &Path) -> Result<PathBuf, OrbitError> {
+    if !path.is_absolute() {
+        return Err(OrbitError::InvalidInput(format!(
+            "pipeline worker log directory must be absolute: {}",
+            path.display()
+        )));
+    }
+    if path
+        .components()
+        .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+    {
+        return Err(OrbitError::InvalidInput(format!(
+            "pipeline worker log directory must not contain traversal components: {}",
+            path.display()
+        )));
+    }
+
+    let parent = path.parent().ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "pipeline worker log directory has no parent: {}",
+            path.display()
+        ))
+    })?;
+    for ancestor in parent.ancestors() {
+        let metadata = std::fs::symlink_metadata(ancestor).map_err(|error| {
+            OrbitError::Io(format!(
+                "inspect pipeline worker log directory '{}': {error}",
+                ancestor.display()
+            ))
+        })?;
+        if metadata.file_type().is_symlink() {
+            return Err(OrbitError::InvalidInput(format!(
+                "pipeline worker log directory must not contain symlinks: {}",
+                path.display()
+            )));
+        }
+    }
+
+    let canonical_parent = parent.canonicalize().map_err(|error| {
+        OrbitError::Io(format!(
+            "canonicalize pipeline worker log parent '{}': {error}",
+            parent.display()
+        ))
+    })?;
+    let file_name = path.file_name().ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "pipeline worker log directory has no final component: {}",
+            path.display()
+        ))
+    })?;
+    let canonical_path = canonical_parent.join(file_name);
+
+    match std::fs::symlink_metadata(&canonical_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(OrbitError::InvalidInput(format!(
+                "pipeline worker log directory must not be a symlink: {}",
+                path.display()
+            )));
+        }
+        Ok(metadata) if !metadata.is_dir() => {
+            return Err(OrbitError::InvalidInput(format!(
+                "pipeline worker log path is not a directory: {}",
+                path.display()
+            )));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "inspect pipeline worker log directory '{}': {error}",
+                path.display()
+            )));
+        }
+    }
+
+    Ok(canonical_path)
+}
+
 pub(crate) fn configure_pipeline_worker_stdio(
     command: &mut Command,
     logs_dir: &Path,
     run_id: &str,
 ) -> Result<PipelineWorkerLog, OrbitError> {
-    let log_path = pipeline_worker_log_path(logs_dir, run_id)?;
+    let mut logs_dir = validated_pipeline_worker_log_directory(logs_dir)?;
+    match std::fs::create_dir(&logs_dir) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "create pipeline worker log directory '{}': {error}",
+                logs_dir.display()
+            )));
+        }
+    }
+    logs_dir = validated_pipeline_worker_log_directory(&logs_dir)?;
+    let log_path = pipeline_worker_log_path(&logs_dir, run_id)?;
 
-    std::fs::create_dir_all(logs_dir).map_err(|error| {
-        OrbitError::Io(format!(
-            "create pipeline worker log directory '{}': {error}",
-            logs_dir.display()
-        ))
-    })?;
-    restrict_pipeline_worker_log_directory(logs_dir)?;
+    restrict_pipeline_worker_log_directory(&logs_dir)?;
 
     let mut options = OpenOptions::new();
     options.create(true).append(true).read(true);
@@ -1979,7 +2067,7 @@ pub(crate) fn configure_pipeline_worker_stdio(
     })?;
     restrict_pipeline_worker_log_file(&log_path)?;
     if let Some(profile) = pipeline_worker_profile_file(
-        logs_dir,
+        &logs_dir,
         run_id,
         std::env::var_os("LLVM_PROFILE_FILE").as_deref(),
     )? {

--- a/crates/orbit-core/src/application/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/application/tests/job_pipeline.rs
@@ -202,6 +202,41 @@ fn pipeline_worker_paths_preserve_safe_run_id_stems() {
 }
 
 #[test]
+fn configure_pipeline_worker_stdio_creates_missing_log_directory_after_validation() {
+    let root = TempDir::new().expect("tempdir");
+    let logs_dir = root.path().join("missing-logs");
+    let mut command = Command::new("true");
+
+    let worker_log = configure_pipeline_worker_stdio(&mut command, &logs_dir, "jrun-child")
+        .expect("missing log directory is created after validation");
+
+    assert!(logs_dir.is_dir());
+    assert_eq!(worker_log.path(), logs_dir.join("jrun-child.worker.log"));
+}
+
+#[cfg(unix)]
+#[test]
+fn configure_pipeline_worker_stdio_rejects_symlinked_log_directory() {
+    let root = TempDir::new().expect("tempdir");
+    let outside = root.path().join("outside");
+    let logs_dir = root.path().join("logs");
+    std::fs::create_dir(&outside).expect("create outside directory");
+    std::os::unix::fs::symlink(&outside, &logs_dir).expect("create log-directory symlink");
+    let mut command = Command::new("true");
+
+    let result = configure_pipeline_worker_stdio(&mut command, &logs_dir, "jrun-child");
+
+    assert!(
+        result.is_err(),
+        "symlinked log directories must fail closed"
+    );
+    assert!(
+        !outside.join("jrun-child.worker.log").exists(),
+        "worker setup must not follow a log-directory symlink"
+    );
+}
+
+#[test]
 fn pipeline_worker_root_override_is_none_in_the_default_split_root_layout() {
     let paths = WorkspacePaths::new(
         PathBuf::from("/repo"),


### PR DESCRIPTION
## Merge conflict handoff

Orbit preserved and pushed this task's candidate after a merge conflict stopped delivery. This PR is intentionally blocked; reconcile the named paths before retrying delivery.

- Task: `ORB-11899`
- Run: `jrun-20260909-0659-6`
- Failed step: `sync_base`
- Error code: `recoverable_vcs_conflict`
- Original base: `7e2a03fff5511a6198dddf76a648b2a4e7513eac`
- Target base: `5e7a443dc779ff2b506b43a85d283a055ee78a4b`

## Conflicting paths

- `.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml`

## Failure

```text
recoverable VCS conflict during 'git_rebase': original base '7e2a03fff5511a6198dddf76a648b2a4e7513eac', target base '5e7a443dc779ff2b506b43a85d283a055ee78a4b'; rebase of 'orbit/ORB-11899-6aa103dd' onto checkpoint '5e7a443dc779ff2b506b43a85d283a055ee78a4b' stopped with conflicts; conflicting paths: .github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
```