### PR TITLE
[code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-search/src/embedder.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,6 +2193,7 @@ version = "0.20.0"
 dependencies = [
  "chrono",
  "fs2",
+ "getrandom 0.3.4",
  "libc",
  "orbit-types",
  "proptest",

--- a/crates/orbit-common/Cargo.toml
+++ b/crates/orbit-common/Cargo.toml
@@ -26,6 +26,7 @@ orbit-types = { path = "../orbit-types" }
 chrono.workspace = true
 rusqlite = { workspace = true, optional = true }
 fs2.workspace = true
+getrandom.workspace = true
 regex.workspace = true
 rsa.workspace = true
 serde.workspace = true

--- a/crates/orbit-common/src/process/jitter.rs
+++ b/crates/orbit-common/src/process/jitter.rs
@@ -9,11 +9,15 @@
 //! The generator is an xorshift64* seeded through SplitMix64 — no external
 //! dependency, not suitable for anything security-sensitive.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Fallback seed used when the entropy sources collapse to zero
 /// (xorshift64* has a fixed point at state 0).
 const SEED_FALLBACK: u64 = 0x9e37_79b9_7f4a_7c15;
+
+/// Separates fallback seeds if the operating system cannot provide entropy.
+static FALLBACK_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Small xorshift64* PRNG for retry jitter. Not cryptographic.
 #[derive(Debug, Clone)]
@@ -22,16 +26,11 @@ pub struct JitterRng {
 }
 
 impl JitterRng {
-    /// Seed from wall-clock nanos, the process id, and a caller-provided
-    /// salt (e.g. a run id) so concurrent workers retrying the same failing
-    /// dependency draw from decorrelated streams.
-    pub fn seeded(salt: &str) -> Self {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_nanos() as u64)
-            .unwrap_or(0);
-        let salt_hash = fnv1a_64(salt.as_bytes());
-        Self::from_seed(nanos ^ salt_hash ^ u64::from(std::process::id()))
+    /// Construct from operating-system entropy so production retry streams
+    /// are independent of application identifiers.
+    pub fn from_entropy() -> Self {
+        let seed = getrandom::u64().unwrap_or_else(|_| fallback_seed());
+        Self::from_seed(seed)
     }
 
     /// Construct from an explicit seed (deterministic; intended for tests).
@@ -66,20 +65,20 @@ impl JitterRng {
     }
 }
 
+fn fallback_seed() -> u64 {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos() as u64)
+        .unwrap_or(0);
+    let sequence = FALLBACK_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    nanos ^ u64::from(std::process::id()) ^ sequence
+}
+
 /// SplitMix64 finalizer — mixes a raw seed into a well-distributed state.
 fn splitmix64(seed: u64) -> u64 {
     let mut z = seed.wrapping_add(0x9e37_79b9_7f4a_7c15);
     z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
     z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
     z ^ (z >> 31)
-}
-
-/// FNV-1a hash of arbitrary bytes; used only for seed salting.
-fn fnv1a_64(bytes: &[u8]) -> u64 {
-    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
-    for byte in bytes {
-        hash ^= u64::from(*byte);
-        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
-    }
-    hash
 }

--- a/crates/orbit-common/src/process/tests/jitter.rs
+++ b/crates/orbit-common/src/process/tests/jitter.rs
@@ -54,12 +54,12 @@ fn zero_seed_does_not_stick_at_zero() {
 }
 
 #[test]
-fn seeded_salts_produce_distinct_streams() {
-    // Two runs with different salts should (overwhelmingly) diverge. Time
-    // and pid feed the seed too, so equality is possible in theory but a
-    // shared 64-draw prefix indicates the salt is being ignored.
-    let mut a = JitterRng::seeded("run-a");
-    let mut b = JitterRng::seeded("run-b");
+fn entropy_instances_produce_distinct_streams() {
+    // Production retry streams come from OS entropy rather than an
+    // application identifier. A shared 64-draw prefix is overwhelmingly
+    // unlikely and indicates that construction stopped drawing a fresh seed.
+    let mut a = JitterRng::from_entropy();
+    let mut b = JitterRng::from_entropy();
     let diverged = (0..64).any(|_| a.next_u64() != b.next_u64());
-    assert!(diverged, "distinct salts produced identical streams");
+    assert!(diverged, "entropy instances produced identical streams");
 }

--- a/crates/orbit-engine/src/activity_job/job_executor/step.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/step.rs
@@ -83,9 +83,9 @@ pub(super) fn run_step_with_retry(
     let mut last_failed_outcome: Option<StepOutcome> = None;
     let max_attempts = retry.max_attempts.max(1);
     // Full-jitter backoff (ORB-10006): parallel workers retrying the same
-    // failing dependency draw sleeps from decorrelated streams instead of
-    // waking in lockstep. Seeded per step from time + run id.
-    let mut jitter = JitterRng::seeded(&ctx.run_id);
+    // failing dependency draw sleeps from independent entropy-backed streams
+    // instead of waking in lockstep.
+    let mut jitter = JitterRng::from_entropy();
     for attempt in 0..max_attempts {
         match run_step_body(step, ctx) {
             Ok(outcome) => {

--- a/crates/orbit-search/src/subprocess.rs
+++ b/crates/orbit-search/src/subprocess.rs
@@ -277,7 +277,7 @@ impl SubprocessEmbedder {
             .io
             .lock()
             .map_err(|error| OrbitError::Execution(format!("companion mutex poisoned: {error}")))?;
-        let mut jitter = JitterRng::seeded(&self.model_arg);
+        let mut jitter = JitterRng::from_entropy();
         let mut last_transient: Option<TransientFailure> = None;
         for attempt in 0..RPC_MAX_ATTEMPTS {
             if attempt > 0 {
@@ -499,7 +499,7 @@ fn spawn_companion_with_retry(
     model: &str,
     stderr: CompanionStderr,
 ) -> Result<ChildIo, OrbitError> {
-    let mut jitter = JitterRng::seeded(model);
+    let mut jitter = JitterRng::from_entropy();
     let mut last_error: Option<std::io::Error> = None;
     for attempt in 0..RPC_MAX_ATTEMPTS {
         if attempt > 0 {


### PR DESCRIPTION
## Task

[ORB-11944](https://orbit-cli.com/tasks/ORB-11944) — [code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-search/src/embedder.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#242`
- Rule: `rust/hard-coded-cryptographic-value` (rust/hard-coded-cryptographic-value)
- Security severity: `critical`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This hard-coded value is used as a salt. This hard-coded value is used as a salt.
- Ref: `refs/heads/agent-main`
- Commit: `79fa18679adb391ffa7f8f501ba5012292b772ef`
- Location: `crates/orbit-search/src/embedder.rs` line 13
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-09T05:50:52Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/242

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.

## Current orchestration evidence
GitHub alert dataflow points to JitterRng::seeded: alert 242 reaches crates/orbit-search/src/subprocess.rs:280 and :502 via the model string; alert 149 reaches crates/orbit-engine/src/activity_job/job_executor/step.rs:88. These are retry jitter seeds, not encryption secrets. Inspect the canonical jitter implementation and callers; address correlated/deterministic production retry seeds with appropriate entropy if confirmed, retain deterministic injection for tests, and preserve bounded retry semantics. Do not randomize semantic model identities, task/run IDs, or rewrite unrelated literals to evade scanning. Determine all alerts covered by the same owner-level fix and report that mapping. Do not suppress or dismiss alerts.

### Acceptance Criteria

- Remediate Code scanning rule `rust/hard-coded-cryptographic-value` at `crates/orbit-search/src/embedder.rs` line 13 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced caller-salted `JitterRng::seeded` with `JitterRng::from_entropy`, which draws operating-system entropy and uses a time/process/counter fallback only if that source is unavailable.
- Updated both search-companion retry loops so semantic model IDs no longer reach retry seed construction; updated the engine retry loop as the same owner-level remediation for alert 149.
- Retained `from_seed` for deterministic tests and added coverage that independent production constructors generate distinct streams.

Criteria:
1. Alert 242: satisfied. The model string from `embedder.rs` no longer flows to any `JitterRng` seed/salt; source scan found no `JitterRng::seeded` remaining in common, search, or engine.
2. Retry semantics: satisfied. Existing full-jitter bounds and retry loops are unchanged; only seed construction changed. OS entropy decorrelates production streams, while explicit deterministic test injection remains available.
3. Validation/security: `cargo test -p orbit-common process::tests::jitter`, `cargo test -p orbit-search`, `make ci-fast`, `make ci-lint`, and `git diff --check` passed. `make audit` initially failed because the sandbox exposes the shared advisory-db lock read-only; reran the same `cargo deny check --disable-fetch` with a temporary copied advisory database and it passed (advisories, bans, licenses, sources). The CodeQL CLI is not installed in this execution environment, so an authoritative local CodeQL rerun was unavailable; static dataflow verification confirms the affected caller-to-salt path has been removed. CI's documented `.github/workflows/codeql.yml` remains the authoritative CodeQL execution.

Alert mapping: alert 242 (search model string) and alert 149 (engine run ID) are covered by the canonical owner-level removal of caller-provided retry salts.

Assessment: focused, uncommitted task-scoped change. No remaining known risk beyond the deferred CI CodeQL analysis; fallback retry seeding is intentionally non-secret and only used when OS entropy fails.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11944-6aa20d0f`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra