### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/docs/walk.rs

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -10,6 +10,12 @@ extensions:
           "manual",
         ]
       - [
+          "orbit_core::application::docs::walk::validated_docs_root_path",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]
+      - [
           "orbit_core::application::job::pipeline::pipeline_worker_file_name",
           "ReturnValue.Field[core::result::Result::Ok(0)]",
           "path-injection",

--- a/crates/orbit-core/src/application/docs/tests/walk.rs
+++ b/crates/orbit-core/src/application/docs/tests/walk.rs
@@ -6,7 +6,7 @@ use tempfile::tempdir;
 
 use super::super::config::DocsRoot;
 use super::super::walk::{
-    git_check_ignore_invocations, reset_git_check_ignore_invocations, walk_docs_roots,
+    expand_root, git_check_ignore_invocations, reset_git_check_ignore_invocations, walk_docs_roots,
 };
 
 fn init_git_repo(root: &std::path::Path) {
@@ -40,6 +40,43 @@ fn walker_skips_dot_orbit_even_when_root_points_above_it() {
             .map(|record| record.path.as_str())
             .collect::<Vec<_>>(),
         vec!["docs/good.md"]
+    );
+}
+
+#[test]
+fn wildcard_root_expands_workspace_relative_directories() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path();
+    fs::create_dir_all(root.join("apps/example/docs")).expect("docs dir");
+    fs::write(
+        root.join("apps/example/docs/guide.md"),
+        "---\ntype: context\nsummary: Guide\n---\nbody\n",
+    )
+    .expect("write guide");
+
+    let records = walk_docs_roots(root, &[DocsRoot::new("apps/*/docs/")]).expect("walk docs");
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].path, "apps/example/docs/guide.md");
+}
+
+#[test]
+fn wildcard_root_rejects_paths_outside_the_workspace() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path().join("repo");
+    let outside = dir.path().join("outside");
+    fs::create_dir_all(&root).expect("repo dir");
+    fs::create_dir_all(outside.join("docs")).expect("outside docs dir");
+
+    assert!(
+        expand_root(&root, "../outside/*")
+            .expect("expand traversal")
+            .is_empty()
+    );
+    assert!(
+        expand_root(&root, &format!("{}/*", outside.display()))
+            .expect("expand absolute path")
+            .is_empty()
     );
 }
 

--- a/crates/orbit-core/src/application/docs/walk.rs
+++ b/crates/orbit-core/src/application/docs/walk.rs
@@ -119,13 +119,51 @@ pub(super) fn expand_root(repo_root: &Path, root: &str) -> Result<Vec<PathBuf>, 
     };
     if !trimmed.contains('*') {
         if absolute.exists() {
-            return Ok(vec![absolute]);
+            return Ok(vec![validated_docs_root_path(repo_root, &absolute)?]);
         }
         return Ok(Vec::new());
     }
+
+    // Wildcard expansion is intentionally workspace-relative. Apart from
+    // making the supported pattern language unambiguous, rejecting rooted and
+    // parent-directory components keeps configured text from selecting the
+    // starting point for a filesystem walk outside the repository.
+    if root_path.is_absolute()
+        || root_path.components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::ParentDir | std::path::Component::Prefix(_)
+            )
+        })
+    {
+        return Ok(Vec::new());
+    }
+
     let mut out = Vec::new();
     expand_wildcard_segments(repo_root, Path::new(trimmed), &mut out)?;
     Ok(out)
+}
+
+/// Resolve a discovered docs path before it reaches a filesystem operation.
+///
+/// Docs roots are workspace-relative configuration, so canonicalizing both
+/// sides prevents `..` traversal and symlinks from redirecting a walk outside
+/// the repository. Callers only use this after confirming the candidate
+/// exists; a missing literal root remains the walker's documented no-op.
+fn validated_docs_root_path(repo_root: &Path, candidate: &Path) -> Result<PathBuf, OrbitError> {
+    let canonical_repo = repo_root.canonicalize().map_err(|error| {
+        OrbitError::Io(format!("canonicalize {}: {error}", repo_root.display()))
+    })?;
+    let canonical_candidate = candidate.canonicalize().map_err(|error| {
+        OrbitError::Io(format!("canonicalize {}: {error}", candidate.display()))
+    })?;
+    if !canonical_candidate.starts_with(&canonical_repo) {
+        return Err(OrbitError::InvalidInput(format!(
+            "docs root path must stay inside the workspace root: {}",
+            candidate.display()
+        )));
+    }
+    Ok(canonical_candidate)
 }
 
 fn expand_wildcard_segments(
@@ -133,10 +171,15 @@ fn expand_wildcard_segments(
     pattern: &Path,
     out: &mut Vec<PathBuf>,
 ) -> Result<(), OrbitError> {
-    fn rec(base: &Path, parts: &[String], out: &mut Vec<PathBuf>) -> Result<(), OrbitError> {
+    fn rec(
+        repo_root: &Path,
+        base: &Path,
+        parts: &[String],
+        out: &mut Vec<PathBuf>,
+    ) -> Result<(), OrbitError> {
         if parts.is_empty() {
             if base.exists() {
-                out.push(base.to_path_buf());
+                out.push(validated_docs_root_path(repo_root, base)?);
             }
             return Ok(());
         }
@@ -146,7 +189,8 @@ fn expand_wildcard_segments(
             if !base.is_dir() {
                 return Ok(());
             }
-            let entries = fs::read_dir(base)
+            let base = validated_docs_root_path(repo_root, base)?;
+            let entries = fs::read_dir(&base)
                 .map_err(|error| OrbitError::Io(format!("read {}: {error}", base.display())))?;
             for entry in entries {
                 let entry = entry.map_err(|error| OrbitError::Io(error.to_string()))?;
@@ -155,12 +199,12 @@ fn expand_wildcard_segments(
                     .map_err(|error| OrbitError::Io(error.to_string()))?
                     .is_dir()
                 {
-                    rec(&entry.path(), tail, out)?;
+                    rec(repo_root, &entry.path(), tail, out)?;
                 }
             }
             return Ok(());
         }
-        rec(&base.join(head), tail, out)
+        rec(repo_root, &base.join(head), tail, out)
     }
 
     let parts = pattern
@@ -168,7 +212,7 @@ fn expand_wildcard_segments(
         .filter_map(super::path_util::component_str)
         .map(ToOwned::to_owned)
         .collect::<Vec<_>>();
-    rec(base, &parts, out)
+    rec(base, base, &parts, out)
 }
 
 fn walk_dir(repo_root: &Path, dir: &Path, candidates: &mut Vec<PathBuf>) -> Result<(), OrbitError> {


### PR DESCRIPTION
## Task

[ORB-11902](https://orbit-cli.com/tasks/ORB-11902) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/docs/walk.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#113`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `f56bfda5297c3e856b22d815c263f8d21dc481c4`
- Location: `crates/orbit-core/src/application/docs/walk.rs` line 149
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:48:41Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/113

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-core/src/application/docs/walk.rs` line 149 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `validated_docs_root_path` in `crates/orbit-core/src/application/docs/walk.rs`; literal and wildcard roots are canonicalized and constrained to the repository, wildcard patterns with rooted or parent-directory components are ignored, and wildcard `read_dir` now receives only the validated path.
- Added walker tests for valid `apps/*/docs/` expansion and rejection of traversal/absolute wildcard roots.
- Added the validator return as a `path-injection` barrier in `.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml`; this is an explicit validation model, not a suppression or exclusion.
Assessment: The reported user-controlled path flow is removed at the filesystem boundary while documented workspace-relative wildcard behavior remains intact.
Acceptance criteria:
- Code scanning remediation: implemented in code and modeled in the existing CodeQL barrier extension; no alert suppression or exclusion was added.
- Intended behavior: focused walker tests passed, including valid wildcard expansion; canonicalization also prevents symlink escapes outside the workspace.
- Validation/security: focused tests, formatting, `make ci-fast`, `make ci-lint`, and CodeQL-extension YAML parsing passed. Actual CodeQL analysis was not run because the CLI is unavailable and the task states there is no agent-side GitHub access; CI CodeQL remains the authoritative confirmation. `cargo deny check` was attempted but could not acquire its advisory database lock because the injected path is read-only.
Validation commands:
- PASSED — `cargo test -p orbit-core --locked application::docs::tests::walk` (7 passed).
- PASSED — `cargo fmt --all -- --check`.
- PASSED — `make ci-fast`; its documented unprivileged bubblewrap namespace test was skipped.
- PASSED — `make ci-lint`.
- PASSED — local Python YAML parse of `.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml`.
- NOT RUN — CodeQL CLI analysis; `codeql` is not installed and no GitHub access is available in this task.
- FAILED/ENVIRONMENT — `cargo deny check`; advisory DB lock was unavailable at `~/.cargo/advisory-dbs/db.lock` because the path is read-only.
Remaining risk: final CodeQL alert retirement must be confirmed by the repository's GitHub CodeQL workflow.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11902-6aa10578`
- Behind base: 0
- Ahead of base: 1