### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/docs/walk.rs

### DIFF
--- a/crates/orbit-core/src/application/docs/walk.rs
+++ b/crates/orbit-core/src/application/docs/walk.rs
@@ -212,26 +212,24 @@ fn expand_wildcard_segments(
         out: &mut Vec<PathBuf>,
     ) -> Result<(), OrbitError> {
         if parts.is_empty() {
-            if base.exists() {
-                match validated_docs_root_path(repo_root, base) {
-                    Ok(path) => out.push(path),
-                    Err(OrbitError::InvalidInput(_)) => return Ok(()),
-                    Err(error) => return Err(error),
-                }
+            match validated_docs_root_path(repo_root, base) {
+                Ok(path) => out.push(path),
+                Err(OrbitError::InvalidInput(_)) => return Ok(()),
+                Err(error) => return Err(error),
             }
             return Ok(());
         }
         let head = &parts[0];
         let tail = &parts[1..];
         if head == "*" {
-            if !base.is_dir() {
-                return Ok(());
-            }
             let base = match validated_docs_root_path(repo_root, base) {
                 Ok(base) => base,
                 Err(OrbitError::InvalidInput(_)) => return Ok(()),
                 Err(error) => return Err(error),
             };
+            if !base.is_dir() {
+                return Ok(());
+            }
             let entries = fs::read_dir(&base)
                 .map_err(|error| OrbitError::Io(format!("read {}: {error}", base.display())))?;
             for entry in entries {


### PR DESCRIPTION
## Task

[ORB-11988](https://orbit-cli.com/tasks/ORB-11988) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/application/docs/walk.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#402`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.27.0`, guid `unknown`)
- Message: This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `9a0b4d11b15b2454cb9dc646b3f0480dd882f6dc`
- Location: `crates/orbit-core/src/application/docs/walk.rs` line 207
- Created: `2026-09-10T02:55:12Z`
- Updated: `2026-09-10T02:58:03Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/402

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-core/src/application/docs/walk.rs` line 207 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `crates/orbit-core/src/application/docs/walk.rs` so wildcard expansion validates each candidate path before calling `exists`-equivalent directory/file checks or `read_dir`.
- Removed the user-configured path flow into the pre-validation `base.exists()` and `base.is_dir()` calls that CodeQL identified; invalid or out-of-workspace candidates remain no-ops, preserving documented walker behavior.

Assessment: The path validation helper is now the authoritative boundary for every wildcard filesystem operation. Existing workspace-relative expansion, missing-root no-op behavior, symlink/out-of-workspace rejection, `.orbit` exclusion, and gitignore handling remain covered by the focused walker tests.

Acceptance criteria:
- `rust/path-injection` remediation: satisfied by the real code change; no suppression, dismissal, exclusion, or CodeQL configuration change was made.
- Intended behavior: satisfied; `cargo test -p orbit-core --lib application::docs::tests::walk` passed all 10 walker tests, including workspace-relative wildcard expansion, missing roots, and out-of-workspace symlink rejection.
- Validation/security confirmation: repository gates passed. The hosted CodeQL scan could not be executed locally because `codeql` is not installed and this task does not provide GitHub access; source inspection confirms all wildcard filesystem checks now follow `validated_docs_root_path`, and the required hosted CodeQL workflow remains the final alert-closure check.

Validation:
- `cargo fmt --all -- --check` — passed.
- `cargo test -p orbit-core --lib application::docs::tests::walk` — passed (10 passed, 0 failed).
- `make ci-fast` — passed; its compiler-cache namespace subcheck reported an environment skip because bubblewrap could not create a mount namespace (`No permissions to create new namespace`).
- `make ci-lint` — passed (`cargo clippy --workspace --all-targets -- -D warnings`).
- `git diff --check` — passed.
- `git status --short` — expected one task-scoped modified file.
- CodeQL — not run locally: `codeql` executable unavailable; hosted workflow confirmation remains required.

Remaining risk: final CodeQL analysis in CI must confirm alert #402 is cleared at the affected location.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11988-6aa22553`
- Behind base: 0
- Ahead of base: 1