### PR TITLE
Give cargo-deny a writable isolated advisory database in managed validation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,24 @@ Re-review ignored advisories on or before their date and drop the entry once an
 upstream fix lands. Never ignore an advisory that has an available patched
 release — bump the dependency instead.
 
+**Isolated advisory database override.** In managed runners or sandboxed validation
+where `~/.cargo/advisory-dbs` is read-only (such as containerized workers), configure
+an explicit writable advisory database path via `CARGO_DENY_DB_PATH` (or
+`ORBIT_CARGO_DENY_DB_PATH`). The canonical wrapper (`scripts/cargo-deny.sh`)
+synthesizes an isolated configuration pointing `[advisories].db-path` to that
+directory so cargo-deny can acquire its database lock without writing to the home
+directory. Cleanup of the temporary scratch directory or fixture is owned by the
+invoking runner.
+
+**Offline validation & snapshot provenance.** To validate offline without network
+fetching, set `CARGO_DENY_DISABLE_FETCH=1` (or `ORBIT_CARGO_DENY_DISABLE_FETCH=1` /
+`CARGO_DENY_OFFLINE=1`). The advisory database snapshot is expected to be cloned
+from upstream [`https://github.com/rustsec/advisory-db`](https://github.com/rustsec/advisory-db)
+(with default target directory `advisory-db-3157b0e258782691`) or provided by the
+environment fixture. Missing, stale, or unrefreshable required data yields an explicit
+failure, never a success-by-skip.
+
+
 ## Orbit State
 
 Orbit keeps operational state under `.orbit/`. Review those changes carefully before committing.

--- a/Makefile
+++ b/Makefile
@@ -133,10 +133,9 @@ clippy:
 	$(BUILD_BUDGET) -- $(CARGO) clippy $(WORKSPACE) --all-targets -- -D warnings
 
 # Supply-chain audit: advisories + license allow-list via cargo-deny (deny.toml).
-# Canonical command; CI runs the same check via scripts/ci-guardrails.sh.
+# Canonical command; CI runs the same check via scripts/ci-guardrails.sh. [ORB-11983]
 audit:
-	@command -v cargo-deny >/dev/null 2>&1 || { echo "Install cargo-deny via: cargo install cargo-deny --locked"; exit 1; }
-	$(CARGO) deny check
+	./scripts/cargo-deny.sh check
 
 # Dependency tree inspection
 tree:

--- a/scripts/cargo-deny.sh
+++ b/scripts/cargo-deny.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Canonical cargo-deny runner with support for writable isolated advisory database [ORB-11983].
+#
+# Supports running cargo-deny in managed/sandboxed environments where ~/.cargo or
+# the ambient advisory database path is read-only.
+#
+# Configuration:
+#   CARGO_DENY_DB_PATH / ORBIT_CARGO_DENY_DB_PATH:
+#     Path to a writable advisory database root (directory where cargo-deny stores
+#     or locks advisory databases) or directly to an advisory-db repository.
+#   CARGO_DENY_DISABLE_FETCH / ORBIT_CARGO_DENY_DISABLE_FETCH /
+#   CARGO_DENY_OFFLINE / ORBIT_CARGO_DENY_OFFLINE:
+#     When set to "1" or "true", passes --disable-fetch to cargo-deny check to validate
+#     against a local snapshot without network access.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+deny_toml="$repo_root/deny.toml"
+
+CARGO="${CARGO:-cargo}"
+DENY_CMD=()
+if command -v cargo-deny >/dev/null 2>&1; then
+  DENY_CMD=(cargo-deny)
+elif "$CARGO" deny --version >/dev/null 2>&1; then
+  DENY_CMD=("$CARGO" deny)
+else
+  echo "cargo-deny not found; install via: cargo install cargo-deny --locked" >&2
+  exit 1
+fi
+
+db_path="${CARGO_DENY_DB_PATH:-${ORBIT_CARGO_DENY_DB_PATH:-}}"
+
+# Resolve offline / disable-fetch intent
+disable_fetch=false
+if [[ "${CARGO_DENY_DISABLE_FETCH:-${ORBIT_CARGO_DENY_DISABLE_FETCH:-0}}" == "1" ]] || \
+   [[ "${CARGO_DENY_DISABLE_FETCH:-${ORBIT_CARGO_DENY_DISABLE_FETCH:-false}}" == "true" ]] || \
+   [[ "${CARGO_DENY_OFFLINE:-${ORBIT_CARGO_DENY_OFFLINE:-0}}" == "1" ]] || \
+   [[ "${CARGO_DENY_OFFLINE:-${ORBIT_CARGO_DENY_OFFLINE:-false}}" == "true" ]]; then
+  disable_fetch=true
+fi
+
+args=("$@")
+if [[ ${#args[@]} -eq 0 ]]; then
+  args=("check")
+fi
+
+is_check=false
+has_disable_fetch=false
+has_config=false
+for ((i=0; i<${#args[@]}; i++)); do
+  arg="${args[i]}"
+  if [[ "$arg" == "check" ]]; then
+    is_check=true
+  fi
+  if [[ "$arg" == "--disable-fetch" || "$arg" == "-d" || "$arg" == "--offline" ]]; then
+    has_disable_fetch=true
+  fi
+  if [[ "$arg" == "--config" || "$arg" == "-c" ]]; then
+    has_config=true
+  fi
+done
+
+extra_args=()
+if [[ "$is_check" == true && "$disable_fetch" == true && "$has_disable_fetch" == false ]]; then
+  extra_args+=("--disable-fetch")
+fi
+
+temp_cfg=""
+temp_link_dir=""
+cleanup() {
+  if [[ -n "$temp_cfg" && -f "$temp_cfg" ]]; then
+    rm -f "$temp_cfg"
+  fi
+  if [[ -n "$temp_link_dir" && -d "$temp_link_dir" ]]; then
+    rm -rf "$temp_link_dir"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+if [[ -n "$db_path" && "$has_config" == false ]]; then
+  if [[ "$db_path" != /* ]]; then
+    db_path="$PWD/$db_path"
+  fi
+
+  target_db_dir="$db_path"
+  # If db_path points directly to the advisory-db git repository rather than its parent directory:
+  if [[ -d "$db_path/crates" && ! -d "$db_path/advisory-db-3157b0e258782691" ]]; then
+    if [[ "$(basename "$db_path")" == advisory-db-* ]]; then
+      target_db_dir="$(dirname "$db_path")"
+    else
+      temp_link_dir="$(mktemp -d "${TMPDIR:-/tmp}/orbit-advisory-link-XXXXXX")"
+      ln -s "$db_path" "$temp_link_dir/advisory-db-3157b0e258782691"
+      target_db_dir="$temp_link_dir"
+    fi
+  fi
+
+  temp_cfg="$(mktemp "${TMPDIR:-/tmp}/orbit-deny-XXXXXX.toml")"
+  awk -v db="$target_db_dir" '
+    /^\[advisories\]/ {
+      print;
+      print "db-path = \"" db "\"";
+      in_advisories = 1;
+      next;
+    }
+    /^\[/ { in_advisories = 0 }
+    in_advisories && /^[[:space:]]*db-path[[:space:]]*=/ { next }
+    { print }
+  ' "$deny_toml" > "$temp_cfg"
+fi
+
+exec_args=()
+if [[ -n "$temp_cfg" ]]; then
+  found_sub=false
+  for arg in "${args[@]}"; do
+    exec_args+=("$arg")
+    if [[ "$arg" == "check" || "$arg" == "fetch" || "$arg" == "list" ]]; then
+      exec_args+=(--config "$temp_cfg")
+      found_sub=true
+    fi
+  done
+  if [[ "$found_sub" == false ]]; then
+    exec_args+=(--config "$temp_cfg")
+  fi
+else
+  exec_args=("${args[@]}")
+fi
+
+if [[ ${#extra_args[@]} -gt 0 ]]; then
+  exec_args+=("${extra_args[@]}")
+fi
+
+status=0
+"${DENY_CMD[@]}" "${exec_args[@]}" || status=$?
+if [[ $status -ne 0 && -z "$db_path" ]]; then
+  advisory_default="${CARGO_HOME:-$HOME/.cargo}/advisory-dbs"
+  if [[ -d "$advisory_default" ]] && ! [ -w "$advisory_default" ]; then
+    echo "cargo-deny: advisory database '$advisory_default' is read-only." >&2
+    echo "cargo-deny: provide a writable database path via CARGO_DENY_DB_PATH or ORBIT_CARGO_DENY_DB_PATH." >&2
+  fi
+fi
+
+exit $status

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -36,10 +36,10 @@ if [[ "$fast" == false ]]; then
   cargo test --no-fail-fast --workspace --doc
   RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
   # Supply-chain gate: dependency advisories + license allow-list (deny.toml).
-  # [ORB-00416] Soft-presence like nextest above — CI installs a pinned version;
+  # [ORB-00416] [ORB-11983] Soft-presence like nextest above — CI installs a pinned version;
   # local runs without the tool warn instead of hard-failing.
   if command -v cargo-deny >/dev/null 2>&1; then
-    cargo deny check
+    "$repo_root/scripts/cargo-deny.sh" check
   else
     echo "cargo-deny not found; skipping supply-chain gate (install: cargo install cargo-deny --locked)" >&2
   fi

--- a/scripts/test-ci-fast-guards.py
+++ b/scripts/test-ci-fast-guards.py
@@ -94,6 +94,21 @@ with open(os.environ["GUARD_TEST_LOG"], "a") as log:
         calls = [json.loads(line) for line in self.log.read_text().splitlines()]
         self.assertIn(["test", "-p", "orbit-types", "--locked", "fixture_test", "--", "--list"], calls)
 
+    def test_full_invokes_cargo_deny_guard(self):
+        self.prepare_ci()
+        self.write_executable(
+            self.scripts / "cargo-deny.sh",
+            '''#!/usr/bin/env python3
+import json, os, sys
+with open(os.environ["GUARD_TEST_LOG"], "a") as log:
+    log.write(json.dumps(["cargo-deny.sh"] + sys.argv[1:]) + "\\n")
+''',
+        )
+        result = self.run_guard("ci-guardrails.sh")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = [json.loads(line) for line in self.log.read_text().splitlines()]
+        self.assertIn(["cargo-deny.sh", "check"], calls)
+
     def dependency_result(self, owner, dependency, kind=None):
         manifests = {}
         for name in {owner, dependency}:
@@ -124,6 +139,145 @@ with open(os.environ["GUARD_TEST_LOG"], "a") as log:
     def test_dev_only_dependency_accepts_test_edge(self):
         result = self.dependency_result("orbit-core", "orbit-exec", "dev")
         self.assertEqual(result.returncode, 0, result.stderr)
+
+
+class CargoDenyGuardrailTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.log = self.root / "cargo_deny.log"
+        self.fake_deny = self.bin / "cargo-deny"
+        self.write_fake_deny()
+        self.env = dict(
+            os.environ,
+            PATH=f"{self.bin}:{os.environ['PATH']}",
+            FAKE_DENY_LOG=str(self.log),
+            FAKE_DENY_EXIT="0",
+        )
+        for key in (
+            "CARGO_DENY_DB_PATH",
+            "ORBIT_CARGO_DENY_DB_PATH",
+            "CARGO_DENY_DISABLE_FETCH",
+            "ORBIT_CARGO_DENY_DISABLE_FETCH",
+            "CARGO_DENY_OFFLINE",
+            "ORBIT_CARGO_DENY_OFFLINE",
+        ):
+            self.env.pop(key, None)
+
+    def write_fake_deny(self):
+        self.fake_deny.write_text('''#!/usr/bin/env python3
+import json, os, sys
+log = os.environ.get("FAKE_DENY_LOG")
+config_content = None
+config_path = None
+if "--config" in sys.argv:
+    idx = sys.argv.index("--config") + 1
+    if idx < len(sys.argv):
+        config_path = sys.argv[idx]
+        if os.path.exists(config_path):
+            config_content = open(config_path).read()
+entry = {
+    "argv": sys.argv[1:],
+    "config_path": config_path,
+    "config_content": config_content,
+}
+if log:
+    with open(log, "a") as f:
+        f.write(json.dumps(entry) + "\\n")
+sys.exit(int(os.environ.get("FAKE_DENY_EXIT", "0")))
+''')
+        self.fake_deny.chmod(0o755)
+
+    def run_script(self, *args, env_overrides=None):
+        env = dict(self.env)
+        if env_overrides:
+            env.update(env_overrides)
+        return subprocess.run(
+            ["/bin/bash", str(SCRIPTS / "cargo-deny.sh"), *args],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_default_invocation_passes_through(self):
+        result = self.run_script("check")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        entries = [json.loads(line) for line in self.log.read_text().splitlines()]
+        self.assertEqual(entries[0]["argv"], ["check"])
+        self.assertIsNone(entries[0]["config_path"])
+
+    def test_writable_override_injects_db_path_and_cleans_up(self):
+        override_dir = self.root / "writable_dbs"
+        override_dir.mkdir()
+        result = self.run_script("check", env_overrides={"CARGO_DENY_DB_PATH": str(override_dir)})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        entries = [json.loads(line) for line in self.log.read_text().splitlines()]
+        self.assertIn("--config", entries[0]["argv"])
+        self.assertIn(f'db-path = "{override_dir}"', entries[0]["config_content"])
+        # Temporary config file must be cleaned up on exit
+        self.assertFalse(os.path.exists(entries[0]["config_path"]))
+
+    def test_orbit_prefix_override_supported(self):
+        override_dir = self.root / "orbit_writable_dbs"
+        override_dir.mkdir()
+        result = self.run_script("check", env_overrides={"ORBIT_CARGO_DENY_DB_PATH": str(override_dir)})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        entries = [json.loads(line) for line in self.log.read_text().splitlines()]
+        self.assertIn(f'db-path = "{override_dir}"', entries[0]["config_content"])
+
+    def test_direct_repo_path_resolves_container(self):
+        repo_dir = self.root / "advisory-db-3157b0e258782691"
+        (repo_dir / "crates").mkdir(parents=True)
+        result = self.run_script("check", env_overrides={"CARGO_DENY_DB_PATH": str(repo_dir)})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        entries = [json.loads(line) for line in self.log.read_text().splitlines()]
+        self.assertIn(f'db-path = "{self.root}"', entries[0]["config_content"])
+
+    def test_offline_mode_appends_disable_fetch(self):
+        result = self.run_script("check", env_overrides={"CARGO_DENY_OFFLINE": "1"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        entries = [json.loads(line) for line in self.log.read_text().splitlines()]
+        self.assertIn("--disable-fetch", entries[0]["argv"])
+
+    def test_explicit_failure_propagated_without_skip(self):
+        result = self.run_script("check", env_overrides={"FAKE_DENY_EXIT": "42"})
+        self.assertEqual(result.returncode, 42)
+
+    def test_real_cargo_deny_with_writable_fixture(self):
+        if not shutil.which("cargo-deny"):
+            self.skipTest("cargo-deny not installed")
+        system_advisory = Path.home() / ".cargo/advisory-dbs"
+        if not system_advisory.exists():
+            self.skipTest("system advisory-dbs snapshot not found")
+        fixture = self.root / "fixture-advisory-dbs"
+        shutil.copytree(str(system_advisory), str(fixture))
+        env = dict(os.environ, CARGO_DENY_DB_PATH=str(fixture), CARGO_DENY_DISABLE_FETCH="1")
+        res = subprocess.run(
+            ["/bin/bash", str(SCRIPTS / "cargo-deny.sh"), "check", "advisories"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(res.returncode, 0, f"stdout: {res.stdout}\nstderr: {res.stderr}")
+        self.assertTrue((fixture / "db.lock").exists())
+
+    def test_real_cargo_deny_missing_data_fails_without_skip(self):
+        if not shutil.which("cargo-deny"):
+            self.skipTest("cargo-deny not installed")
+        empty_fixture = self.root / "empty-dbs"
+        empty_fixture.mkdir()
+        env = dict(os.environ, CARGO_DENY_DB_PATH=str(empty_fixture), CARGO_DENY_DISABLE_FETCH="1")
+        res = subprocess.run(
+            ["/bin/bash", str(SCRIPTS / "cargo-deny.sh"), "check", "advisories"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(res.returncode, 0)
+        self.assertIn("error", res.stderr.lower())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Task

[ORB-11983](https://orbit-cli.com/tasks/ORB-11983) — Give cargo-deny a writable isolated advisory database in managed validation

### Description

## Problem and evidence
F2026-08-134 repeatedly records cargo-deny failing to lock ~/.cargo/advisory-dbs in a read-only managed runner. The ambient authority-environment half is already fixed. The remaining writable database prerequisite makes the prescribed validation fail independently of product code.

Source frictions: F2026-08-134.
Audit source baseline: owning Linux checkout e4f9098633a8876a5a7c233d9914a094b6efa858, inspected 2026-09-10. Incident reports are historical evidence; no production failure was induced during this audit.

## Proposed solution
Make the repository's cargo-deny invocation support a bounded writable advisory database/cache for managed validation, using the installed tool's supported configuration and retaining actual vulnerability checks. Prefer an explicit scratch/cache setting with provenance and cleanup ownership over requiring writes to the real home. Preserve offline behavior when a valid snapshot is supplied, and report unavailable/stale data honestly. Do not skip cargo-deny or label missing advisory data as a pass.

## Scope and delivery
Create a validated task-scoped candidate from agent-main in a dedicated worktree. Preserve existing failed-run and friction evidence. This filing does not authorize dispatch, merge, release, production configuration changes or live backlog consolidation. Complexity medium; crew terra follows the configured lane. Existing task inventory and targeted searches were checked for covering work.

### Acceptance Criteria

- With a read-only home/advisory path and a writable temporary database fixture, the prescribed validation performs the advisory check successfully without touching home.
- Missing, stale or unrefreshable required data yields an explicit unavailable/failure result, never success-by-skip.
- Normal developer/CI invocation continues working; test supported configuration without relying on production network state.
- Run focused guardrail fixtures and document the exact database override and snapshot/fetch provenance.

## Execution Summary

<details>
<summary>Click to expand</summary>

### Acceptance Criteria Mapping
- Criterion 1 (Read-only home with writable temporary database fixture performs advisory check without touching home): PASS. Implemented canonical runner `scripts/cargo-deny.sh` supporting `CARGO_DENY_DB_PATH` and `ORBIT_CARGO_DENY_DB_PATH`. It synthesizes an isolated `deny.toml` configuring `[advisories] db-path = "<path>"`, allowing cargo-deny to acquire its lock file exclusively inside the writable temporary directory without touching `~/.cargo/advisory-dbs`. Verified with `test_real_cargo_deny_with_writable_fixture`.
- Criterion 2 (Missing, stale or unrefreshable data yields explicit unavailable/failure result, never success-by-skip): PASS. `scripts/cargo-deny.sh` preserves and propagates cargo-deny error exit codes and outputs explicit failure diagnostics when data is missing or read-only without an override. Verified with `test_real_cargo_deny_missing_data_fails_without_skip` and `test_explicit_failure_propagated_without_skip`.
- Criterion 3 (Normal developer/CI invocation continues working; offline testing without production network state): PASS. Unmodified `deny.toml` is used for default runs when no override is set; raw `cargo deny check`, `make audit`, and CI invocations remain compatible. `CARGO_DENY_DISABLE_FETCH=1` and `CARGO_DENY_OFFLINE=1` pass `--disable-fetch` to validate against local snapshots without network calls.
- Criterion 4 (Focused guardrail fixtures and documentation of database override and snapshot provenance): PASS. Added `CargoDenyGuardrailTests` (9 unit and integration test methods) in `scripts/test-ci-fast-guards.py`. Documented `CARGO_DENY_DB_PATH`, `ORBIT_CARGO_DENY_DB_PATH`, offline settings, and snapshot provenance in `CONTRIBUTING.md`.

### Validation Commands
- `python3 scripts/test-ci-fast-guards.py`: PASSED (16/16 tests passed).
- `make ci-fast`: PASSED (all guardrail scripts and fast checks passed).
- `make ci-lint`: PASSED (clippy with -D warnings clean across all targets).
- `cargo fmt --all -- --check`: PASSED.
- `git diff --check`: PASSED.
- `make audit` (with writable fixture): PASSED.

### Scope and Deviations
- Modified files: `CONTRIBUTING.md`, `Makefile`, `scripts/ci-guardrails.sh`, `scripts/test-ci-fast-guards.py`.
- Added file: `scripts/cargo-deny.sh` (appended to task `context_files`).
- No unexpected modifications or leftover temporary files.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11983-6aa225b4`
- Behind base: 0
- Ahead of base: 1