### PR TITLE
[code-review] Publication binding paths still resolve an authoritative workspace ID through the id-or-name selector

### DIFF
--- a/crates/orbit-cli/src/command/task/publication.rs
+++ b/crates/orbit-cli/src/command/task/publication.rs
@@ -115,15 +115,15 @@ impl Execute for TaskPublicationPublishArgs {
         let host = load_host_identity(&global_root)?;
         let registry_path = workspace_registry::registry_path_for(&global_root);
         let mut registry = workspace_registry::load_registry_from(&registry_path)?;
-        let binding = workspace_registry::find_publication_binding(&registry, &workspace_id)?
+        let binding = workspace_registry::find_publication_binding_by_id(&registry, &workspace_id)
             .cloned()
             .ok_or_else(|| {
                 orbit_core::OrbitError::WorkspaceError(format!(
                     "workspace '{workspace_id}' has no publication binding; run `orbit workspace publication bind` first"
                 ))
             })?;
-        let checkout =
-            workspace_registry::find_checkout(&registry, &workspace_id)?.ok_or_else(|| {
+        let checkout = workspace_registry::find_checkout_by_id(&registry, &workspace_id)
+            .ok_or_else(|| {
                 orbit_core::OrbitError::WorkspaceError(format!(
                     "workspace '{workspace_id}' has no local checkout"
                 ))
@@ -158,7 +158,7 @@ impl Execute for TaskPublicationPublishArgs {
         };
         let outcome = runtime.publish_task_publication(request, &policy)?;
 
-        workspace_registry::record_publication_success(
+        workspace_registry::record_publication_success_by_id(
             &mut registry,
             &workspace_id,
             outcome.generation,
@@ -188,7 +188,7 @@ impl Execute for TaskPublicationStatusArgs {
         let registry = workspace_registry::load_registry_from(
             &workspace_registry::registry_path_for(&runtime.global_root()),
         )?;
-        let binding = workspace_registry::find_publication_binding(&registry, &workspace_id)?
+        let binding = workspace_registry::find_publication_binding_by_id(&registry, &workspace_id)
             .ok_or_else(|| {
                 orbit_core::OrbitError::WorkspaceError(format!(
                     "workspace '{workspace_id}' has no publication binding"
@@ -476,19 +476,23 @@ fn assert_restore_authority(
     let registry = workspace_registry::load_registry_from(&workspace_registry::registry_path_for(
         &global_root,
     ))?;
-    let workspace = workspace_registry::find_workspace(&registry, &selected)?.ok_or_else(|| {
-        orbit_core::OrbitError::WorkspaceError(format!("workspace '{selected}' is not registered"))
-    })?;
+    let workspace =
+        workspace_registry::find_workspace_by_id(&registry, &selected).ok_or_else(|| {
+            orbit_core::OrbitError::WorkspaceError(format!(
+                "workspace '{selected}' is not registered"
+            ))
+        })?;
     if workspace.owner_machine_id.as_deref() != Some(local_machine_id.as_str()) {
         return Err(orbit_core::OrbitError::PolicyDenied(format!(
             "workspace '{selected}' is not owned by local machine '{local_machine_id}'"
         )));
     }
-    let checkout = workspace_registry::find_checkout(&registry, &selected)?.ok_or_else(|| {
-        orbit_core::OrbitError::WorkspaceError(format!(
-            "workspace '{selected}' has no local checkout"
-        ))
-    })?;
+    let checkout =
+        workspace_registry::find_checkout_by_id(&registry, &selected).ok_or_else(|| {
+            orbit_core::OrbitError::WorkspaceError(format!(
+                "workspace '{selected}' has no local checkout"
+            ))
+        })?;
     if checkout.role != Some(WorkspaceCheckoutRole::Owner) {
         return Err(orbit_core::OrbitError::PolicyDenied(format!(
             "workspace '{selected}' is a replica checkout; restore requires the declared owner destination"

--- a/crates/orbit-cli/src/command/workspace/publication.rs
+++ b/crates/orbit-cli/src/command/workspace/publication.rs
@@ -63,7 +63,7 @@ impl WorkspacePublicationBindArgs {
         let registry_path = workspace_registry::registry_path_for(&global_root);
         let mut registry = workspace_registry::load_registry_from(&registry_path)?;
         let binding = if rebind {
-            workspace_registry::rebind_publication(
+            workspace_registry::rebind_publication_by_id(
                 &mut registry,
                 &workspace_id,
                 &self.remote,
@@ -72,7 +72,7 @@ impl WorkspacePublicationBindArgs {
                 Some(&machine_id),
             )?
         } else {
-            workspace_registry::bind_publication(
+            workspace_registry::bind_publication_by_id(
                 &mut registry,
                 &workspace_id,
                 &self.remote,
@@ -115,7 +115,7 @@ impl Execute for WorkspacePublicationShowArgs {
         let registry = workspace_registry::load_registry_from(
             &workspace_registry::registry_path_for(&runtime.global_root()),
         )?;
-        match workspace_registry::find_publication_binding(&registry, &workspace_id)? {
+        match workspace_registry::find_publication_binding_by_id(&registry, &workspace_id) {
             Some(binding) => {
                 Ok(Payload::detail(binding_json(binding, "shown"), format_binding(binding)).into())
             }
@@ -153,7 +153,7 @@ impl Execute for WorkspacePublicationRemoveArgs {
         let machine_id = load_host_identity(&global_root)?.machine_id;
         let registry_path = workspace_registry::registry_path_for(&global_root);
         let mut registry = workspace_registry::load_registry_from(&registry_path)?;
-        let removed = workspace_registry::unbind_publication(
+        let removed = workspace_registry::unbind_publication_by_id(
             &mut registry,
             &workspace_id,
             Some(&machine_id),

--- a/crates/orbit-cli/tests/workspace_selector.rs
+++ b/crates/orbit-cli/tests/workspace_selector.rs
@@ -342,6 +342,175 @@ fn checkout_path_and_cwd_resolve_an_id_that_collides_with_another_workspace_name
     }
 }
 
+/// A workspace whose ID equals another workspace's name must still allow publication
+/// binding, rebinding, showing, and removing when selected from its own checkout or
+/// by its unambiguous name [ORB-11879].
+#[test]
+fn publication_lifecycle_survives_id_collision_when_selected_by_checkout_or_name() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let alpha_repo = temp.path().join("alpha");
+    let shadow_repo = temp.path().join("ws-alpha");
+    let elsewhere = temp.path().join("elsewhere");
+    fs::create_dir_all(&home).expect("home");
+    fs::create_dir_all(&elsewhere).expect("elsewhere");
+
+    init_git_repo(&alpha_repo);
+    run_git(
+        &alpha_repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:example/alpha.git",
+        ],
+    );
+    init_git_repo(&shadow_repo);
+    run_git(
+        &shadow_repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:example/shadow.git",
+        ],
+    );
+
+    run_orbit(
+        &alpha_repo,
+        &home,
+        &[
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "selector-host",
+            "--task-prefix",
+            "SEL",
+        ],
+    )
+    .success();
+    run_orbit(
+        &alpha_repo,
+        &home,
+        &["workspace", "init", "--name", "alpha"],
+    )
+    .success();
+    run_orbit(
+        &shadow_repo,
+        &home,
+        &["workspace", "init", "--name", "ws_alpha"],
+    )
+    .success();
+
+    // 1. From alpha's checkout (selected by checkout), binding succeeds.
+    let bound = run_orbit_json(
+        &alpha_repo,
+        &home,
+        &[
+            "workspace",
+            "publication",
+            "bind",
+            "--remote",
+            "git@github.com:example/pub.git",
+            "--publication-id",
+            "pub_alpha",
+            "--json",
+        ],
+    );
+    assert_eq!(bound["workspace_id"], "ws_alpha");
+    assert_eq!(bound["publication_id"], "pub_alpha");
+
+    // 2. From alpha's checkout, show succeeds.
+    let shown = run_orbit_json(
+        &alpha_repo,
+        &home,
+        &["workspace", "publication", "show", "--json"],
+    );
+    assert_eq!(shown["workspace_id"], "ws_alpha");
+    assert_eq!(shown["bound"], true);
+
+    // 3. From alpha's checkout, rebind succeeds.
+    let rebound = run_orbit_json(
+        &alpha_repo,
+        &home,
+        &[
+            "workspace",
+            "publication",
+            "rebind",
+            "--remote",
+            "git@github.com:example/pub2.git",
+            "--publication-id",
+            "pub_alpha_v2",
+            "--json",
+        ],
+    );
+    assert_eq!(rebound["workspace_id"], "ws_alpha");
+    assert_eq!(rebound["publication_id"], "pub_alpha_v2");
+
+    // 4. From alpha's checkout, remove succeeds.
+    let removed = run_orbit_json(
+        &alpha_repo,
+        &home,
+        &["workspace", "publication", "remove", "--confirm", "--json"],
+    );
+    assert_eq!(removed["workspace_id"], "ws_alpha");
+    assert_eq!(removed["removed"], true);
+
+    // 5. From elsewhere, selected unambiguously by name (--workspace alpha), bind and remove succeed.
+    let bound_by_name = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "--workspace",
+            "alpha",
+            "workspace",
+            "publication",
+            "bind",
+            "--remote",
+            "git@github.com:example/pub.git",
+            "--publication-id",
+            "pub_alpha",
+            "--json",
+        ],
+    );
+    assert_eq!(bound_by_name["workspace_id"], "ws_alpha");
+
+    let removed_by_name = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "--workspace",
+            "alpha",
+            "workspace",
+            "publication",
+            "remove",
+            "--confirm",
+            "--json",
+        ],
+    );
+    assert_eq!(removed_by_name["workspace_id"], "ws_alpha");
+    assert_eq!(removed_by_name["removed"], true);
+
+    // 6. Typing the ambiguous selector ws_alpha genuinely matches two workspaces and fails closed.
+    let assert = run_orbit(
+        &elsewhere,
+        &home,
+        &[
+            "--workspace",
+            "ws_alpha",
+            "workspace",
+            "publication",
+            "show",
+        ],
+    )
+    .failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("ambiguous workspace selector"),
+        "operator-typed colliding selector must fail closed: {stderr}"
+    );
+}
+
 /// `task show` is the one verb whose target is a machine-global primary key, so
 /// omitting `--workspace` follows the ID instead of the cwd [ORB-10797].
 #[test]

--- a/crates/orbit-registry/src/tests/workspace_publication.rs
+++ b/crates/orbit-registry/src/tests/workspace_publication.rs
@@ -10,8 +10,10 @@ use serde_json::{Value, json};
 use tempfile::tempdir;
 
 use crate::workspace_registry::{
-    bind_publication, find_publication_binding, load_registry_from, rebind_publication,
-    record_publication_success, save_registry_to, unbind_publication,
+    bind_publication, bind_publication_by_id, find_publication_binding,
+    find_publication_binding_by_id, load_registry_from, rebind_publication,
+    rebind_publication_by_id, record_publication_success, record_publication_success_by_id,
+    save_registry_to, unbind_publication, unbind_publication_by_id,
 };
 
 fn timestamp() -> chrono::DateTime<Utc> {
@@ -463,4 +465,155 @@ fn record_publication_success_is_idempotent_across_commit_hex_case() {
     assert_eq!(first, second);
     assert_eq!(first.last_success_generation, Some(3));
     assert_eq!(first.last_success_commit.as_deref(), Some(LOWER));
+}
+
+#[test]
+fn publication_lifecycle_survives_workspace_id_and_name_collision() {
+    let mut registry = owner_registry();
+    registry.workspaces.push(Workspace {
+        id: "ws_other".to_string(),
+        name: "ws_orbit".to_string(),
+        owner_machine_id: Some("hm_owner".to_string()),
+        git_remote: Some("git@github.com:example/other.git".to_string()),
+        ship_mode: Some("pr".to_string()),
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: timestamp(),
+        updated_at: timestamp(),
+    });
+    registry.checkouts.push(owner_checkout("ws_other"));
+
+    // 1. Binding unambiguously by name "orbit" must succeed.
+    let bound = bind_publication(
+        &mut registry,
+        "orbit",
+        "git@github.com:example/tasks.git",
+        "main",
+        "tp_orbit_tasks",
+        Some("hm_owner"),
+    )
+    .expect("bind publication by unambiguous name must succeed");
+    assert_eq!(bound.workspace_id, "ws_orbit");
+
+    // 2. Lookup unambiguously by name "orbit" must succeed.
+    let found = find_publication_binding(&registry, "orbit")
+        .expect("lookup by name")
+        .expect("found binding");
+    assert_eq!(found.workspace_id, "ws_orbit");
+
+    // 3. Recording publication success unambiguously by name "orbit" must succeed.
+    let recorded = record_publication_success(
+        &mut registry,
+        "orbit",
+        1,
+        "1111111111111111111111111111111111111111",
+        Some("hm_owner"),
+    )
+    .expect("record publication success by unambiguous name must succeed");
+    assert_eq!(recorded.last_success_generation, Some(1));
+
+    // 4. Rebinding unambiguously by name "orbit" must succeed.
+    let rebound = rebind_publication(
+        &mut registry,
+        "orbit",
+        "https://github.com/example/tasks-v2.git",
+        "refs/heads/publication",
+        "tp_orbit_tasks_v2",
+        Some("hm_owner"),
+    )
+    .expect("rebind publication by unambiguous name must succeed");
+    assert_eq!(rebound.publication_id, "tp_orbit_tasks_v2");
+
+    // 5. Unbinding unambiguously by name "orbit" must succeed.
+    let unbound = unbind_publication(&mut registry, "orbit", Some("hm_owner"))
+        .expect("unbind publication by unambiguous name must succeed");
+    assert_eq!(unbound.workspace_id, "ws_orbit");
+
+    // 6. Operator-typed colliding selector "ws_orbit" genuinely matches two workspaces
+    // and must fail closed with the ambiguous-selector error.
+    let err = bind_publication(
+        &mut registry,
+        "ws_orbit",
+        "git@github.com:example/tasks.git",
+        "main",
+        "tp_orbit_tasks",
+        Some("hm_owner"),
+    )
+    .expect_err("colliding selector must fail closed on bind")
+    .to_string();
+    assert!(err.contains("ambiguous workspace selector"), "{err}");
+
+    let err = find_publication_binding(&registry, "ws_orbit")
+        .expect_err("colliding selector must fail closed on find")
+        .to_string();
+    assert!(err.contains("ambiguous workspace selector"), "{err}");
+
+    let err = rebind_publication(
+        &mut registry,
+        "ws_orbit",
+        "git@github.com:example/tasks.git",
+        "main",
+        "tp_orbit_tasks",
+        Some("hm_owner"),
+    )
+    .expect_err("colliding selector must fail closed on rebind")
+    .to_string();
+    assert!(err.contains("ambiguous workspace selector"), "{err}");
+
+    let err = unbind_publication(&mut registry, "ws_orbit", Some("hm_owner"))
+        .expect_err("colliding selector must fail closed on unbind")
+        .to_string();
+    assert!(err.contains("ambiguous workspace selector"), "{err}");
+
+    let err = record_publication_success(
+        &mut registry,
+        "ws_orbit",
+        2,
+        "2222222222222222222222222222222222222222",
+        Some("hm_owner"),
+    )
+    .expect_err("colliding selector must fail closed on record_publication_success")
+    .to_string();
+    assert!(err.contains("ambiguous workspace selector"), "{err}");
+
+    // 7. Direct exact-ID publication operations for "ws_orbit" succeed even in the presence of the collision.
+    let by_id_bound = bind_publication_by_id(
+        &mut registry,
+        "ws_orbit",
+        "git@github.com:example/tasks.git",
+        "main",
+        "tp_orbit_tasks_exact",
+        Some("hm_owner"),
+    )
+    .expect("bind publication by exact id must succeed");
+    assert_eq!(by_id_bound.workspace_id, "ws_orbit");
+
+    let by_id_found = find_publication_binding_by_id(&registry, "ws_orbit")
+        .expect("find publication binding by exact id");
+    assert_eq!(by_id_found.publication_id, "tp_orbit_tasks_exact");
+
+    let by_id_recorded = record_publication_success_by_id(
+        &mut registry,
+        "ws_orbit",
+        2,
+        "2222222222222222222222222222222222222222",
+        Some("hm_owner"),
+    )
+    .expect("record publication success by exact id must succeed");
+    assert_eq!(by_id_recorded.last_success_generation, Some(2));
+
+    let by_id_rebound = rebind_publication_by_id(
+        &mut registry,
+        "ws_orbit",
+        "https://github.com/example/tasks-v2.git",
+        "refs/heads/publication",
+        "tp_orbit_tasks_exact_v2",
+        Some("hm_owner"),
+    )
+    .expect("rebind publication by exact id must succeed");
+    assert_eq!(by_id_rebound.publication_id, "tp_orbit_tasks_exact_v2");
+
+    let by_id_unbound = unbind_publication_by_id(&mut registry, "ws_orbit", Some("hm_owner"))
+        .expect("unbind publication by exact id must succeed");
+    assert_eq!(by_id_unbound.workspace_id, "ws_orbit");
 }

--- a/crates/orbit-registry/src/workspace_registry/catalog.rs
+++ b/crates/orbit-registry/src/workspace_registry/catalog.rs
@@ -429,10 +429,23 @@ pub fn find_checkout<'a>(
     let Some(workspace) = find_workspace(registry, id_or_name)? else {
         return Ok(None);
     };
-    Ok(registry
+    Ok(find_checkout_by_id(registry, &workspace.id))
+}
+
+/// Finds the local checkout for an exact workspace ID.
+///
+/// Persisted relations and resolved bindings already store `workspace_id`.
+/// Those lookups must not reuse [`find_checkout`], which treats the argument
+/// as an id-or-name selector and fails closed when one workspace's ID equals
+/// another's name.
+pub fn find_checkout_by_id<'a>(
+    registry: &'a WorkspaceRegistry,
+    workspace_id: &str,
+) -> Option<&'a WorkspaceCheckout> {
+    registry
         .checkouts
         .iter()
-        .find(|checkout| checkout.workspace_id == workspace.id))
+        .find(|checkout| checkout.workspace_id == workspace_id)
 }
 
 /// Iterates logical workspaces that have a machine-local checkout binding.

--- a/crates/orbit-registry/src/workspace_registry/mod.rs
+++ b/crates/orbit-registry/src/workspace_registry/mod.rs
@@ -6,18 +6,21 @@ mod publication;
 
 pub use catalog::{
     WorkspaceRegistryHostContext, WorkspaceSourceRemoteRebind, assign_checkout_role, find_checkout,
-    find_checkout_by_path, find_workspace, find_workspace_by_id, find_workspace_by_path,
-    local_workspaces, parse_workspace_registry, rebind_workspace_source_remote, register_checkout,
-    register_workspace, remove_workspace, rename_local_owner_host_id, resolve_logical_workspace,
-    set_path_override, validate_workspace_registry, validate_workspaces,
+    find_checkout_by_id, find_checkout_by_path, find_workspace, find_workspace_by_id,
+    find_workspace_by_path, local_workspaces, parse_workspace_registry,
+    rebind_workspace_source_remote, register_checkout, register_workspace, remove_workspace,
+    rename_local_owner_host_id, resolve_logical_workspace, set_path_override,
+    validate_workspace_registry, validate_workspaces,
 };
 pub use io::{
     global_orbit_dir, load_registry, load_registry_from, registry_path, registry_path_for,
     save_registry, save_registry_to, with_registry_lock,
 };
 pub use publication::{
-    bind_publication, find_publication_binding, rebind_publication, record_publication_success,
-    unbind_publication,
+    bind_publication, bind_publication_by_id, find_publication_binding,
+    find_publication_binding_by_id, rebind_publication, rebind_publication_by_id,
+    record_publication_success, record_publication_success_by_id, unbind_publication,
+    unbind_publication_by_id,
 };
 
 #[cfg(test)]

--- a/crates/orbit-registry/src/workspace_registry/publication.rs
+++ b/crates/orbit-registry/src/workspace_registry/publication.rs
@@ -10,7 +10,20 @@ use orbit_types::workspace::{
     validate_publication_remote,
 };
 
-use super::{WorkspaceRegistryHostContext, find_checkout, find_workspace};
+use super::{
+    WorkspaceRegistryHostContext, find_checkout_by_id, find_workspace, find_workspace_by_id,
+};
+
+/// Locate the publication binding for an exact workspace ID.
+pub fn find_publication_binding_by_id<'a>(
+    registry: &'a WorkspaceRegistry,
+    workspace_id: &str,
+) -> Option<&'a WorkspacePublicationBinding> {
+    registry
+        .publication_bindings
+        .iter()
+        .find(|binding| binding.workspace_id == workspace_id)
+}
 
 /// Locate the publication binding for a workspace id or name.
 pub fn find_publication_binding<'a>(
@@ -20,23 +33,21 @@ pub fn find_publication_binding<'a>(
     let Some(workspace) = find_workspace(registry, id_or_name)? else {
         return Ok(None);
     };
-    Ok(registry
-        .publication_bindings
-        .iter()
-        .find(|binding| binding.workspace_id == workspace.id))
+    Ok(find_publication_binding_by_id(registry, &workspace.id))
 }
 
-/// Create a publication binding. Fails when one already exists; use
-/// [`rebind_publication`] to replace it.
-pub fn bind_publication(
+/// Create a publication binding for an exact workspace ID. Fails when one
+/// already exists; use [`rebind_publication_by_id`] to replace it.
+pub fn bind_publication_by_id(
     registry: &mut WorkspaceRegistry,
-    id_or_name: &str,
+    workspace_id: &str,
     publication_remote: &str,
     publication_branch: &str,
     publication_id: &str,
     local_machine_id: Option<&str>,
 ) -> Result<WorkspacePublicationBinding, OrbitError> {
-    let workspace_id = bindable_workspace(registry, id_or_name, local_machine_id)?.id;
+    let workspace = bindable_workspace_by_id(registry, workspace_id, local_machine_id)?;
+    let workspace_id = workspace.id.clone();
     if registry
         .publication_bindings
         .iter()
@@ -57,9 +68,9 @@ pub fn bind_publication(
     Ok(binding)
 }
 
-/// Replace an existing publication binding. Last-success state is cleared
-/// because the lineage or remote is changing.
-pub fn rebind_publication(
+/// Create a publication binding. Fails when one already exists; use
+/// [`rebind_publication`] to replace it.
+pub fn bind_publication(
     registry: &mut WorkspaceRegistry,
     id_or_name: &str,
     publication_remote: &str,
@@ -67,7 +78,31 @@ pub fn rebind_publication(
     publication_id: &str,
     local_machine_id: Option<&str>,
 ) -> Result<WorkspacePublicationBinding, OrbitError> {
-    let workspace_id = bindable_workspace(registry, id_or_name, local_machine_id)?.id;
+    let workspace = find_workspace(registry, id_or_name)?
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, id_or_name.to_string()))?;
+    let workspace_id = workspace.id.clone();
+    bind_publication_by_id(
+        registry,
+        &workspace_id,
+        publication_remote,
+        publication_branch,
+        publication_id,
+        local_machine_id,
+    )
+}
+
+/// Replace an existing publication binding for an exact workspace ID. Last-success
+/// state is cleared because the lineage or remote is changing.
+pub fn rebind_publication_by_id(
+    registry: &mut WorkspaceRegistry,
+    workspace_id: &str,
+    publication_remote: &str,
+    publication_branch: &str,
+    publication_id: &str,
+    local_machine_id: Option<&str>,
+) -> Result<WorkspacePublicationBinding, OrbitError> {
+    let workspace = bindable_workspace_by_id(registry, workspace_id, local_machine_id)?;
+    let workspace_id = workspace.id.clone();
     let index = registry
         .publication_bindings
         .iter()
@@ -88,13 +123,37 @@ pub fn rebind_publication(
     Ok(binding)
 }
 
-/// Remove the publication binding for a workspace.
-pub fn unbind_publication(
+/// Replace an existing publication binding. Last-success state is cleared
+/// because the lineage or remote is changing.
+pub fn rebind_publication(
     registry: &mut WorkspaceRegistry,
     id_or_name: &str,
+    publication_remote: &str,
+    publication_branch: &str,
+    publication_id: &str,
     local_machine_id: Option<&str>,
 ) -> Result<WorkspacePublicationBinding, OrbitError> {
-    let workspace_id = bindable_workspace(registry, id_or_name, local_machine_id)?.id;
+    let workspace = find_workspace(registry, id_or_name)?
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, id_or_name.to_string()))?;
+    let workspace_id = workspace.id.clone();
+    rebind_publication_by_id(
+        registry,
+        &workspace_id,
+        publication_remote,
+        publication_branch,
+        publication_id,
+        local_machine_id,
+    )
+}
+
+/// Remove the publication binding for an exact workspace ID.
+pub fn unbind_publication_by_id(
+    registry: &mut WorkspaceRegistry,
+    workspace_id: &str,
+    local_machine_id: Option<&str>,
+) -> Result<WorkspacePublicationBinding, OrbitError> {
+    let workspace = bindable_workspace_by_id(registry, workspace_id, local_machine_id)?;
+    let workspace_id = workspace.id.clone();
     let index = registry
         .publication_bindings
         .iter()
@@ -107,16 +166,29 @@ pub fn unbind_publication(
     Ok(registry.publication_bindings.remove(index))
 }
 
-/// Record a successful publication generation and commit without rebinding.
-pub fn record_publication_success(
+/// Remove the publication binding for a workspace.
+pub fn unbind_publication(
     registry: &mut WorkspaceRegistry,
     id_or_name: &str,
+    local_machine_id: Option<&str>,
+) -> Result<WorkspacePublicationBinding, OrbitError> {
+    let workspace = find_workspace(registry, id_or_name)?
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, id_or_name.to_string()))?;
+    let workspace_id = workspace.id.clone();
+    unbind_publication_by_id(registry, &workspace_id, local_machine_id)
+}
+
+/// Record a successful publication generation and commit without rebinding for an exact workspace ID.
+pub fn record_publication_success_by_id(
+    registry: &mut WorkspaceRegistry,
+    workspace_id: &str,
     generation: u64,
     commit: &str,
     local_machine_id: Option<&str>,
 ) -> Result<WorkspacePublicationBinding, OrbitError> {
     let commit = commit.to_ascii_lowercase();
-    let workspace_id = bindable_workspace(registry, id_or_name, local_machine_id)?.id;
+    let workspace = bindable_workspace_by_id(registry, workspace_id, local_machine_id)?;
+    let workspace_id = workspace.id.clone();
     let binding = registry
         .publication_bindings
         .iter_mut()
@@ -155,6 +227,26 @@ pub fn record_publication_success(
     .map_err(workspace_error)?;
     *binding = next.clone();
     Ok(next)
+}
+
+/// Record a successful publication generation and commit without rebinding.
+pub fn record_publication_success(
+    registry: &mut WorkspaceRegistry,
+    id_or_name: &str,
+    generation: u64,
+    commit: &str,
+    local_machine_id: Option<&str>,
+) -> Result<WorkspacePublicationBinding, OrbitError> {
+    let workspace = find_workspace(registry, id_or_name)?
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, id_or_name.to_string()))?;
+    let workspace_id = workspace.id.clone();
+    record_publication_success_by_id(
+        registry,
+        &workspace_id,
+        generation,
+        commit,
+        local_machine_id,
+    )
 }
 
 pub(crate) fn validate_publication_bindings(
@@ -242,24 +334,18 @@ pub(crate) fn validate_publication_bindings(
     Ok(())
 }
 
-struct BindableWorkspace {
-    id: String,
-}
-
-fn bindable_workspace(
-    registry: &WorkspaceRegistry,
-    id_or_name: &str,
+fn bindable_workspace_by_id<'a>(
+    registry: &'a WorkspaceRegistry,
+    workspace_id: &str,
     local_machine_id: Option<&str>,
-) -> Result<BindableWorkspace, OrbitError> {
+) -> Result<&'a Workspace, OrbitError> {
     if let Some(machine_id) = local_machine_id {
         validate_machine_id(machine_id)?;
     }
-    let workspace = find_workspace(registry, id_or_name)?
-        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, id_or_name.to_string()))?;
+    let workspace = find_workspace_by_id(registry, workspace_id)
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, workspace_id.to_string()))?;
     publisher_allowed(registry, workspace, local_machine_id).map_err(publication_error)?;
-    Ok(BindableWorkspace {
-        id: workspace.id.clone(),
-    })
+    Ok(workspace)
 }
 
 fn publisher_allowed(
@@ -267,9 +353,7 @@ fn publisher_allowed(
     workspace: &Workspace,
     local_machine_id: Option<&str>,
 ) -> Result<(), String> {
-    if let Some(checkout) =
-        find_checkout(registry, &workspace.id).map_err(|error| error.to_string())?
-    {
+    if let Some(checkout) = find_checkout_by_id(registry, &workspace.id) {
         if checkout.role == Some(WorkspaceCheckoutRole::Replica) {
             return Err(format!(
                 "workspace '{}' is a replica checkout; only the declared owner can manage a publication binding",
@@ -306,7 +390,7 @@ fn build_binding(
     publication_branch: &str,
     publication_id: &str,
 ) -> Result<WorkspacePublicationBinding, OrbitError> {
-    let workspace = find_workspace(registry, workspace_id)?
+    let workspace = find_workspace_by_id(registry, workspace_id)
         .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, workspace_id.to_string()))?;
     let Some(fingerprint) = workspace.git_remote.as_deref() else {
         return Err(publication_error(format!(


### PR DESCRIPTION
## Task

[ORB-11879](https://orbit-cli.com/tasks/ORB-11879) — [code-review] Publication binding paths still resolve an authoritative workspace ID through the id-or-name selector

### Description

## Problem

ORB-11805 introduced `find_workspace_by_id` precisely so that "checkout
bindings and other persisted relations" stop reinterpreting an authoritative
`workspace_id` as an id-or-name selector (`catalog.rs:352-372`). It converted
`crates/orbit-cmd/src/registry_runtime.rs` and several CLI sites, but the
publication paths were not converted and still route a resolved ID through
`find_workspace`, which fails closed on an ID/name collision.

- `crates/orbit-registry/src/workspace_registry/publication.rs:270-272` —
  `publisher_allowed` calls `find_checkout(registry, &workspace.id)` with a
  workspace it has *already* resolved. `find_checkout`
  (`catalog.rs:424-435`) delegates to `find_workspace`, which returns
  `Err(ambiguous_workspace_selector)` when that ID also matches another
  workspace's name.
- `crates/orbit-registry/src/workspace_registry/publication.rs:309` —
  `build_binding` calls `find_workspace(registry, workspace_id)` where
  `workspace_id` came from `bindable_workspace(...)?.id`.
- `crates/orbit-cli/src/command/task/publication.rs:126` —
  `find_checkout(&registry, &workspace_id)` where `workspace_id` is
  `selected_workspace_id(runtime)`, i.e. the binding's
  `logical_workspace_id` (`publication.rs:393-398`).

Nothing prevents the collision: `register_workspace` (`catalog.rs:18-35`)
rejects a duplicate id and a duplicate name, but never a name that equals
another workspace's id.

## Observed evidence

Verified against live code at HEAD `d3681fdcb` with a temporary test in
`crates/orbit-registry/src/tests/workspace_publication.rs` (added, run,
reverted — the working tree is clean):

```rust
let mut registry = owner_registry();            // A = { id: "ws_orbit", name: "orbit" }
registry.workspaces.push(Workspace {            // B = { id: "ws_other", name: "ws_orbit" }
    id: "ws_other".into(), name: "ws_orbit".into(), /* ... */
});
bind_publication(&mut registry, "orbit", "git@github.com:example/publication.git",
                 "main", "pub_probe", Some("hm_owner"))
```

The selector `"orbit"` matches exactly one workspace, yet the call fails:

```
Err(WorkspaceError("invalid input: ambiguous workspace selector 'ws_orbit'; \
it matches more than one registered workspace"))
```

The reported selector is `ws_orbit` — A's own ID — not the caller's `"orbit"`,
which locates the failure inside `publisher_allowed`, not at the caller's
selector.

## Impact

A workspace whose ID collides with another workspace's name cannot have its
publication binding created, rebound, unbound, or recorded, and
`orbit task publication` cannot resolve its checkout — even when the caller
selected it unambiguously by name or from its own checkout. The error blames an
"ambiguous selector" the operator never typed. This is the same defect class
ORB-11805 repaired for the runtime/CLI resolution paths, left in place on the
publication paths.

## Expected

Resolved-ID lookups in the publication paths use exact-ID resolution
(`find_workspace_by_id`, or an ID-exact `find_checkout` variant). Operator-typed
id-or-name selectors — `bindable_workspace`'s own `find_workspace` at
`publication.rs:257` — keep failing closed on genuine ambiguity.

### Acceptance Criteria

- With two registered workspaces where one workspace's id equals the other's name, binding, rebinding, unbinding, and recording publication success for the id-owning workspace all succeed when selected unambiguously by name or by its own checkout.
- An operator-typed id-or-name selector that genuinely matches two workspaces still fails closed with the ambiguous-selector error.
- A regression test in crates/orbit-registry covers the collision through the publication surface and fails against the current code.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed publication binding paths where an already-resolved workspace ID was mistakenly re-routed through id-or-name selector lookups (find_workspace and find_checkout), which failed closed when one workspace ID collided with another workspace name.

Changes:
1. crates/orbit-registry: Added `find_checkout_by_id` in catalog and re-exported in workspace_registry. Implemented exact-ID publication helpers `find_publication_binding_by_id`, `bind_publication_by_id`, `rebind_publication_by_id`, `unbind_publication_by_id`, and `record_publication_success_by_id`. Updated `build_binding` and `publisher_allowed` to look up by ID instead of selector. Refactored `bind_publication`, `rebind_publication`, `unbind_publication`, and `record_publication_success` to resolve selector upfront with `find_workspace` (preserving fail-closed behavior on ambiguous operator input) and delegate to `*_by_id` functions.
2. crates/orbit-cli: Updated `src/command/task/publication.rs` and `src/command/workspace/publication.rs` to use `*_by_id` publication and checkout lookup functions for runtime-resolved workspace IDs.
3. Regression tests: Added `publication_lifecycle_survives_workspace_id_and_name_collision` in `crates/orbit-registry/src/tests/workspace_publication.rs` and `publication_lifecycle_survives_id_collision_when_selected_by_checkout_or_name` in `crates/orbit-cli/tests/workspace_selector.rs`.

Validation:
- cargo test -p orbit-registry: 56 passed
- cargo test -p orbit-cli --test task_publication: passed
- cargo test -p orbit-cli --test workspace_selector: 6 passed
- cargo test -p orbit-cli --bin orbit publication: 4 passed
- make ci-fast: passed
- make ci-lint: passed
- git diff --check: clean

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11879-6aa224cd`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra