### PR TITLE
Validate CodeQL extension row schemas in the fast handoff gate

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -83,6 +83,11 @@ extensions:
         ]
       - [
           "orbit_store::driver::file::friction_store::validated_friction_root",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]
+      - [
           "orbit_cmd::diagnostics::validated_diagnostics_file_path",
           "ReturnValue.Field[core::result::Result::Ok(0)]",
           "path-injection",

--- a/scripts/check-codeql-extension-schema.py
+++ b/scripts/check-codeql-extension-schema.py
@@ -1,0 +1,597 @@
+#!/usr/bin/env python3
+"""Validate CodeQL data-extension row schemas used by this repository.
+
+Conflict recovery can merge two independent barrier paths into one YAML list
+row. The file still parses, but CodeQL rejects the tuple against the
+extensible predicate. This check is the local schema gate: YAML parse
+success is not treated as validation.
+"""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from pathlib import Path
+import sys
+from typing import Any
+
+
+# Pinned to the CodeQL rust-all data-extension contract:
+# https://codeql.github.com/docs/codeql-language-guides/customizing-library-models-for-rust/
+RUST_ALL_PACK = "codeql/rust-all"
+RUST_ALL_PREDICATES = {
+    "sourceModel": ("path", "output", "kind", "provenance"),
+    "sinkModel": ("path", "input", "kind", "provenance"),
+    "summaryModel": ("path", "input", "output", "kind", "provenance"),
+    "neutralModel": ("path", "kind", "provenance"),
+    "barrierModel": ("path", "output", "kind", "provenance"),
+    "barrierGuardModel": ("path", "input", "acceptingValue", "kind", "provenance"),
+}
+SUPPORTED_PACKS = {RUST_ALL_PACK: RUST_ALL_PREDICATES}
+EXTENSIONS_ROOT = Path(".github/codeql/extensions")
+PACK_FILENAME = "codeql-pack.yml"
+
+
+class YamlError(Exception):
+    """Restricted YAML subset could not be loaded."""
+
+    def __init__(self, message: str, line: int | None = None) -> None:
+        self.line = line
+        if line is None:
+            super().__init__(message)
+        else:
+            super().__init__(f"line {line}: {message}")
+
+
+class LogicalLine:
+    __slots__ = ("indent", "text", "line")
+
+    def __init__(self, indent: int, text: str, line: int) -> None:
+        self.indent = indent
+        self.text = text
+        self.line = line
+
+
+def _strip_comment(line: str) -> str:
+    in_single = False
+    in_double = False
+    index = 0
+    while index < len(line):
+        char = line[index]
+        if char == "\\" and in_double:
+            index += 2
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        elif char == "#" and not in_single and not in_double:
+            return line[:index].rstrip()
+        index += 1
+    return line.rstrip()
+
+
+def _flow_depth(text: str) -> int:
+    depth = 0
+    in_single = False
+    in_double = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char == "\\" and in_double:
+            index += 2
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        elif not in_single and not in_double:
+            if char in "[{":
+                depth += 1
+            elif char in "]}":
+                depth -= 1
+        index += 1
+    return depth
+
+
+def _logical_lines(text: str) -> list[LogicalLine]:
+    physical = text.splitlines()
+    lines: list[LogicalLine] = []
+    index = 0
+    while index < len(physical):
+        raw = physical[index]
+        line_no = index + 1
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            index += 1
+            continue
+        leading = raw[: len(raw) - len(raw.lstrip(" \t"))]
+        if "\t" in leading:
+            raise YamlError("tab indentation is not allowed", line_no)
+        indent = len(leading)
+        content = _strip_comment(raw)[indent:].rstrip()
+        if not content:
+            index += 1
+            continue
+        start_line = line_no
+        depth = _flow_depth(content)
+        while depth > 0:
+            index += 1
+            if index >= len(physical):
+                raise YamlError("unclosed flow collection", start_line)
+            content += "\n" + physical[index]
+            depth = _flow_depth(content)
+        if depth < 0:
+            raise YamlError("unbalanced flow collection", start_line)
+        lines.append(LogicalLine(indent, content, start_line))
+        index += 1
+    return lines
+
+
+def _parse_quoted(text: str, start: int, line: int) -> tuple[str, int]:
+    quote = text[start]
+    index = start + 1
+    chars: list[str] = []
+    while index < len(text):
+        char = text[index]
+        if quote == '"' and char == "\\":
+            if index + 1 >= len(text):
+                raise YamlError("unterminated escape in string", line)
+            escaped = text[index + 1]
+            mapping = {"n": "\n", "t": "\t", "r": "\r", '"': '"', "\\": "\\"}
+            chars.append(mapping.get(escaped, escaped))
+            index += 2
+            continue
+        if quote == "'" and char == "'" and index + 1 < len(text) and text[index + 1] == "'":
+            chars.append("'")
+            index += 2
+            continue
+        if char == quote:
+            return "".join(chars), index + 1
+        chars.append(char)
+        index += 1
+    raise YamlError("unterminated quoted string", line)
+
+
+def _parse_plain_scalar(text: str) -> Any:
+    value = text.strip()
+    if value in {"null", "Null", "NULL", "~"}:
+        return None
+    lowered = value.lower()
+    if lowered in {"true", "yes", "on"}:
+        return True
+    if lowered in {"false", "no", "off"}:
+        return False
+    if value.startswith(("+", "-")) and value[1:].isdigit():
+        return int(value)
+    if value.isdigit():
+        return int(value)
+    if len(value) > 1 and value.count(".") == 1:
+        left, right = value.split(".")
+        signed = left.startswith(("+", "-"))
+        digits = left[1:] if signed else left
+        if digits.isdigit() and right.isdigit():
+            return float(value)
+    return value
+
+
+def _skip_space(text: str, index: int) -> int:
+    while index < len(text) and text[index] in " \t\n\r":
+        index += 1
+    return index
+
+
+def _parse_flow(text: str, start: int, line: int) -> tuple[Any, int]:
+    index = _skip_space(text, start)
+    if index >= len(text):
+        raise YamlError("expected a value", line)
+    char = text[index]
+    if char in {'"', "'"}:
+        return _parse_quoted(text, index, line)
+    if char == "[":
+        items: list[Any] = []
+        index += 1
+        while True:
+            index = _skip_space(text, index)
+            if index >= len(text):
+                raise YamlError("unclosed flow sequence", line)
+            if text[index] == "]":
+                return items, index + 1
+            if text[index] == ",":
+                index += 1
+                continue
+            item, index = _parse_flow(text, index, line)
+            items.append(item)
+            index = _skip_space(text, index)
+            if index < len(text) and text[index] == ",":
+                index += 1
+        raise YamlError("unclosed flow sequence", line)
+    if char == "{":
+        mapping: dict[str, Any] = {}
+        index += 1
+        while True:
+            index = _skip_space(text, index)
+            if index >= len(text):
+                raise YamlError("unclosed flow mapping", line)
+            if text[index] == "}":
+                return mapping, index + 1
+            if text[index] == ",":
+                index += 1
+                continue
+            key_obj, index = _parse_flow(text, index, line)
+            if not isinstance(key_obj, str):
+                raise YamlError("flow mapping keys must be strings", line)
+            index = _skip_space(text, index)
+            if index >= len(text) or text[index] != ":":
+                raise YamlError("expected ':' in flow mapping", line)
+            value, index = _parse_flow(text, index + 1, line)
+            mapping[key_obj] = value
+            index = _skip_space(text, index)
+            if index < len(text) and text[index] == ",":
+                index += 1
+        raise YamlError("unclosed flow mapping", line)
+
+    end = index
+    while end < len(text) and text[end] not in ",]}:\n":
+        end += 1
+    if end == index:
+        raise YamlError("expected a scalar value", line)
+    return _parse_plain_scalar(text[index:end]), end
+
+
+def _parse_scalar(text: str, line: int) -> Any:
+    stripped = text.strip()
+    if not stripped:
+        return None
+    if stripped[0] in {'"', "'", "[", "{"}:
+        value, index = _parse_flow(stripped, 0, line)
+        index = _skip_space(stripped, index)
+        if index != len(stripped):
+            raise YamlError("trailing content after value", line)
+        return value
+    return _parse_plain_scalar(stripped)
+
+
+def _split_key(text: str, line: int) -> tuple[str, str | None]:
+    in_single = False
+    in_double = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char == "\\" and in_double:
+            index += 2
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        elif char == ":" and not in_single and not in_double:
+            rest = text[index + 1 :]
+            if rest and rest[0] not in " \t\n#":
+                index += 1
+                continue
+            key = text[:index].strip()
+            if not key:
+                raise YamlError("empty mapping key", line)
+            if key[0] in {'"', "'"}:
+                parsed, consumed = _parse_quoted(key, 0, line)
+                if consumed != len(key):
+                    raise YamlError("invalid quoted mapping key", line)
+                key = parsed
+            value = rest.strip()
+            return key, (value if value else None)
+        index += 1
+    return text.strip(), None
+
+
+def _is_sequence_item(text: str) -> bool:
+    return text == "-" or text.startswith("- ") or text.startswith("-[") or text.startswith("-{")
+
+
+def _sequence_item_text(text: str) -> str:
+    if text == "-":
+        return ""
+    if text.startswith("- "):
+        return text[2:].lstrip(" ")
+    return text[1:]
+
+
+def _parse_mapping(lines: list[LogicalLine], index: int, indent: int) -> tuple[dict[str, Any], int]:
+    mapping: dict[str, Any] = {}
+    while index < len(lines):
+        current = lines[index]
+        if current.indent != indent or _is_sequence_item(current.text):
+            break
+        key, inline = _split_key(current.text, current.line)
+        if key in mapping:
+            raise YamlError(f"duplicate mapping key {key!r}", current.line)
+        if inline is not None:
+            mapping[key] = _parse_scalar(inline, current.line)
+            index += 1
+            continue
+        if index + 1 >= len(lines) or lines[index + 1].indent <= indent:
+            mapping[key] = None
+            index += 1
+            continue
+        mapping[key], index = _parse_node(lines, index + 1, indent + 1)
+    return mapping, index
+
+
+def _parse_sequence(lines: list[LogicalLine], index: int, indent: int) -> tuple[list[Any], int]:
+    items: list[Any] = []
+    while index < len(lines):
+        current = lines[index]
+        if current.indent != indent or not _is_sequence_item(current.text):
+            break
+        item_text = _sequence_item_text(current.text)
+        if item_text == "":
+            if index + 1 >= len(lines) or lines[index + 1].indent <= indent:
+                items.append(None)
+                index += 1
+                continue
+            value, index = _parse_node(lines, index + 1, indent + 1)
+            items.append(value)
+            continue
+        key, inline = _split_key(item_text, current.line)
+        if ":" in item_text and (inline is not None or item_text.endswith(":")):
+            mapping: dict[str, Any] = {}
+            if inline is not None:
+                mapping[key] = _parse_scalar(inline, current.line)
+                index += 1
+            elif index + 1 < len(lines) and lines[index + 1].indent > indent:
+                mapping[key], index = _parse_node(lines, index + 1, indent + 1)
+            else:
+                mapping[key] = None
+                index += 1
+            while index < len(lines) and lines[index].indent > indent:
+                nested, index = _parse_mapping(lines, index, lines[index].indent)
+                mapping.update(nested)
+            items.append(mapping)
+            continue
+        items.append(_parse_scalar(item_text, current.line))
+        index += 1
+    return items, index
+
+
+def _parse_node(lines: list[LogicalLine], index: int, min_indent: int) -> tuple[Any, int]:
+    if index >= len(lines):
+        raise YamlError("unexpected end of file")
+    current = lines[index]
+    if current.indent < min_indent:
+        raise YamlError("unexpected dedent", current.line)
+    if _is_sequence_item(current.text):
+        return _parse_sequence(lines, index, current.indent)
+    if _split_key(current.text, current.line)[1] is not None or current.text.endswith(":"):
+        return _parse_mapping(lines, index, current.indent)
+    return _parse_scalar(current.text, current.line), index + 1
+
+
+def load_yaml(text: str) -> Any:
+    """Load the YAML subset used by CodeQL packs and data extensions."""
+    lines = _logical_lines(text)
+    if not lines:
+        return None
+    value, index = _parse_node(lines, 0, 0)
+    if index != len(lines):
+        raise YamlError("unexpected trailing content", lines[index].line)
+    return value
+
+
+def _rel(root: Path, path: Path) -> str:
+    return path.resolve().relative_to(root.resolve()).as_posix()
+
+
+def _type_name(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "float"
+    if isinstance(value, list):
+        return "list"
+    if isinstance(value, dict):
+        return "mapping"
+    return type(value).__name__
+
+
+def _error(path: str, message: str) -> str:
+    return f"check-codeql-extension-schema: {path}: {message}"
+
+
+def validate_data_extension(path: str, document: Any) -> list[str]:
+    """Return schema errors for one loaded data-extension document."""
+    errors: list[str] = []
+    if not isinstance(document, dict):
+        return [_error(path, f"expected a mapping, found {_type_name(document)}")]
+    if "extensions" not in document:
+        return [_error(path, "missing 'extensions' list")]
+    extensions = document["extensions"]
+    if not isinstance(extensions, list):
+        return [_error(path, f"'extensions' must be a list, found {_type_name(extensions)}")]
+
+    for extension_index, extension in enumerate(extensions, start=1):
+        prefix = f"extension {extension_index}"
+        if not isinstance(extension, dict):
+            errors.append(_error(path, f"{prefix}: expected a mapping, found {_type_name(extension)}"))
+            continue
+        adds_to = extension.get("addsTo")
+        if not isinstance(adds_to, dict):
+            errors.append(
+                _error(path, f"{prefix}: missing 'addsTo' mapping (found {_type_name(adds_to)})")
+            )
+            continue
+        pack = adds_to.get("pack")
+        predicate = adds_to.get("extensible")
+        if not isinstance(pack, str) or not pack.strip():
+            errors.append(_error(path, f"{prefix}: 'addsTo.pack' must be a non-empty string"))
+            continue
+        if not isinstance(predicate, str) or not predicate.strip():
+            errors.append(_error(path, f"{prefix}: 'addsTo.extensible' must be a non-empty string"))
+            continue
+        supported = SUPPORTED_PACKS.get(pack)
+        if supported is None:
+            errors.append(_error(path, f"{prefix}: unsupported extension pack {pack!r}"))
+            continue
+        fields = supported.get(predicate)
+        if fields is None:
+            errors.append(
+                _error(
+                    path,
+                    f"{prefix}: unsupported extensible predicate {predicate!r} for pack {pack!r}",
+                )
+            )
+            continue
+        rows = extension.get("data")
+        if not isinstance(rows, list):
+            errors.append(
+                _error(path, f"{prefix}: '{predicate}' data must be a list, found {_type_name(rows)}")
+            )
+            continue
+        expected = len(fields)
+        field_list = ", ".join(fields)
+        for row_index, row in enumerate(rows, start=1):
+            location = f"{predicate} row {row_index}"
+            if not isinstance(row, list):
+                errors.append(
+                    _error(path, f"{location}: expected a list of {expected} fields, found {_type_name(row)}")
+                )
+                continue
+            if len(row) != expected:
+                errors.append(
+                    _error(
+                        path,
+                        f"{location}: expected {expected} fields ({field_list}), found {len(row)}",
+                    )
+                )
+                continue
+            for field_index, (field_name, value) in enumerate(zip(fields, row), start=1):
+                if not isinstance(value, str) or not value.strip():
+                    errors.append(
+                        _error(
+                            path,
+                            f"{location} field {field_index} ({field_name}): "
+                            f"expected a non-empty string, found {_type_name(value)}",
+                        )
+                    )
+    return errors
+
+
+def _load_file(path: Path) -> Any:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise YamlError(str(error)) from error
+    return load_yaml(text)
+
+
+def _pack_data_extensions(pack_dir: Path, document: Any, pack_path: str) -> tuple[list[Path], list[str]]:
+    if not isinstance(document, dict):
+        return [], [_error(pack_path, f"expected a mapping, found {_type_name(document)}")]
+    declared = document.get("dataExtensions")
+    if declared is None:
+        return [], [_error(pack_path, "missing 'dataExtensions' list")]
+    if not isinstance(declared, list):
+        return [], [_error(pack_path, f"'dataExtensions' must be a list, found {_type_name(declared)}")]
+
+    files: list[Path] = []
+    errors: list[str] = []
+    for index, entry in enumerate(declared, start=1):
+        if not isinstance(entry, str) or not entry.strip():
+            errors.append(
+                _error(pack_path, f"dataExtensions[{index}] must be a non-empty string")
+            )
+            continue
+        candidate = Path(entry)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            errors.append(
+                _error(pack_path, f"dataExtensions[{index}] must be a path inside the pack directory")
+            )
+            continue
+        resolved = (pack_dir / candidate).resolve()
+        if pack_dir.resolve() not in resolved.parents and resolved != pack_dir.resolve():
+            errors.append(
+                _error(pack_path, f"dataExtensions[{index}] must be a path inside the pack directory")
+            )
+            continue
+        if not resolved.is_file():
+            errors.append(_error(pack_path, f"dataExtensions[{index}] not found: {entry}"))
+            continue
+        files.append(resolved)
+    return files, errors
+
+
+def discover_packs(root: Path) -> list[Path]:
+    base = root / EXTENSIONS_ROOT
+    if not base.is_dir():
+        return []
+    packs = []
+    for child in sorted(path for path in base.iterdir() if path.is_dir()):
+        pack = child / PACK_FILENAME
+        if pack.is_file():
+            packs.append(pack)
+    return packs
+
+
+def validate_root(root: Path) -> list[str]:
+    """Validate every CodeQL data extension declared under the repository root."""
+    packs = discover_packs(root)
+    if not packs:
+        return [
+            _error(
+                EXTENSIONS_ROOT.as_posix(),
+                "no CodeQL extension packs found",
+            )
+        ]
+
+    errors: list[str] = []
+    for pack in packs:
+        pack_path = _rel(root, pack)
+        try:
+            document = _load_file(pack)
+        except YamlError as error:
+            errors.append(_error(pack_path, f"malformed YAML: {error}"))
+            continue
+        files, pack_errors = _pack_data_extensions(pack.parent, document, pack_path)
+        errors.extend(pack_errors)
+        for data_file in files:
+            relative = _rel(root, data_file)
+            try:
+                extension = _load_file(data_file)
+            except YamlError as error:
+                errors.append(_error(relative, f"malformed YAML: {error}"))
+                continue
+            errors.extend(validate_data_extension(relative, extension))
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        help="repository root containing .github/codeql/extensions (default: this repo)",
+    )
+    arguments = parser.parse_args(argv)
+    root = (arguments.root or Path(__file__).resolve().parent.parent).resolve()
+
+    try:
+        errors = validate_root(root)
+    except OSError as error:
+        print(f"check-codeql-extension-schema: {error}", file=sys.stderr)
+        return 2
+
+    if errors:
+        print(
+            "CodeQL data-extension rows must match the pinned rust-all schema; "
+            "YAML parse success is not schema validation:",
+            file=sys.stderr,
+        )
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -51,6 +51,8 @@ fi
 "$repo_root/scripts/test-mcp-registry-publish-workflow.sh"
 "$repo_root/scripts/check-dependency-direction.sh"
 "$repo_root/scripts/test-ci-fast-guards.py"
+"$repo_root/scripts/test-codeql-extension-schema.py"
+"$repo_root/scripts/check-codeql-extension-schema.py"
 "$repo_root/scripts/check-cli-imports.sh"
 "$repo_root/scripts/check-terminal-state-guard.sh"
 "$repo_root/scripts/check-history-note-size.sh"

--- a/scripts/test-ci-fast-guards.py
+++ b/scripts/test-ci-fast-guards.py
@@ -72,6 +72,21 @@ jobs:
         calls = [json.loads(line) for line in self.log.read_text().splitlines()]
         self.assertEqual(calls, [["fmt", "--all", "--", "--check"]])
 
+    def test_fast_invokes_codeql_extension_schema_check(self):
+        self.prepare_ci()
+        self.write_executable(
+            self.scripts / "check-codeql-extension-schema.py",
+            '''#!/usr/bin/env python3
+import json, os, sys
+with open(os.environ["GUARD_TEST_LOG"], "a") as log:
+    log.write(json.dumps(["check-codeql-extension-schema.py"] + sys.argv[1:]) + "\\n")
+''',
+        )
+        result = self.run_guard("ci-guardrails.sh", "--fast")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = [json.loads(line) for line in self.log.read_text().splitlines()]
+        self.assertIn(["check-codeql-extension-schema.py"], calls)
+
     def test_full_still_checks_workflow_test_matches(self):
         self.prepare_ci()
         result = self.run_guard("ci-guardrails.sh")

--- a/scripts/test-codeql-extension-schema.py
+++ b/scripts/test-codeql-extension-schema.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Positive and negative fixtures for the CodeQL extension schema gate."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+SCRIPTS = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPTS.parent
+CHECKER_PATH = SCRIPTS / "check-codeql-extension-schema.py"
+
+_SPEC = importlib.util.spec_from_file_location("check_codeql_extension_schema", CHECKER_PATH)
+if _SPEC is None or _SPEC.loader is None:
+    raise RuntimeError(f"unable to load {CHECKER_PATH}")
+CHECK = importlib.util.module_from_spec(_SPEC)
+sys.modules["check_codeql_extension_schema"] = CHECK
+_SPEC.loader.exec_module(CHECK)
+
+
+PACK_YML = """name: constellation-works/orbit-rust-path-validation
+version: 0.0.1
+library: true
+
+extensionTargets:
+  codeql/rust-all: "*"
+
+dataExtensions:
+  - path-validation.yml
+"""
+
+TWO_VALID_ROWS = """extensions:
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: barrierModel
+    data:
+      - [
+          "orbit_store::driver::file::friction_store::validated_friction_root",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]
+      - [
+          "orbit_cmd::diagnostics::validated_diagnostics_file_path",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]
+"""
+
+FIVE_FIELD_MERGED_ROW = """extensions:
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: barrierModel
+    data:
+      - [
+          "orbit_store::driver::file::friction_store::validated_friction_root",
+          "orbit_cmd::diagnostics::validated_diagnostics_file_path",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]
+"""
+
+MALFORMED_YAML = """extensions:
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: barrierModel
+    data:
+      - [
+          "crate::sanitize",
+"""
+
+UNSUPPORTED_PREDICATE = """extensions:
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: notAModel
+    data:
+      - [
+          "crate::sanitize",
+          "ReturnValue",
+          "path-injection",
+          "manual",
+        ]
+"""
+
+UNSUPPORTED_PACK = """extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: barrierModel
+    data:
+      - [
+          "crate::sanitize",
+          "ReturnValue",
+          "path-injection",
+          "manual",
+        ]
+"""
+
+INVALID_ROW_TYPES = """extensions:
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: barrierModel
+    data:
+      - [
+          "crate::sanitize",
+          "ReturnValue",
+          true,
+          "manual",
+        ]
+"""
+
+
+class CodeqlExtensionSchemaTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="orbit-codeql-schema-")
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+
+    def write_pack(self, data_yml, pack_yml=None):
+        pack_dir = self.root / ".github/codeql/extensions/orbit-rust-path-validation"
+        pack_dir.mkdir(parents=True)
+        (pack_dir / "codeql-pack.yml").write_text(pack_yml or PACK_YML, encoding="utf-8")
+        (pack_dir / "path-validation.yml").write_text(data_yml, encoding="utf-8")
+        return pack_dir / "path-validation.yml"
+
+    def errors(self):
+        return CHECK.validate_root(self.root)
+
+    def test_two_valid_four_field_rows_pass(self):
+        self.write_pack(TWO_VALID_ROWS)
+        self.assertEqual(self.errors(), [])
+
+    def test_five_field_merged_barrier_reports_file_predicate_and_row(self):
+        data_file = self.write_pack(FIVE_FIELD_MERGED_ROW)
+        errors = self.errors()
+        self.assertEqual(len(errors), 1, errors)
+        message = errors[0]
+        self.assertIn(data_file.relative_to(self.root).as_posix(), message)
+        self.assertIn("barrierModel", message)
+        self.assertIn("row 1", message)
+        self.assertIn("expected 4 fields", message)
+        self.assertIn("found 5", message)
+
+    def test_malformed_yaml_fails_clearly(self):
+        data_file = self.write_pack(MALFORMED_YAML)
+        errors = self.errors()
+        self.assertEqual(len(errors), 1, errors)
+        self.assertIn("malformed YAML", errors[0])
+        self.assertIn(data_file.relative_to(self.root).as_posix(), errors[0])
+
+    def test_unsupported_predicate_fails_clearly(self):
+        self.write_pack(UNSUPPORTED_PREDICATE)
+        errors = self.errors()
+        self.assertEqual(len(errors), 1, errors)
+        self.assertIn("unsupported extensible predicate 'notAModel'", errors[0])
+        self.assertIn("codeql/rust-all", errors[0])
+
+    def test_unsupported_pack_fails_clearly(self):
+        self.write_pack(UNSUPPORTED_PACK)
+        errors = self.errors()
+        self.assertEqual(len(errors), 1, errors)
+        self.assertIn("unsupported extension pack 'codeql/java-all'", errors[0])
+
+    def test_invalid_row_value_types_fail_clearly(self):
+        self.write_pack(INVALID_ROW_TYPES)
+        errors = self.errors()
+        self.assertEqual(len(errors), 1, errors)
+        self.assertIn("barrierModel row 1", errors[0])
+        self.assertIn("kind", errors[0])
+        self.assertIn("expected a non-empty string", errors[0])
+        self.assertIn("boolean", errors[0])
+
+    def test_current_extension_files_pass(self):
+        self.assertEqual(CHECK.validate_root(REPO_ROOT), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Task

[ORB-11979](https://orbit-cli.com/tasks/ORB-11979) — Validate CodeQL extension row schemas in the fast handoff gate

### Description

## Problem and evidence
F2026-09-103 reports conflict recovery merging two barrier paths into a five-field row for a four-field extensible predicate. YAML parsed but CodeQL rejected it. Current scripts/Makefile searches show no local barrier-row schema gate; the existing GitHub workflow discovers it only during CodeQL analysis.

Source frictions: F2026-09-103.
Audit source baseline: owning Linux checkout e4f9098633a8876a5a7c233d9914a094b6efa858, inspected 2026-09-10. Incident reports are historical evidence; no production failure was induced during this audit.

## Proposed solution
Add a deterministic checked-in validation step for the CodeQL extensions actually used by this repo and wire it into the normal fast pre-handoff gate so post-conflict edits are checked. Validate supported extension/predicate identities, row arity and expected value shapes from the repository's pinned schema contract. Keep independent validators in separate rows. Do not suppress security findings or treat YAML parse success as schema validation.

## Scope and delivery
Create a validated task-scoped candidate from agent-main in a dedicated worktree. Preserve existing failed-run and friction evidence. This filing does not authorize dispatch, merge, release, production configuration changes or live backlog consolidation. Complexity medium; crew terra follows the configured lane. Existing task inventory and targeted searches were checked for covering work.

### Acceptance Criteria

- The recorded five-field merged barrier row fails locally with filename, predicate and row location; two valid four-field rows pass.
- Malformed YAML, unsupported predicate/schema and invalid row value types fail clearly; all current valid extension files pass.
- The required fast gate invokes the check so conflict recovery's standard revalidation catches semantic row corruption before push.
- Add focused positive/negative fixtures and run repository gates.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Split the recorded five-field merged `barrierModel` row in `.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml` into two independent four-field rows (`validated_friction_root` and `validated_diagnostics_file_path`).
- Added `scripts/check-codeql-extension-schema.py`, a stdlib YAML-subset schema gate over packs under `.github/codeql/extensions/`. It pins the `codeql/rust-all` predicate arities and requires non-empty string fields; YAML parse success is not treated as validation.
- Added `scripts/test-codeql-extension-schema.py` with focused fixtures: five-field merge (filename, predicate, row), two valid four-field rows, malformed YAML, unsupported pack/predicate, invalid boolean row values, and the live extension tree.
- Wired the test and live check into the unconditional path of `scripts/ci-guardrails.sh` so `make ci-fast` runs them. Extended `scripts/test-ci-fast-guards.py` to assert `--fast` invokes the checker.
- Makefile unchanged: `ci-fast` already calls `ci-guardrails.sh --fast`.
- Added context selectors for the two new scripts.

Assessment: The local gate now rejects the exact conflict-recovery corruption (five-field barrier row) with file, predicate, and row location, while the repaired live pack passes.

Criteria:
1. Passed: five-field merged barrier fixture fails with path-validation.yml, `barrierModel`, and `row 1`; two valid four-field rows pass.
2. Passed: malformed YAML, unsupported pack/predicate, and boolean row values fail clearly; live extension files pass.
3. Passed: `ci-guardrails.sh --fast` invokes `check-codeql-extension-schema.py` (unit assertion plus `make ci-fast`).
4. Passed: fixtures live in `scripts/test-codeql-extension-schema.py`; repository gates run.

Validation:
- `python3 scripts/test-codeql-extension-schema.py`: passed (7 tests)
- `python3 scripts/test-ci-fast-guards.py`: passed (7 tests)
- `python3 scripts/check-codeql-extension-schema.py`: passed (via live-tree test and `make ci-fast`)
- `make ci-fast`: passed (exit 0). `test-compiler-cache-namespaces` self-skipped (bwrap user-namespace denial); pre-existing, unrelated to this change.
- `git diff --check`: passed
- `git status --short`: path-validation.yml, ci-guardrails.sh, test-ci-fast-guards.py modified; two new scripts untracked. Makefile unchanged.

Strategic decisions: stdlib YAML subset parser so CI images without PyYAML still fail closed on schema, not only on missing packages. Official rust-all predicates are pinned so unused-but-valid models are allowed and unknown packs/predicates are not.

Design weaknesses / risks:
- Severity: low. The subset parser covers the checked-in CodeQL YAML shape, not full YAML 1.2. Mitigation: malformed YAML still fails, and live files are exercised in ci-fast.
- Severity: low. This gate does not load CodeQL itself; it enforces the documented tuple contract. Remaining CodeQL analysis stays in the GitHub workflow.

Deviations from original plan: none.

Friction: none filed. F2026-09-103 is the source incident and is preserved.

Remaining risks: uncommitted working tree; pipeline owns commit/PR. No security findings were suppressed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11979-6aa22285`
- Behind base: 0
- Ahead of base: 1