### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -46,6 +46,12 @@ extensions:
           "manual",
         ]
       - [
+          "orbit_core::adapter::engine_host::v2_host::sandbox::validated_linux_provider_state_root",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]
+      - [
           "orbit_common::storage::sqlite::validated_sqlite_path",
           "ReturnValue.Field[core::result::Result::Ok(0)]",
           "path-injection",

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "linux")]
+use std::ffi::OsString;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -378,24 +380,131 @@ fn append_linux_provider_state_roots(
     }
     // [ORB-10946] Copilot's roots are appended only when Copilot is the
     // provider being dispatched. This mirrors the macOS gate, and it matters
-    // more here than on macOS: every entry in this list is *created* by
-    // `ensure_owned_directory` below, so an unconditional entry would mkdir a
-    // `~/.copilot` on hosts that have never installed the CLI.
+    // more here than on macOS: every entry in this list is *created* by the
+    // validated provider-root path below, so an unconditional entry would
+    // mkdir a `~/.copilot` on hosts that have never installed the CLI.
     directories.extend(linux_copilot_state_roots(provider, home.as_deref()));
     directories.extend(linux_cursor_state_roots_with(provider, home.as_deref()));
     directories.extend(linux_pi_state_roots(provider, home.as_deref()));
     directories.extend(linux_opencode_state_roots(provider, home.as_deref()));
     for directory in directories {
-        ensure_owned_directory(&directory)?;
-        let canonical = directory.canonicalize().map_err(|error| {
-            DispatchError::CliInvocationPermanent(format!(
-                "canonicalize Linux provider state root `{}`: {error}",
-                directory.display()
-            ))
-        })?;
+        let canonical = ensure_linux_provider_directory(&directory, home.as_deref())?;
         append_unique_modify_root(resolved, canonical.display().to_string());
     }
     Ok(())
+}
+
+/// Resolve a provider state root before creating it on behalf of a child.
+///
+/// Provider-specific environment variables are operator-configurable, but
+/// they must not turn sandbox preparation into an arbitrary path creator.
+/// Reject relative paths, path traversal, root/home-wide targets, and symlink
+/// components. The returned path has an existing canonical ancestor and only
+/// the validated missing suffix, so the caller can safely materialize it.
+#[cfg(target_os = "linux")]
+pub(super) fn validated_linux_provider_state_root(
+    path: &Path,
+    home: Option<&Path>,
+) -> Result<PathBuf, DispatchError> {
+    if !path.is_absolute() {
+        return Err(DispatchError::CliInvocationPermanent(format!(
+            "Linux provider state root `{}` must be absolute",
+            path.display()
+        )));
+    }
+    if path.parent().is_none() {
+        return Err(DispatchError::CliInvocationPermanent(
+            "Linux provider state root must not be the filesystem root".to_string(),
+        ));
+    }
+    if home.is_some_and(|home| {
+        let canonical_home = home.canonicalize().unwrap_or_else(|_| home.to_path_buf());
+        path == canonical_home || canonical_home.starts_with(path)
+    }) {
+        return Err(DispatchError::CliInvocationPermanent(format!(
+            "Linux provider state root `{}` is broader than the user's home directory",
+            path.display()
+        )));
+    }
+
+    let mut prefix = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::RootDir => prefix.push(component),
+            std::path::Component::Normal(name) => {
+                prefix.push(name);
+                match std::fs::symlink_metadata(&prefix) {
+                    Ok(metadata) if metadata.file_type().is_symlink() => {
+                        return Err(DispatchError::CliInvocationPermanent(format!(
+                            "Linux provider state root `{}` must not contain symlink `{}`",
+                            path.display(),
+                            prefix.display()
+                        )));
+                    }
+                    Ok(_) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => break,
+                    Err(error) => {
+                        return Err(DispatchError::CliInvocationPermanent(format!(
+                            "inspect Linux provider state root `{}`: {error}",
+                            path.display()
+                        )));
+                    }
+                }
+            }
+            _ => {
+                return Err(DispatchError::CliInvocationPermanent(format!(
+                    "Linux provider state root `{}` must not contain traversal components",
+                    path.display()
+                )));
+            }
+        }
+    }
+
+    let mut existing = path.to_path_buf();
+    let mut missing = Vec::<OsString>::new();
+    while !existing.exists() {
+        let Some(name) = existing.file_name() else {
+            return Err(DispatchError::CliInvocationPermanent(format!(
+                "Linux provider state root `{}` has no existing ancestor",
+                path.display()
+            )));
+        };
+        missing.push(name.to_os_string());
+        existing.pop();
+    }
+
+    let canonical_existing = existing.canonicalize().map_err(|error| {
+        DispatchError::CliInvocationPermanent(format!(
+            "canonicalize Linux provider state root ancestor `{}`: {error}",
+            existing.display()
+        ))
+    })?;
+    let mut validated = canonical_existing;
+    for component in missing.iter().rev() {
+        validated.push(component);
+    }
+
+    Ok(validated)
+}
+
+#[cfg(target_os = "linux")]
+pub(super) fn ensure_linux_provider_directory(
+    path: &Path,
+    home: Option<&Path>,
+) -> Result<PathBuf, DispatchError> {
+    let validated = validated_linux_provider_state_root(path, home)?;
+    std::fs::create_dir_all(&validated).map_err(|error| {
+        DispatchError::CliInvocationPermanent(format!(
+            "create Linux provider state root `{}`: {error}",
+            validated.display()
+        ))
+    })?;
+    validated.canonicalize().map_err(|error| {
+        DispatchError::CliInvocationPermanent(format!(
+            "canonicalize Linux provider state root `{}`: {error}",
+            validated.display()
+        ))
+    })
 }
 
 /// Writable state root for an active Cursor executor on Linux. The CLI stores

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
@@ -888,6 +888,62 @@ mod copilot_state_roots {
 }
 
 #[cfg(target_os = "linux")]
