### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-cmd/src/diagnostics.rs

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -69,3 +69,15 @@ extensions:
           "path-injection",
           "manual",
         ]
+      - [
+          "orbit_cmd::diagnostics::validated_diagnostics_category_dir",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]
+      - [
+          "orbit_cmd::diagnostics::validated_diagnostics_month_dir",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]

--- a/crates/orbit-cmd/src/diagnostics.rs
+++ b/crates/orbit-cmd/src/diagnostics.rs
@@ -76,7 +76,7 @@ impl DiagnosticsCommands for OrbitRuntime {
 
 /// Ascending list of `YYYY-MM` subdirectories under `state/diagnostics/<category>/`.
 fn list_jsonl_months(root: &Path, category: &str) -> Result<Vec<String>, OrbitError> {
-    let category_dir = root.join("state").join("diagnostics").join(category);
+    let category_dir = validated_diagnostics_category_dir(root, category)?;
     if !category_dir.exists() {
         return Ok(Vec::new());
     }
@@ -100,16 +100,105 @@ fn is_year_month(name: &str) -> bool {
         && bytes[5..].iter().all(u8::is_ascii_digit)
 }
 
+fn validated_diagnostics_root(root: &Path) -> Result<PathBuf, OrbitError> {
+    let canonical_root = root.canonicalize().map_err(|error| {
+        OrbitError::Io(format!(
+            "resolve diagnostics root {}: {error}",
+            root.display()
+        ))
+    })?;
+    if !canonical_root.is_dir() {
+        return Err(OrbitError::InvalidInput(format!(
+            "diagnostics root must be a directory: {}",
+            canonical_root.display()
+        )));
+    }
+    Ok(canonical_root)
+}
+
+/// Resolve a diagnostics category beneath the runtime's canonical data root.
+/// Categories are an internal allow-list rather than path segments supplied by
+/// callers, and the returned path is bounded to that root before any read.
+fn validated_diagnostics_category_dir(root: &Path, category: &str) -> Result<PathBuf, OrbitError> {
+    let canonical_root = validated_diagnostics_root(root)?;
+    let category = validated_diagnostics_category_name(category)?;
+
+    validate_diagnostics_path(
+        &canonical_root,
+        canonical_root
+            .join("state")
+            .join("diagnostics")
+            .join(category),
+    )
+}
+
+/// Resolve a diagnostics month after converting the accepted text into a
+/// canonical value. The original caller-provided string never reaches a path
+/// operation, so traversal and separator characters cannot affect the lookup.
+fn validated_diagnostics_month_dir(
+    root: &Path,
+    category: &str,
+    year_month: &str,
+) -> Result<PathBuf, OrbitError> {
+    let canonical_root = validated_diagnostics_root(root)?;
+    let category = validated_diagnostics_category_name(category)?;
+    let canonical_month = validated_year_month(year_month)?;
+    let category_dir = canonical_root
+        .join("state")
+        .join("diagnostics")
+        .join(category);
+
+    validate_diagnostics_path(&canonical_root, category_dir.join(canonical_month))
+}
+
+fn validated_diagnostics_category_name(category: &str) -> Result<&'static str, OrbitError> {
+    match category {
+        "metrics" => Ok("metrics"),
+        "friction" => Ok("friction"),
+        _ => Err(OrbitError::InvalidInput(format!(
+            "unsupported diagnostics category: {category}"
+        ))),
+    }
+}
+
+fn validated_year_month(year_month: &str) -> Result<String, OrbitError> {
+    if !is_year_month(year_month) {
+        return Err(OrbitError::InvalidInput(format!(
+            "diagnostics month must use YYYY-MM format: {year_month}"
+        )));
+    }
+
+    let year = year_month[..4].parse::<u16>().map_err(|_| {
+        OrbitError::InvalidInput("diagnostics month contains an invalid year".to_string())
+    })?;
+    let month = year_month[5..].parse::<u8>().map_err(|_| {
+        OrbitError::InvalidInput("diagnostics month contains an invalid month".to_string())
+    })?;
+    Ok(format!("{year:04}-{month:02}"))
+}
+
+fn validate_diagnostics_path(root: &Path, path: PathBuf) -> Result<PathBuf, OrbitError> {
+    match path.canonicalize() {
+        Ok(canonical) if canonical.starts_with(root) => Ok(canonical),
+        Ok(canonical) => Err(OrbitError::InvalidInput(format!(
+            "diagnostics path '{}' resolves outside {}",
+            canonical.display(),
+            root.display()
+        ))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(path),
+        Err(error) => Err(OrbitError::Io(format!(
+            "resolve diagnostics path {}: {error}",
+            path.display()
+        ))),
+    }
+}
+
 fn read_jsonl_month<T: DeserializeOwned>(
     root: &Path,
     category: &str,
     year_month: &str,
 ) -> Result<Vec<T>, OrbitError> {
-    let month_dir: PathBuf = root
-        .join("state")
-        .join("diagnostics")
-        .join(category)
-        .join(year_month);
+    let month_dir = validated_diagnostics_month_dir(root, category, year_month)?;
     if !month_dir.exists() {
         return Ok(Vec::new());
     }
@@ -156,11 +245,7 @@ fn read_jsonl_month_limited<T: DeserializeOwned>(
         return Ok(Vec::new());
     }
 
-    let month_dir: PathBuf = root
-        .join("state")
-        .join("diagnostics")
-        .join(category)
-        .join(year_month);
+    let month_dir = validated_diagnostics_month_dir(root, category, year_month)?;
     if !month_dir.exists() {
         return Ok(Vec::new());
     }
@@ -231,7 +316,10 @@ fn parse_jsonl_values<T: DeserializeOwned>(line: &str) -> Result<Vec<T>, serde_j
 mod tests {
     use serde_json::{Value, json};
 
-    use super::{is_year_month, list_jsonl_months, parse_jsonl_values};
+    use super::{
+        is_year_month, list_jsonl_months, parse_jsonl_values, read_jsonl_month,
+        validated_diagnostics_month_dir, validated_year_month,
+    };
 
     #[test]
     fn parse_jsonl_values_recovers_concatenated_objects() {
@@ -254,6 +342,31 @@ mod tests {
         assert!(!is_year_month("26-03"));
         assert!(!is_year_month("2026/03"));
         assert!(!is_year_month(""));
+    }
+
+    #[test]
+    fn validated_year_month_rebuilds_only_the_allowed_components() {
+        assert_eq!(validated_year_month("2026-03").unwrap(), "2026-03");
+        assert!(validated_year_month("2026/03").is_err());
+        assert!(validated_year_month("../secrets").is_err());
+    }
+
+    #[test]
+    fn validated_month_dir_rejects_unknown_categories() {
+        let root = tempfile::tempdir().expect("tempdir");
+
+        let error = validated_diagnostics_month_dir(root.path(), "secrets", "2026-03").unwrap_err();
+
+        assert!(matches!(error, orbit_common::OrbitError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn read_month_rejects_path_traversal() {
+        let root = tempfile::tempdir().expect("tempdir");
+
+        let error = read_jsonl_month::<Value>(root.path(), "metrics", "../secrets").unwrap_err();
+
+        assert!(matches!(error, orbit_common::OrbitError::InvalidInput(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Task

[ORB-11914](https://orbit-cli.com/tasks/ORB-11914) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-cmd/src/diagnostics.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#116`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `60e2ce391962caafaca3c4b70343900fcb4bee0c`
- Location: `crates/orbit-cmd/src/diagnostics.rs` line 83
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:48:41Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/116

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-cmd/src/diagnostics.rs` line 83 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added diagnostics path validation that canonicalizes the runtime root, allow-lists metrics/friction categories, rejects traversal-shaped month input, reconstructs the YYYY-MM path component from parsed digits, and rejects existing symlinked diagnostics paths that resolve outside the root.
- Routed both full and limited diagnostics readers plus month enumeration through the validated paths.
- Added focused regression tests for invalid months and categories, and registered both validated path helpers in the repository's CodeQL Rust path-injection barrier model.

Acceptance criteria:
1. Met — the raw runtime/category/month paths no longer reach diagnostics filesystem reads; this is enforced by production validation code and CodeQL barrier-model entries, with no suppression, dismissal, or exclusion.
2. Met — valid YYYY-MM reads and month enumeration retain their existing behavior; invalid path-shaped input now fails closed with InvalidInput.
3. Met with local limitation — cargo fmt check, focused orbit-cmd diagnostics tests (8 passed), make ci-fast, make ci-lint, git diff --check, and a source-flow check all passed. The repository's documented CodeQL workflow was reviewed, but the CodeQL CLI is unavailable in this executor and agent-side GitHub access is not required by the task; actual CodeQL alert re-analysis remains for CI.

Validation:
- Passed: cargo fmt --all -- --check
- Passed: cargo test -p orbit-cmd diagnostics (8 passed, 0 failed)
- Passed: make ci-fast
- Passed: make ci-lint
- Passed: git diff --check
- Passed: source-flow check confirmed no raw caller month reaches Path::join
- Not run: CodeQL database analysis; codeql executable unavailable locally

Risks / deviations:
- The ci-fast compiler-cache namespace subcheck reported its documented sandbox limitation (bwrap cannot create a mount namespace); the overall make ci-fast command still passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11914-6aa21bf5`
- Behind base: 0
- Ahead of base: 1