### PR TITLE
[code-review] A symlinked docs root hard-fails `orbit docs index` while the wildcard form silently skips

### DIFF
--- a/crates/orbit-core/src/application/docs/tests/walk.rs
+++ b/crates/orbit-core/src/application/docs/tests/walk.rs
@@ -6,7 +6,8 @@ use tempfile::tempdir;
 
 use super::super::config::DocsRoot;
 use super::super::walk::{
-    expand_root, git_check_ignore_invocations, reset_git_check_ignore_invocations, walk_docs_roots,
+    expand_root, git_check_ignore_invocations, reset_git_check_ignore_invocations,
+    validated_docs_root_path, walk_docs_roots,
 };
 
 fn init_git_repo(root: &std::path::Path) {
@@ -179,5 +180,91 @@ fn override_root_still_excludes_nested_dot_orbit() {
     assert!(
         records.is_empty(),
         "expected .orbit exclusion to hold under an override root: {records:?}"
+    );
+}
+
+#[test]
+fn symlinked_in_repo_docs_root_outside_workspace_behaves_consistently() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path().join("repo");
+    let outside = dir.path().join("outside");
+    fs::create_dir_all(&root).expect("repo dir");
+    fs::create_dir_all(&outside).expect("outside dir");
+    fs::write(
+        outside.join("doc.md"),
+        "---\ntype: context\nsummary: Outside doc\n---\nbody\n",
+    )
+    .expect("write outside doc");
+
+    orbit_common::fs::io::create_dir_symlink(&outside, &root.join("docs")).expect("create symlink");
+
+    let valid_docs = root.join("valid_docs");
+    fs::create_dir_all(&valid_docs).expect("valid docs dir");
+    fs::write(
+        valid_docs.join("valid.md"),
+        "---\ntype: context\nsummary: Valid doc\n---\nbody\n",
+    )
+    .expect("write valid doc");
+
+    // 1. Literal form of symlinked root ("docs/")
+    let literal_records = walk_docs_roots(&root, &[DocsRoot::new("docs/")]).expect("walk literal");
+    assert!(
+        literal_records.is_empty(),
+        "expected symlinked root outside workspace to be skipped: {literal_records:?}"
+    );
+
+    // 2. Wildcard form of symlinked root ("docs/*")
+    let wildcard_records =
+        walk_docs_roots(&root, &[DocsRoot::new("docs/*")]).expect("walk wildcard");
+    assert!(
+        wildcard_records.is_empty(),
+        "expected wildcard form to produce the same outcome: {wildcard_records:?}"
+    );
+
+    // 3. Both produce the same outcome
+    assert_eq!(literal_records, wildcard_records);
+
+    // 4. Literal and wildcard expand_root produce the same outcome
+    let literal_expanded = expand_root(&root, "docs/").expect("expand literal");
+    let wildcard_expanded = expand_root(&root, "docs/*").expect("expand wildcard");
+    assert_eq!(literal_expanded, wildcard_expanded);
+    assert!(literal_expanded.is_empty());
+
+    // 5. One unusable docs root does not abort the walk of remaining configured roots
+    let combined_records = walk_docs_roots(
+        &root,
+        &[DocsRoot::new("docs/"), DocsRoot::new("valid_docs/")],
+    )
+    .expect("walk with unusable root should not abort");
+    assert_eq!(
+        combined_records
+            .iter()
+            .map(|r| r.path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["valid_docs/valid.md"]
+    );
+}
+
+#[test]
+fn out_of_workspace_root_validation_error_names_resolved_target() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path().join("repo");
+    let outside = dir.path().join("outside");
+    fs::create_dir_all(&root).expect("repo dir");
+    fs::create_dir_all(&outside).expect("outside dir");
+
+    orbit_common::fs::io::create_dir_symlink(&outside, &root.join("docs")).expect("create symlink");
+
+    let err = validated_docs_root_path(&root, &root.join("docs"))
+        .expect_err("should reject outside root");
+    let msg = err.to_string();
+    let canonical_outside = outside.canonicalize().expect("canonicalize outside");
+    assert!(
+        msg.contains(&canonical_outside.display().to_string()),
+        "error message should name resolved target {canonical_outside:?}, got: {msg}"
+    );
+    assert!(
+        msg.contains(&root.join("docs").display().to_string()),
+        "error message should name configured path, got: {msg}"
     );
 }

