### PR TITLE
[code-review] TrustedHostActivityError::activity is dead after redaction and the sibling variant still names the asset

### DIFF
--- a/crates/orbit-engine/src/activity_job/asset_loader.rs
+++ b/crates/orbit-engine/src/activity_job/asset_loader.rs
@@ -46,6 +46,12 @@ pub enum AssetLoadError {
     },
     #[error("kind mismatch: expected `{expected}`, got `{actual}`")]
     KindMismatch { expected: String, actual: String },
+    // Both asset-validation refusals below name the offending activity, and
+    // they stay in step. An activity's `metadata.name` identifies a workspace
+    // file the operator can open and fix, so naming it is what makes the
+    // refusal actionable; redaction here is reserved for credentials and
+    // user-identifying paths. Redacting one arm alone only costs
+    // diagnosability, because the other still reports the same value.
     #[error("activity `{activity}` tool allowlist invalid: {source}")]
     ToolAllowlist {
         activity: String,

--- a/crates/orbit-engine/src/activity_job/tests/asset_loader.rs
+++ b/crates/orbit-engine/src/activity_job/tests/asset_loader.rs
@@ -157,8 +157,10 @@ fn load_activity_asset_rejects_trusted_host_execution_on_any_other_activity() {
         matches!(error, AssetLoadError::TrustedHostActivity(_)),
         "expected a trusted-host refusal, got {error:?}"
     );
-    assert!(error.to_string().contains("an activity declares"));
-    assert!(!error.to_string().contains("agent_implement"));
+    assert!(
+        error.to_string().contains("activity `agent_implement`"),
+        "the refusal must name the refused asset: {error}"
+    );
 }
 
 #[test]

