### PR TITLE
Make task artifact discovery metadata-only and bounded

### DIFF
--- a/crates/orbit-cli/src/command/task/artifacts.rs
+++ b/crates/orbit-cli/src/command/task/artifacts.rs
@@ -31,18 +31,8 @@ impl Execute for ArtifactsCommand {
 }
 
 fn show_task_artifacts(runtime: &OrbitRuntime, task_id: &str) -> CommandOut {
-    let artifacts = runtime.get_task_artifacts(task_id)?;
-    let values: Vec<serde_json::Value> = artifacts
-        .iter()
-        .map(|a| {
-            serde_json::json!({
-                "path": a.path,
-                "media_type": a.media_type,
-                "size": a.content.len(),
-            })
-        })
-        .collect();
-    let doc = serde_json::Value::Array(values);
+    let artifacts = runtime.get_task_artifact_manifest(task_id)?;
+    let doc = orbit_types::task::serialize_task_artifacts(&artifacts);
 
     if artifacts.is_empty() {
         return Ok(
@@ -54,15 +44,8 @@ fn show_task_artifacts(runtime: &OrbitRuntime, task_id: &str) -> CommandOut {
     for a in &artifacts {
         lines.push(format!(
             "--- {} ({}, {} bytes) ---",
-            a.path,
-            a.media_type,
-            a.content.len()
+            a.path, a.media_type, a.size_bytes
         ));
-        if let Some(content) = a.text_content() {
-            lines.push(content.to_string());
-        } else {
-            lines.push("[binary content omitted]".to_string());
-        }
     }
     Ok(Payload::detail(doc, lines.join("\n")).into())
 }

--- a/crates/orbit-cli/src/command/task/output.rs
+++ b/crates/orbit-cli/src/command/task/output.rs
@@ -7,7 +7,7 @@ use orbit_core::{
     resolve_task_relations,
 };
 use orbit_types::task::{
-    ArtifactManifestFileV2, TaskArtifact, TaskComment, TaskHistoryEntry,
+    ArtifactManifestFileV2, TaskComment, TaskHistoryEntry, serialize_task_artifacts,
     task_show_record_field_json, unknown_task_show_field_message,
 };
 use serde_json::{Value, json};
@@ -326,8 +326,8 @@ pub(super) fn task_field_to_json(
         "orchestrator" => {
             serde_json::to_value(&task.orchestrator).map_err(|e| OrbitError::Io(e.to_string()))
         }
-        "artifacts" => Ok(task_artifacts_to_json(
-            &runtime.get_task_artifacts(&task.id)?,
+        "artifacts" => Ok(serialize_task_artifacts(
+            &runtime.get_task_artifact_manifest(&task.id)?,
         )),
         other => task_show_record_field_json(task, other)
             .ok_or_else(|| OrbitError::InvalidInput(unknown_task_show_field_message(other))),
@@ -505,7 +505,7 @@ fn write_single_task_field(
         }
         "artifacts" => {
             use crate::output::color::bold;
-            let artifacts = runtime.get_task_artifacts(&task.id)?;
+            let artifacts = runtime.get_task_artifact_manifest(&task.id)?;
             for (index, artifact) in artifacts.iter().enumerate() {
                 if index > 0 {
                     text.push('\n');
@@ -516,13 +516,8 @@ fn write_single_task_field(
                     bold("Artifact:"),
                     artifact.path,
                     artifact.media_type,
-                    artifact.content.len()
+                    artifact.size_bytes
                 );
-                if let Some(content) = artifact.text_content() {
-                    text.push_str(content);
-                } else {
-                    let _ = writeln!(text, "[binary content omitted]");
-                }
             }
             Ok(())
         }
@@ -541,30 +536,6 @@ fn write_single_task_field(
             ))),
         },
     }
-}
-
-pub(crate) fn task_artifacts_to_json(artifacts: &[TaskArtifact]) -> Value {
-    Value::Array(
-        artifacts
-            .iter()
-            .map(|artifact| {
-                let mut object = serde_json::Map::new();
-                object.insert("path".to_string(), Value::String(artifact.path.clone()));
-                object.insert(
-                    "media_type".to_string(),
-                    Value::String(artifact.media_type.clone()),
-                );
-                object.insert(
-                    "size".to_string(),
-                    Value::Number(serde_json::Number::from(artifact.content.len())),
-                );
-                if let Some(content) = artifact.text_content() {
-                    object.insert("content".to_string(), Value::String(content.to_string()));
-                }
-                Value::Object(object)
-            })
-            .collect(),
-    )
 }
 
 pub(crate) fn task_artifact_manifest_to_json(files: &[ArtifactManifestFileV2]) -> Value {

--- a/crates/orbit-cli/src/command/task/show.rs
+++ b/crates/orbit-cli/src/command/task/show.rs
@@ -135,16 +135,14 @@ impl Execute for TaskShowArgs {
                     );
                 }
             }
-            let artifacts = runtime.get_task_artifacts(&task.id)?;
+            let artifacts = runtime.get_task_artifact_manifest(&task.id)?;
             if !artifacts.is_empty() {
                 let _ = writeln!(out, "{}", bold("Artifacts:"));
                 for artifact in artifacts {
                     let _ = writeln!(
                         out,
                         "  - {} ({}, {} bytes)",
-                        artifact.path,
-                        artifact.media_type,
-                        artifact.content.len()
+                        artifact.path, artifact.media_type, artifact.size_bytes
                     );
                 }
             }

--- a/crates/orbit-cli/src/command/task/tests/artifact.rs
+++ b/crates/orbit-cli/src/command/task/tests/artifact.rs
@@ -11,7 +11,11 @@ use crate::command::{Cli, Commands};
 use super::super::artifact::{
     TaskArtifactCommand, TaskArtifactGetArgs, TaskArtifactPutArgs, TaskArtifactSubcommand,
 };
+use super::super::artifacts::ArtifactsCommand;
+use super::super::show::TaskShowArgs;
+use crate::command::CommandOutput;
 use crate::command::task::TaskSubcommand;
+use crate::output::payload::{Block, View};
 
 #[test]
 fn cli_parses_task_artifact_put() {
@@ -182,6 +186,188 @@ fn artifact_get_refuses_to_print_binary_content_without_an_output_file() {
         error.to_string().contains("--out"),
         "the error should name the remedy: {error}"
     );
+}
+
+#[test]
+fn task_show_and_artifacts_command_are_metadata_only_and_lazy() {
+    let (_root, runtime, repo_root) = test_runtime();
+
+    let text_payload = "A".repeat(100 * 1024);
+    let text_source = repo_root.join("large.txt");
+    std::fs::write(&text_source, &text_payload).expect("write text source");
+
+    let mut png = b"\x89PNG\r\n\x1a\n".to_vec();
+    png.extend_from_slice(&[0x00, 0xFF, 0x10, 0x42, 0x00]);
+    let png_source = repo_root.join("diagram.png");
+    std::fs::write(&png_source, &png).expect("write png source");
+
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Metadata only test".to_string(),
+            description: "Artifact listing must be metadata only".to_string(),
+            workspace_path: Some(repo_root.to_string_lossy().into_owned()),
+            ..Default::default()
+        })
+        .expect("create task");
+
+    TaskArtifactPutArgs {
+        id: task.id.clone(),
+        source_path: text_source,
+        artifact_path: Some("docs/large.txt".to_string()),
+        model: Some("codex".to_string()),
+        json: false,
+    }
+    .execute(&runtime)
+    .expect("put large text");
+
+    TaskArtifactPutArgs {
+        id: task.id.clone(),
+        source_path: png_source,
+        artifact_path: Some("diagrams/diagram.png".to_string()),
+        model: Some("codex".to_string()),
+        json: false,
+    }
+    .execute(&runtime)
+    .expect("put binary png");
+
+    // 1. TaskShowArgs with --fields artifacts returns metadata only
+    let CommandOutput::Payload(field_payload) = (TaskShowArgs {
+        id: task.id.clone(),
+        json: true,
+        fields: vec!["artifacts".to_string()],
+        with_context: false,
+        max_docs: None,
+    })
+    .execute(&runtime)
+    .expect("task show --fields artifacts") else {
+        panic!("expected payload");
+    };
+
+    let (field_doc, field_view) = field_payload.into_view();
+    let artifacts = field_doc.as_array().expect("artifacts field is array");
+    assert_eq!(artifacts.len(), 2);
+    for item in artifacts {
+        assert!(item.get("path").is_some());
+        assert!(item.get("media_type").is_some());
+        assert!(item.get("size").is_some());
+        assert!(item.get("created_by").is_some());
+        assert!(item.get("content").is_none(), "content must be omitted");
+        assert!(
+            item.get("content_base64").is_none(),
+            "content_base64 must be omitted"
+        );
+    }
+    let serialized_field_doc = serde_json::to_string(&field_doc).unwrap();
+    assert!(
+        serialized_field_doc.len() < 1000,
+        "serialized metadata document should be small, got {} bytes",
+        serialized_field_doc.len()
+    );
+
+    let View::Blocks(field_blocks) = field_view else {
+        panic!("expected blocks view");
+    };
+    for block in field_blocks {
+        if let Block::Text(text) = block {
+            assert!(!text.contains(&text_payload));
+            assert!(text.contains("docs/large.txt (text/plain, 102400 bytes)"));
+        }
+    }
+
+    // 2. Full TaskShowArgs returns metadata only in artifacts field
+    let CommandOutput::Payload(full_payload) = (TaskShowArgs {
+        id: task.id.clone(),
+        json: true,
+        fields: vec![],
+        with_context: false,
+        max_docs: None,
+    })
+    .execute(&runtime)
+    .expect("full task show") else {
+        panic!("expected payload");
+    };
+    let (full_doc, full_view) = full_payload.into_view();
+    let full_artifacts = full_doc["artifacts"]
+        .as_array()
+        .expect("artifacts array in full doc");
+    assert_eq!(full_artifacts.len(), 2);
+    for item in full_artifacts {
+        assert!(item.get("content").is_none());
+        assert!(item.get("content_base64").is_none());
+    }
+    let View::Blocks(full_blocks) = full_view else {
+        panic!("expected blocks view");
+    };
+    for block in full_blocks {
+        if let Block::Text(text) = block {
+            assert!(!text.contains(&text_payload));
+            assert!(text.contains("docs/large.txt (text/plain, 102400 bytes)"));
+        }
+    }
+
+    // 3. ArtifactsCommand (task: true) returns metadata only
+    let CommandOutput::Payload(cmd_payload) = (ArtifactsCommand {
+        id: task.id.clone(),
+        task: true,
+        json: true,
+    })
+    .execute(&runtime)
+    .expect("task artifacts command") else {
+        panic!("expected payload");
+    };
+    let (cmd_doc, cmd_view) = cmd_payload.into_view();
+    let cmd_artifacts = cmd_doc.as_array().expect("artifacts array in cmd doc");
+    assert_eq!(cmd_artifacts.len(), 2);
+    for item in cmd_artifacts {
+        assert!(item.get("content").is_none());
+        assert!(item.get("content_base64").is_none());
+    }
+    let View::Blocks(cmd_blocks) = cmd_view else {
+        panic!("expected blocks view");
+    };
+    for block in cmd_blocks {
+        if let Block::Text(text) = block {
+            assert!(!text.contains(&text_payload));
+            assert!(text.contains("--- docs/large.txt (text/plain, 102400 bytes) ---"));
+        }
+    }
+
+    // 4. Verify artifact retrieval via artifact get preserves content and rejects unknown paths
+    let out = repo_root.join("retrieved_large.txt");
+    TaskArtifactGetArgs {
+        id: task.id.clone(),
+        path: "docs/large.txt".to_string(),
+        out: Some(out.clone()),
+        json: false,
+    }
+    .execute(&runtime)
+    .expect("get large text");
+    assert_eq!(
+        std::fs::read_to_string(&out).expect("read retrieved"),
+        text_payload
+    );
+
+    let png_out = repo_root.join("retrieved_diagram.png");
+    TaskArtifactGetArgs {
+        id: task.id.clone(),
+        path: "diagrams/diagram.png".to_string(),
+        out: Some(png_out.clone()),
+        json: false,
+    }
+    .execute(&runtime)
+    .expect("get binary png");
+    assert_eq!(std::fs::read(&png_out).expect("read retrieved png"), png);
+
+    // Unknown artifact path rejected
+    let err = TaskArtifactGetArgs {
+        id: task.id.clone(),
+        path: "docs/nonexistent.txt".to_string(),
+        out: Some(repo_root.join("none.txt")),
+        json: false,
+    }
+    .execute(&runtime)
+    .expect_err("unknown artifact path should fail");
+    assert!(matches!(err, orbit_core::OrbitError::NotFound { .. }));
 }
 
 fn test_runtime() -> (tempfile::TempDir, OrbitRuntime, PathBuf) {

--- a/crates/orbit-core/src/adapter/tool_host/json.rs
+++ b/crates/orbit-core/src/adapter/tool_host/json.rs
@@ -6,7 +6,8 @@ use orbit_common::OrbitError;
 use orbit_types::task::{
     ArtifactPresentation, MAX_TASK_ARTIFACT_CONTENT_BYTES, Task, TaskArtifact, TaskComment,
     TaskHistoryEntry, TaskStatus, artifact_presentation, resolve_task_dependencies,
-    resolve_task_relations, task_show_record_field_json, unknown_task_show_field_message,
+    resolve_task_relations, serialize_task_artifacts, task_show_record_field_json,
+    unknown_task_show_field_message,
 };
 use serde_json::{Map, Value, json};
 
@@ -168,38 +169,11 @@ fn task_field_to_json(
         "orchestrator" => serde_json::to_value(&task.orchestrator)
             .map_err(serialize_error("serialize orchestrator")),
         "artifacts" => Ok(serialize_task_artifacts(
-            &runtime.get_task_artifacts(&task.id)?,
+            &runtime.get_task_artifact_manifest(&task.id)?,
         )),
         other => task_show_record_field_json(task, other)
             .ok_or_else(|| OrbitError::InvalidInput(unknown_task_show_field_message(other))),
     }
-}
-
-pub(super) fn serialize_task_artifacts(artifacts: &[TaskArtifact]) -> Value {
-    Value::Array(
-        artifacts
-            .iter()
-            .map(|artifact| {
-                let mut object = Map::new();
-                object.insert("path".to_string(), Value::String(artifact.path.clone()));
-                object.insert(
-                    "media_type".to_string(),
-                    Value::String(artifact.media_type.clone()),
-                );
-                if let Some(created_by) = &artifact.created_by {
-                    object.insert("created_by".to_string(), Value::String(created_by.clone()));
-                }
-                object.insert(
-                    "size".to_string(),
-                    Value::Number(serde_json::Number::from(artifact.content.len())),
-                );
-                if let Some(content) = artifact.text_content() {
-                    object.insert("content".to_string(), Value::String(content.to_string()));
-                }
-                Value::Object(object)
-            })
-            .collect(),
-    )
 }
 
 fn serialize_comments(comments: &[TaskComment]) -> Result<Value, OrbitError> {

--- a/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
@@ -2626,6 +2626,96 @@ mod artifact_get {
     }
 
     #[test]
+    fn task_artifact_discovery_is_metadata_only_and_bounded() {
+        let (_root, runtime, repo_root) = test_runtime();
+        let id = seeded_task(&runtime, &repo_root);
+        let png = synthetic_png();
+        let large_text = "line of text\n".repeat(10_000); // 130,000 bytes
+        attach(&runtime, &id, "diagrams/flow.png", png.clone());
+        attach(
+            &runtime,
+            &id,
+            "logs/large.txt",
+            large_text.as_bytes().to_vec(),
+        );
+
+        // Baseline comparison task with tiny text artifact
+        let tiny_id = seeded_task(&runtime, &repo_root);
+        attach(&runtime, &tiny_id, "diagrams/flow.png", png.clone());
+        attach(&runtime, &tiny_id, "logs/large.txt", b"tiny\n".to_vec());
+
+        let listed = run_tool_as_operator(
+            &runtime,
+            "orbit.task.show",
+            json!({"id": id, "fields": "artifacts"}),
+        )
+        .expect("list artifacts");
+        let rows = listed.as_array().expect("artifact rows");
+        assert_eq!(rows.len(), 2);
+
+        for row in rows {
+            assert!(
+                row.get("content").is_none(),
+                "content must not ride along in metadata listing"
+            );
+            assert!(
+                row.get("content_base64").is_none(),
+                "content_base64 must not ride along in metadata listing"
+            );
+            assert!(row.get("path").is_some());
+            assert!(row.get("media_type").is_some());
+            assert!(row.get("size").is_some());
+            assert!(row.get("created_by").is_some());
+        }
+
+        assert_eq!(rows[0]["path"], "diagrams/flow.png");
+        assert_eq!(rows[0]["size"], png.len());
+        assert_eq!(rows[1]["path"], "logs/large.txt");
+        assert_eq!(rows[1]["size"], large_text.len());
+
+        // Serialized response growth depends on metadata formatting, not blob size
+        let tiny_listed = run_tool_as_operator(
+            &runtime,
+            "orbit.task.show",
+            json!({"id": tiny_id, "fields": "artifacts"}),
+        )
+        .expect("list artifacts for tiny task");
+        let large_json_str = serde_json::to_string(&listed).expect("serialize large listing");
+        let tiny_json_str = serde_json::to_string(&tiny_listed).expect("serialize tiny listing");
+        let len_diff = (large_json_str.len() as isize - tiny_json_str.len() as isize).abs();
+        assert!(
+            len_diff < 20,
+            "serialized response growth must not depend on blob size ({len_diff} byte diff for 130KB blob)"
+        );
+
+        // artifact.get still retrieves payload and preserves byte integrity
+        let read_text = get(&runtime, &id, "logs/large.txt");
+        assert_eq!(read_text["presentation"], "text");
+        assert_eq!(read_text["encoding"], "utf8");
+        assert_eq!(read_text["content"], large_text);
+
+        let read_png = get(&runtime, &id, "diagrams/flow.png");
+        assert_eq!(read_png["presentation"], "image");
+        assert_eq!(read_png["encoding"], "base64");
+        let decoded = BASE64_STANDARD
+            .decode(read_png["content_base64"].as_str().expect("base64"))
+            .expect("decode");
+        assert_eq!(decoded, png);
+
+        // Unknown path is rejected
+        let error = run_tool_as_operator(
+            &runtime,
+            "orbit.task.artifact.get",
+            json!({"id": id, "path": "nonexistent/file.txt"}),
+        )
+        .expect_err("unknown artifact path must fail");
+        assert!(
+            matches!(error, orbit_common::OrbitError::NotFound { .. }),
+            "expected NotFound, got {error}"
+        );
+    }
+
+    #[test]
     fn text_artifacts_are_returned_as_utf8_rather_than_base64() {
         let (_root, runtime, repo_root) = test_runtime();
         let id = seeded_task(&runtime, &repo_root);

--- a/crates/orbit-store/src/repository/task/v2/artifacts.rs
+++ b/crates/orbit-store/src/repository/task/v2/artifacts.rs
@@ -39,7 +39,7 @@ impl TaskV2Store {
         id: &str,
     ) -> Result<Option<Vec<ArtifactManifestFileV2>>, OrbitError> {
         orbit_types::task::validate_orb_task_id(id)?;
-        let bundle = match self.bundle_store.read_bundle(id) {
+        let bundle = match self.bundle_store.read_bundle_lightweight(id) {
             Ok(bundle) => bundle,
             Err(OrbitError::NotFound {
                 kind: NotFoundKind::Task,

--- a/crates/orbit-store/src/repository/task/v2/tests/listing.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/listing.rs
@@ -436,12 +436,29 @@ fn lightweight_listing_skips_artifact_payload_io() {
     let strict_ms = strict_started.elapsed().as_secs_f64() * 1000.0;
     let strict_payload_opens = take_artifact_payload_reads();
 
+    let manifest_started = Instant::now();
+    for id in &ids {
+        let manifest = store.get_task_artifact_manifest(id).unwrap().unwrap();
+        assert_eq!(manifest.len(), 1);
+    }
+    let manifest_ms = manifest_started.elapsed().as_secs_f64() * 1000.0;
+    let manifest_payload_opens = take_artifact_payload_reads();
+
+    let single_artifact = store
+        .get_task_artifact(&ids[0], "proof.txt")
+        .unwrap()
+        .unwrap();
+    assert_eq!(single_artifact.content.len(), BLOB_BYTES);
+    let single_artifact_opens = take_artifact_payload_reads();
+
     assert_eq!(listed.len(), TASKS);
     assert_eq!(searched.len(), TASKS);
     assert_eq!(page.items.len(), TASKS);
     assert_eq!(list_payload_opens, 0);
     assert_eq!(search_payload_opens, 0);
     assert_eq!(row_payload_opens, 0);
+    assert_eq!(manifest_payload_opens, 0);
+    assert_eq!(single_artifact_opens, 1);
     assert_eq!(strict_payload_opens, TASKS);
 
     println!(
@@ -452,6 +469,7 @@ fn lightweight_listing_skips_artifact_payload_io() {
             "lightweight_list_ms": list_ms,
             "lightweight_search_ms": search_ms,
             "lightweight_rows_ms": rows_ms,
+            "lightweight_manifest_ms": manifest_ms,
             "strict_get_all_ms": strict_ms,
             "lightweight_list_payload_opens": list_payload_opens,
             "lightweight_search_payload_opens": search_payload_opens,

--- a/crates/orbit-store/src/repository/task/v2_bundle.rs
+++ b/crates/orbit-store/src/repository/task/v2_bundle.rs
@@ -261,6 +261,18 @@ impl TaskBundleStoreV2 {
         read_bundle_consistently(&bundle_dir)
     }
 
+    /// Assemble a task bundle without opening artifact payload bytes.
+    pub(crate) fn read_bundle_lightweight(
+        &self,
+        task_id: &str,
+    ) -> Result<TaskBundleV2, OrbitError> {
+        #[cfg(test)]
+        self.bundle_reads
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let bundle_dir = self.bundle_path(task_id)?;
+        read_bundle_lightweight_consistently(&bundle_dir)
+    }
+
     pub(crate) fn delete_bundle(&self, task_id: &str) -> Result<bool, OrbitError> {
         orbit_types::task::validate_orb_task_id(task_id)?;
         let bundle_dir = self.bundle_path(task_id)?;

--- a/crates/orbit-types/src/task/artifacts.rs
+++ b/crates/orbit-types/src/task/artifacts.rs
@@ -364,6 +364,92 @@ impl ArtifactManifestFileV2 {
     }
 }
 
+/// Common metadata interface for task artifacts across manifest and runtime DTO representations.
+pub trait TaskArtifactMetadata {
+    fn path(&self) -> &str;
+    fn media_type(&self) -> &str;
+    fn size(&self) -> u64;
+    fn created_by(&self) -> Option<&str>;
+}
+
+impl TaskArtifactMetadata for ArtifactManifestFileV2 {
+    fn path(&self) -> &str {
+        &self.path
+    }
+
+    fn media_type(&self) -> &str {
+        &self.media_type
+    }
+
+    fn size(&self) -> u64 {
+        self.size_bytes
+    }
+
+    fn created_by(&self) -> Option<&str> {
+        let trimmed = self.created_by.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    }
+}
+
+impl TaskArtifactMetadata for crate::task::TaskArtifact {
+    fn path(&self) -> &str {
+        &self.path
+    }
+
+    fn media_type(&self) -> &str {
+        &self.media_type
+    }
+
+    fn size(&self) -> u64 {
+        self.content.len() as u64
+    }
+
+    fn created_by(&self) -> Option<&str> {
+        self.created_by
+            .as_deref()
+            .map(str::trim)
+            .filter(|trimmed| !trimmed.is_empty())
+    }
+}
+
+/// Serialize task artifact metadata for task discovery and projection surfaces (`task.show`).
+///
+/// Emits bounded metadata only (`path`, `media_type`, `size`, `created_by`); payload content
+/// is never included and must be retrieved explicitly via `orbit.task.artifact.get`.
+pub fn serialize_task_artifacts<T: TaskArtifactMetadata>(artifacts: &[T]) -> serde_json::Value {
+    serde_json::Value::Array(
+        artifacts
+            .iter()
+            .map(|artifact| {
+                let mut object = serde_json::Map::new();
+                object.insert(
+                    "path".to_string(),
+                    serde_json::Value::String(artifact.path().to_string()),
+                );
+                object.insert(
+                    "media_type".to_string(),
+                    serde_json::Value::String(artifact.media_type().to_string()),
+                );
+                if let Some(created_by) = artifact.created_by() {
+                    object.insert(
+                        "created_by".to_string(),
+                        serde_json::Value::String(created_by.to_string()),
+                    );
+                }
+                object.insert(
+                    "size".to_string(),
+                    serde_json::Value::Number(serde_json::Number::from(artifact.size())),
+                );
+                serde_json::Value::Object(object)
+            })
+            .collect(),
+    )
+}
+
 pub fn validate_relative_artifact_path(path: &str) -> Result<(), TaskError> {
     let trimmed = path.trim();
     if trimmed.is_empty() {

--- a/crates/orbit-types/src/task/mod.rs
+++ b/crates/orbit-types/src/task/mod.rs
@@ -15,11 +15,11 @@ pub use artifacts::{
     ORB_TASK_ID_WIDTH, TASK_ACCEPTANCE_FILE_NAME, TASK_ARTIFACT_FILES_DIR_NAME,
     TASK_ARTIFACT_MANIFEST_FILE_NAME, TASK_ARTIFACT_SCHEMA_VERSION, TASK_ARTIFACTS_DIR_NAME,
     TASK_COMMENTS_FILE_NAME, TASK_DESCRIPTION_FILE_NAME, TASK_ENVELOPE_FILE_NAME,
-    TASK_EVENTS_FILE_NAME, TASK_EXECUTION_SUMMARY_FILE_NAME, TASK_PLAN_FILE_NAME, TaskCommentRowV2,
-    TaskEnvelopeV2, TaskEventRowV2, TaskRelation, TaskRelationEdge, TaskRelationType,
-    format_orb_task_id, format_task_id, is_valid_orb_task_id, is_valid_task_id_prefix,
-    parse_task_number, task_id_prefix, validate_orb_task_id, validate_relative_artifact_path,
-    validate_task_relations_for_source,
+    TASK_EVENTS_FILE_NAME, TASK_EXECUTION_SUMMARY_FILE_NAME, TASK_PLAN_FILE_NAME,
+    TaskArtifactMetadata, TaskCommentRowV2, TaskEnvelopeV2, TaskEventRowV2, TaskRelation,
+    TaskRelationEdge, TaskRelationType, format_orb_task_id, format_task_id, is_valid_orb_task_id,
+    is_valid_task_id_prefix, parse_task_number, serialize_task_artifacts, task_id_prefix,
+    validate_orb_task_id, validate_relative_artifact_path, validate_task_relations_for_source,
 };
 pub use model::{
     ArtifactPresentation, DEFAULT_TASK_LIST_LIMIT, DependencyDeadEnd, ExternalRef,

--- a/docs/design/task-artifacts/2_design.md
+++ b/docs/design/task-artifacts/2_design.md
@@ -139,7 +139,7 @@ files:
 
 Manifest paths are stored in canonical relative form: slash-separated, no absolute paths, no `..`, no `.`, and no leading `./`. Writers that ingest hand-authored manifests should normalize a leading `./` before validation. SHA-256 values are lowercase hex; writer code should format digest bytes with lowercase hex (`{:x}`).
 
-Text artifacts may still be rendered inline by `orbit.task.show --field artifacts`, but storage and API DTOs must not require UTF-8.
+Task artifact discovery surfaces (`orbit.task.show --field artifacts`, `orbit task artifacts --task <ID>`) emit bounded metadata only (path, media type, size, attribution); storage and API DTOs must not require UTF-8, and artifact payload bytes are retrieved on demand through `orbit.task.artifact.get` or the dashboard download route.
 
 ## 5a. Image Artifacts, Presentation, and Retrieval
 
@@ -159,7 +159,7 @@ Metadata listing stays compact and payloads are fetched on demand:
 | view | CLI | `orbit task artifact get <ID> <PATH> [--out FILE]` |
 | view | dashboard | task detail → click the artifact row |
 
-The listing never carries binary payloads, so a task with a large screenshot stays cheap to inspect. `orbit.task.artifact.get` reads through the same owning task bundle the dashboard route uses — there is no second artifact store, and no way to reach an artifact except through the task that owns it.
+The listing never carries artifact payloads, so a task with a large screenshot or log stays cheap to inspect. `orbit.task.artifact.get` reads through the same owning task bundle the dashboard route uses — there is no second artifact store, and no way to reach an artifact except through the task that owns it.
 
 ### Supported formats and the presentation classes
 


### PR DESCRIPTION
## Task

[ORB-11976](https://orbit-cli.com/tasks/ORB-11976) — Make task artifact discovery metadata-only and bounded

### Description

## Problem and evidence
F2026-09-067 reports a 577731-token discovery response. Current adapter/tool_host/json.rs serialize_task_artifacts still inserts text content for every artifact while task_tools.rs advertises compact metadata and payload retrieval only through artifact.get.

Source frictions: F2026-09-067.
Audit source baseline: owning Linux checkout e4f9098633a8876a5a7c233d9914a094b6efa858, inspected 2026-09-10. Incident reports are historical evidence; no production failure was induced during this audit.

## Proposed solution
Make task.show artifacts and default discovery surfaces emit bounded metadata only (path, media type, size, attribution). Keep bytes behind explicit artifact.get with its existing limits/redaction. Audit shared consumers so human/dashboard rendering still retrieves selected content explicitly. Prefer storage metadata reads rather than loading every blob merely to list it. Align descriptions and tests with the actual contract.

## Scope and delivery
Create a validated task-scoped candidate from agent-main in a dedicated worktree. Preserve existing failed-run and friction evidence. This filing does not authorize dispatch, merge, release, production configuration changes or live backlog consolidation. Complexity medium; crew terra follows the configured lane. Existing task inventory and targeted searches were checked for covering work.

### Acceptance Criteria

- A fixture with a large text artifact and binary image lists metadata without content/base64 in task.show artifacts and default discovery projections; serialized response growth depends on metadata, not blob size.
- artifact.get still retrieves the chosen supported artifact and preserves size limits, redaction and access checks; unknown paths remain rejected.
- Tests cover human/API consumers affected by the shared serializer and verify listing does not unnecessarily read all artifact payloads.
- Run focused artifact/tool projection regressions and repository gates.

## Execution Summary

<details>
<summary>Click to expand</summary>

Addressed friction F2026-09-067 where task artifact discovery emitted raw payload content instead of bounded metadata:
- Defined TaskArtifactMetadata trait and unified serialize_task_artifacts in orbit-types::task::artifacts, emitting bounded metadata (path, media_type, size, created_by) without content or content_base64.
- Switched tool host task_fields_to_json to query runtime.get_task_artifact_manifest and use the shared metadata serializer.
- Updated orbit-cli (task_fields_to_json, format_task_fields, show_task_artifacts, and TaskShowArgs) to use runtime.get_task_artifact_manifest and formatted metadata instead of reading all payload blobs into memory.
- Added read_bundle_lightweight on TaskBundleStoreV2 and wired get_task_artifact_manifest to use lightweight bundle reads, ensuring listing does not read blob bytes.
- Updated design doc docs/design/task-artifacts/2_design.md to align with the metadata-only discovery contract.
- Added comprehensive unit tests in orbit-core (task_artifact_discovery_is_metadata_only_and_bounded), orbit-cli (task_show_and_artifacts_command_are_metadata_only_and_lazy), and orbit-store (lightweight_listing_skips_artifact_payload_io asserting manifest_payload_opens == 0).
- Validated with make ci-fast and make ci-lint.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11976-6aa22287`
- Behind base: 0
- Ahead of base: 1