### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/docs/walk.rs

### DIFF
--- a/crates/orbit-core/src/application/docs/tests/walk.rs
+++ b/crates/orbit-core/src/application/docs/tests/walk.rs
@@ -82,6 +82,18 @@ fn wildcard_root_rejects_paths_outside_the_workspace() {
 }
 
 #[test]
+fn missing_literal_root_is_a_noop() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path();
+
+    assert!(
+        expand_root(root, "missing/docs/")
+            .expect("expand missing root")
+            .is_empty()
+    );
+}
+
+#[test]
 fn walker_batches_git_ignore_once_per_walk() {
     let dir = tempdir().expect("tempdir");
     let root = dir.path();

--- a/crates/orbit-core/src/application/docs/walk.rs
+++ b/crates/orbit-core/src/application/docs/walk.rs
@@ -127,23 +127,19 @@ pub(super) fn expand_root(repo_root: &Path, root: &str) -> Result<Vec<PathBuf>, 
         repo_root.join(root_path)
     };
     if !trimmed.contains('*') {
-        if absolute.exists() {
-            return match validated_docs_root_path(repo_root, &absolute) {
-                Ok(path) => Ok(vec![path]),
-                Err(OrbitError::InvalidInput(_)) => {
-                    // Chosen policy: out-of-workspace docs roots (such as in-repo
-                    // symlinks pointing outside the workspace, parent traversal,
-                    // or absolute paths) are skipped as unusable roots (returning
-                    // an empty list) rather than aborting the walk. This matches
-                    // the wildcard branch and the walker's documented no-op
-                    // behavior for missing roots, ensuring literal and wildcard
-                    // forms produce the same outcome.
-                    Ok(Vec::new())
-                }
-                Err(error) => Err(error),
-            };
-        }
-        return Ok(Vec::new());
+        return match validated_docs_root_path(repo_root, &absolute) {
+            Ok(path) => Ok(vec![path]),
+            Err(OrbitError::InvalidInput(_)) => {
+                // Chosen policy: out-of-workspace docs roots (such as in-repo
+                // symlinks pointing outside the workspace, parent traversal,
+                // absolute paths outside the workspace, or missing roots) are
+                // skipped as unusable roots rather than aborting the walk.
+                // This matches the wildcard branch and preserves the walker's
+                // no-op behavior.
+                Ok(Vec::new())
+            }
+            Err(error) => Err(error),
+        };
     }
 
     // Wildcard expansion is intentionally workspace-relative. Apart from
@@ -179,9 +175,21 @@ pub(super) fn validated_docs_root_path(
     let canonical_repo = repo_root.canonicalize().map_err(|error| {
         OrbitError::Io(format!("canonicalize {}: {error}", repo_root.display()))
     })?;
-    let canonical_candidate = candidate.canonicalize().map_err(|error| {
-        OrbitError::Io(format!("canonicalize {}: {error}", candidate.display()))
-    })?;
+    let canonical_candidate = match candidate.canonicalize() {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(OrbitError::InvalidInput(format!(
+                "docs root path does not exist: {}",
+                candidate.display()
+            )));
+        }
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "canonicalize {}: {error}",
+                candidate.display()
+            )));
+        }
+    };
     if !canonical_candidate.starts_with(&canonical_repo) {
         return Err(OrbitError::InvalidInput(format!(
             "docs root path must stay inside the workspace root: {} (resolves to {})",


### PR DESCRIPTION
## Task

[ORB-11987](https://orbit-cli.com/tasks/ORB-11987) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/docs/walk.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#401`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.27.0`, guid `unknown`)
- Message: This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `9a0b4d11b15b2454cb9dc646b3f0480dd882f6dc`
- Location: `crates/orbit-core/src/application/docs/walk.rs` line 130
- Created: `2026-09-10T02:55:12Z`
- Updated: `2026-09-10T02:58:03Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/401

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-core/src/application/docs/walk.rs` line 130 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Removed the user-controlled literal-root `absolute.exists()` filesystem check from `expand_root`; all literal roots now pass through the existing `validated_docs_root_path` CodeQL barrier before use.
- Preserved missing, parent-traversal, and out-of-workspace roots as no-ops by translating missing canonicalization to the existing invalid-input skip policy.
- Added `missing_literal_root_is_a_noop` regression coverage.

Acceptance criteria:
- Code scanning remediation: satisfied in `crates/orbit-core/src/application/docs/walk.rs`; the reported sink is gone and no suppression/exclusion was added.
- Intended behavior: satisfied; existing symlink/out-of-workspace tests and the new missing-root test pass.
- Validation/security: repository gates passed. Local CodeQL execution was not run because the `codeql` CLI is unavailable and the task explicitly does not require agent-side GitHub access; the source-level evidence is that the path now enters the registered `validated_docs_root_path` barrier before filesystem traversal. CI CodeQL remains the authoritative confirmation.

Validation:
- `cargo fmt --all -- --check` — passed.
- `cargo test -p orbit-core application::docs::tests::walk` — passed, 10 tests.
- `make ci-fast` — passed; its compiler-cache namespace subcheck reported an environment skip because bubblewrap cannot create a non-privileged mount namespace.
- `make ci-lint` — passed.
- `git diff --check` — passed.
- `codeql version` — not run; executable unavailable.

Assessment: Small, boundary-focused fix with preserved no-op semantics and regression coverage. No unrelated files changed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11987-6aa22285`
- Behind base: 0
- Ahead of base: 1