+mod provider_state_root_validation {
+    use std::path::Path;
+
+    use crate::adapter::engine_host::v2_host::sandbox::{
+        ensure_linux_provider_directory, validated_linux_provider_state_root,
+    };
+
+    #[test]
+    fn rejects_root_and_home_wide_targets() {
+        let home = tempfile::tempdir().expect("home");
+
+        assert!(validated_linux_provider_state_root(Path::new("/"), Some(home.path())).is_err());
+        assert!(validated_linux_provider_state_root(home.path(), Some(home.path())).is_err());
+        assert!(
+            validated_linux_provider_state_root(
+                home.path().parent().expect("home parent"),
+                Some(home.path()),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn accepts_absolute_custom_root_beneath_an_existing_parent() {
+        let parent = tempfile::tempdir().expect("parent");
+        let custom = parent.path().join("provider").join("state");
+
+        let validated = validated_linux_provider_state_root(&custom, Some(parent.path()))
+            .expect("validate custom provider root");
+
+        assert_eq!(validated, custom);
+    }
+
+    #[test]
+    fn creates_a_validated_custom_root() {
+        let parent = tempfile::tempdir().expect("parent");
+        let custom = parent.path().join("provider").join("state");
+
+        let created = ensure_linux_provider_directory(&custom, Some(parent.path()))
+            .expect("create custom provider root");
+
+        assert!(custom.is_dir());
+        assert_eq!(
+            created,
+            custom.canonicalize().expect("canonical custom root")
+        );
+    }
+
+    #[test]
+    fn rejects_relative_and_traversal_paths() {
+        assert!(validated_linux_provider_state_root(Path::new("provider/state"), None).is_err());
+        assert!(validated_linux_provider_state_root(Path::new("/tmp/../provider"), None).is_err());
+    }
+}
+
+#[cfg(target_os = "linux")]
 mod cursor_state_roots {
     use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
## Task

[ORB-11898](https://orbit-cli.com/tasks/ORB-11898) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#107`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `f56bfda5297c3e856b22d815c263f8d21dc481c4`
- Location: `crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs` line 577
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:48:41Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/107

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs` line 577 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added Linux provider-state-root validation before sandbox preparation creates directories. It rejects relative paths, traversal components, filesystem-root or home-wide targets, and symlink components, while preserving valid absolute custom roots and canonicalizing the result.
- Routed provider-state directory creation through the validated path and registered the validator as a CodeQL rust/path-injection barrier.
- Added four focused regression tests covering rejected roots, traversal/relative inputs, valid custom roots, and actual validated directory creation.

Acceptance criteria:
- rust/path-injection at sandbox.rs line 577: satisfied by validating the provider-root path before create_dir_all and adding the non-suppressing CodeQL barrier model.
- Intended behavior: satisfied; supported absolute custom roots still resolve, materialize, and receive the canonical write grant; broad or redirected paths fail closed.
- Repository/security validation: repository gates pass; CodeQL itself is not installed in this checkout, so alert closure requires the normal external CodeQL workflow.

Validation:
- cargo fmt --all -- --check: passed.
- cargo test -p orbit-core adapter::engine_host::v2_host::tests::sandbox: passed, 26 tests.
- cargo test -p orbit-core provider_state_root_validation: passed, 4 tests.
- make ci-fast: passed. Its compiler-cache namespace subcheck was explicitly skipped because this runner lacks permission to create an unprivileged mount namespace.
- make ci-lint: passed with workspace clippy and warnings denied.
- git diff --check: passed; status contains only the three task-scoped files.
- CodeQL scan: not run; the codeql executable is unavailable in the workspace environment. Ruby YAML parsing was also unavailable, but the checked-in extension follows the repository's existing barrier format.

Risks and deviations:
- The external CodeQL alert cannot be directly re-run from this agent checkout; CI/CodeQL remains the authoritative confirmation of alert closure.
- Full make ci was not run because repository guidance reserves it for the PR merge gate.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11898-6aa103dc`
- Behind base: 0
- Ahead of base: 1