### PR TITLE
[code-scanning-sweep] Fix rust/command-line-injection in crates/orbit-core/src/runtime/tool_exec.rs

### DIFF
--- a/crates/orbit-core/src/runtime/tool_exec.rs
+++ b/crates/orbit-core/src/runtime/tool_exec.rs
@@ -227,8 +227,7 @@ fn git_checkout_root(path: &Path) -> Option<PathBuf> {
     GIT_CHECKOUT_PROBES.with(|count| count.set(count.get() + 1));
 
     let output = Command::new("git")
-        .arg("-C")
-        .arg(path)
+        .current_dir(path)
         .args(["rev-parse", "--show-toplevel"])
         .output()
         .ok()?;
@@ -256,8 +255,7 @@ fn git_common_dir(path: &Path) -> Option<PathBuf> {
     GIT_COMMON_DIR_PROBES.with(|count| count.set(count.get() + 1));
 
     let output = Command::new("git")
-        .arg("-C")
-        .arg(path)
+        .current_dir(path)
         .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
         .output()
         .ok()?;


### PR DESCRIPTION
## Task

[ORB-11969](https://orbit-cli.com/tasks/ORB-11969) — [code-scanning-sweep] Fix rust/command-line-injection in crates/orbit-core/src/runtime/tool_exec.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#396`
- Rule: `rust/command-line-injection` (rust/command-line-injection)
- Security severity: `critical`
- Tool: `CodeQL` (version `2.27.0`, guid `unknown`)
- Message: This command line depends on a user-provided value. This command line depends on a user-provided value. This command line depends on a user-provided value. This command line depends on a user-provided value. This command line depends on a user-provided value. This command line depends on a user-prov
- Ref: `refs/heads/agent-main`
- Commit: `18f96262c11401440e7faf674ce2bcd121066ccd`
- Location: `crates/orbit-core/src/runtime/tool_exec.rs` line 260
- Created: `2026-09-09T17:14:49Z`
- Updated: `2026-09-09T17:14:50Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/396

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/command-line-injection` at `crates/orbit-core/src/runtime/tool_exec.rs` line 260 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced both user-controlled `Path` arguments to the `git` subprocess with `Command::current_dir(path)`; the subprocess now receives only fixed `rev-parse` arguments while retaining the same checkout/common-directory probes.
- No configuration suppression, dismissal, or CodeQL exclusion was added.

Assessment: The reported command-line data flow is removed at its source-to-argv boundary, and the existing linked-worktree and unrelated-checkout behavior remains covered by the focused runtime tests.

Acceptance criteria:
- Criterion 1: satisfied by the real implementation change in `crates/orbit-core/src/runtime/tool_exec.rs`; no alert suppression or exclusion was used.
- Criterion 2: satisfied by using the supplied path only as the subprocess working directory and preserving the existing `git rev-parse` operations; all five focused `tool_exec` tests passed.
- Criterion 3: repository validation passed as listed below. The local CodeQL CLI is unavailable, so the repository's GitHub CodeQL workflow was not executable locally; a source check confirms there are no remaining `.arg(path)`/path-based argument calls at the affected code. The changed code is ready for the CI CodeQL analysis to provide the authoritative alert result.

Validation:
- PASSED — `cargo fmt --all -- --check`.
- PASSED — `cargo test -p orbit-core --lib runtime::tests::tool_exec` (5 passed).
- PASSED — `make ci-fast` (includes formatting and repository guardrails; its compiler-cache namespace subcheck reported the documented environment skip because unprivileged namespaces are unavailable).
- PASSED — `make ci-lint`.
- PASSED — `CARGO_HOME=<temporary task directory> cargo deny check` (advisories, bans, licenses, and sources all ok; only existing unmatched-allowance warnings).
- NOT RUN — CodeQL CLI analysis; `codeql` is unavailable locally. The configured authoritative workflow is `.github/workflows/codeql.yml`.
- PASSED — `git diff --check`.
- PASSED — `git status --short`; only the scoped source file is modified.

Remaining risks or deviations:
- The exact CodeQL alert re-evaluation must occur in GitHub CI because this executor has no CodeQL CLI or agent-side GitHub access.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11969-6aa21050`
- Behind base: 0
- Ahead of base: 1