### PR TITLE
[code-review] Pipeline workers cannot spawn when any ancestor of the log directory is a symlink

### DIFF
--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -1,4 +1,4 @@
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Component, Path, PathBuf};
@@ -1950,9 +1950,13 @@ fn pipeline_worker_file_name(run_id: &str, suffix: &str) -> Result<String, Orbit
 }
 
 /// Resolve the worker-log directory before using it for any file operation.
-/// Runtime initialization normally owns this directory, but a missing final
-/// component is created only after its existing parent has passed the same
-/// checks. Symlinked paths and traversal syntax fail closed.
+///
+/// Containment is the nearest existing parent, canonicalized, plus the final
+/// component. Ancestor symlinks are followed rather than rejected so ordinary
+/// layouts (a symlinked `/tmp`, `$HOME`, or project root) can still spawn a
+/// worker. A missing parent is rebuilt from that canonical ancestor so the
+/// caller can create intermediate directories. The final component itself
+/// must not be a symlink or a non-directory; traversal syntax fails closed.
 fn validated_pipeline_worker_log_directory(path: &Path) -> Result<PathBuf, OrbitError> {
     if !path.is_absolute() {
         return Err(OrbitError::InvalidInput(format!(
@@ -1976,34 +1980,20 @@ fn validated_pipeline_worker_log_directory(path: &Path) -> Result<PathBuf, Orbit
             path.display()
         ))
     })?;
-    for ancestor in parent.ancestors() {
-        let metadata = std::fs::symlink_metadata(ancestor).map_err(|error| {
-            OrbitError::Io(format!(
-                "inspect pipeline worker log directory '{}': {error}",
-                ancestor.display()
-            ))
-        })?;
-        if metadata.file_type().is_symlink() {
-            return Err(OrbitError::InvalidInput(format!(
-                "pipeline worker log directory must not contain symlinks: {}",
-                path.display()
-            )));
-        }
-    }
-
-    let canonical_parent = parent.canonicalize().map_err(|error| {
-        OrbitError::Io(format!(
-            "canonicalize pipeline worker log parent '{}': {error}",
-            parent.display()
-        ))
-    })?;
     let file_name = path.file_name().ok_or_else(|| {
         OrbitError::InvalidInput(format!(
             "pipeline worker log directory has no final component: {}",
             path.display()
         ))
     })?;
+    let canonical_parent = canonical_pipeline_worker_log_parent(parent)?;
     let canonical_path = canonical_parent.join(file_name);
+    if !canonical_path.starts_with(&canonical_parent) {
+        return Err(OrbitError::InvalidInput(format!(
+            "pipeline worker log directory must not contain traversal components: {}",
+            path.display()
+        )));
+    }
 
     match std::fs::symlink_metadata(&canonical_path) {
         Ok(metadata) if metadata.file_type().is_symlink() => {
@@ -2031,22 +2021,63 @@ fn validated_pipeline_worker_log_directory(path: &Path) -> Result<PathBuf, Orbit
     Ok(canonical_path)
 }
 
+/// Canonicalize the nearest existing ancestor of `parent` and rejoin any
+/// missing suffix. Unrelated ancestor symlinks are resolved; a dangling
+/// symlink at an existing component still fails closed via `canonicalize`.
+fn canonical_pipeline_worker_log_parent(parent: &Path) -> Result<PathBuf, OrbitError> {
+    let mut existing = parent.to_path_buf();
+    let mut missing = Vec::<OsString>::new();
+    loop {
+        match std::fs::symlink_metadata(&existing) {
+            Ok(_) => break,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let Some(name) = existing.file_name() else {
+                    return Err(OrbitError::InvalidInput(format!(
+                        "pipeline worker log directory has no parent: {}",
+                        parent.display()
+                    )));
+                };
+                missing.push(name.to_os_string());
+                if !existing.pop() {
+                    return Err(OrbitError::InvalidInput(format!(
+                        "pipeline worker log directory has no parent: {}",
+                        parent.display()
+                    )));
+                }
+            }
+            Err(error) => {
+                return Err(OrbitError::Io(format!(
+                    "inspect pipeline worker log directory '{}': {error}",
+                    existing.display()
+                )));
+            }
+        }
+    }
+
+    let mut canonical = existing.canonicalize().map_err(|error| {
+        OrbitError::Io(format!(
+            "canonicalize pipeline worker log parent '{}': {error}",
+            existing.display()
+        ))
+    })?;
+    for name in missing.into_iter().rev() {
+        canonical.push(name);
+    }
+    Ok(canonical)
+}
+
 pub(crate) fn configure_pipeline_worker_stdio(
     command: &mut Command,
     logs_dir: &Path,
     run_id: &str,
 ) -> Result<PipelineWorkerLog, OrbitError> {
     let mut logs_dir = validated_pipeline_worker_log_directory(logs_dir)?;
-    match std::fs::create_dir(&logs_dir) {
-        Ok(()) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
-        Err(error) => {
-            return Err(OrbitError::Io(format!(
-                "create pipeline worker log directory '{}': {error}",
-                logs_dir.display()
-            )));
-        }
-    }
+    std::fs::create_dir_all(&logs_dir).map_err(|error| {
+        OrbitError::Io(format!(
+            "create pipeline worker log directory '{}': {error}",
+            logs_dir.display()
+        ))
+    })?;
     logs_dir = validated_pipeline_worker_log_directory(&logs_dir)?;
     let log_path = pipeline_worker_log_path(&logs_dir, run_id)?;
 

--- a/crates/orbit-core/src/application/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/application/tests/job_pipeline.rs
@@ -210,8 +210,14 @@ fn configure_pipeline_worker_stdio_creates_missing_log_directory_after_validatio
     let worker_log = configure_pipeline_worker_stdio(&mut command, &logs_dir, "jrun-child")
         .expect("missing log directory is created after validation");
 
-    assert!(logs_dir.is_dir());
-    assert_eq!(worker_log.path(), logs_dir.join("jrun-child.worker.log"));
+    let resolved_logs = logs_dir
+        .canonicalize()
+        .expect("canonicalize created log directory");
+    assert!(resolved_logs.is_dir());
+    assert_eq!(
+        worker_log.path(),
+        resolved_logs.join("jrun-child.worker.log")
+    );
 }
 
 #[cfg(unix)]
@@ -226,13 +232,89 @@ fn configure_pipeline_worker_stdio_rejects_symlinked_log_directory() {
 
     let result = configure_pipeline_worker_stdio(&mut command, &logs_dir, "jrun-child");
 
+    let error = match result {
+        Ok(_) => panic!("symlinked log directories must fail closed"),
+        Err(error) => error,
+    };
     assert!(
-        result.is_err(),
-        "symlinked log directories must fail closed"
+        error.to_string().contains("must not be a symlink"),
+        "{error}"
     );
     assert!(
         !outside.join("jrun-child.worker.log").exists(),
         "worker setup must not follow a log-directory symlink"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn configure_pipeline_worker_stdio_accepts_symlinked_ancestor_of_log_directory() {
+    let root = TempDir::new().expect("tempdir");
+    let real = root.path().join("real");
+    std::fs::create_dir_all(real.join("state")).expect("create real state directory");
+    let linked = root.path().join("linked");
+    std::os::unix::fs::symlink(&real, &linked).expect("create ancestor symlink");
+
+    let logs_dir = linked.join("state").join("logs");
+    let mut command = Command::new("true");
+    let worker_log = configure_pipeline_worker_stdio(&mut command, &logs_dir, "jrun-child")
+        .expect("symlinked ancestors of a real log directory must be accepted");
+
+    let resolved_logs = real
+        .join("state")
+        .join("logs")
+        .canonicalize()
+        .expect("canonicalize resolved log directory");
+    assert!(resolved_logs.is_dir());
+    assert_eq!(
+        worker_log.path(),
+        resolved_logs.join("jrun-child.worker.log")
+    );
+    assert!(worker_log.path().is_file());
+}
+
+#[test]
+fn configure_pipeline_worker_stdio_creates_missing_intermediate_log_directories() {
+    let root = TempDir::new().expect("tempdir");
+    let logs_dir = root.path().join("state").join("logs");
+    let mut command = Command::new("true");
+
+    let worker_log = configure_pipeline_worker_stdio(&mut command, &logs_dir, "jrun-child")
+        .expect("missing intermediate directories are created");
+
+    let resolved_logs = logs_dir
+        .canonicalize()
+        .expect("canonicalize created log directory");
+    assert!(resolved_logs.is_dir());
+    assert_eq!(
+        worker_log.path(),
+        resolved_logs.join("jrun-child.worker.log")
+    );
+}
+
+#[test]
+fn configure_pipeline_worker_stdio_rejects_traversal_in_log_directory() {
+    let root = TempDir::new().expect("tempdir");
+    let logs_dir = root.path().join("nested").join("..").join("logs");
+    let mut command = Command::new("true");
+
+    let error = match configure_pipeline_worker_stdio(&mut command, &logs_dir, "jrun-child") {
+        Ok(_) => panic!("traversal components must fail closed"),
+        Err(error) => error,
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("must not contain traversal components"),
+        "{error}"
+    );
+    assert!(
+        !root
+            .path()
+            .join("logs")
+            .join("jrun-child.worker.log")
+            .exists(),
+        "worker setup must not resolve traversal into a log directory"
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-11971](https://orbit-cli.com/tasks/ORB-11971) — [code-review] Pipeline workers cannot spawn when any ancestor of the log directory is a symlink

### Description

## Problem

The `rust/path-injection` remediation for `crates/orbit-core/src/application/job/pipeline.rs`
(ORB-11854 / ORB-11902 family, merged as `4883938e1`/`242c1023c` in the
`d3681fdcb..e2ea810e4` window) added `validated_pipeline_worker_log_directory`,
which rejects the worker-log directory if **any** ancestor anywhere in its
absolute path is a symlink:

- `crates/orbit-core/src/application/job/pipeline.rs:1979-1992` —
  `for ancestor in parent.ancestors() { ... if metadata.file_type().is_symlink() { return Err(...) } }`.
  `Path::ancestors()` yields every prefix up to `/`, so a symlink at `/tmp`,
  `/var`, `/home`, or any project-path component fails the whole call.
- `crates/orbit-core/src/application/job/pipeline.rs:2039` —
  `configure_pipeline_worker_stdio` calls it, and
  `crates/orbit-core/src/application/job/pipeline.rs:1329-1333`
  (`spawn_pipeline_worker`) propagates the error, so **no pipeline worker can be
  spawned at all** for that workspace.

The containment goal only requires that the final log directory is not itself
redirected — which the separate final-component check at
`crates/orbit-core/src/application/job/pipeline.rs:2010-2018` already enforces,
along with the canonical-parent join at `:1995-2008`. The ancestor sweep adds no
containment guarantee (the parent is canonicalized immediately afterwards) and
instead turns an ordinary filesystem layout into a hard failure.

## Observed evidence

Verified against live code at HEAD `e2ea810e40cf1f50dffe20157d0ffba8e8a354ec`
with a temporary test in `crates/orbit-core/src/application/tests/job_pipeline.rs`
(added, run, reverted — the working tree is clean). The log directory itself is
**not** a symlink; only an ancestor is:

```rust
let real = root.path().join("real");
std::fs::create_dir_all(real.join("state")).unwrap();
let linked = root.path().join("linked");
std::os::unix::fs::symlink(&real, &linked).unwrap();

let logs_dir = linked.join("state").join("logs");
configure_pipeline_worker_stdio(&mut Command::new("true"), &logs_dir, "jrun-child")
```

```
Err(InvalidInput("pipeline worker log directory must not contain symlinks: \
/tmp/.tmp9Caa0d/linked/state/logs"))
```

A second, related regression in the same function: `configure_pipeline_worker_stdio`
replaced `create_dir_all(logs_dir)` with `std::fs::create_dir(&logs_dir)`
(`crates/orbit-core/src/application/job/pipeline.rs:2040`) while the validator
requires every ancestor of the final component to already exist
(`:1979-1986`, which maps a `NotFound` from `symlink_metadata` to `OrbitError::Io`).
A missing grandparent is now fatal rather than created:

```
Err(Io("inspect pipeline worker log directory '/tmp/.tmpGdAh96/state': \
No such file or directory (os error 2)"))
```

(`state_dir` is normally created by `ensure_workspace_dirs`,
`crates/orbit-core/src/bootstrap/init.rs:468-484`, so this second case is the
less likely of the two — but it is a real narrowing of the previous contract.)

## Impact

Every job run, routine dispatch, and pipeline worker spawn fails for any
workspace whose Orbit state path traverses a symlink. Concretely:

- **macOS**: `/tmp` → `private/tmp` and `/var` → `private/var` are symlinks, and
  the default `TMPDIR` is `/var/folders/...`. Any workspace under `/tmp` or a
  tempdir is permanently broken, and so are the pipeline tests — which is why
  this did not go red in CI: `.github/workflows/ci-macos.yml:78-93` runs only
  `orbit-exec`, `orbit-core ... sandbox`, `orbit-common process::tests::identity`
  and `orbit-core application::job::run::tests::{owner,actions}`. The new
  `application::tests::job_pipeline` cases never execute on macOS, and on Linux
  `/tmp` is a real directory so they pass.
- **Linux**: a symlinked `$HOME`, a symlinked project directory
  (`~/work -> /mnt/data/work`), or a symlinked data root produces the same total
  failure.

The failure message ("must not contain symlinks") names a path the operator
never configured as a symlink, so the cause is not obvious from the error.

## Expected

Containment is enforced by canonicalizing the parent and checking the final
component, not by forbidding symlinks in unrelated ancestors. Drop the
`parent.ancestors()` sweep (or restrict it to components at or below the
Orbit-owned root), and restore creation of missing intermediate directories so a
first spawn into a fresh state root still works. A regression test should cover
a log directory reached through a symlinked ancestor and fail against the
current code.

### Acceptance Criteria

- `configure_pipeline_worker_stdio` succeeds for a log directory whose absolute path traverses a symlinked ancestor while the final component is a real directory, and the worker log is created under the resolved directory.
- A log directory whose final component is itself a symlink, or whose final component resolves outside the canonical parent, still fails closed with the existing error.
- A missing intermediate directory between an existing Orbit root and the log directory is created rather than reported as an inspect error.
- A regression test in `crates/orbit-core/src/application/tests/job_pipeline.rs` covers the symlinked-ancestor case and fails against the current code.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Dropped the `parent.ancestors()` symlink sweep in `validated_pipeline_worker_log_directory`. Containment is now the nearest existing parent, canonicalized (ancestor symlinks followed), plus the final component.
- Missing parents are rebuilt from that canonical ancestor so `configure_pipeline_worker_stdio` can `create_dir_all` instead of failing inspect on a missing intermediate.
- Final-component symlink, non-directory, and `.`/`..` checks are unchanged; a join that would leave the canonical parent still uses the existing traversal error.
- Added `configure_pipeline_worker_stdio_accepts_symlinked_ancestor_of_log_directory` (the previously failing layout), a missing-intermediate creation test, and a traversal rejection test. Canonicalized the existing missing-log-directory path assertion so macOS `/tmp` resolution matches the returned log path.
Assessment: Scoped to the worker-log validator and its sibling tests. Existing fail-closed cases still hold; the ancestor test fails on HEAD `2e339ce` (`must not contain symlinks`) and passes with this change.

Criteria:
1. Symlinked ancestor, real final component — passed. Worker log is created under the canonical directory (`real/state/logs/...`), not rejected.
2. Final component is a symlink, or path contains `..` — passed. Existing errors: `must not be a symlink` and `must not contain traversal components`. No log is created outside the parent.
3. Missing intermediate (`state/logs` under an existing root) — passed. Directories are created; no inspect `NotFound`.
4. Regression test fails against current code — passed. Restored HEAD `pipeline.rs`, ran `configure_pipeline_worker_stdio_accepts_symlinked_ancestor_of_log_directory`: FAILED with `InvalidInput("pipeline worker log directory must not contain symlinks: /tmp/.tmpG6plLx/linked/state/logs")`. Restored the fix; the same test passed.

Validation:
- `cargo test -p orbit-core --lib configure_pipeline_worker_stdio` — passed (5 tests)
- `cargo test -p orbit-core --lib application::tests::job_pipeline` — passed (29 tests)
- Pre-fix replay of the ancestor test against HEAD `pipeline.rs` — failed as required (exit 101), then restored
- `make ci-fast` — passed
- `make ci-lint` — passed (`cargo clippy --workspace --all-targets -- -D warnings`)
- `git diff --check` — passed
- `make ci` — not run (merge gate; not required per task)

Risks:
- `create_dir_all` can still follow a raced intermediate symlink while creating missing suffix components. Re-validation rejects a final-component symlink afterward; that TOCTOU is the restored pre-remediation contract, not a new hole.
- macOS CI still does not run `application::tests::job_pipeline`; the new tests cover the `/tmp` symlink layout on Linux via an explicit ancestor link.

Uncommitted files: `crates/orbit-core/src/application/job/pipeline.rs`, `crates/orbit-core/src/application/tests/job_pipeline.rs`. HEAD `2e339ce041ba77baade08028fea82a6df34b48b9`. No friction filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11971-6aa216fe`
- Behind base: 0
- Ahead of base: 1