### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-registry/src/host_identity.rs

### DIFF
--- a/crates/orbit-registry/src/host_identity.rs
+++ b/crates/orbit-registry/src/host_identity.rs
@@ -12,7 +12,6 @@
 //! no silent fallback to the OS hostname. Routine `hosts:` pinning,
 //! the sweep, and status all resolve through [`HostIdentity::host_id`].
 
-use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -170,35 +169,33 @@ fn host_toml_path(global_root: &Path) -> PathBuf {
 }
 
 fn existing_host_toml_path(global_root: &Path) -> Result<Option<PathBuf>, OrbitError> {
-    let path = host_toml_path(global_root);
-    if !path.exists() {
-        return Ok(None);
-    }
+    let canonical_root = match global_root.canonicalize() {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "failed to canonicalize host identity directory '{}': {error}",
+                global_root.display()
+            )));
+        }
+    };
+    let canonical_path = canonical_root.join(HOST_TOML_FILE);
 
-    let canonical_root = global_root.canonicalize().map_err(|error| {
-        OrbitError::Io(format!(
-            "failed to canonicalize host identity directory '{}': {error}",
-            global_root.display()
-        ))
-    })?;
-    let canonical_path = path.canonicalize().map_err(|error| {
-        OrbitError::Io(format!(
-            "failed to canonicalize host identity '{}': {error}",
-            path.display()
-        ))
-    })?;
-    if !canonical_path.starts_with(&canonical_root)
-        || canonical_path.file_name() != Some(OsStr::new(HOST_TOML_FILE))
-        || !canonical_path.is_file()
-    {
-        return Err(OrbitError::InvalidInput(format!(
-            "host identity path must be a regular {HOST_TOML_FILE} file inside '{}': {}",
-            global_root.display(),
-            path.display()
-        )));
+    match std::fs::symlink_metadata(&canonical_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            Err(OrbitError::InvalidInput(format!(
+                "host identity path must be a regular {HOST_TOML_FILE} file inside '{}': {}",
+                global_root.display(),
+                canonical_path.display()
+            )))
+        }
+        Ok(_) => Ok(Some(canonical_path)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(OrbitError::Io(format!(
+            "failed to inspect host identity '{}': {error}",
+            canonical_path.display()
+        ))),
     }
-
-    Ok(Some(canonical_root.join(HOST_TOML_FILE)))
 }
 
 fn non_blank(value: &Option<String>) -> Option<String> {


### PR DESCRIPTION
## Task

[ORB-11961](https://orbit-cli.com/tasks/ORB-11961) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-registry/src/host_identity.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#386`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.27.0`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `3fced6f6a6bcfc1d6e85aa5e876f0acbc7c85ada`
- Location: `crates/orbit-registry/src/host_identity.rs` line 174
- Created: `2026-09-09T06:07:10Z`
- Updated: `2026-09-09T06:40:24Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/386

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-registry/src/host_identity.rs` line 174 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Reworked `existing_host_toml_path` in `crates/orbit-registry/src/host_identity.rs` to canonicalize the configured root before filesystem probing, derive the fixed `host.toml` child from that trusted root, reject final-component symlinks/non-regular files with `symlink_metadata`, and preserve absent-root/absent-file behavior.
- No CodeQL suppression, dismissal, exclusion, or configuration bypass was added.

Acceptance criteria:
- rust/path-injection remediation: satisfied by removing the user-controlled `.exists()` probe and replacing it with root canonicalization plus fixed-child validation; the changed path is now at lines 171-198.
- Intended behavior: satisfied; focused host identity tests pass, including absent-file handling, creation/migration, current-schema loading, and outside-root symlink rejection.
- Validation/security: repository checks pass below. The repository's CodeQL scan is GitHub Actions-only in `.github/workflows/codeql.yml`; `codeql` is not installed in this executor, so final alert confirmation is deferred to the CI CodeQL run. Static review confirms the prior `.exists()` data flow is gone and no suppression was introduced.

Validation:
- `cargo test -p orbit-registry host_identity --lib`: passed (18 passed, 0 failed).
- `cargo fmt --all -- --check`: passed.
- `make ci-fast`: passed; its namespace-cache subcheck explicitly skipped because this executor cannot create a bubblewrap mount namespace.
- `make ci-lint`: passed (`cargo clippy --workspace --all-targets -- -D warnings`).
- `git diff --check`: passed.
- `git status --short`: only `crates/orbit-registry/src/host_identity.rs` modified.

Assessment: scoped, fail-closed path validation removes the reported unsafe filesystem probe while retaining the documented absent and invalid-file behavior. No remaining implementation changes are required.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11961-6aa22282`
- Behind base: 0
- Ahead of base: 1