### PR TITLE
[code-scanning-sweep] Fix rust/command-line-injection in crates/orbit-core/src/application/docs/walk.rs

### DIFF
--- a/crates/orbit-core/src/application/docs/walk.rs
+++ b/crates/orbit-core/src/application/docs/walk.rs
@@ -279,11 +279,10 @@ fn git_ignored_paths(repo_root: &Path, relatives: &[PathBuf]) -> HashSet<PathBuf
     #[cfg(test)]
     record_git_check_ignore_invocation();
     let mut child = match Command::new("git")
-        .arg("-C")
-        .arg(repo_root)
         .arg("check-ignore")
         .arg("-z")
         .arg("--stdin")
+        .current_dir(repo_root)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())


### PR DESCRIPTION
## Task

[ORB-11964](https://orbit-cli.com/tasks/ORB-11964) — [code-scanning-sweep] Fix rust/command-line-injection in crates/orbit-core/src/application/docs/walk.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#395`
- Rule: `rust/command-line-injection` (rust/command-line-injection)
- Security severity: `critical`
- Tool: `CodeQL` (version `2.27.0`, guid `unknown`)
- Message: This command line depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `3fced6f6a6bcfc1d6e85aa5e876f0acbc7c85ada`
- Location: `crates/orbit-core/src/application/docs/walk.rs` line 239
- Created: `2026-09-09T17:14:49Z`
- Updated: `2026-09-09T17:14:50Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/395

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/command-line-injection` at `crates/orbit-core/src/application/docs/walk.rs` line 239 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated `git_ignored_paths` in `crates/orbit-core/src/application/docs/walk.rs` to set `repo_root` with `Command::current_dir` instead of passing the caller-derived path through Git's command-line arguments. The command remains fixed (`git check-ignore -z --stdin`), preserving NUL-delimited ignore checks while removing the CodeQL command-line-injection data flow.
Assessment: Focused docs walker behavior and workspace-wide lint/guardrails pass. Static review confirms `repo_root` is no longer an argument to the subprocess; hosted CodeQL alert confirmation remains pending because the task explicitly provides no agent-side GitHub access.
Criteria evidence:
- Criterion 1: Real source fix removes the user-derived `repo_root` argument; no suppression, dismissal, or exclusion was added.
- Criterion 2: Existing seven docs walker tests pass, including gitignored-file filtering, override behavior, batching, and path handling.
- Criterion 3: Repository checks passed as listed below; local CodeQL CLI/database was unavailable, so hosted CodeQL re-scan is the remaining verification step.
Validation:
- `cargo test -p orbit-core application::docs::tests::walk --lib` — passed (7 tests).
- `make ci-fast` — passed; the repository's compiler-cache namespace subcheck reported its documented environment skip because unprivileged namespaces are unavailable.
- `make ci-lint` — passed (`cargo clippy --workspace --all-targets -- -D warnings`).
- `git diff --check` — passed.
- Static `rg` checks for `arg(\"-C\")` and `arg(repo_root)` in the affected file — no matches.
- `git status --short` — only the scoped source file is modified.
Remaining risk: The actual GitHub CodeQL re-scan was not runnable in this agent environment and should confirm alert #395 clears after delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11964-6aa20edc`
- Behind base: 0
- Ahead of base: 1