### PR TITLE
Make auto-drain admission conflict-aware and expose lock-waiting capacity

### DIFF
--- a/crates/orbit-cli/src/command/run/readiness.rs
+++ b/crates/orbit-cli/src/command/run/readiness.rs
@@ -74,6 +74,9 @@ fn readiness_lines(payload: &Value) -> Vec<String> {
         "Snapshot only — eligible does not guarantee a task will start. Active leaf runs: {}/{}; free slots: {}.",
         capacity["active_leaf_runs"], capacity["max_active_leaf_runs"], capacity["free_slots"],
     )];
+    if let Some(phases) = occupancy_phases(&capacity["occupancy"]["phases"]) {
+        lines.push(format!("Occupied slots: {phases}."));
+    }
     if let Some(tasks) = payload["tasks"].as_array() {
         for task in tasks {
             let task_id = task["task_id"].as_str().unwrap_or("-");
@@ -83,13 +86,41 @@ fn readiness_lines(payload: &Value) -> Vec<String> {
                 .as_str()
                 .map(|crew| format!(" crew={crew}"))
                 .unwrap_or_default();
+            let blocked_by = blocking_task_ids(&task["blocking_task_ids"])
+                .map(|ids| format!(" blocked-by={ids}"))
+                .unwrap_or_default();
             lines.push(format!(
-                "{task_id}: {} ({reason}){crew}",
+                "{task_id}: {} ({reason}){crew}{blocked_by}",
                 if eligible { "eligible" } else { "waiting" }
             ));
         }
     }
     lines
+}
+
+/// [ORB-11973] A saturated drain reads the same whether its slots are working
+/// or queued on each other's locks, so name the phases beside the count.
+/// Phases that are zero are omitted; an occupancy block with nothing in it
+/// prints no line at all.
+fn occupancy_phases(phases: &Value) -> Option<String> {
+    let named = phases
+        .as_object()?
+        .iter()
+        .filter_map(|(phase, count)| {
+            let count = count.as_u64().filter(|count| *count > 0)?;
+            Some(format!("{count} {}", phase.replace('_', "-")))
+        })
+        .collect::<Vec<_>>();
+    (!named.is_empty()).then(|| named.join(", "))
+}
+
+fn blocking_task_ids(blocking: &Value) -> Option<String> {
+    let ids = blocking
+        .as_array()?
+        .iter()
+        .filter_map(Value::as_str)
+        .collect::<Vec<_>>();
+    (!ids.is_empty()).then(|| ids.join(","))
 }
 
 #[cfg(test)]
@@ -114,6 +145,44 @@ mod tests {
         assert!(text.contains("Snapshot only"), "{text}");
         assert!(
             text.contains("ORB-1: waiting (capacity_saturated)"),
+            "{text}"
+        );
+        assert!(
+            !text.contains("Occupied slots"),
+            "a payload without an occupancy block prints no phase line: {text}"
+        );
+    }
+
+    #[test]
+    fn readiness_payload_separates_lock_waiting_slots_from_working_ones() {
+        let text = readiness_lines(&json!({
+            "capacity": {
+                "active_leaf_runs": 10,
+                "max_active_leaf_runs": 10,
+                "free_slots": 0,
+                "occupancy": {
+                    "phases": {
+                        "implementing": 4,
+                        "lock_waiting": 5,
+                        "post_implementation": 1,
+                        "unknown": 0,
+                    }
+                }
+            },
+            "tasks": [{
+                "task_id": "ORB-1",
+                "eligible": false,
+                "reason": "conflict_deferred",
+                "blocking_task_ids": ["ORB-9", "ORB-10"],
+            }]
+        }))
+        .join("\n");
+        assert!(
+            text.contains("Occupied slots: 4 implementing, 5 lock-waiting, 1 post-implementation."),
+            "zero-count phases are omitted: {text}"
+        );
+        assert!(
+            text.contains("ORB-1: waiting (conflict_deferred) blocked-by=ORB-9,ORB-10"),
             "{text}"
         );
     }

--- a/crates/orbit-core/assets/activities/classify_workspace_auto_tasks.yaml
+++ b/crates/orbit-core/assets/activities/classify_workspace_auto_tasks.yaml
@@ -6,16 +6,33 @@ spec:
   type: deterministic
   description: >
     Materialize the admissible work for one workspace drain iteration. Returns
-    the loose backlog leaves that may start right now, in `list_backlog`
-    priority/age order and one task per dispatch, plus at most one backlog epic
-    root. The two are independent answers, not a choice: an `in-progress` epic
-    root already reserves the union of its descendants' `context_files`, so
-    `list_backlog_tasks` excludes exactly the leaves that overlap it and
-    conflict-free chores keep shipping alongside it. Leaves are capped at the
-    number of free leaf-run slots (`max_active_leaf_runs` minus the live
-    `task_auto_pipeline` runs), and tasks a live child is already carrying are
-    excluded — a detached leaf stays `backlog` until its child moves it to
-    `in-progress`, so the child's run input is the only claim record until then.
+    the loose backlog leaves that may start right now, in backlog priority/age
+    order and one task per dispatch, plus at most one backlog epic root. The
+    backlog snapshot behind this is the same one `orbit run readiness` reads,
+    so the two cannot disagree about which task takes a slot. The two answers
+    are independent, not a choice: an `in-progress` epic root already reserves
+    the union of its descendants' `context_files`, so the snapshot excludes
+    exactly the leaves that overlap it and conflict-free chores keep shipping
+    alongside it. Leaves are capped at the number of free leaf-run slots
+    (`max_active_leaf_runs` minus the live `task_auto_pipeline` runs), and tasks
+    a live child is already carrying are excluded — a detached leaf stays
+    `backlog` until its child moves it to `in-progress`, so the child's run
+    input is the only claim record until then.
+    The leaves that fill those slots are pairwise conflict-free. Candidates are
+    taken in priority/age order, but one is admitted only when its effective
+    lock footprint is free of every footprint already spoken for: a task lock
+    held by an `in-progress` or `review` task, a task a live `task_auto_pipeline`
+    wrapper is already carrying, and the leaves selected earlier in this same
+    iteration. A candidate that would collide is skipped rather than allowed to
+    consume a slot and then queue at `task_gate_pipeline`, and the iteration
+    continues to independent work behind it. `deferred_conflicts` explains each
+    skip with the blocking task IDs, the overlapping selectors, and whether the
+    blocker holds the lock (`held_lock`), is a live wrapper's claim
+    (`live_claim`), or was chosen earlier this iteration (`same_wave`). Final
+    lock acquisition stays with `reserve_locks`; this is a prediction, not a
+    reservation. `max_tasks` bounds how much backlog one iteration expands
+    footprints for, and `candidate_pool_truncated` reports the case where that
+    bound, not the free slots, ended the wave.
     An epic root is offered only when no `epic_pipeline` run is pending or
     running, because that job admits one active run and a second dispatch would
     queue rather than execute; `active_epic_run_id` names the live run when one
@@ -78,6 +95,14 @@ spec:
         type: number
       pending_backlog:
         type: number
+      deferred_conflicts:
+        type: array
+        items:
+          type: object
+      candidate_pool_size:
+        type: number
+      candidate_pool_truncated:
+        type: boolean
       active_leaf_runs:
         type: number
       free_slots:

--- a/crates/orbit-core/assets/skills/orbit/references/orchestration.md
+++ b/crates/orbit-core/assets/skills/orbit/references/orchestration.md
@@ -108,6 +108,22 @@ never creates a run, reconciles stale runs, reserves files, or mutates a task.
 Its answer can change immediately after the snapshot, so `eligible` means
 "would be admitted by this snapshot", never a guarantee that work will start.
 
