### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-automation/src/auto_tasks/loader.rs

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -58,6 +58,12 @@ extensions:
           "manual",
         ]
       - [
+          "orbit_automation::auto_tasks::loader::validated_auto_tasks_dir",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]
+      - [
           "orbit_common::fs::io::validated_atomic_target",
           "ReturnValue.Field[core::result::Result::Ok(0)]",
           "path-injection",

--- a/crates/orbit-automation/src/auto_tasks/loader.rs
+++ b/crates/orbit-automation/src/auto_tasks/loader.rs
@@ -5,6 +5,7 @@
 //! identity and the provenance-tag suffix stay in lockstep.
 
 use std::path::{Path, PathBuf};
+use std::{fmt, fs};
 
 use orbit_common::protocol::yaml::parse_auto_task_yaml;
 use orbit_types::workflow::AutoTaskDefinition;
@@ -51,26 +52,118 @@ pub struct AutoTaskCollection {
     pub errors: Vec<AutoTaskLoadError>,
 }
 
+#[derive(Debug)]
+enum AutoTasksDirectoryError {
+    Missing,
+    Invalid(String),
+}
+
+/// Resolve the configured auto-task directory before it reaches `read_dir`.
+///
+/// The runtime supplies the Orbit root, while the directory name is fixed by
+/// this module. Canonicalizing both components and requiring the exact direct
+/// child prevents a symlinked `auto_tasks` directory from redirecting a scan.
+fn validated_auto_tasks_dir(orbit_dir: &Path) -> Result<PathBuf, AutoTasksDirectoryError> {
+    let canonical_orbit_dir = match fs::canonicalize(orbit_dir) {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(AutoTasksDirectoryError::Missing);
+        }
+        Err(error) => {
+            return Err(AutoTasksDirectoryError::Invalid(format!(
+                "failed to resolve Orbit directory {}: {error}",
+                orbit_dir.display()
+            )));
+        }
+    };
+    let expected_dir = canonical_orbit_dir.join(AUTO_TASKS_DIR);
+    let canonical_dir = match fs::canonicalize(&expected_dir) {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(AutoTasksDirectoryError::Missing);
+        }
+        Err(error) => {
+            return Err(AutoTasksDirectoryError::Invalid(format!(
+                "failed to resolve auto_tasks directory {}: {error}",
+                expected_dir.display()
+            )));
+        }
+    };
+
+    if canonical_dir != expected_dir || !canonical_dir.is_dir() {
+        return Err(AutoTasksDirectoryError::Invalid(format!(
+            "auto_tasks directory must be a regular directory directly under {}",
+            canonical_orbit_dir.display()
+        )));
+    }
+
+    Ok(canonical_dir)
+}
+
+impl fmt::Display for AutoTasksDirectoryError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Missing => formatter.write_str("auto_tasks directory is missing"),
+            Self::Invalid(message) => formatter.write_str(message),
+        }
+    }
+}
+
 /// Load every `*.yaml` under `<orbit_dir>/auto_tasks/`, fail-closed per file.
 /// A missing directory is a clean empty collection.
 pub fn collect_auto_tasks(orbit_dir: &Path) -> AutoTaskCollection {
     let mut collection = AutoTaskCollection::default();
-    let dir = auto_tasks_dir(orbit_dir);
-    if !dir.is_dir() {
-        return collection;
-    }
+    let dir = match validated_auto_tasks_dir(orbit_dir) {
+        Ok(dir) => dir,
+        Err(AutoTasksDirectoryError::Missing) => return collection,
+        Err(error) => {
+            collection.errors.push(AutoTaskLoadError {
+                path: Some(auto_tasks_dir(orbit_dir)),
+                message: error.to_string(),
+            });
+            return collection;
+        }
+    };
 
-    let mut paths: Vec<PathBuf> = match std::fs::read_dir(&dir) {
-        Ok(entries) => entries
-            .filter_map(|entry| entry.ok().map(|e| e.path()))
-            .filter(|path| {
-                path.extension()
+    let mut paths = Vec::new();
+    match fs::read_dir(&dir) {
+        Ok(entries) => {
+            for entry in entries {
+                let entry = match entry {
+                    Ok(entry) => entry,
+                    Err(error) => {
+                        collection.errors.push(AutoTaskLoadError {
+                            path: Some(dir.clone()),
+                            message: format!("failed to read auto_tasks directory entry: {error}"),
+                        });
+                        continue;
+                    }
+                };
+                let path = entry.path();
+                let metadata = match fs::symlink_metadata(&path) {
+                    Ok(metadata) => metadata,
+                    Err(error) => {
+                        collection.errors.push(AutoTaskLoadError {
+                            path: Some(path),
+                            message: format!("failed to inspect auto-task entry: {error}"),
+                        });
+                        continue;
+                    }
+                };
+                if !metadata.file_type().is_file() {
+                    continue;
+                }
+                if path
+                    .extension()
                     .and_then(|ext| ext.to_str())
                     .is_some_and(|ext| {
                         ext.eq_ignore_ascii_case("yaml") || ext.eq_ignore_ascii_case("yml")
                     })
-            })
-            .collect(),
+                {
+                    paths.push(path);
+                }
+            }
+        }
         Err(error) => {
             collection.errors.push(AutoTaskLoadError {
                 path: Some(dir),
@@ -78,7 +171,7 @@ pub fn collect_auto_tasks(orbit_dir: &Path) -> AutoTaskCollection {
             });
             return collection;
         }
-    };
+    }
     paths.sort();
 
     for path in paths {

--- a/crates/orbit-automation/src/auto_tasks/tests/loader.rs
+++ b/crates/orbit-automation/src/auto_tasks/tests/loader.rs
@@ -4,6 +4,38 @@ use tempfile::tempdir;
 
 use crate::auto_tasks::loader::{auto_tasks_dir, collect_auto_tasks};
 
+fn write_valid_definition(definitions: &std::path::Path, name: &str) {
+    fs::write(
+        definitions.join(format!("{name}.yaml")),
+        format!(
+            r#"schemaVersion: 1
+name: {name}
+schedule:
+  every_minutes: 60
+template:
+  title: Fixture {name}
+"#
+        ),
+    )
+    .expect("definition fixture");
+}
+
+#[test]
+fn loads_regular_yaml_files_and_ignores_other_entries() {
+    let root = tempdir().expect("temporary definition root");
+    let definitions = auto_tasks_dir(root.path());
+    fs::create_dir_all(&definitions).expect("auto-task definitions directory");
+    write_valid_definition(&definitions, "valid");
+    fs::write(definitions.join("notes.txt"), "not an auto-task").expect("non-definition fixture");
+    fs::create_dir(definitions.join("nested.yaml")).expect("nested fixture");
+
+    let collection = collect_auto_tasks(root.path());
+
+    assert_eq!(collection.definitions.len(), 1);
+    assert_eq!(collection.definitions[0].definition.name, "valid");
+    assert!(collection.errors.is_empty());
+}
+
 #[test]
 fn rejects_definition_with_invalid_cron_during_collection() {
     let root = tempdir().expect("temporary definition root");
@@ -30,4 +62,44 @@ template:
             .message
             .contains("invalid cron expression 'every day'")
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_auto_tasks_directory_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempdir().expect("temporary Orbit root");
+    let outside = tempdir().expect("outside directory");
+    let outside_definitions = outside.path().join("auto_tasks");
+    fs::create_dir_all(&outside_definitions).expect("outside definitions directory");
+    write_valid_definition(&outside_definitions, "escaped");
+    symlink(&outside_definitions, auto_tasks_dir(root.path())).expect("directory symlink");
+
+    let collection = collect_auto_tasks(root.path());
+
+    assert!(collection.definitions.is_empty());
+    assert_eq!(collection.errors.len(), 1);
+    assert!(collection.errors[0].message.contains("directly under"));
+}
+
+#[cfg(unix)]
+#[test]
+fn ignores_symlinked_definition_files() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempdir().expect("temporary Orbit root");
+    let outside = tempdir().expect("outside directory");
+    let definitions = auto_tasks_dir(root.path());
+    fs::create_dir_all(&definitions).expect("auto-task definitions directory");
+    let outside_definition = outside.path().join("linked.yaml");
+    write_valid_definition(outside.path(), "linked");
+    symlink(&outside_definition, definitions.join("linked.yaml")).expect("definition symlink");
+    write_valid_definition(&definitions, "local");
+
+    let collection = collect_auto_tasks(root.path());
+
+    assert_eq!(collection.definitions.len(), 1);
+    assert_eq!(collection.definitions[0].definition.name, "local");
+    assert!(collection.errors.is_empty());
 }


### PR DESCRIPTION
## Task

[ORB-11904](https://orbit-cli.com/tasks/ORB-11904) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-automation/src/auto_tasks/loader.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#115`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `f56bfda5297c3e856b22d815c263f8d21dc481c4`
- Location: `crates/orbit-automation/src/auto_tasks/loader.rs` line 63
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:48:41Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/115

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-automation/src/auto_tasks/loader.rs` line 63 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added validated_auto_tasks_dir to canonicalize the Orbit root and fixed auto_tasks child before read_dir; missing roots remain clean empty collections and redirected/non-directory roots fail closed.
- Enumerate only regular, non-symlink YAML/YML entries so definition reads cannot follow symlinks outside the validated directory.
- Added loader coverage for valid regular entries, nested/non-YAML entries, escaped auto_tasks directory symlinks, and symlinked YAML definitions.
- Registered validated_auto_tasks_dir in the existing rust/path-injection CodeQL barrier model; no suppression, dismissal, or exclusion was added.

Criteria:
- Code scanning remediation: satisfied by the filesystem boundary validation, non-symlink enumeration, and barrier-model registration at the affected loader flow.
- Intended behavior: satisfied; valid regular definitions still load, missing roots remain empty, malformed definitions remain fail-closed, and symlink redirections are rejected or ignored.
- Validation/security confirmation: repository validation passed and the changed CodeQL model is ready for the hosted workflow. The local CodeQL CLI is unavailable, so a local scan could not confirm alert #115 clearance; GitHub workflow execution is outside this managed checkout.

Validation:
- PASS cargo fmt --all -- --check
- PASS cargo test -p orbit-automation auto_tasks::tests::loader (4 tests)
- PASS cargo test -p orbit-automation (112 tests plus doc-tests)
- PASS make ci-fast; compiler-cache namespace smoke test was environment-skipped because bubblewrap cannot create an unprivileged mount namespace.
- PASS make ci-lint
- PASS git diff --check
- NOT RUN CodeQL CLI scan: codeql is not installed; hosted GitHub CodeQL execution is not available from this checkout.

Assessment: Task-scoped uncommitted changes are limited to the loader, its sibling tests, and the existing CodeQL barrier model. Remaining risk is limited to hosted CodeQL confirmation of alert #115.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11904-6aa21bf5`
- Behind base: 0
- Ahead of base: 1