--- a/crates/orbit-core/src/application/docs/walk.rs
+++ b/crates/orbit-core/src/application/docs/walk.rs
@@ -59,7 +59,16 @@ pub(super) fn walk_docs_with_bodies(
     let mut candidates: HashMap<PathBuf, bool> = HashMap::new();
     for root in roots {
         let mut found = Vec::new();
-        for path in expand_root(repo_root, &root.path)? {
+        let expanded = match expand_root(repo_root, &root.path) {
+            Ok(paths) => paths,
+            Err(error) => {
+                // One unusable docs root does not abort the walk of the remaining
+                // configured roots.
+                tracing::warn!(root = %root.path, %error, "skipping unusable docs root");
+                continue;
+            }
+        };
+        for path in expanded {
             if path_is_or_contains_dot_orbit(repo_root, &path) {
                 continue;
             }
@@ -119,7 +128,20 @@ pub(super) fn expand_root(repo_root: &Path, root: &str) -> Result<Vec<PathBuf>, 
     };
     if !trimmed.contains('*') {
         if absolute.exists() {
-            return Ok(vec![validated_docs_root_path(repo_root, &absolute)?]);
+            return match validated_docs_root_path(repo_root, &absolute) {
+                Ok(path) => Ok(vec![path]),
+                Err(OrbitError::InvalidInput(_)) => {
+                    // Chosen policy: out-of-workspace docs roots (such as in-repo
+                    // symlinks pointing outside the workspace, parent traversal,
+                    // or absolute paths) are skipped as unusable roots (returning
+                    // an empty list) rather than aborting the walk. This matches
+                    // the wildcard branch and the walker's documented no-op
+                    // behavior for missing roots, ensuring literal and wildcard
+                    // forms produce the same outcome.
+                    Ok(Vec::new())
+                }
+                Err(error) => Err(error),
+            };
         }
         return Ok(Vec::new());
     }
@@ -150,7 +172,10 @@ pub(super) fn expand_root(repo_root: &Path, root: &str) -> Result<Vec<PathBuf>, 
 /// sides prevents `..` traversal and symlinks from redirecting a walk outside
 /// the repository. Callers only use this after confirming the candidate
 /// exists; a missing literal root remains the walker's documented no-op.
-fn validated_docs_root_path(repo_root: &Path, candidate: &Path) -> Result<PathBuf, OrbitError> {
+pub(super) fn validated_docs_root_path(
+    repo_root: &Path,
+    candidate: &Path,
+) -> Result<PathBuf, OrbitError> {
     let canonical_repo = repo_root.canonicalize().map_err(|error| {
         OrbitError::Io(format!("canonicalize {}: {error}", repo_root.display()))
     })?;
@@ -159,8 +184,9 @@ fn validated_docs_root_path(repo_root: &Path, candidate: &Path) -> Result<PathBu
     })?;
     if !canonical_candidate.starts_with(&canonical_repo) {
         return Err(OrbitError::InvalidInput(format!(
-            "docs root path must stay inside the workspace root: {}",
-            candidate.display()
+            "docs root path must stay inside the workspace root: {} (resolves to {})",
+            candidate.display(),
+            canonical_candidate.display()
         )));
     }
     Ok(canonical_candidate)
@@ -179,7 +205,11 @@ fn expand_wildcard_segments(
     ) -> Result<(), OrbitError> {
         if parts.is_empty() {
             if base.exists() {
-                out.push(validated_docs_root_path(repo_root, base)?);
+                match validated_docs_root_path(repo_root, base) {
+                    Ok(path) => out.push(path),
+                    Err(OrbitError::InvalidInput(_)) => return Ok(()),
+                    Err(error) => return Err(error),
+                }
             }
             return Ok(());
         }
@@ -189,7 +219,11 @@ fn expand_wildcard_segments(
             if !base.is_dir() {
                 return Ok(());
             }
-            let base = validated_docs_root_path(repo_root, base)?;
+            let base = match validated_docs_root_path(repo_root, base) {
+                Ok(base) => base,
+                Err(OrbitError::InvalidInput(_)) => return Ok(()),
+                Err(error) => return Err(error),
+            };
             let entries = fs::read_dir(&base)
                 .map_err(|error| OrbitError::Io(format!("read {}: {error}", base.display())))?;
             for entry in entries {


### PR DESCRIPTION
## Task

[ORB-11972](https://orbit-cli.com/tasks/ORB-11972) — [code-review] A symlinked docs root hard-fails `orbit docs index` while the wildcard form silently skips

### Description

## Problem

The `rust/path-injection` remediation in
`crates/orbit-core/src/application/docs/walk.rs` (merged in the
`d3681fdcb..e2ea810e4` window) added `validated_docs_root_path`, which
canonicalizes both the workspace root and the candidate and returns
`OrbitError::InvalidInput` when the candidate resolves outside the workspace
(`crates/orbit-core/src/application/docs/walk.rs:153-171`).

The two branches of `expand_root` then apply **opposite** policies to the same
configuration:

- `crates/orbit-core/src/application/docs/walk.rs:122` — the literal (no `*`)
  branch returns `Err` via `validated_docs_root_path(repo_root, &absolute)?`.
- `crates/orbit-core/src/application/docs/walk.rs:126-140` — the wildcard branch
  returns `Ok(Vec::new())` for a rooted or `..`-bearing pattern, silently
  skipping it.

`walk_docs_with_bodies` propagates the literal branch's `Err`
(`crates/orbit-core/src/application/docs/walk.rs:284`), so a single unusable
root aborts the entire walk instead of contributing nothing.

## Observed evidence

Verified against live code at HEAD `e2ea810e40cf1f50dffe20157d0ffba8e8a354ec`
with a temporary test in `crates/orbit-core/src/application/docs/tests/walk.rs`
(added, run, reverted — the working tree is clean):

```
wildcard    = Ok([])
literal     = Err(InvalidInput("docs root path must stay inside the workspace root: \
                                /tmp/.tmpM8p5kt/repo/../outside"))
literal_abs = Err(InvalidInput("docs root path must stay inside the workspace root: \
                                /tmp/.tmpM8p5kt/outside"))
symlinked   = Err(InvalidInput("docs root path must stay inside the workspace root: \
                                /tmp/.tmpM8p5kt/repo/docs"))
```

The last line is the important one: `docs` is a **symlink inside the repo**
pointing at a directory outside it, and `docs/` is the default configured root
(`.orbit/config.toml:72`, and `default_doc_roots` at
`crates/orbit-core/src/application/docs/config.rs:226-228`). No `..` or absolute
path appears in the operator's configuration.

The new test added alongside the fix
(`crates/orbit-core/src/application/docs/tests/walk.rs`,
`wildcard_root_rejects_paths_outside_the_workspace`) only asserts the
fail-open wildcard behavior, so the literal branch's hard failure is uncovered.

## Impact

A workspace that reaches its documentation through a symlinked `docs/` — a
normal monorepo or shared-docs layout — now fails `orbit docs index`,
`orbit docs list`, `orbit docs search`, and task-context doc resolution outright,
rather than indexing nothing for that root. The error names the in-repo path the
operator configured, giving no hint that the symlink target is the cause.

Separately, the two branches disagree about whether an out-of-workspace root is a
configuration error or a no-op, so the same intent expressed as `../shared` and
`../shared/*` behaves differently.

## Expected

One policy for an out-of-workspace docs root, applied to both branches. Given the
walker's documented no-op for an unusable root (see the doc comment at
`crates/orbit-core/src/application/docs/walk.rs:147-152`), skipping is the
consistent choice: drop the root, optionally warn, and keep walking the rest. If
the hard error is deliberate instead, the wildcard branch must fail the same way
and the failure must name the resolved target so the operator can act on it.
Either way a regression test should cover a symlinked in-repo docs root.

### Acceptance Criteria

- A workspace whose configured `docs/` root is an in-repo symlink to a directory outside the workspace produces the same outcome for the literal and wildcard forms of that root, and the chosen outcome is stated next to the code.
- One unusable docs root does not abort the walk of the remaining configured roots.
- If an out-of-workspace root still errors, the message names the resolved target rather than only the configured path.
- A regression test in `crates/orbit-core/src/application/docs/tests/walk.rs` covers the symlinked in-repo docs root and fails against the current code.

## Execution Summary

<details>
<summary>Click to expand</summary>

### Acceptance Criteria Results
- Criterion 1 (Consistent outcome for literal and wildcard symlinked root outside workspace, policy stated next to code): PASSED. Literal (`docs/`) and wildcard (`docs/*`) forms of an out-of-workspace docs root now consistently skip the root (returning empty results). The chosen skipping policy is documented in code comments next to `expand_root` in `crates/orbit-core/src/application/docs/walk.rs`.
- Criterion 2 (One unusable root does not abort walk of remaining roots): PASSED. Unusable roots return empty results and `walk_docs_with_bodies` warns and continues if `expand_root` errors, ensuring remaining configured roots are walked.
- Criterion 3 (Validation error message names resolved target): PASSED. `validated_docs_root_path` error message includes both the candidate path and canonical resolved target path.
- Criterion 4 (Regression test in tests/walk.rs): PASSED. Regression test `symlinked_in_repo_docs_root_outside_workspace_behaves_consistently` confirmed to fail against current code before changes, and now passes along with `out_of_workspace_root_validation_error_names_resolved_target`.

### Validation Commands
- `cargo test -p orbit-core --lib application::docs::tests::walk`: passed (9/9 passed)
- `cargo test -p orbit-core --lib application::docs`: passed (31/31 passed)
- `cargo test --test docs`: passed (12/12 passed)
- `make ci-fast`: passed
- `make ci-lint`: passed

### Risks & Deviations
None.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11972-6aa216f1`
- Behind base: 0
- Ahead of base: 1