### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-cmd/src/diagnostics.rs

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -81,3 +81,9 @@ extensions:
           "path-injection",
           "manual",
         ]
+      - [
+          "orbit_cmd::diagnostics::validated_diagnostics_file_path",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]

--- a/crates/orbit-cmd/src/diagnostics.rs
+++ b/crates/orbit-cmd/src/diagnostics.rs
@@ -101,17 +101,13 @@ fn is_year_month(name: &str) -> bool {
 }
 
 fn validated_diagnostics_root(root: &Path) -> Result<PathBuf, OrbitError> {
-    let canonical_root = root.canonicalize().map_err(|error| {
-        OrbitError::Io(format!(
-            "resolve diagnostics root {}: {error}",
-            root.display()
-        ))
-    })?;
+    let canonical_root = root
+        .canonicalize()
+        .map_err(|error| OrbitError::Io(format!("resolve diagnostics root: {error}")))?;
     if !canonical_root.is_dir() {
-        return Err(OrbitError::InvalidInput(format!(
-            "diagnostics root must be a directory: {}",
-            canonical_root.display()
-        )));
+        return Err(OrbitError::InvalidInput(
+            "diagnostics root must be a directory".to_string(),
+        ));
     }
     Ok(canonical_root)
 }
@@ -180,17 +176,48 @@ fn validated_year_month(year_month: &str) -> Result<String, OrbitError> {
 fn validate_diagnostics_path(root: &Path, path: PathBuf) -> Result<PathBuf, OrbitError> {
     match path.canonicalize() {
         Ok(canonical) if canonical.starts_with(root) => Ok(canonical),
-        Ok(canonical) => Err(OrbitError::InvalidInput(format!(
-            "diagnostics path '{}' resolves outside {}",
-            canonical.display(),
-            root.display()
-        ))),
+        Ok(_) => Err(OrbitError::InvalidInput(
+            "diagnostics path resolves outside the data root".to_string(),
+        )),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(path),
-        Err(error) => Err(OrbitError::Io(format!(
-            "resolve diagnostics path {}: {error}",
-            path.display()
-        ))),
+        Err(error) => Err(OrbitError::Io(format!("resolve diagnostics path: {error}"))),
     }
+}
+
+/// Canonicalize an enumerated JSONL file and keep it inside its validated
+/// month directory. Directory validation alone is insufficient because a
+/// JSONL entry may itself be a symlink to a different file.
+fn validated_diagnostics_file_path(
+    root: &Path,
+    month_dir: &Path,
+    path: PathBuf,
+) -> Result<PathBuf, OrbitError> {
+    let canonical_month_dir = month_dir
+        .canonicalize()
+        .map_err(|error| OrbitError::Io(format!("resolve diagnostics month: {error}")))?;
+    let canonical_file = path
+        .canonicalize()
+        .map_err(|error| OrbitError::Io(format!("resolve diagnostics file: {error}")))?;
+
+    if canonical_file.starts_with(root) && canonical_file.starts_with(&canonical_month_dir) {
+        Ok(canonical_file)
+    } else {
+        Err(OrbitError::InvalidInput(
+            "diagnostics file resolves outside its month directory".to_string(),
+        ))
+    }
+}
+
+fn diagnostics_jsonl_files(root: &Path, month_dir: &Path) -> Result<Vec<PathBuf>, OrbitError> {
+    let mut files = fs::read_dir(month_dir)
+        .map_err(|e| OrbitError::Io(e.to_string()))?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("jsonl"))
+        .map(|path| validated_diagnostics_file_path(root, month_dir, path))
+        .collect::<Result<Vec<_>, _>>()?;
+    files.sort();
+    Ok(files)
 }
 
 fn read_jsonl_month<T: DeserializeOwned>(
@@ -202,13 +229,7 @@ fn read_jsonl_month<T: DeserializeOwned>(
     if !month_dir.exists() {
         return Ok(Vec::new());
     }
-    let mut files = fs::read_dir(&month_dir)
-        .map_err(|e| OrbitError::Io(e.to_string()))?
-        .filter_map(Result::ok)
-        .map(|e| e.path())
-        .filter(|p| p.extension().and_then(|v| v.to_str()) == Some("jsonl"))
-        .collect::<Vec<_>>();
-    files.sort();
+    let files = diagnostics_jsonl_files(root, &month_dir)?;
 
     let mut entries = Vec::new();
     for path in files {
@@ -249,13 +270,7 @@ fn read_jsonl_month_limited<T: DeserializeOwned>(
     if !month_dir.exists() {
         return Ok(Vec::new());
     }
-    let mut files = fs::read_dir(&month_dir)
-        .map_err(|e| OrbitError::Io(e.to_string()))?
-        .filter_map(Result::ok)
-        .map(|e| e.path())
-        .filter(|p| p.extension().and_then(|v| v.to_str()) == Some("jsonl"))
-        .collect::<Vec<_>>();
-    files.sort();
+    let files = diagnostics_jsonl_files(root, &month_dir)?;
 
     let mut entries = Vec::new();
     for path in files.into_iter().rev() {
@@ -365,6 +380,27 @@ mod tests {
         let root = tempfile::tempdir().expect("tempdir");
 
         let error = read_jsonl_month::<Value>(root.path(), "metrics", "../secrets").unwrap_err();
+
+        assert!(matches!(error, orbit_common::OrbitError::InvalidInput(_)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_month_rejects_jsonl_symlink_outside_month() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let month_dir = root
+            .path()
+            .join("state")
+            .join("diagnostics")
+            .join("metrics")
+            .join("2026-03");
+        std::fs::create_dir_all(&month_dir).unwrap();
+        let outside_file = outside.path().join("outside.jsonl");
+        std::fs::write(&outside_file, r#"{"value":1}"#).unwrap();
+        std::os::unix::fs::symlink(&outside_file, month_dir.join("entries.jsonl")).unwrap();
+
+        let error = read_jsonl_month::<Value>(root.path(), "metrics", "2026-03").unwrap_err();
 
         assert!(matches!(error, orbit_common::OrbitError::InvalidInput(_)));
     }


### PR DESCRIPTION
## Task

[ORB-11923](https://orbit-cli.com/tasks/ORB-11923) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-cmd/src/diagnostics.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#125`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `6727038735ac262099d41caa611cc8946e9dcf93`
- Location: `crates/orbit-cmd/src/diagnostics.rs` line 113
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:48:41Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/125

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-cmd/src/diagnostics.rs` line 113 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Hardened `crates/orbit-cmd/src/diagnostics.rs` so every JSONL path returned by directory enumeration is canonicalized and required to remain inside the validated diagnostics month and data root before reading.
- Removed user-derived filesystem path text from diagnostics validation errors.
- Added a Unix regression test rejecting a JSONL symlink that resolves outside the month.
- Registered the new real validator in `.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml`; no rule suppression, dismissal, or path exclusion was added.

Acceptance criteria:
- Code scanning remediation: satisfied by the real per-file canonicalization/containment check and its CodeQL barrier-model entry.
- Intended behavior: preserved for valid diagnostics reads; traversal and external symlink paths are rejected, with focused tests covering both existing traversal rejection and the new symlink case.
- Validation/security: repository gates passed. Local CodeQL execution was not run because the `codeql` binary is unavailable; the GitHub CodeQL workflow is required for scanner confirmation on the affected branch.

Validation:
- `cargo fmt --all -- --check`: passed.
- `cargo test -p orbit-cmd diagnostics --lib`: passed, 9/9 tests.
- `make ci-fast`: passed (exit 0); its compiler-cache namespace smoke test reported an environment limitation because bubblewrap user namespaces are unavailable.
- `make ci-lint`: passed (workspace clippy, all targets, warnings denied).
- `git diff --check`: passed.
- `git status --short`: only the two task-scoped files are modified.

Assessment: The diagnostics filesystem boundary now validates the final file path actually opened, closing the remaining symlink/data-flow gap while keeping the existing category/month allow-list and read behavior.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11923-6aa21f1c`
- Behind base: 0
- Ahead of base: 1