--- a/crates/orbit-types/src/workflow/activity_job/tests/trusted_host.rs
+++ b/crates/orbit-types/src/workflow/activity_job/tests/trusted_host.rs
@@ -21,17 +21,16 @@ fn admission() -> TrustedHostAdmission {
 #[test]
 fn only_the_builtin_activity_may_declare_trusted_host_execution() {
     assert!(validate_trusted_host_activity(TRUSTED_HOST_ACTIVITY, true).is_ok());
-    let error = validate_trusted_host_activity("operator-controlled-name", true)
+    let error = validate_trusted_host_activity("agent_implement", true)
         .expect_err("a second activity must not be able to claim the mode");
-    assert_eq!(error.activity, "<redacted>");
-    assert_eq!(
-        error.to_string(),
-        "an activity declares `trustedHostExecution: true`, which only the built-in `agent_invoke` activity may declare; an unsandboxed provider subprocess is admitted per invocation by an operator, never by an asset"
+    assert_eq!(error.activity, "agent_implement");
+    assert!(
+        error.to_string().contains("activity `agent_implement`"),
+        "the refusal must name the asset the operator has to fix: {error}"
     );
-    assert!(!format!("{error:?}").contains("operator-controlled-name"));
     assert!(
         error.to_string().contains("admitted per invocation"),
-        "the refusal must say where the mode actually comes from"
+        "the refusal must say where the mode actually comes from: {error}"
     );
 }
 

--- a/crates/orbit-types/src/workflow/activity_job/trusted_host.rs
+++ b/crates/orbit-types/src/workflow/activity_job/trusted_host.rs
@@ -113,18 +113,21 @@ pub fn strip_trusted_host_admission(input: &mut Value) -> bool {
 
 /// Refusal to load an asset that claims trusted-host execution it may not have.
 ///
-/// The offending asset name is replaced with a constant marker. Asset metadata
-/// is operator-controlled input and this error can cross logging boundaries;
-/// the stable diagnostic preserves the validation reason without copying that
-/// input into a value that may be formatted later.
+/// The refusal names the offending activity. An activity's `metadata.name`
+/// identifies a workspace asset file, not secret material, and the operator
+/// reading this error is the person who has to find and edit that file — a
+/// refusal that will not say which asset it refused is not actionable.
+/// Redaction in this workspace covers credentials and user-identifying paths
+/// (`orbit_common::security::redaction`), and the sibling
+/// `AssetLoadError::ToolAllowlist` names the same value on the same grounds.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error(
-    "an activity declares `trustedHostExecution: true`, which only the built-in \
+    "activity `{activity}` declares `trustedHostExecution: true`, which only the built-in \
      `{TRUSTED_HOST_ACTIVITY}` activity may declare; an unsandboxed provider subprocess is \
      admitted per invocation by an operator, never by an asset"
 )]
 pub struct TrustedHostActivityError {
-    /// Redacted marker retained for source compatibility with error consumers.
+    /// Name of the offending activity asset.
     pub activity: String,
 }
 
@@ -138,7 +141,7 @@ pub fn validate_trusted_host_activity(
 ) -> Result<(), TrustedHostActivityError> {
     if declares_trusted_host && activity != TRUSTED_HOST_ACTIVITY {
         return Err(TrustedHostActivityError {
-            activity: "<redacted>".to_string(),
+            activity: activity.to_string(),
         });
     }
     Ok(())


### PR DESCRIPTION
## Task

[ORB-11880](https://orbit-cli.com/tasks/ORB-11880) — [code-review] TrustedHostActivityError::activity is dead after redaction and the sibling variant still names the asset

### Description

## Problem

The `rust/cleartext-logging` remediation for `TrustedHostActivityError` removed
`{activity}` from the `#[error]` format string and pinned the field to a
constant, leaving a struct field that can only ever hold one value.

- `crates/orbit-types/src/workflow/activity_job/trusted_host.rs:139-142` —
  `validate_trusted_host_activity` always constructs
  `TrustedHostActivityError { activity: "<redacted>".to_string() }`; the caller's
  `activity` argument is used only in the comparison on line 138.
- `crates/orbit-types/src/workflow/activity_job/trusted_host.rs:126-129` — the
  field is documented as a "Redacted marker retained for source compatibility
  with error consumers", but the only consumer is
  `AssetLoadError::TrustedHostActivity(#[from] TrustedHostActivityError)`
  (`crates/orbit-engine/src/activity_job/asset_loader.rs:55`), which is
  `#[error(transparent)]` and never reads the field. No other site references
  `.activity`.

This conflicts with the repository rule against keeping a compatibility layer
with no concrete consumer, and against dead code that a change made obsolete
(`CLAUDE.md`, "Simplicity and ownership" and "Rust Practices").

## Inconsistency in the same enum

The redaction is also incomplete relative to its own premise. The sibling
variant declared four lines above still interpolates the same
operator-controlled activity name:

- `crates/orbit-engine/src/activity_job/asset_loader.rs:49-53` —
  `#[error("activity `{activity}` tool allowlist invalid: {source}")]`.

So the asset name is still formatted into an `AssetLoadError` that crosses the
same logging boundaries; only the trusted-host arm was changed. Either asset
names are safe to name in an error (in which case the redaction cost
diagnosability for nothing) or they are not (in which case `ToolAllowlist` is
still exposed).

## Impact

Low. Nothing is broken at runtime, but an operator whose asset is refused for
declaring `trustedHostExecution: true` no longer learns which asset it was, and
the codebase carries an always-constant field plus a redaction rule applied to
one of two adjacent variants.

## Expected

Settle the rule once: either restore the asset name in both variants, or redact
in both and drop the dead `activity` field so the error carries only what it
actually reports.

### Acceptance Criteria

- `TrustedHostActivityError` carries no field whose value is a compile-time constant; if the asset name is not reported, the field is removed rather than pinned to a marker.
- `AssetLoadError::TrustedHostActivity` and `AssetLoadError::ToolAllowlist` apply the same rule to the operator-controlled activity name, with the rule stated next to the code.
- An operator can still determine which asset was refused for declaring `trustedHostExecution: true`, from the error or from a deliberate, documented alternative.

## Execution Summary

<details>
<summary>Click to expand</summary>

Settled the rule in the "name the asset" direction: both AssetLoadError arms now report the operator-controlled activity name, and the always-constant field is gone because the field carries the real name again.

## Decision and evidence

The redaction came from c55d19ba9 (ORB-11826), a code-scanning sweep whose stated target was `crates/orbit-agent/src/providers/antigravity/antigravity_cli.rs`; the trusted-host change was collateral in that sweep, not a finding against this file. The workspace's own redaction policy (`crates/orbit-common/src/security/redaction.rs`) scopes redaction to credential-shaped env values (SECRET/TOKEN/PASSWORD/API_KEY), HTTP auth headers, `sk-…` keys, and `$HOME` paths. An activity asset's `metadata.name` is none of those — it is a workspace file identifier, and the sibling `AssetLoadError::ToolAllowlist`, `AssetLoadError::RetiredRole`, `CatalogError::ToolAllowlist` and `CatalogError::DuplicateName` all already name it. Restoring is therefore the consistent option; redacting both would have degraded `ToolAllowlist` and still left `CatalogError` (out of scope) naming the same value.

## Changes

- `crates/orbit-types/src/workflow/activity_job/trusted_host.rs` — restored `{activity}` in the `#[error]` format string; `validate_trusted_host_activity` now stores the caller's `activity` instead of `"<redacted>"`; field doc back to "Name of the offending activity asset"; the type doc states the rule and why (asset identifier, not secret material; points at `orbit_common::security::redaction` for what redaction does cover, and at the sibling variant).
- `crates/orbit-engine/src/activity_job/asset_loader.rs` — comment above the `ToolAllowlist` / `TrustedHostActivity` pair stating the shared rule and that the two arms stay in step, so a future sweep does not redact one alone.
- `crates/orbit-types/src/workflow/activity_job/tests/trusted_host.rs` — asserts `error.activity == "agent_implement"` and that the message contains ``activity `agent_implement` ``; dropped the exact-string and negative-`Debug` assertions that pinned the redacted form.
- `crates/orbit-engine/src/activity_job/tests/asset_loader.rs` — asserts the loader refusal names the refused asset.

No new context files were needed; all four edits are within the declared scope. No docs describe the redaction (grepped `docs/` and `crates/orbit-core/assets/`), so none needed updating.

## Acceptance criteria

1. **Met.** `TrustedHostActivityError` has one field, `activity`, and it now holds the caller-supplied name. No compile-time-constant field remains; `<redacted>` no longer appears anywhere in the workspace (`rg '<redacted>' crates/ docs/` → no hits).
2. **Met.** Both `AssetLoadError::TrustedHostActivity` (via the inner error's format string) and `AssetLoadError::ToolAllowlist` name the activity, and the rule is stated in a comment immediately above the two variants in `asset_loader.rs`, plus on the error type in `trusted_host.rs`.
3. **Met, from the error itself.** A refused asset produces "activity `agent_implement` declares `trustedHostExecution: true` …". Verified by `load_activity_asset_rejects_trusted_host_execution_on_any_other_activity`, which drives the real loader end to end. The catalog path additionally wraps this in `CatalogError::Parse { path, .. }`, so directory loads report the file as well.

## Validation

- `make ci-fast` — **passed.** One environment skip, unrelated to this change: `test-compiler-cache-namespaces: skip: cannot create a mount namespace (bwrap: No permissions to create new namespace…)`.
- `make ci-lint` — **passed**, no warnings.
- `cargo test -p orbit-types --lib trusted_host` — **passed**, 6/6.
- `cargo test -p orbit-engine --lib activity_job::tests::asset_loader` — **passed**, 10/10.
- Full `make ci` — **not run**; per CLAUDE.md it is the CI merge gate, not a per-task local check.
- `git diff --check` clean; `git status --short` shows exactly the four modified files, no stray artifacts.

## Risks

If a future `rust/cleartext-logging` sweep re-flags these format strings, it should be resolved by dismissing the alert rather than re-redacting — the in-code comments now record that reasoning at both sites. Beyond that, the change is a message/field restoration with no runtime behavior change: the same inputs are still refused, only the diagnostic differs.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11880-6aa227fe`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra