### PR TITLE
[dependabot-sweep] Update smol-toml in website/package-lock.json

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7023,9 +7023,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
-      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"


### PR DESCRIPTION
## Task

[ORB-11967](https://orbit-cli.com/tasks/ORB-11967) — [dependabot-sweep] Update smol-toml in website/package-lock.json

### Description

This task was filed from a bounded, redacted Dependabot snapshot collected on the host before the task existed. The implementing agent does not need GitHub credentials.

## Dependency bump

- Repository: `constellation-works/orbit`
- Ecosystem: `npm`
- Package: `smol-toml`
- Manifest path: `website/package-lock.json`
- First patched version: `1.7.1`

## Open alerts

- **GHSA-7w5x-hrqm-74c2 / CVE-2026-85730** — severity `high`; smol-toml: Denial of Service via malformed TOML documents; vulnerable range `<= 1.7.0`; first patched version `1.7.1`; https://github.com/constellation-works/orbit/security/dependabot/50

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": [],
  "pull_requests_at_cap": false,
  "pull_requests_limit": 100
}
```

Update the dependency and regenerate the lockfile through the repository's normal package-manager workflow. Verify that the manifest and lockfile agree and run the documented pre-handoff checks.


### Acceptance Criteria

- Bump `smol-toml` to a non-vulnerable version that resolves every alert listed in the task description.
- `website/package-lock.json` and the repository lockfile agree on the resolved `smol-toml` version.
- The repository's documented pre-handoff checks pass without weakening security checks or suppressing the advisories.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Regenerated website/package-lock.json with npm, updating the sole resolved smol-toml package from 1.7.0 to 1.8.0 (above the 1.7.1 patched minimum).

Criteria evidence:
1. The lockfile resolves smol-toml 1.8.0; npm audit --package-lock-only --audit-level=high reported 0 vulnerabilities.
2. npm --prefix website ls smol-toml --package-lock-only reports every consumer deduped to smol-toml 1.8.0, matching the sole repository npm lockfile entry.
3. Required repository gates passed without security-check changes.

Validation:
- Passed: npm --prefix website update smol-toml --package-lock-only --ignore-scripts (regenerated lockfile).
- Passed: npm --prefix website ls smol-toml --package-lock-only (all dependency paths resolve to 1.8.0).
- Passed: npm --prefix website audit --package-lock-only --audit-level=high (0 vulnerabilities).
- Passed: npm --prefix website ci and npm --prefix website run check (Astro: 0 errors, 0 warnings, 0 hints).
- Passed: make ci-fast.
- Passed: make ci-lint.
- Passed: git diff --check.

Assessment: Minimal lockfile-only security update; no security checks were weakened or suppressed.

Remaining risk / deviation: npm was unavailable on PATH and its default cache was read-only, so the documented Node 24 npm binary was used with a temporary writable cache. The validation-created ignored website/node_modules directory could not be removed because the runner denied the requested rm -rf cleanup; it is an untracked ignored workspace artifact and does not affect the patch. No friction record was filed because the cache behavior is already covered by the website validation runbook and the cleanup denial was a bounded runner-policy outcome.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11967-6aa21751`
- Behind base: 0
- Ahead of base: 1