+Two of its answers separate contention from capacity:
+
+- `conflict_deferred` means a slot was free and this task did not take it,
+  because its files overlap something already spoken for.
+  `blocking_task_ids` and `conflicts` name the tasks and selectors, and
+  `provenance` says whether the blocker holds the lock (`held_lock`), is a
+  task a live child is already carrying (`live_claim`), or was chosen earlier
+  in the same admission wave (`same_wave`). `capacity_saturated`, by contrast,
+  means there was no free slot at all.
+- `capacity.occupancy` breaks the occupied slots down by what each is doing —
+  `lock_waiting`, `implementing`, `post_implementation`, or `unknown` — with
+  the wrapper, task, and descendant run IDs behind each. A drain whose slots
+  are all `lock_waiting` is queued on itself, which the occupancy total alone
+  cannot show. Phase comes from durable run state only; where that evidence is
+  missing the phase is `unknown` and names the reason.
+
 ```bash
 orbit run history -j task_auto_pipeline
 orbit run show <run_id>

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/auto_admission.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/auto_admission.rs
@@ -1,0 +1,281 @@
+//! Conflict-aware admission selection for one auto-drain wave [ORB-11973].
+//!
+//! The classifier and the read-only readiness diagnostic both have to answer
+//! "which backlog tasks may take a free leaf slot right now". Answering it
+//! twice is how they drifted: each took a blind `free_slots`-long prefix of the
+//! priority/age order, so a run of mutually overlapping candidates could fill
+//! every slot and then serialize on `reserve_locks` inside
+//! `task_gate_pipeline` while independent work stayed queued behind them.
+//!
+//! This module is the single answer. It walks the existing order and keeps a
+//! candidate only when its effective lock footprint is free of every footprint
+//! already spoken for — by a real task lock, by a live leaf wrapper's claim,
+//! and by the candidates selected earlier in this same wave. Skipping a
+//! blocked candidate does not skip the ones behind it, so the wave reaches
+//! independent work instead of stopping at the cluster.
+//!
+//! Footprints come from `lock_context_files_for_task` and are compared with
+//! `workspace_relative_paths_overlap`, so canonical file/directory/symbol
+//! normalization and an epic root's descendant coverage are the same semantics
+//! the gate will enforce later. Nothing here reserves anything: the wave is a
+//! prediction, and `reserve_locks` stays authoritative for the race.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use orbit_common::fs::path::workspace_relative_paths_overlap;
+use orbit_types::task::{Task, TaskStatus};
+use serde_json::{Value, json};
+
+use crate::runtime::task::locks::lock_context_files_for_task;
+
+/// Where a blocking footprint came from, so a deferral says whether the lock is
+/// genuinely held or merely planned.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum ConflictProvenance {
+    /// The blocker holds a real task lock: it is `in-progress` or `review`.
+    HeldLock,
+    /// A live leaf wrapper is already carrying the blocker, which is still
+    /// `backlog` because the wrapper's child has not moved it yet. Nothing is
+    /// reserved, but the wrapper is on its way to `reserve_locks`, so admitting
+    /// an overlapping candidate would only queue two waiters on one footprint.
+    LiveClaim,
+    /// The blocker was selected earlier in this same wave. No lock exists yet;
+    /// this is the conflict the drain would otherwise create for itself.
+    SameWave,
+}
+
+impl ConflictProvenance {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            ConflictProvenance::HeldLock => "held_lock",
+            ConflictProvenance::LiveClaim => "live_claim",
+            ConflictProvenance::SameWave => "same_wave",
+        }
+    }
+}
+
+/// One overlapping selector pair that kept a candidate out of the wave.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) struct AdmissionConflict {
+    /// The candidate's own selector.
+    pub(super) requested_selector: String,
+    /// The selector it overlaps. Not necessarily equal: a `dir:` scope and a
+    /// `file:` beneath it overlap without matching.
+    pub(super) blocking_selector: String,
+    pub(super) blocking_task_id: String,
+    pub(super) provenance: ConflictProvenance,
+}
+
+/// A candidate that was examined, had a free slot available, and still could
+/// not take it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct DeferredAdmission {
+    pub(super) task_id: String,
+    pub(super) conflicts: Vec<AdmissionConflict>,
+}
+
+impl DeferredAdmission {
+    /// The distinct tasks an operator would have to wait on, in a stable order.
+    pub(super) fn blocking_task_ids(&self) -> Vec<String> {
+        self.conflicts
+            .iter()
+            .map(|conflict| conflict.blocking_task_id.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
+    pub(super) fn to_json(&self) -> Value {
+        json!({
+            "task_id": self.task_id,
+            "blocking_task_ids": self.blocking_task_ids(),
+            "conflicts": self
+                .conflicts
+                .iter()
+                .map(|conflict| json!({
+                    "requested_selector": conflict.requested_selector,
+                    "blocking_selector": conflict.blocking_selector,
+                    "blocking_task_id": conflict.blocking_task_id,
+                    "provenance": conflict.provenance.as_str(),
+                }))
+                .collect::<Vec<_>>(),
+        })
+    }
+}
+
+/// The outcome of one wave, partitioned so every candidate is accounted for.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(super) struct AdmissionSelection {
+    /// Mutually compatible tasks, in the candidate order they were offered in.
+    pub(super) selected: Vec<String>,
+    /// Examined against a free slot and blocked.
+    pub(super) deferred: Vec<DeferredAdmission>,
+    /// Never examined: the wave was already full when they came up. These are
+    /// saturated, not conflicted, and saying so keeps the two diagnoses apart.
+    pub(super) queued_behind_capacity: Vec<String>,
+}
+
+impl AdmissionSelection {
+    pub(super) fn deferred_for(&self, task_id: &str) -> Option<&DeferredAdmission> {
+        self.deferred
+            .iter()
+            .find(|deferred| deferred.task_id == task_id)
+    }
+
+    pub(super) fn deferred_json(&self) -> Vec<Value> {
+        self.deferred
+            .iter()
+            .map(DeferredAdmission::to_json)
+            .collect()
+    }
+}
+
+/// Every lock footprint a wave must respect, keyed by selector.
+///
+/// Held locks and live claims are kept apart rather than merged because the
+/// remedies differ: a held lock clears when its task leaves `in-progress`, a
+/// live claim clears when a wrapper's child finishes.
+#[derive(Clone, Debug, Default)]
+pub(super) struct AdmissionHolders {
+    held: BTreeMap<String, Vec<String>>,
+    claimed: BTreeMap<String, Vec<String>>,
+}
+
+impl AdmissionHolders {
+    /// Build the pre-wave footprints from the snapshot's lock holders and the
+    /// tasks live leaf wrappers are carrying.
+    ///
+    /// A claimed task that already reached `in-progress` or `review` is left to
+    /// the held set: it is the same footprint, and reporting it twice under two
+    /// provenances would misstate why the candidate is waiting.
+    pub(super) fn new(
+        lock_holders: &BTreeMap<String, Vec<String>>,
+        live_claims: &BTreeSet<String>,
+        task_lookup: &BTreeMap<String, Task>,
+        workspace_root: &Path,
+    ) -> Self {
+        let mut claimed: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for task_id in live_claims {
+            let Some(task) = task_lookup.get(task_id) else {
+                continue;
+            };
+            if matches!(task.status, TaskStatus::InProgress | TaskStatus::Review) {
+                continue;
+            }
+            for selector in lock_context_files_for_task(task, task_lookup, workspace_root) {
+                claimed.entry(selector).or_default().push(task.id.clone());
+            }
+        }
+        for claiming_task_ids in claimed.values_mut() {
+            claiming_task_ids.sort();
+            claiming_task_ids.dedup();
+        }
+
+        Self {
+            held: lock_holders.clone(),
+            claimed,
+        }
+    }
+
+    fn conflicts_for(&self, requested_selector: &str) -> Vec<AdmissionConflict> {
+        let held = self
+            .held
+            .iter()
+            .map(|entry| (entry, ConflictProvenance::HeldLock));
+        let claimed = self
+            .claimed
+            .iter()
+            .map(|entry| (entry, ConflictProvenance::LiveClaim));
+
+        held.chain(claimed)
+            .filter(|((blocking_selector, _), _)| {
+                workspace_relative_paths_overlap(requested_selector, blocking_selector)
+            })
+            .flat_map(|((blocking_selector, blocking_task_ids), provenance)| {
+                blocking_task_ids
+                    .iter()
+                    .map(move |blocking_task_id| AdmissionConflict {
+                        requested_selector: requested_selector.to_string(),
+                        blocking_selector: blocking_selector.clone(),
+                        blocking_task_id: blocking_task_id.clone(),
+                        provenance,
+                    })
+            })
+            .collect()
+    }
+}
+
+/// Fill the free slots with a pairwise non-conflicting set, preserving the
+/// candidate order among compatible tasks.
+///
+/// `ordered_candidates` is the caller's priority/age order, already filtered for
+/// dependencies, crew, epic membership, live claims, and grant scope. This
+/// function adds exactly one rule: a candidate joins the wave only if nothing
+/// it would touch is already spoken for.
+pub(super) fn select_admissions(
+    ordered_candidates: &[String],
+    task_lookup: &BTreeMap<String, Task>,
+    workspace_root: &Path,
+    holders: &AdmissionHolders,
+    free_slots: usize,
+) -> AdmissionSelection {
+    let mut selection = AdmissionSelection::default();
+    // Selectors this wave has already promised, and the task each was promised
+    // to. Grown as tasks are selected, which is what makes the wave internally
+    // consistent rather than merely consistent with the stores.
+    let mut wave: BTreeMap<String, String> = BTreeMap::new();
+
+    for candidate_id in ordered_candidates {
+        if selection.selected.len() >= free_slots {
+            selection.queued_behind_capacity.push(candidate_id.clone());
+            continue;
+        }
+        let Some(task) = task_lookup.get(candidate_id) else {
+            // A candidate the snapshot no longer knows cannot have its
+            // footprint expanded, so it cannot be shown to be compatible.
+            selection.queued_behind_capacity.push(candidate_id.clone());
+            continue;
+        };
+
+        let footprint = lock_context_files_for_task(task, task_lookup, workspace_root);
+        let mut conflicts = Vec::new();
+        for requested_selector in &footprint {
+            conflicts.extend(holders.conflicts_for(requested_selector));
+            conflicts.extend(wave_conflicts(requested_selector, &wave));
+        }
+        conflicts.sort();
+        conflicts.dedup();
+
+        if conflicts.is_empty() {
+            for selector in footprint {
+                wave.entry(selector).or_insert_with(|| candidate_id.clone());
+            }
+            selection.selected.push(candidate_id.clone());
+        } else {
+            selection.deferred.push(DeferredAdmission {
+                task_id: candidate_id.clone(),
+                conflicts,
+            });
+        }
+    }
+
+    selection
+}
+
+fn wave_conflicts(
+    requested_selector: &str,
+    wave: &BTreeMap<String, String>,
+) -> Vec<AdmissionConflict> {
+    wave.iter()
+        .filter(|(blocking_selector, _)| {
+            workspace_relative_paths_overlap(requested_selector, blocking_selector)
+        })
+        .map(|(blocking_selector, blocking_task_id)| AdmissionConflict {
+            requested_selector: requested_selector.to_string(),
+            blocking_selector: blocking_selector.clone(),
+            blocking_task_id: blocking_task_id.clone(),
+            provenance: ConflictProvenance::SameWave,
+        })
+        .collect()
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs
@@ -64,6 +64,11 @@ pub(super) struct BacklogSnapshot {
     pub(super) status_by_id: BTreeMap<String, TaskStatus>,
     pub(super) admissible_leaves: Vec<Task>,
     pub(super) excluded: Vec<BacklogTaskExclusion>,
+    /// Selector -> the `in-progress` / `review` tasks holding it. Carried on
+    /// the snapshot rather than recomputed by each consumer so admission
+    /// selection, exclusion reasons, and the lock-wait diagnostic all name the
+    /// same holder for the same selector [ORB-11973].
+    pub(super) lock_holders: BTreeMap<String, Vec<String>>,
 }
 
 fn active_task_lock_holders(
@@ -361,6 +366,7 @@ pub(super) fn backlog_snapshot(
         status_by_id,
         admissible_leaves: backlog,
         excluded,
+        lock_holders,
     })
 }
 

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/leaf_occupancy.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/leaf_occupancy.rs
@@ -1,0 +1,393 @@
+//! What the drain's occupied leaf slots are actually doing [ORB-11973].
+//!
+//! A saturated drain used to report one number and a flat list of wrapper run
+//! ids, which cannot distinguish the two situations an operator has to tell
+//! apart: ten slots doing ten pieces of work, and ten slots where half are
+//! queued behind each other's locks inside `task_gate_pipeline`. The occupancy
+//! itself is identical; only the phase of each wrapper's descendant separates
+//! them.
+//!
+//! Phase is read from durable run state and nothing else. A wrapper's
+//! `child_dispatches` name its gate run, the gate's name the implementation
+//! run, and the gate's `waiting_on_locks` is the record `reserve_locks` writes
+//! when it parks. Where that evidence is missing the phase is reported as
+//! `unknown` with the reason, because a guessed phase is worse than an
+//! acknowledged gap in a diagnostic an operator uses to decide whether to
+//! intervene.
+//!
+//! This module reads; it never writes. Occupancy stays wrapper-based, so a
+//! wrapper with several descendants still consumes exactly one slot.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use orbit_common::OrbitError;
+use orbit_common::fs::path::workspace_relative_paths_overlap;
+use orbit_types::workflow::{ChildDispatch, PipelineState};
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+
+/// The wrapper job that occupies a leaf slot.
+const LEAF_JOB_NAME: &str = "task_auto_pipeline";
+
+/// The wrapper's own child: waits for the bundle's lock window, reserves it,
+/// then dispatches the implementation run.
+const GATE_JOB_NAME: &str = "task_gate_pipeline";
+
+/// How far the dispatch walk follows lineage. The wrapper -> gate ->
+/// implementation chain is two hops; the bound is a loop guard for a
+/// malformed or cyclic dispatch record, not a tuning knob.
+const MAX_DISPATCH_DEPTH: usize = 2;
+
+/// What a live leaf wrapper is doing, as far as durable state can say.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum LeafRunPhase {
+    /// The gate has parked on `reserve_locks`: it holds a slot but no lock.
+    LockWaiting,
+    /// An implementation run is live under the gate.
+    Implementing,
+    /// The gate recorded an implementation dispatch that has since gone
+    /// terminal, so the slot is doing post-implementation work — the base
+    /// sync, reservation release, and gate teardown. This is the sync/other
+    /// bucket: it is neither waiting for a lock nor implementing.
+    PostImplementation,
+    /// No durable evidence resolved a phase. Always accompanied by the reason.
+    Unknown,
+}
+
+impl LeafRunPhase {
+    fn as_str(self) -> &'static str {
+        match self {
+            LeafRunPhase::LockWaiting => "lock_waiting",
+            LeafRunPhase::Implementing => "implementing",
+            LeafRunPhase::PostImplementation => "post_implementation",
+            LeafRunPhase::Unknown => "unknown",
+        }
+    }
+
+    /// How advanced a phase is, for a wrapper carrying more than one gate. The
+    /// drain dispatches one task per wrapper, so this is a tie-break for
+    /// hand-submitted bundles rather than the normal path.
+    fn rank(self) -> u8 {
+        match self {
+            LeafRunPhase::Implementing => 3,
+            LeafRunPhase::PostImplementation => 2,
+            LeafRunPhase::LockWaiting => 1,
+            LeafRunPhase::Unknown => 0,
+        }
+    }
+}
+
+/// One occupied slot, its lineage, and the evidence behind its phase.
+pub(super) struct LeafRunOccupancy {
+    pub(super) run_id: String,
+    pub(super) task_ids: Vec<String>,
+    pub(super) phase: LeafRunPhase,
+    /// Every descendant run the dispatch records name, deduplicated.
+    pub(super) descendant_run_ids: Vec<String>,
+    /// Selectors the gate is parked on, with the holders they resolve to.
+    pub(super) lock_wait: Option<LockWait>,
+    /// Why the phase is `unknown`, and only then.
+    pub(super) unknown_reason: Option<&'static str>,
+}
+
+/// The gate's parked-lock record, resolved against current holders.
+pub(super) struct LockWait {
+    pub(super) gate_run_id: String,
+    pub(super) selectors: Vec<String>,
+    /// Selectors that map to a task currently holding a lock.
+    pub(super) blockers: Vec<LockWaitBlocker>,
+    /// Selectors no current holder explains. The gate recorded a conflict, so
+    /// the wait is real; the holder has since moved on, or holds through a
+    /// reservation rather than a task status. Reported rather than dropped so
+    /// the missing evidence is visible instead of looking like no conflict.
+    pub(super) unresolved_selectors: Vec<String>,
+}
+
+pub(super) struct LockWaitBlocker {
+    pub(super) selector: String,
+    pub(super) holder_task_ids: Vec<String>,
+}
+
+impl LeafRunOccupancy {
+    fn to_json(&self) -> Value {
+        let mut entry = json!({
+            "run_id": self.run_id,
+            "task_ids": self.task_ids,
+            "phase": self.phase.as_str(),
+            "descendant_run_ids": self.descendant_run_ids,
+        });
+        let Some(object) = entry.as_object_mut() else {
+            return entry;
+        };
+        if let Some(reason) = self.unknown_reason {
+            object.insert("unknown_reason".to_string(), json!(reason));
+        }
+        if let Some(lock_wait) = &self.lock_wait {
+            object.insert(
+                "lock_wait".to_string(),
+                json!({
+                    "gate_run_id": lock_wait.gate_run_id,
+                    "selectors": lock_wait.selectors,
+                    "blockers": lock_wait
+                        .blockers
+                        .iter()
+                        .map(|blocker| json!({
+                            "selector": blocker.selector,
+                            "holder_task_ids": blocker.holder_task_ids,
+                        }))
+                        .collect::<Vec<_>>(),
+                    "unresolved_selectors": lock_wait.unresolved_selectors,
+                }),
+            );
+        }
+        entry
+    }
+}
+
+/// Project the occupied slots into the readiness payload's `occupancy` block.
+///
+/// `free_slots` is passed through rather than recomputed so the block cannot
+/// disagree with the capacity figures beside it.
+pub(super) fn occupancy_json(runs: &[LeafRunOccupancy], free_slots: usize) -> Value {
+    let mut phases: BTreeMap<&'static str, usize> = BTreeMap::from([
+        ("lock_waiting", 0),
+        ("implementing", 0),
+        ("post_implementation", 0),
+        ("unknown", 0),
+    ]);
+    for run in runs {
+        *phases.entry(run.phase.as_str()).or_default() += 1;
+    }
+    // A task carried by two wrappers is one task but two occupied slots; the
+    // per-run entries keep the slots and this roll-up keeps the tasks.
+    let task_ids: BTreeSet<&String> = runs.iter().flat_map(|run| run.task_ids.iter()).collect();
+
+    json!({
+        "active_leaf_runs": runs.len(),
+        "free_slots": free_slots,
+        "phases": phases,
+        "task_ids": task_ids,
+        "runs": runs.iter().map(LeafRunOccupancy::to_json).collect::<Vec<_>>(),
+    })
+}
+
+/// Resolve the phase of every live leaf wrapper from durable run state.
+///
+/// `lock_holders` is the readiness snapshot's selector -> holder map, reused so
+/// a blocker named here is the same task the exclusion reasons name.
+pub(super) fn read_leaf_occupancy(
+    runtime: &OrbitRuntime,
+    leaf_runs: &[(String, Vec<String>)],
+    lock_holders: &BTreeMap<String, Vec<String>>,
+) -> Result<Vec<LeafRunOccupancy>, OrbitError> {
+    let lineage = read_dispatch_lineage(
+        runtime,
+        &leaf_runs
+            .iter()
+            .map(|(run_id, _)| run_id.clone())
+            .collect::<Vec<_>>(),
+    )?;
+
+    Ok(leaf_runs
+        .iter()
+        .map(|(run_id, task_ids)| {
+            let resolved = resolve_phase(run_id, &lineage, lock_holders);
+            LeafRunOccupancy {
+                run_id: run_id.clone(),
+                task_ids: task_ids.clone(),
+                phase: resolved.phase,
+                descendant_run_ids: descendants_of(run_id, &lineage),
+                lock_wait: resolved.lock_wait,
+                unknown_reason: resolved.unknown_reason,
+            }
+        })
+        .collect())
+}
+
+/// Every run state reachable from the wrappers within [`MAX_DISPATCH_DEPTH`],
+/// read one level at a time so each level costs one batched store call.
+fn read_dispatch_lineage(
+    runtime: &OrbitRuntime,
+    wrapper_run_ids: &[String],
+) -> Result<BTreeMap<String, PipelineState>, OrbitError> {
+    let mut lineage: BTreeMap<String, PipelineState> = BTreeMap::new();
+    let mut frontier = wrapper_run_ids.to_vec();
+
+    for _ in 0..=MAX_DISPATCH_DEPTH {
+        frontier.retain(|run_id| !lineage.contains_key(run_id));
+        if frontier.is_empty() {
+            break;
+        }
+        let states = runtime.read_run_states(&frontier)?;
+        let mut next = BTreeSet::new();
+        for (run_id, state) in states {
+            let Some(state) = state else {
+                continue;
+            };
+            for dispatch in &state.child_dispatches {
+                next.insert(dispatch.child_run_id.clone());
+            }
+            lineage.insert(run_id, state);
+        }
+        frontier = next.into_iter().collect();
+    }
+
+    Ok(lineage)
+}
+
+struct ResolvedPhase {
+    phase: LeafRunPhase,
+    lock_wait: Option<LockWait>,
+    unknown_reason: Option<&'static str>,
+}
+
+fn resolve_phase(
+    wrapper_run_id: &str,
+    lineage: &BTreeMap<String, PipelineState>,
+    lock_holders: &BTreeMap<String, Vec<String>>,
+) -> ResolvedPhase {
+    let Some(wrapper) = lineage.get(wrapper_run_id) else {
+        return unknown("no readable pipeline state for this leaf run");
+    };
+    let gates = wrapper
+        .child_dispatches
+        .iter()
+        .filter(|dispatch| dispatch.job_name == GATE_JOB_NAME)
+        .collect::<Vec<_>>();
+    if gates.is_empty() {
+        return unknown("leaf run has not recorded a gate dispatch yet");
+    }
+
+    // Take the most advanced gate: a wrapper carrying a bundle occupies its
+    // slot until its last gate finishes, so the furthest one describes what the
+    // slot is doing.
+    gates
+        .into_iter()
+        .map(|gate| resolve_gate_phase(gate, lineage, lock_holders))
+        .max_by_key(|resolved| resolved.phase.rank())
+        .unwrap_or_else(|| unknown("leaf run has not recorded a gate dispatch yet"))
+}
+
+fn resolve_gate_phase(
+    gate: &ChildDispatch,
+    lineage: &BTreeMap<String, PipelineState>,
+    lock_holders: &BTreeMap<String, Vec<String>>,
+) -> ResolvedPhase {
+    let Some(state) = lineage.get(&gate.child_run_id) else {
+        return unknown("no readable pipeline state for this gate run");
+    };
+
+    let implementation = state
+        .child_dispatches
+        .iter()
+        .filter(|dispatch| is_implementation_job(&dispatch.job_name))
+        .collect::<Vec<_>>();
+    if implementation
+        .iter()
+        .any(|dispatch| dispatch.phase.is_open())
+    {
+        return resolved(LeafRunPhase::Implementing, None);
+    }
+    if !implementation.is_empty() {
+        return resolved(LeafRunPhase::PostImplementation, None);
+    }
+
+    let selectors = state.waiting_on_locks.clone().unwrap_or_default();
+    if selectors.is_empty() {
+        return unknown("gate run recorded neither a lock wait nor a dispatch");
+    }
+    resolved(
+        LeafRunPhase::LockWaiting,
+        Some(resolve_lock_wait(
+            gate.child_run_id.clone(),
+            selectors,
+            lock_holders,
+        )),
+    )
+}
+
+/// The gate's child is `task_{mode}_pipeline`, so the implementation job name
+/// is not a closed set — anything the gate dispatches that is not another gate
+/// or another wrapper is the implementation it was waiting to start.
+fn is_implementation_job(job_name: &str) -> bool {
+    job_name != GATE_JOB_NAME
+        && job_name != LEAF_JOB_NAME
+        && job_name.starts_with("task_")
+        && job_name.ends_with("_pipeline")
+}
+
+fn resolve_lock_wait(
+    gate_run_id: String,
+    selectors: Vec<String>,
+    lock_holders: &BTreeMap<String, Vec<String>>,
+) -> LockWait {
+    let mut blockers = Vec::new();
+    let mut unresolved_selectors = Vec::new();
+
+    for selector in &selectors {
+        let holder_task_ids = lock_holders
+            .iter()
+            .filter(|(held_selector, _)| workspace_relative_paths_overlap(selector, held_selector))
+            .flat_map(|(_, holder_task_ids)| holder_task_ids.iter().cloned())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        if holder_task_ids.is_empty() {
+            unresolved_selectors.push(selector.clone());
+        } else {
+            blockers.push(LockWaitBlocker {
+                selector: selector.clone(),
+                holder_task_ids,
+            });
+        }
+    }
+
+    LockWait {
+        gate_run_id,
+        selectors,
+        blockers,
+        unresolved_selectors,
+    }
+}
+
+fn descendants_of(wrapper_run_id: &str, lineage: &BTreeMap<String, PipelineState>) -> Vec<String> {
+    let mut descendants = BTreeSet::new();
+    let mut frontier = vec![wrapper_run_id.to_string()];
+
+    for _ in 0..=MAX_DISPATCH_DEPTH {
+        let mut next = Vec::new();
+        for run_id in &frontier {
+            let Some(state) = lineage.get(run_id) else {
+                continue;
+            };
+            for dispatch in &state.child_dispatches {
+                if descendants.insert(dispatch.child_run_id.clone()) {
+                    next.push(dispatch.child_run_id.clone());
+                }
+            }
+        }
+        if next.is_empty() {
+            break;
+        }
+        frontier = next;
+    }
+
+    descendants.into_iter().collect()
+}
+
+fn resolved(phase: LeafRunPhase, lock_wait: Option<LockWait>) -> ResolvedPhase {
+    ResolvedPhase {
+        phase,
+        lock_wait,
+        unknown_reason: None,
+    }
+}
+
+fn unknown(reason: &'static str) -> ResolvedPhase {
+    ResolvedPhase {
+        phase: LeafRunPhase::Unknown,
+        lock_wait: None,
+        unknown_reason: Some(reason),
+    }
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/mod.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/mod.rs
@@ -7,6 +7,7 @@
 //! HTTP agent-loop transport and CLI subprocess execution both live in
 //! `orbit-engine`, so this module never names orbit-agent types.
 
+pub(super) mod auto_admission;
 pub(super) mod backlog_exclusion;
 pub(super) mod child_dispatch;
 pub(super) mod ci_failure_admission;
@@ -15,6 +16,7 @@ pub(super) mod cli_executor;
 pub(super) mod dependabot_alert_tasks;
 pub(super) mod dispatch;
 pub(super) mod duplicate_tasks;
+pub(super) mod leaf_occupancy;
 pub(super) mod pipeline_actions;
 pub(super) mod sandbox;
 pub(super) mod scan_unresolved;

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/auto_admission.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/auto_admission.rs
@@ -1,0 +1,652 @@
+//! Conflict-aware admission selection [ORB-11973].
+//!
+//! The unit tests drive `select_admissions` directly so the selection rule is
+//! exercised at the boundary that owns it; the end-to-end tests then confirm
+//! the classifier and readiness both reach that rule with the same pool.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use orbit_engine::RuntimeHost;
+use orbit_tools::ToolContext;
+use orbit_types::task::{Task, TaskPriority, TaskStatus, TaskType};
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+use crate::adapter::engine_host::v2_host::auto_admission::{
+    AdmissionHolders, ConflictProvenance, select_admissions,
+};
+use crate::adapter::engine_host::v2_host::backlog_exclusion::backlog_snapshot;
+use crate::adapter::engine_host::v2_host::test_support::{
+    runtime_with_workspace_layout, seed_list_backlog_task, write_workspace_file,
+};
+use crate::application::job::crew_pools::CapturedCrewPools;
+use crate::application::task::TaskUpdateParams;
+
+fn task_lookup(runtime: &OrbitRuntime) -> BTreeMap<String, Task> {
+    runtime
+        .list_tasks()
+        .expect("list tasks")
+        .into_iter()
+        .map(|task| (task.id.clone(), task))
+        .collect()
+}
+
+fn lock_holders(runtime: &OrbitRuntime) -> BTreeMap<String, Vec<String>> {
+    backlog_snapshot(runtime, "test", None, &CapturedCrewPools::new())
+        .expect("backlog snapshot")
+        .lock_holders
+}
+
+/// The snapshot's own priority/age ordering of the admissible leaves, which is
+/// the order the classifier and readiness both hand to the selection routine.
+fn ordered_candidates(runtime: &OrbitRuntime) -> Vec<String> {
+    backlog_snapshot(runtime, "test", None, &CapturedCrewPools::new())
+        .expect("backlog snapshot")
+        .admissible_leaves
+        .into_iter()
+        .map(|task| task.id)
+        .collect()
+}
+
+fn backlog_task(
+    runtime: &OrbitRuntime,
+    repo_root: &Path,
+    title: &str,
+    priority: TaskPriority,
+    context_files: Vec<&str>,
+) -> Task {
+    for selector in &context_files {
+        if let Some(path) = selector.strip_prefix("file:") {
+            write_workspace_file(repo_root, path);
+        }
+    }
+    seed_list_backlog_task(
+        runtime,
+        title,
+        TaskStatus::Backlog,
+        priority,
+        TaskType::Chore,
+        None,
+        context_files,
+    )
+}
+
+fn classify_with(runtime: &OrbitRuntime, input: Value) -> Value {
+    runtime
+        .run_deterministic(
+            "classify_workspace_auto_tasks",
+            &json!({}),
+            &input,
+            ToolContext::default(),
+        )
+        .expect("classify workspace auto tasks")
+}
+
+fn readiness_task<'a>(output: &'a Value, task_id: &str) -> &'a Value {
+    output["tasks"]
+        .as_array()
+        .expect("readiness tasks")
+        .iter()
+        .find(|task| task["task_id"] == task_id)
+        .expect("readiness task")
+}
+
+fn string_ids(value: &Value) -> Vec<String> {
+    value
+        .as_array()
+        .expect("array of task ids")
+        .iter()
+        .filter_map(|entry| entry.as_str().map(ToOwned::to_owned))
+        .collect()
+}
+
+/// The F2026-09-104 shape: a run of overlapping high-priority tasks at the head
+/// of the queue used to consume every slot and then serialize at the gate. The
+/// wave must take one of them and walk on to the independent work behind them.
+#[test]
+fn a_ten_slot_wave_walks_past_a_conflicting_cluster_to_independent_work() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    let cluster = (0..6)
+        .map(|index| {
+            backlog_task(
+                &runtime,
+                &repo_root,
+                &format!("Cluster {index}"),
+                TaskPriority::High,
+                vec!["file:crates/hot/src/lib.rs"],
+            )
+        })
+        .collect::<Vec<_>>();
+    let independent = (0..12)
+        .map(|index| {
+            let selector = format!("file:crates/independent/src/leaf_{index}.rs");
+            backlog_task(
+                &runtime,
+                &repo_root,
+                &format!("Independent {index}"),
+                TaskPriority::Medium,
+                vec![selector.as_str()],
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let selection = select_admissions(
+        &ordered_candidates(&runtime),
+        &task_lookup(&runtime),
+        &repo_root,
+        &AdmissionHolders::default(),
+        10,
+    );
+
+    assert_eq!(selection.selected.len(), 10, "every free slot is filled");
+    let mut expected = vec![cluster[0].id.clone()];
+    expected.extend(independent[..9].iter().map(|task| task.id.clone()));
+    assert_eq!(
+        selection.selected, expected,
+        "the highest-priority member of the cluster keeps its place and the \
+         remaining slots go to the next compatible candidates in order"
+    );
+    assert_eq!(
+        selection
+            .deferred
+            .iter()
+            .map(|deferred| deferred.task_id.clone())
+            .collect::<Vec<_>>(),
+        cluster[1..]
+            .iter()
+            .map(|task| task.id.clone())
+            .collect::<Vec<_>>(),
+        "only the cluster members that would collide are deferred"
+    );
+    for deferred in &selection.deferred {
+        assert_eq!(deferred.blocking_task_ids(), vec![cluster[0].id.clone()]);
+        assert!(
+            deferred
+                .conflicts
+                .iter()
+                .all(|conflict| conflict.provenance == ConflictProvenance::SameWave),
+            "a task selected earlier this wave holds no lock yet"
+        );
+    }
+}
+
+/// Every selected pair must actually be admissible together, not merely
+/// distinct: the point of the wave is that no two members reach the gate on the
+/// same footprint.
+#[test]
+fn a_wave_is_pairwise_nonconflicting_across_shared_directories() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "crates/shared/src/lib.rs");
+    write_workspace_file(&repo_root, "crates/shared/src/other.rs");
+    let directory = backlog_task(
+        &runtime,
+        &repo_root,
+        "Directory scope",
+        TaskPriority::High,
+        vec!["dir:crates/shared"],
+    );
+    let inside = backlog_task(
+        &runtime,
+        &repo_root,
+        "File beneath the directory",
+        TaskPriority::Medium,
+        vec!["file:crates/shared/src/lib.rs"],
+    );
+    let symbol = seed_list_backlog_task(
+        &runtime,
+        "Symbol in the same file",
+        TaskStatus::Backlog,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        None,
+        vec!["symbol:crates/shared/src/other.rs#helper:function"],
+    );
+    let outside = backlog_task(
+        &runtime,
+        &repo_root,
+        "Unrelated crate",
+        TaskPriority::Low,
+        vec!["file:crates/other/src/lib.rs"],
+    );
+
+    let selection = select_admissions(
+        &ordered_candidates(&runtime),
+        &task_lookup(&runtime),
+        &repo_root,
+        &AdmissionHolders::default(),
+        4,
+    );
+
+    assert_eq!(
+        selection.selected,
+        vec![directory.id.clone(), outside.id.clone()],
+        "a `dir:` scope covers both the file and the symbol beneath it"
+    );
+    let deferred = selection
+        .deferred
+        .iter()
+        .map(|deferred| deferred.task_id.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(deferred, vec![inside.id.clone(), symbol.id.clone()]);
+    let symbol_conflict = selection
+        .deferred_for(&symbol.id)
+        .expect("symbol candidate is deferred");
+    assert_eq!(
+        symbol_conflict.conflicts[0].blocking_selector, "dir:crates/shared",
+        "the deferral names the selector that actually covers it"
+    );
+    assert_eq!(
+        symbol_conflict.conflicts[0].requested_selector,
+        "symbol:crates/shared/src/other.rs#helper:function"
+    );
+}
+
+/// An epic root reserves the union of its descendants' context files, so a leaf
+/// overlapping any descendant must not join the same wave as the root.
+#[test]
+fn an_epic_roots_descendant_coverage_defers_an_overlapping_leaf() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "crates/epic/src/child.rs");
+    let epic = seed_list_backlog_task(
+        &runtime,
+        "Epic root",
+        TaskStatus::Backlog,
+        TaskPriority::High,
+        TaskType::Feature,
+        None,
+        vec![],
+    );
+    runtime
+        .update_task(
+            &epic.id,
+            TaskUpdateParams {
+                tags: Some(vec!["epic".to_string()]),
+                ..Default::default()
+            },
+        )
+        .expect("tag epic root");
+    seed_list_backlog_task(
+        &runtime,
+        "Epic descendant",
+        TaskStatus::Backlog,
+        TaskPriority::High,
+        TaskType::Chore,
+        Some(epic.id.clone()),
+        vec!["file:crates/epic/src/child.rs"],
+    );
+    let overlapping_leaf = backlog_task(
+        &runtime,
+        &repo_root,
+        "Leaf touching the descendant's file",
+        TaskPriority::Medium,
+        vec!["file:crates/epic/src/child.rs"],
+    );
+
+    // The epic family is excluded from the leaf population, so the leaf is the
+    // only candidate; the root's reservation reaches it through the holder set.
+    let lookup = task_lookup(&runtime);
+    let holders = AdmissionHolders::new(
+        &BTreeMap::new(),
+        &BTreeSet::from([epic.id.clone()]),
+        &lookup,
+        &repo_root,
+    );
+    let selection = select_admissions(
+        std::slice::from_ref(&overlapping_leaf.id),
+        &lookup,
+        &repo_root,
+        &holders,
+        5,
+    );
+
+    assert!(selection.selected.is_empty());
+    let deferred = selection
+        .deferred_for(&overlapping_leaf.id)
+        .expect("overlapping leaf is deferred");
+    assert_eq!(deferred.blocking_task_ids(), vec![epic.id.clone()]);
+    assert_eq!(
+        deferred.conflicts[0].provenance,
+        ConflictProvenance::LiveClaim
+    );
+}
+
+/// A task a live wrapper is carrying is still `backlog`, so its footprint is
+/// invisible to the task-status lock holders. Admitting a leaf that overlaps it
+/// only queues a second waiter on the same footprint at the gate.
+#[test]
+fn a_live_wrapper_claim_defers_an_overlapping_candidate_before_the_gate() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    let claimed = backlog_task(
+        &runtime,
+        &repo_root,
+        "Carried by a live wrapper",
+        TaskPriority::High,
+        vec!["file:crates/contended/src/lib.rs"],
+    );
+    let overlapping = backlog_task(
+        &runtime,
+        &repo_root,
+        "Overlaps the carried task",
+        TaskPriority::Medium,
+        vec!["file:crates/contended/src/lib.rs"],
+    );
+    let independent = backlog_task(
+        &runtime,
+        &repo_root,
+        "Independent",
+        TaskPriority::Medium,
+        vec!["file:crates/free/src/lib.rs"],
+    );
+
+    let lookup = task_lookup(&runtime);
+    let holders = AdmissionHolders::new(
+        &BTreeMap::new(),
+        &BTreeSet::from([claimed.id.clone()]),
+        &lookup,
+        &repo_root,
+    );
+    let selection = select_admissions(
+        &[overlapping.id.clone(), independent.id.clone()],
+        &lookup,
+        &repo_root,
+        &holders,
+        5,
+    );
+
+    assert_eq!(selection.selected, vec![independent.id.clone()]);
+    let deferred = selection
+        .deferred_for(&overlapping.id)
+        .expect("overlapping candidate is deferred");
+    assert_eq!(deferred.blocking_task_ids(), vec![claimed.id.clone()]);
+    assert_eq!(
+        deferred.conflicts[0].provenance,
+        ConflictProvenance::LiveClaim,
+        "a claim is not a held lock, and the remedy differs"
+    );
+}
+
+/// A claimed task that has reached `in-progress` holds a real lock. The
+/// deferral must say so rather than describing the same footprint twice.
+#[test]
+fn an_in_progress_holder_defers_with_held_lock_provenance() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    let holder = backlog_task(
+        &runtime,
+        &repo_root,
+        "Already implementing",
+        TaskPriority::High,
+        vec!["file:crates/contended/src/lib.rs"],
+    );
+    runtime
+        .update_task(
+            &holder.id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::InProgress),
+                ..Default::default()
+            },
+        )
+        .expect("move holder to in-progress");
+    let overlapping = backlog_task(
+        &runtime,
+        &repo_root,
+        "Overlaps the holder",
+        TaskPriority::Medium,
+        vec!["file:crates/contended/src/lib.rs"],
+    );
+
+    let lookup = task_lookup(&runtime);
+    let holders = AdmissionHolders::new(
+        &lock_holders(&runtime),
+        &BTreeSet::from([holder.id.clone()]),
+        &lookup,
+        &repo_root,
+    );
+    let selection = select_admissions(
+        std::slice::from_ref(&overlapping.id),
+        &lookup,
+        &repo_root,
+        &holders,
+        5,
+    );
+
+    let deferred = selection
+        .deferred_for(&overlapping.id)
+        .expect("overlapping candidate is deferred");
+    assert_eq!(deferred.blocking_task_ids(), vec![holder.id.clone()]);
+    assert_eq!(
+        deferred
+            .conflicts
+            .iter()
+            .map(|conflict| conflict.provenance)
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([ConflictProvenance::HeldLock]),
+        "an in-progress claim is reported once, as the held lock it is"
+    );
+}
+
+/// Candidates the wave never reached are saturated, not conflicted. Collapsing
+/// the two would tell an operator to clear locks that are not the problem.
+#[test]
+fn candidates_past_a_full_wave_are_saturated_rather_than_conflicted() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    let seeded = (0..5)
+        .map(|index| {
+            let selector = format!("file:crates/independent/src/leaf_{index}.rs");
+            backlog_task(
+                &runtime,
+                &repo_root,
+                &format!("Independent {index}"),
+                TaskPriority::Medium,
+                vec![selector.as_str()],
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let selection = select_admissions(
+        &ordered_candidates(&runtime),
+        &task_lookup(&runtime),
+        &repo_root,
+        &AdmissionHolders::default(),
+        2,
+    );
+
+    assert_eq!(
+        selection.selected,
+        vec![seeded[0].id.clone(), seeded[1].id.clone()]
+    );
+    assert!(selection.deferred.is_empty(), "nothing collided");
+    assert_eq!(
+        selection.queued_behind_capacity,
+        seeded[2..]
+            .iter()
+            .map(|task| task.id.clone())
+            .collect::<Vec<_>>()
+    );
+}
+
+/// A zero-slot wave does no lock work at all: everything is behind capacity.
+#[test]
+fn a_saturated_drain_examines_no_candidate_for_conflicts() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    let first = backlog_task(
+        &runtime,
+        &repo_root,
+        "First",
+        TaskPriority::High,
+        vec!["file:crates/hot/src/lib.rs"],
+    );
+    let second = backlog_task(
+        &runtime,
+        &repo_root,
+        "Second on the same file",
+        TaskPriority::Medium,
+        vec!["file:crates/hot/src/lib.rs"],
+    );
+
+    let selection = select_admissions(
+        &[first.id.clone(), second.id.clone()],
+        &task_lookup(&runtime),
+        &repo_root,
+        &AdmissionHolders::default(),
+        0,
+    );
+
+    assert!(selection.selected.is_empty());
+    assert!(selection.deferred.is_empty());
+    assert_eq!(selection.queued_behind_capacity, vec![first.id, second.id]);
+}
+
+/// The classifier and readiness must not be able to disagree about which task
+/// takes a slot, because an operator uses one to predict the other.
+#[test]
+fn the_classifier_and_readiness_select_the_same_tasks_for_one_snapshot() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    for index in 0..4 {
+        backlog_task(
+            &runtime,
+            &repo_root,
+            &format!("Cluster {index}"),
+            TaskPriority::High,
+            vec!["file:crates/hot/src/lib.rs"],
+        );
+    }
+    for index in 0..4 {
+        let selector = format!("file:crates/independent/src/leaf_{index}.rs");
+        backlog_task(
+            &runtime,
+            &repo_root,
+            &format!("Independent {index}"),
+            TaskPriority::Medium,
+            vec![selector.as_str()],
+        );
+    }
+
+    let classified = classify_with(&runtime, json!({ "max_active_leaf_runs": 3 }));
+    let readiness = runtime
+        .workspace_auto_readiness(&[], Some(3), 50, &[])
+        .expect("explain readiness");
+    let eligible = readiness["tasks"]
+        .as_array()
+        .expect("readiness tasks")
+        .iter()
+        .filter(|task| task["eligible"] == json!(true))
+        .map(|task| task["task_id"].as_str().unwrap_or_default().to_string())
+        .collect::<Vec<_>>();
+
+    assert_eq!(string_ids(&classified["loose_task_ids"]).len(), 3);
+    assert_eq!(
+        string_ids(&classified["loose_task_ids"])
+            .into_iter()
+            .collect::<BTreeSet<_>>(),
+        eligible.into_iter().collect::<BTreeSet<_>>(),
+        "one selection routine, one answer"
+    );
+    assert_eq!(
+        classified["deferred_conflicts"], readiness["capacity"]["deferred_conflicts"],
+        "and one explanation for the tasks it passed over"
+    );
+}
+
+/// Readiness names the blocker and the overlapping selectors so an operator can
+/// tell a lock problem from a capacity problem without reading the code.
+#[test]
+fn readiness_explains_a_deferred_conflict_and_clears_it_when_the_blocker_goes() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    let first = backlog_task(
+        &runtime,
+        &repo_root,
+        "First on the hot file",
+        TaskPriority::High,
+        vec!["file:crates/hot/src/lib.rs"],
+    );
+    let second = backlog_task(
+        &runtime,
+        &repo_root,
+        "Second on the hot file",
+        TaskPriority::Medium,
+        vec!["file:crates/hot/src/lib.rs"],
+    );
+
+    let blocked = runtime
+        .workspace_auto_readiness(&[], Some(5), 50, &[])
+        .expect("explain readiness");
+    let entry = readiness_task(&blocked, &second.id);
+    assert_eq!(entry["eligible"], json!(false));
+    assert_eq!(entry["reason"], "conflict_deferred");
+    assert_eq!(entry["blocking_task_ids"], json!([first.id]));
+    assert_eq!(
+        entry["conflicts"][0]["requested_selector"],
+        "file:crates/hot/src/lib.rs"
+    );
+    assert_eq!(entry["conflicts"][0]["provenance"], "same_wave");
+    assert_eq!(
+        readiness_task(&blocked, &first.id)["reason"],
+        "ready",
+        "the blocker itself still starts"
+    );
+
+    // The deferral is not a permanent exclusion: once the blocker leaves the
+    // population the candidate becomes eligible on the very next snapshot.
+    runtime
+        .update_task(
+            &first.id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Done),
+                ..Default::default()
+            },
+        )
+        .expect("finish the blocker");
+    let cleared = runtime
+        .workspace_auto_readiness(&[], Some(5), 50, &[])
+        .expect("explain readiness");
+    assert_eq!(readiness_task(&cleared, &second.id)["reason"], "ready");
+    assert_eq!(
+        readiness_task(&cleared, &second.id)["eligible"],
+        json!(true)
+    );
+    assert_eq!(cleared["capacity"]["deferred_conflicts"], json!([]));
+}
+
+/// `max_tasks` bounds how much backlog one iteration expands footprints for. A
+/// prefix of conflicting candidates must not make that bound look like an empty
+/// backlog: the short wave says the pool was truncated.
+#[test]
+fn a_truncated_candidate_pool_is_reported_when_conflicts_exhaust_it() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    for index in 0..4 {
+        backlog_task(
+            &runtime,
+            &repo_root,
+            &format!("Cluster {index}"),
+            TaskPriority::High,
+            vec!["file:crates/hot/src/lib.rs"],
+        );
+    }
+    let independent = backlog_task(
+        &runtime,
+        &repo_root,
+        "Independent behind the cluster",
+        TaskPriority::Medium,
+        vec!["file:crates/independent/src/lib.rs"],
+    );
+
+    let truncated = classify_with(
+        &runtime,
+        json!({ "max_active_leaf_runs": 5, "max_tasks": 3 }),
+    );
+    assert_eq!(truncated["candidate_pool_size"], json!(3));
+    assert_eq!(truncated["candidate_pool_truncated"], json!(true));
+    assert_eq!(string_ids(&truncated["loose_task_ids"]).len(), 1);
+
+    // With the whole pool examined the independent task behind the cluster is
+    // reached, and the truncation flag goes back down.
+    let whole = classify_with(&runtime, json!({ "max_active_leaf_runs": 5 }));
+    assert_eq!(
+        string_ids(&whole["loose_task_ids"]).len(),
+        2,
+        "the cluster costs one slot, not the whole wave"
+    );
+    assert!(string_ids(&whole["loose_task_ids"]).contains(&independent.id));
+    assert_eq!(whole["candidate_pool_truncated"], json!(false));
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/leaf_occupancy.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/leaf_occupancy.rs
@@ -1,0 +1,432 @@
+//! What an occupied leaf slot is doing, from durable run state [ORB-11973].
+//!
+//! The fixtures reproduce the F2026-09-104 shape with a temporary store rather
+//! than replaying the historical drain: ten wrappers at concurrency ten, five
+//! parked in `task_gate_pipeline` before lock acquisition, four with a live
+//! implementation run, and one past its implementation.
+
+use std::collections::BTreeSet;
+
+use chrono::Utc;
+use orbit_types::task::{TaskPriority, TaskStatus, TaskType};
+use orbit_types::workflow::{ChildDispatch, ChildDispatchPhase, PipelineState};
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+use crate::adapter::engine_host::v2_host::test_support::{
+    runtime_with_workspace_layout, seed_list_backlog_task, write_workspace_file,
+};
+use crate::application::task::TaskUpdateParams;
+
+/// A live wrapper run carrying `task_ids`, as `invoke_detached` leaves one.
+fn seed_wrapper_run(runtime: &OrbitRuntime, task_ids: &[&str]) -> String {
+    seed_run(
+        runtime,
+        "task_auto_pipeline",
+        json!({ "task_ids": task_ids }),
+    )
+}
+
+fn seed_run(runtime: &OrbitRuntime, job_name: &str, input: Value) -> String {
+    runtime
+        .stores()
+        .jobs()
+        .insert_job_run(job_name, 1, Utc::now(), Some(input), None)
+        .expect("insert job run")
+        .run_id
+}
+
+fn dispatch(child_run_id: &str, job_name: &str, phase: ChildDispatchPhase) -> ChildDispatch {
+    let mut dispatch = ChildDispatch::submitted(
+        child_run_id.to_string(),
+        job_name.to_string(),
+        "invoke_and_wait".to_string(),
+        true,
+        false,
+        Utc::now(),
+    );
+    dispatch.phase = phase;
+    if phase == ChildDispatchPhase::Terminal {
+        dispatch.child_status = Some("succeeded".to_string());
+    }
+    dispatch
+}
+
+fn write_state(
+    runtime: &OrbitRuntime,
+    run_id: &str,
+    job_id: &str,
+    dispatches: Vec<ChildDispatch>,
+    waiting_on_locks: Option<Vec<String>>,
+) {
+    let mut state = PipelineState::new(run_id.to_string(), job_id.to_string(), json!({}));
+    state.child_dispatches = dispatches;
+    state.waiting_on_locks = waiting_on_locks;
+    runtime
+        .write_run_state(run_id, &state)
+        .expect("write run state");
+}
+
+/// One wrapper parked at its gate, with the selectors the gate recorded.
+fn seed_lock_waiting_wrapper(
+    runtime: &OrbitRuntime,
+    task_id: &str,
+    waiting_on_locks: &[&str],
+) -> (String, String) {
+    let gate_run_id = seed_run(
+        runtime,
+        "task_gate_pipeline",
+        json!({ "task_ids": [task_id] }),
+    );
+    let wrapper_run_id = seed_wrapper_run(runtime, &[task_id]);
+    write_state(
+        runtime,
+        &wrapper_run_id,
+        "task_auto_pipeline",
+        vec![dispatch(
+            &gate_run_id,
+            "task_gate_pipeline",
+            ChildDispatchPhase::Waiting,
+        )],
+        None,
+    );
+    write_state(
+        runtime,
+        &gate_run_id,
+        "task_gate_pipeline",
+        Vec::new(),
+        Some(
+            waiting_on_locks
+                .iter()
+                .map(|selector| (*selector).to_string())
+                .collect(),
+        ),
+    );
+    (wrapper_run_id, gate_run_id)
+}
+
+/// One wrapper whose gate has reserved and dispatched. `implementation_phase`
+/// separates a live implementation run from one the gate has already joined.
+fn seed_dispatched_wrapper(
+    runtime: &OrbitRuntime,
+    task_id: &str,
+    implementation_phase: ChildDispatchPhase,
+) -> (String, String, String) {
+    let implementation_run_id = seed_run(
+        runtime,
+        "task_pr_pipeline",
+        json!({ "task_ids": [task_id] }),
+    );
+    let gate_run_id = seed_run(
+        runtime,
+        "task_gate_pipeline",
+        json!({ "task_ids": [task_id] }),
+    );
+    let wrapper_run_id = seed_wrapper_run(runtime, &[task_id]);
+    write_state(
+        runtime,
+        &wrapper_run_id,
+        "task_auto_pipeline",
+        vec![dispatch(
+            &gate_run_id,
+            "task_gate_pipeline",
+            ChildDispatchPhase::Waiting,
+        )],
+        None,
+    );
+    write_state(
+        runtime,
+        &gate_run_id,
+        "task_gate_pipeline",
+        vec![dispatch(
+            &implementation_run_id,
+            "task_pr_pipeline",
+            implementation_phase,
+        )],
+        None,
+    );
+    (wrapper_run_id, gate_run_id, implementation_run_id)
+}
+
+fn occupancy_run<'a>(readiness: &'a Value, run_id: &str) -> &'a Value {
+    readiness["capacity"]["occupancy"]["runs"]
+        .as_array()
+        .expect("occupancy runs")
+        .iter()
+        .find(|run| run["run_id"] == run_id)
+        .expect("occupancy entry for run")
+}
+
+fn descendant_ids(entry: &Value) -> BTreeSet<String> {
+    entry["descendant_run_ids"]
+        .as_array()
+        .expect("descendant run ids")
+        .iter()
+        .filter_map(|value| value.as_str().map(ToOwned::to_owned))
+        .collect()
+}
+
+fn readiness(runtime: &OrbitRuntime, concurrency: u32) -> Value {
+    runtime
+        .workspace_auto_readiness(&[], Some(concurrency), 50, &[])
+        .expect("explain readiness")
+}
+
+/// The incident shape. Ten occupied slots and no free ones read identically
+/// before this change; the phase split is the only thing that says half the
+/// drain is queued on locks rather than working.
+#[test]
+fn a_saturated_drain_reports_lock_waiting_implementing_and_post_implementation_slots() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "crates/held/src/lib.rs");
+    let holder = seed_list_backlog_task(
+        &runtime,
+        "Holds the contended file",
+        TaskStatus::Backlog,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        None,
+        vec!["file:crates/held/src/lib.rs"],
+    );
+    runtime
+        .update_task(
+            &holder.id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::InProgress),
+                ..Default::default()
+            },
+        )
+        .expect("move holder to in-progress");
+
+    let carried = (0..10)
+        .map(|index| {
+            seed_list_backlog_task(
+                &runtime,
+                &format!("Carried leaf {index}"),
+                TaskStatus::Backlog,
+                TaskPriority::Medium,
+                TaskType::Chore,
+                None,
+                vec![],
+            )
+            .id
+        })
+        .collect::<Vec<_>>();
+
+    // Three gates park on a selector a live holder explains; two park on one no
+    // current holder does, which must be reported rather than dropped.
+    let resolved = (0..3)
+        .map(|index| {
+            seed_lock_waiting_wrapper(&runtime, &carried[index], &["crates/held/src/lib.rs"])
+        })
+        .collect::<Vec<_>>();
+    let unresolved = (3..5)
+        .map(|index| {
+            seed_lock_waiting_wrapper(&runtime, &carried[index], &["crates/departed/src/lib.rs"])
+        })
+        .collect::<Vec<_>>();
+    let implementing = (5..9)
+        .map(|index| {
+            seed_dispatched_wrapper(&runtime, &carried[index], ChildDispatchPhase::Waiting)
+        })
+        .collect::<Vec<_>>();
+    let syncing = seed_dispatched_wrapper(&runtime, &carried[9], ChildDispatchPhase::Terminal);
+
+    let readiness = readiness(&runtime, 10);
+    let capacity = &readiness["capacity"];
+    let occupancy = &capacity["occupancy"];
+
+    assert_eq!(capacity["active_leaf_runs"], json!(10));
+    assert_eq!(capacity["free_slots"], json!(0));
+    assert_eq!(occupancy["active_leaf_runs"], json!(10));
+    assert_eq!(
+        occupancy["free_slots"], capacity["free_slots"],
+        "the breakdown cannot disagree with the capacity beside it"
+    );
+    assert_eq!(
+        occupancy["phases"],
+        json!({
+            "lock_waiting": 5,
+            "implementing": 4,
+            "post_implementation": 1,
+            "unknown": 0,
+        }),
+        "five slots hold a slot without holding a lock"
+    );
+    assert_eq!(
+        occupancy["runs"].as_array().map(Vec::len),
+        Some(10),
+        "one entry per occupied slot, and no slot counted twice"
+    );
+    assert_eq!(
+        occupancy["task_ids"],
+        json!(carried.iter().cloned().collect::<BTreeSet<_>>()),
+        "ten distinct carried tasks, deduplicated"
+    );
+
+    let (wrapper, gate) = &resolved[0];
+    let entry = occupancy_run(&readiness, wrapper);
+    assert_eq!(entry["phase"], "lock_waiting");
+    assert_eq!(descendant_ids(entry), BTreeSet::from([gate.clone()]));
+    assert_eq!(entry["lock_wait"]["gate_run_id"], json!(gate));
+    assert_eq!(
+        entry["lock_wait"]["blockers"],
+        json!([{
+            "selector": "crates/held/src/lib.rs",
+            "holder_task_ids": [holder.id],
+        }]),
+        "an available blocker is named"
+    );
+    assert_eq!(entry["lock_wait"]["unresolved_selectors"], json!([]));
+
+    let (wrapper, _) = &unresolved[0];
+    let entry = occupancy_run(&readiness, wrapper);
+    assert_eq!(entry["phase"], "lock_waiting");
+    assert_eq!(entry["lock_wait"]["blockers"], json!([]));
+    assert_eq!(
+        entry["lock_wait"]["unresolved_selectors"],
+        json!(["crates/departed/src/lib.rs"]),
+        "a wait no current holder explains stays visible as missing evidence"
+    );
+
+    let (wrapper, gate, implementation) = &implementing[0];
+    let entry = occupancy_run(&readiness, wrapper);
+    assert_eq!(entry["phase"], "implementing");
+    assert_eq!(
+        descendant_ids(entry),
+        BTreeSet::from([gate.clone(), implementation.clone()]),
+        "the gate and the implementation run it dispatched are both named"
+    );
+    assert_eq!(entry["lock_wait"], Value::Null);
+
+    let (wrapper, gate, implementation) = &syncing;
+    let entry = occupancy_run(&readiness, wrapper);
+    assert_eq!(
+        entry["phase"], "post_implementation",
+        "a joined implementation run leaves the slot doing sync/teardown work"
+    );
+    assert_eq!(
+        descendant_ids(entry),
+        BTreeSet::from([gate.clone(), implementation.clone()])
+    );
+}
+
+/// A phase the stores cannot support is reported as unknown with the reason.
+/// Guessing here would put a made-up number in the diagnostic an operator uses
+/// to decide whether to intervene.
+#[test]
+fn a_slot_without_durable_evidence_reports_unknown_and_says_why() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let stateless = seed_wrapper_run(&runtime, &["ORB-STATELESS"]);
+    let no_gate = seed_wrapper_run(&runtime, &["ORB-NO-GATE"]);
+    write_state(&runtime, &no_gate, "task_auto_pipeline", Vec::new(), None);
+    let silent_gate_run = seed_run(&runtime, "task_gate_pipeline", json!({}));
+    let silent_gate = seed_wrapper_run(&runtime, &["ORB-SILENT-GATE"]);
+    write_state(
+        &runtime,
+        &silent_gate,
+        "task_auto_pipeline",
+        vec![dispatch(
+            &silent_gate_run,
+            "task_gate_pipeline",
+            ChildDispatchPhase::Waiting,
+        )],
+        None,
+    );
+    write_state(
+        &runtime,
+        &silent_gate_run,
+        "task_gate_pipeline",
+        Vec::new(),
+        None,
+    );
+
+    let readiness = readiness(&runtime, 5);
+    assert_eq!(
+        readiness["capacity"]["occupancy"]["phases"]["unknown"],
+        json!(3)
+    );
+    assert_eq!(
+        occupancy_run(&readiness, &stateless)["unknown_reason"],
+        "no readable pipeline state for this leaf run"
+    );
+    assert_eq!(
+        occupancy_run(&readiness, &no_gate)["unknown_reason"],
+        "leaf run has not recorded a gate dispatch yet"
+    );
+    assert_eq!(
+        occupancy_run(&readiness, &silent_gate)["unknown_reason"],
+        "gate run recorded neither a lock wait nor a dispatch"
+    );
+}
+
+/// Slots and tasks are counted on different axes: two wrappers carrying one
+/// task occupy two slots, and the task roll-up still names it once.
+#[test]
+fn two_wrappers_carrying_one_task_occupy_two_slots_and_name_it_once() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let first = seed_wrapper_run(&runtime, &["ORB-SHARED"]);
+    let second = seed_wrapper_run(&runtime, &["ORB-SHARED"]);
+
+    let readiness = readiness(&runtime, 5);
+    let occupancy = &readiness["capacity"]["occupancy"];
+    assert_eq!(occupancy["active_leaf_runs"], json!(2));
+    assert_eq!(occupancy["free_slots"], json!(3));
+    assert_eq!(occupancy["task_ids"], json!(["ORB-SHARED"]));
+    assert_ne!(first, second);
+    assert_eq!(occupancy["runs"].as_array().map(Vec::len), Some(2));
+}
+
+/// Readiness reads; it must not reconcile, reserve, or move anything. The
+/// occupancy walk added store reads, so re-assert the whole snapshot is inert.
+#[test]
+fn reading_occupancy_mutates_no_task_run_or_lock() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "crates/held/src/lib.rs");
+    let backlog = seed_list_backlog_task(
+        &runtime,
+        "Waiting leaf",
+        TaskStatus::Backlog,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        None,
+        vec!["file:crates/held/src/lib.rs"],
+    );
+    let (wrapper, gate) =
+        seed_lock_waiting_wrapper(&runtime, "ORB-CARRIED", &["crates/held/src/lib.rs"]);
+
+    let tasks_before = runtime.list_tasks().expect("list tasks");
+    let runs_before = runtime
+        .stores()
+        .jobs()
+        .list_pending_or_running_job_runs("task_auto_pipeline")
+        .expect("list wrapper runs");
+    let gate_state_before = runtime.read_run_state(&gate).expect("read gate state");
+    let locks_before = crate::runtime::task::locks::list(&runtime).expect("list task locks");
+
+    let _ = readiness(&runtime, 5);
+
+    assert_eq!(runtime.list_tasks().expect("list tasks"), tasks_before);
+    assert_eq!(
+        runtime
+            .stores()
+            .jobs()
+            .list_pending_or_running_job_runs("task_auto_pipeline")
+            .expect("list wrapper runs")
+            .len(),
+        runs_before.len()
+    );
+    assert_eq!(
+        runtime.read_run_state(&gate).expect("read gate state"),
+        gate_state_before
+    );
+    assert_eq!(
+        crate::runtime::task::locks::list(&runtime).expect("list task locks"),
+        locks_before
+    );
+    assert_eq!(
+        runtime.get_task(&backlog.id).expect("read task").status,
+        TaskStatus::Backlog
+    );
+    assert!(!wrapper.is_empty());
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
@@ -1,3 +1,4 @@
+mod auto_admission;
 mod backlog_exclusion;
 mod ci_failure_admission;
 mod ci_failure_cancelled;
@@ -5,6 +6,7 @@ mod ci_failure_tasks;
 mod cli_executor;
 mod dependabot_alert_tasks;
 mod dispatch;
+mod leaf_occupancy;
 mod pipeline_actions;
 mod required_tools;
 mod sandbox;

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
@@ -16,10 +16,12 @@ use crate::application::operation::{admission_state, live_admission, promote_wit
 
 use crate::runtime::engine::crew::CrewAllowlist;
 
+use super::auto_admission::{AdmissionHolders, select_admissions};
 use super::backlog_exclusion::{
     BacklogTaskExclusionReason, EpicFamilyMembership, allowlist_from_input, backlog_snapshot,
-    epic_family_membership, list_backlog_tasks, sort_tasks_for_automatic_dispatch,
+    epic_family_membership, sort_tasks_for_automatic_dispatch,
 };
+use super::leaf_occupancy::{occupancy_json, read_leaf_occupancy};
 
 /// The job that supervises one epic root. `classify_workspace_auto_tasks`
 /// reads its live runs to decide whether another root may start.
@@ -55,6 +57,11 @@ const DEFAULT_IDLE_SLEEP_SECONDS: u64 = 60;
 
 const MAX_READINESS_LIMIT: usize = 500;
 
+/// Default and ceiling for the backlog prefix one iteration examines, matching
+/// `list_backlog_tasks`'s `max_tasks` bound.
+const DEFAULT_CANDIDATE_POOL: u64 = 50;
+const MAX_CANDIDATE_POOL: u64 = 500;
+
 /// Longest drain window a caller may request, in seconds (24h). The window is
 /// the caller's, not a safety property, but an unbounded deadline would let a
 /// typo hold `workspace_auto_pipeline`'s single active-run slot indefinitely.
@@ -66,7 +73,7 @@ const MAX_DRAIN_WINDOW_SECONDS: f64 = 86_400.0;
 /// this tick". Loose leaves and an epic root are independent answers: a
 /// conflict-free chore ships in the same iteration that an epic is running,
 /// because an `in-progress` epic root already reserves the union of its
-/// descendants' `context_files` (ORB-10816) and `list_backlog_tasks` drops
+/// descendants' `context_files` (ORB-10816) and `backlog_snapshot` drops
 /// exactly the leaves that overlap it. That reservation is why the former
 /// `hold` decision is gone — a blanket freeze excluded conflict-free work the
 /// lock surface had no reason to exclude.
@@ -76,9 +83,15 @@ const MAX_DRAIN_WINDOW_SECONDS: f64 = 86_400.0;
 /// re-listed every iteration and the free slots are topped up from it, so a
 /// task that entered `backlog` a minute ago starts as soon as any one child
 /// finishes — not after the slowest member of the batch that was running when
-/// it arrived. One task per dispatch: `list_backlog_tasks` already bundles
-/// singletons, so a multi-task child bought nothing but a coarser refill unit,
-/// and a one-task child is crew-homogeneous by construction.
+/// it arrived. One task per dispatch: a multi-task child bought nothing but a
+/// coarser refill unit, and a one-task child is crew-homogeneous by
+/// construction.
+///
+/// [ORB-11973] Which leaves fill those slots is `select_admissions`' answer,
+/// not a prefix of the queue: the wave is pairwise conflict-free, so a cluster
+/// of overlapping candidates costs one slot instead of all of them. Readiness
+/// reads the same snapshot and calls the same routine, which is what keeps the
+/// diagnostic and the drain from disagreeing about who starts.
 pub(super) fn classify_workspace_auto_tasks(
     runtime: &OrbitRuntime,
     action: &str,
@@ -144,26 +157,52 @@ pub(super) fn classify_workspace_auto_tasks(
     let pools = runtime
         .auto_crew_pools_for_input(input)
         .map_err(|error| action_failed(action, error.to_string()))?;
-    let backlog = list_backlog_tasks(runtime, action, input)?;
-    // Priority/age order is `list_backlog_tasks`'s, and the truncation to the
-    // free slots has to preserve it: the slots are scarce, so they go to the
-    // front of the queue rather than to whichever tasks happen to sort last.
-    let pending: Vec<String> = backlog
-        .get("task_ids")
-        .and_then(Value::as_array)
-        .map(Vec::as_slice)
-        .unwrap_or_default()
+    let allowlist = allowlist_from_input(runtime, action, input)?;
+    // The same snapshot readiness reads, so the two cannot disagree about the
+    // eligible population before they even reach the selection rule.
+    let snapshot = backlog_snapshot(runtime, action, allowlist.as_ref(), &pools)?;
+    // Priority/age order is the snapshot's, and everything below preserves it:
+    // the slots are scarce, so they go to the front of the queue rather than to
+    // whichever tasks happen to sort last.
+    let pending: Vec<String> = snapshot
+        .admissible_leaves
         .iter()
-        .filter_map(Value::as_str)
-        .filter(|task_id| !claimed.contains(*task_id))
+        .map(|task| task.id.clone())
+        .filter(|task_id| !claimed.contains(task_id))
         .filter(|task_id| {
             operation
                 .as_ref()
-                .is_none_or(|operation| operation.scope.contains(*task_id))
+                .is_none_or(|operation| operation.scope.contains(task_id))
         })
-        .map(ToOwned::to_owned)
         .collect();
-    let admitted = &pending[..pending.len().min(free_slots)];
+
+    // [ORB-11973] The wave used to be `pending[..free_slots]`, which could hand
+    // every slot to one cluster of overlapping tasks and leave independent work
+    // queued behind a contention it created itself. Select a mutually
+    // compatible set instead, walking past a blocked candidate to the next
+    // compatible one rather than stopping at it.
+    let max_tasks = candidate_pool_limit(action, input)?;
+    let examined = &pending[..pending.len().min(max_tasks)];
+    let holders = AdmissionHolders::new(
+        &snapshot.lock_holders,
+        &claimed,
+        &snapshot.task_lookup,
+        runtime.paths().repo_root.as_path(),
+    );
+    let selection = select_admissions(
+        examined,
+        &snapshot.task_lookup,
+        runtime.paths().repo_root.as_path(),
+        &holders,
+        free_slots,
+    );
+    // `max_tasks` bounds how much of the backlog one iteration expands lock
+    // footprints for. It only hides work when the wave ran out of *examined*
+    // candidates rather than out of slots, so report exactly that case instead
+    // of leaving a short wave looking like an empty backlog.
+    let candidate_pool_truncated =
+        pending.len() > examined.len() && selection.selected.len() < free_slots;
+    let admitted = &selection.selected;
     let loose_task_dispatches: Vec<Value> = admitted
         .iter()
         .map(|task_id| json!({ "task_ids": [task_id] }))
@@ -180,13 +219,7 @@ pub(super) fn classify_workspace_auto_tasks(
     let epic_task_id = if admissions_stopped || !operation_open || active_epic.is_some() {
         None
     } else {
-        next_admissible_epic_root(
-            runtime,
-            action,
-            allowlist_from_input(runtime, action, input)?.as_ref(),
-            &pools,
-        )?
-        .filter(|root| {
+        next_admissible_epic_root(runtime, action, allowlist.as_ref(), &pools)?.filter(|root| {
             operation
                 .as_ref()
                 .is_none_or(|operation| operation.scope.contains(root))
@@ -215,6 +248,13 @@ pub(super) fn classify_workspace_auto_tasks(
         "idle": idle,
         "sleep_seconds": sleep_seconds,
         "pending_backlog": pending.len(),
+        // [ORB-11973] Why a wave is shorter than its free slots. A deferral
+        // names the tasks and selectors it would have collided with, so a drain
+        // that looks under-filled can be read as contention rather than as an
+        // empty backlog.
+        "deferred_conflicts": selection.deferred_json(),
+        "candidate_pool_size": examined.len(),
+        "candidate_pool_truncated": candidate_pool_truncated,
         "active_leaf_runs": live_leaves.len(),
         "free_slots": free_slots,
         "max_active_leaf_runs": max_active_leaf_runs,
@@ -386,11 +426,33 @@ pub fn explain_workspace_auto_readiness(
         })
         .map(|task| task.id.clone())
         .collect::<Vec<_>>();
-    let admitted = pending
-        .iter()
-        .take(free_slots)
-        .cloned()
-        .collect::<BTreeSet<_>>();
+    // [ORB-11973] The identical routine the classifier runs, over the identical
+    // ordered pool, so readiness explains the wave the drain would actually
+    // admit rather than a second guess at it.
+    let workspace_root = runtime.paths().repo_root.as_path();
+    let claimed = claimed_by_task.keys().cloned().collect::<BTreeSet<_>>();
+    let holders = AdmissionHolders::new(
+        &snapshot.lock_holders,
+        &claimed,
+        &snapshot.task_lookup,
+        workspace_root,
+    );
+    let selection = select_admissions(
+        &pending,
+        &snapshot.task_lookup,
+        workspace_root,
+        &holders,
+        free_slots,
+    );
+    let admitted = selection.selected.iter().cloned().collect::<BTreeSet<_>>();
+    let occupancy = read_leaf_occupancy(
+        runtime,
+        &live_leaves
+            .iter()
+            .map(|run| (run.run_id.clone(), run.task_ids.clone()))
+            .collect::<Vec<_>>(),
+        &snapshot.lock_holders,
+    )?;
     let excluded_by_id = snapshot
         .excluded
         .iter()
@@ -536,6 +598,12 @@ pub fn explain_workspace_auto_readiness(
             } else if admitted.contains(&task.id) {
                 object.insert("eligible".to_string(), Value::Bool(true));
                 object.insert("reason".to_string(), Value::String("ready".to_string()));
+            } else if let Some(deferred) = selection.deferred_for(&task.id) {
+                // [ORB-11973] A slot was free and this task did not take it,
+                // which is a different problem from having no slot at all.
+                object.insert("reason".to_string(), Value::String("conflict_deferred".to_string()));
+                object.insert("blocking_task_ids".to_string(), json!(deferred.blocking_task_ids()));
+                object.insert("conflicts".to_string(), deferred.to_json()["conflicts"].clone());
             } else {
                 object.insert("reason".to_string(), Value::String("capacity_saturated".to_string()));
                 object.insert("active_run_ids".to_string(), json!(live_leaves.iter().map(|run| &run.run_id).collect::<Vec<_>>()));
@@ -553,6 +621,11 @@ pub fn explain_workspace_auto_readiness(
             "max_active_leaf_runs": max_active_leaf_runs,
             "active_leaf_runs": live_leaves.len(),
             "free_slots": free_slots,
+            // [ORB-11973] The same occupancy, broken down by what each slot is
+            // doing. A drain with every slot parked in `task_gate_pipeline` is
+            // indistinguishable from a busy one by the counts above alone.
+            "occupancy": occupancy_json(&occupancy, free_slots),
+            "deferred_conflicts": selection.deferred_json(),
             "limit_source": limit_source,
             "drain_run_id": active_drain.as_ref().map(|drain| &drain.run_id),
             "worker_limit": active_drain.as_ref().and_then(|drain| drain.limit.clone()),
@@ -742,6 +815,17 @@ fn templated_u64(
             format!("`{name}` must be a number, got {other}"),
         )),
     }
+}
+
+/// How many backlog candidates one iteration may expand lock footprints for.
+///
+/// Mirrors `list_backlog_tasks`'s `max_tasks` bound — same default, same
+/// ceiling — because the two describe the same scan. It goes through
+/// [`templated_u64`] rather than `as_u64` because the drain job templates the
+/// value, which renders `50` as `"50"`.
+fn candidate_pool_limit(action: &str, input: &Value) -> Result<usize, DispatchError> {
+    let requested = templated_u64(action, input, "max_tasks", DEFAULT_CANDIDATE_POOL)?;
+    Ok(usize::try_from(requested.clamp(1, MAX_CANDIDATE_POOL)).unwrap_or(usize::MAX))
 }
 
 /// A live `task_auto_pipeline` run and the tasks it is carrying.

--- a/crates/orbit-core/src/application/operation/tests/pipeline.rs
+++ b/crates/orbit-core/src/application/operation/tests/pipeline.rs
@@ -231,6 +231,20 @@ fn grant_bound_drain_inherits_the_snapshot_and_rechecks_the_grant_per_child() {
     let a = seed_task(runtime, "in scope A", TaskStatus::Backlog);
     let b = seed_task(runtime, "in scope B", TaskStatus::Backlog);
     let outside = seed_task(runtime, "outside", TaskStatus::Backlog);
+    // Everything below is about grant scope and the captured ceiling, so keep A
+    // and B off each other's files. `seed_task` gives every task `README.md`,
+    // and a shared footprint would defer B for contention with the live child
+    // carrying A [ORB-11973] rather than for anything the grant decided.
+    std::fs::write(fixture.repo.join("in_scope_b.rs"), "fixture\n").expect("write B's own file");
+    runtime
+        .update_task(
+            &b.id,
+            crate::application::task::TaskUpdateParams {
+                context_files: Some(vec!["file:in_scope_b.rs".to_string()]),
+                ..Default::default()
+            },
+        )
+        .expect("give B a footprint of its own");
     let grant = enable(
         runtime,
         &[a.id.clone(), b.id.clone()],

--- a/docs/design/resident-orchestrator/2_design.md
+++ b/docs/design/resident-orchestrator/2_design.md
@@ -217,6 +217,16 @@ the short-circuit above it: `classify_workspace_auto_tasks` returns an admissibl
 (`loose_task_ids` + at most one `epic_task_id`) instead of a four-way
 `ship`/`hold`/`epic`/`empty` decision, and `hold` is gone.
 
+[ORB-11973] closed the gap between those two checks. Discovery excluded leaves that overlapped a
+*held* lock, but the set it then handed out was a blind prefix of the priority order, so leaves
+that overlapped each other — or a task a live `task_auto_pipeline` wrapper was already carrying,
+which stays `backlog` and holds no lock — could take every slot and then serialize at the gate
+while independent work stayed queued. `select_admissions` now fills the free slots with a pairwise
+compatible set over the same order, skipping a blocked candidate rather than spending a slot on it,
+and both the classifier and `orbit run readiness` call it, so the diagnostic and the drain cannot
+disagree about which task starts. `reserve_locks` remains authoritative for the race; the wave is a
+prediction, not a reservation.
+
 A task is in the **epic family** when it carries `tag: epic` or any ancestor does. Walk `parent_id`
 the same way `list_backlog_tasks` already walks it for lock grouping.
 

--- a/plugin/skills/orbit/references/orchestration.md
+++ b/plugin/skills/orbit/references/orchestration.md
@@ -108,6 +108,22 @@ never creates a run, reconciles stale runs, reserves files, or mutates a task.
 Its answer can change immediately after the snapshot, so `eligible` means
 "would be admitted by this snapshot", never a guarantee that work will start.
 
+Two of its answers separate contention from capacity:
+
+- `conflict_deferred` means a slot was free and this task did not take it,
+  because its files overlap something already spoken for.
+  `blocking_task_ids` and `conflicts` name the tasks and selectors, and
+  `provenance` says whether the blocker holds the lock (`held_lock`), is a
+  task a live child is already carrying (`live_claim`), or was chosen earlier
+  in the same admission wave (`same_wave`). `capacity_saturated`, by contrast,
+  means there was no free slot at all.
+- `capacity.occupancy` breaks the occupied slots down by what each is doing —
+  `lock_waiting`, `implementing`, `post_implementation`, or `unknown` — with
+  the wrapper, task, and descendant run IDs behind each. A drain whose slots
+  are all `lock_waiting` is queued on itself, which the occupancy total alone
+  cannot show. Phase comes from durable run state only; where that evidence is
+  missing the phase is `unknown` and names the reason.
+
 ```bash
 orbit run history -j task_auto_pipeline
 orbit run show <run_id>


### PR DESCRIPTION
## Task

[ORB-11973](https://orbit-cli.com/tasks/ORB-11973) — Make auto-drain admission conflict-aware and expose lock-waiting capacity

### Description

## Problem and evidence
F2026-09-104 reports drain jrun-20260910-0151 at concurrency 10: readiness showed 10 active leaf wrappers and no free slots, while five task_auto_pipeline wrappers waited in task_gate_pipeline before lock acquisition, four implemented, and one performed post-implementation sync. This is incident evidence from the friction, not a fresh measurement of that run.

Read-only inspection of the owning Linux checkout on 2026-09-10 confirms the mechanism: crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs takes pending[..pending.len().min(free_slots)]; backlog_exclusion.rs builds context holders only from InProgress/Review tasks; readiness independently takes free_slots candidates and otherwise reports capacity_saturated with wrapper IDs. Tasks selected together can contend while independent tasks remain queued.

## Proposed solution
Use one deterministic admission selection routine for the classifier and read-only readiness. Walk existing priority/age order and select a mutually compatible set, checking canonical effective lock footprints against current holders, already admitted live leaf tasks (including wrappers not yet in-progress), and tasks selected earlier in this wave. Skip conflicting candidates and continue to independent eligible tasks until slots are filled or the eligible population is exhausted. Preserve priority among compatible candidates. Reuse lock_context_files_for_task and existing overlap semantics, including directory/symbol normalization and descendant coverage. Check max_tasks truncation so a prefix of conflicting candidates cannot conceal independent work.

Explain deferred conflicts with blocking task IDs and overlapping selectors, distinguishing planned same-wave conflicts from actual held locks. Enrich readiness with deduplicated wrapper/task IDs, actual descendant phase, and lock-wait/blocker details supported by durable evidence. Unknown phase or missing blocker evidence must be explicit. Report implementing, lock-waiting, sync/other phases separately while retaining total occupancy and ceiling semantics.

Keep readiness read-only and share scheduling decisions. Keep final lock acquisition authoritative for races. Preserve grant scope, crew filters, dependencies, stop/expiry/revocation, dynamic worker limits, and epic constraints. Do not reclaim waiter slots or oversubscribe to mask contention; do not cancel or resubmit existing runs.

## Scope and handoff
Reproduce with deterministic temporary-store fixtures, independent of the historical drain. Prepare a validated candidate in a dedicated Orbit worktree from agent-main; merge/release are not authorized.
Related completed work: ORB-11218 (readiness explanations), ORB-11253 (live concurrency). Duplicate searches found no open matching admission task or task referencing F2026-09-104. Hard / sol because this affects shared admission, live-run occupancy and diagnostic consistency.

### Acceptance Criteria

- With clustered high-priority overlapping tasks plus enough independent eligible tasks, a 10-slot admission selects 10 pairwise nonconflicting tasks in deterministic priority/age order among compatible candidates.
- Tests cover InProgress/Review holders, live pre-lock wrappers, same-wave overlap, canonical file/directory/symbol and descendant lock semantics, and independent candidates beyond the initial truncated prefix. Deferred candidates become eligible after blockers clear.
- Readiness and classifier select identical task IDs for the same snapshot and limits. Deferred conflicts identify blocker task IDs and selectors with accurate held-versus-selected provenance.
- A nested-run fixture matching 5 lock-waiting / 4 implementing / 1 syncing reports occupancy 10, free slots 0, phase counts and wrapper/task/descendant IDs without double counting; available blockers are visible and unknown evidence explicit.
- Readiness causes no task/run/lock mutation. Regression coverage preserves grants, crew restrictions, dependencies, stop/expiry/revocation, dynamic ceilings, epic constraints and final lock enforcement.
- Run targeted admission/readiness tests and repository pre-handoff checks; persist commands, results and a before/after JSON example in the execution summary.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Outcome

Auto-drain admission is now conflict-aware and readiness reports what each occupied
slot is doing. Base HEAD `2e339ce041ba77baade08028fea82a6df34b48b9`, branch
`orbit/ORB-11973-6aa216ec`, left uncommitted for the pipeline.

### Root cause fixed

1. `classify_workspace_auto_tasks` took `pending[..pending.len().min(free_slots)]` — a
   blind prefix. A cluster of overlapping high-priority candidates could take every slot
   and then serialize on `reserve_locks` in `task_gate_pipeline` while independent work
   stayed queued. This is the F2026-09-104 shape.
2. `active_task_lock_holders` builds holders only from `InProgress`/`Review` tasks. A leaf
   a live `task_auto_pipeline` wrapper is carrying stays `backlog`, so its footprint was
   invisible; only the claimed task itself was dropped, not the leaves overlapping it.
3. Readiness independently took `free_slots` candidates and otherwise said
   `capacity_saturated` with a flat wrapper-id list.

### Changes

- **New `v2_host/auto_admission.rs`** — `select_admissions`: one deterministic routine over
  the existing priority/age order. A candidate joins the wave only when its effective
  footprint (`lock_context_files_for_task`, compared with
  `workspace_relative_paths_overlap`, so canonical file/dir/symbol normalization and epic
  descendant coverage are reused) is free of held task locks, live wrapper claims, and the
  candidates already selected this wave. A blocked candidate is skipped, not stopped at.
  Deferrals carry blocking task IDs, both overlapping selectors, and provenance
  `held_lock` / `live_claim` / `same_wave`. Candidates the full wave never reached are
  `queued_behind_capacity`, kept distinct from conflicts.
- **New `v2_host/leaf_occupancy.rs`** — walks `PipelineState.child_dispatches` from each
  live wrapper to its gate (batched `read_run_states`, two levels) and resolves a phase from
  durable state only: `implementing` (gate has an open `task_*_pipeline` dispatch),
  `post_implementation` (that dispatch is terminal — the sync/other bucket), `lock_waiting`
  (gate recorded `waiting_on_locks`), `unknown` (names the missing evidence). Lock-wait
  selectors resolve to holder task IDs; selectors no holder explains are reported as
  `unresolved_selectors` rather than dropped. Occupancy is wrapper-based; task IDs are
  deduplicated separately.
- **`workspace_auto.rs`** — the classifier now builds `backlog_snapshot` directly (the same
  snapshot readiness reads) instead of round-tripping `list_backlog_tasks` JSON, and both
  callers run `select_admissions` over the same ordered pool. New classifier output:
  `deferred_conflicts`, `candidate_pool_size`, `candidate_pool_truncated`. New readiness
  output: `capacity.occupancy`, `capacity.deferred_conflicts`, and a `conflict_deferred`
  per-task reason. Readiness stays read-only.
- **`backlog_exclusion.rs`** — `BacklogSnapshot.lock_holders` exposed so admission,
  exclusion reasons, and the lock-wait diagnostic name the same holder for a selector.
- **Contracts/consumers** — `classify_workspace_auto_tasks.yaml` describes the rule and
  declares the new fields; `orbit run readiness` prints the phase breakdown and
  `blocked-by=`; `orchestration.md` (+ synced plugin mirror) and
  `docs/design/resident-orchestrator/2_design.md` updated.

### Before / after (captured from a real run, 3 free slots, 4 tasks on `crates/hot/src/lib.rs` + 4 independent)

Pending order: `["ORB-00000","ORB-00001","ORB-00002","ORB-00003","ORB-00004","ORB-00005","ORB-00006","ORB-00007"]`

Before — all three slots to one footprint, then serialize at the gate:
```json
{"loose_task_ids": ["ORB-00000", "ORB-00001", "ORB-00002"], "free_slots": 3}
```

After:
```json
{
  "loose_task_ids": ["ORB-00000", "ORB-00004", "ORB-00005"],
  "free_slots": 3, "pending_backlog": 8,
  "candidate_pool_size": 8, "candidate_pool_truncated": false,
  "deferred_conflicts": [
    {"task_id": "ORB-00001", "blocking_task_ids": ["ORB-00000"],
     "conflicts": [{"requested_selector": "file:crates/hot/src/lib.rs",
                    "blocking_selector": "file:crates/hot/src/lib.rs",
                    "blocking_task_id": "ORB-00000", "provenance": "same_wave"}]},
    {"task_id": "ORB-00002", "...": "same shape"},
    {"task_id": "ORB-00003", "...": "same shape"}
  ]
}
```

## Acceptance criteria

1. **10-slot clustered admission** — PASSED.
   `auto_admission::a_ten_slot_wave_walks_past_a_conflicting_cluster_to_independent_work`:
   6 overlapping high-priority + 12 independent, 10 slots → exactly
   `[cluster0, independent0..8]`, priority order preserved among compatible candidates.
   `a_wave_is_pairwise_nonconflicting_across_shared_directories` proves the set is pairwise
   compatible, not merely distinct.
2. **Coverage** — PASSED. `an_in_progress_holder_defers_with_held_lock_provenance`
   (InProgress/Review holders), `a_live_wrapper_claim_defers_an_overlapping_candidate_before_the_gate`
   (live pre-lock wrapper), the cluster test (same-wave),
   `a_wave_is_pairwise_nonconflicting_across_shared_directories` (file/dir/symbol) and
   `an_epic_roots_descendant_coverage_defers_an_overlapping_leaf` (descendant), and
   `a_truncated_candidate_pool_is_reported_when_conflicts_exhaust_it` (independent work
   beyond the prefix, plus the `max_tasks` bound). Deferred-then-eligible:
   `readiness_explains_a_deferred_conflict_and_clears_it_when_the_blocker_goes`.
3. **Classifier/readiness agreement + provenance** — PASSED.
   `the_classifier_and_readiness_select_the_same_tasks_for_one_snapshot` asserts identical
   IDs and identical `deferred_conflicts`. Provenance asserted per case in the tests above.
4. **5 / 4 / 1 nested-run fixture** — PASSED.
   `leaf_occupancy::a_saturated_drain_reports_lock_waiting_implementing_and_post_implementation_slots`:
   occupancy 10, free slots 0, phases `{lock_waiting: 5, implementing: 4,
   post_implementation: 1, unknown: 0}`, 10 run entries, 10 deduplicated task IDs, gate and
   implementation run IDs per wrapper. 3 of the 5 lock-waiting slots resolve a blocker task
   ID; 2 report `unresolved_selectors`. `a_slot_without_durable_evidence_reports_unknown_and_says_why`
   covers all three explicit unknown reasons; `two_wrappers_carrying_one_task_occupy_two_slots_and_name_it_once`
   covers slot-vs-task double counting.
5. **Read-only + regressions preserved** — PASSED.
   `reading_occupancy_mutates_no_task_run_or_lock` re-asserts inertness across tasks, job
   runs, run state, and `task locks list` now that readiness reads run state. All 8
   `application::operation::tests::pipeline` grant tests (scope, stop, expiry, revocation,
   ceilings, completion, promotion) pass, as do the existing crew/dependency/epic/ceiling
   tests in `tests/workspace_auto.rs` (32) and the whole 1275-test `orbit-core` lib suite.
   `reserve_locks` remains authoritative for the race; nothing here reserves, oversubscribes,
   cancels, or resubmits.
6. **Commands and evidence** — PASSED. Listed below.

## Validation commands

| Command | Result |
|---|---|
| `cargo test -p orbit-core --lib v2_host::tests::auto_admission` | passed — 10/10 |
| `cargo test -p orbit-core --lib v2_host::tests::leaf_occupancy` | passed — 4/4 |
| `cargo test -p orbit-core --lib v2_host::` | passed — 311, 0 failed, 2 ignored |
| `cargo test -p orbit-core --lib application::operation::tests::pipeline` | passed — 8/8 |
| `cargo test -p orbit-core --lib` | passed — 1275, 0 failed, 2 ignored |
| `cargo test -p orbit-cli` | passed — 652 across 26 binaries, 0 failed |
| `cargo test -p orbit-web` | passed — 375, 0 failed, 1 ignored |
| `cargo fmt --all --check` | passed — clean |
| `make ci-fast` | passed — exit 0 |
| `make ci-lint` | passed — exit 0 (clippy, all targets, `-D warnings`) |
| `git diff --check` / `git status --short` | clean; 10 modified + 4 new files, all intended, no build or cache artifacts |

`make ci` was not run per workspace policy (it is the CI merge gate, not a per-task local check).
One environment note, not a defect: `make ci-fast`'s `test-compiler-cache-namespaces` step
self-skips on this host (`bwrap`: unprivileged user namespaces disabled). The target still
exits 0; that sub-check is unproven here.

## Deviations and risks

- **One existing test fixture adjusted.**
  `grant_bound_drain_inherits_the_snapshot_and_rechecks_the_grant_per_child` seeds every task
  with `context_files: ["README.md"]`, so task B genuinely conflicted with the live child
  carrying task A and was correctly deferred by the new rule. Rather than weaken the
  assertion, B was given its own file so the test keeps proving what it is named for — grant
  scope and the captured ceiling — instead of conflating that with lock contention. The new
  behavior it would otherwise have exercised is covered directly by
  `a_live_wrapper_claim_defers_an_overlapping_candidate_before_the_gate`.
- **Behavior change for tasks with empty `context_files`.** They have no footprint, so they
  never conflict and the wave still admits them together — unchanged, and the same reason
  `orchestration.md` already tells operators to fill selectors before dispatching under
  traffic.
- **Classifier no longer honors an explicit `task_ids` input.** It builds the snapshot
  directly instead of routing through `list_backlog_tasks`. `task_ids` was never in this
  activity's declared `input_schema_json`, the drain job never passes it, and no test used
  it; `list_backlog_tasks` itself is untouched for `task_auto_pipeline`.
- **Observation, not fixed (out of scope).** `list_backlog_tasks` reads `max_tasks` with
  `Value::as_u64`, but `workspace_auto_pipeline.yaml` templates it, so it arrives as `"50"`
  and silently falls back to the default 50 — benign only because the two values coincide.
  This is the same string-vs-number durable-input class as [ORB-11273]. The new
  `candidate_pool_limit` goes through `templated_u64` and does honor the value; changing
  `list_backlog_tasks` would alter `task_auto_pipeline` behavior beyond this task's scope.
- **Cost.** Readiness adds up to three batched `read_run_states` calls per invocation, and
  the classifier expands lock footprints for the candidates it examines (bounded by
  `max_tasks`, default 50) rather than only for the free slots.
- **Environment.** All checks ran on Linux (x86_64, kernel 6.8) against temporary in-process
  stores. No macOS or real multi-process drain was exercised; concurrency behavior under a
  live drain rests on `reserve_locks`, which is unchanged.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11973-6aa216ec`
- Behind base: 0
- Ahead of base: 1