### PR TITLE
Group code-scanning alerts into bounded remediation tasks with per-alert coverage

### DIFF
--- a/crates/orbit-core/assets/activities/consolidate_code_scanning_tasks.yaml
+++ b/crates/orbit-core/assets/activities/consolidate_code_scanning_tasks.yaml
@@ -1,0 +1,101 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: consolidate_code_scanning_tasks
+spec:
+  type: deterministic
+  description: >
+    Fold unstarted per-alert Code scanning tasks into the bounded remediation
+    groups the sweep now files. Previews by default: the dry run names the
+    exact source tasks and the replacement group for each shared cause and
+    writes nothing. Only proposed and backlog tasks carrying exactly one
+    parseable alert record are candidates; started, deferred, already grouped
+    and unreadable records are reported and left untouched. An explicit apply
+    mints the replacement with every member's per-alert coverage key, the
+    union of the sources' dependencies and scope, and a supersedes relation to
+    each source, then retires the sources with a covering-task comment. A
+    group whose sources moved since the preview is abandoned whole rather than
+    partially applied, and a second run finds nothing left to consolidate.
+  input_schema_json:
+    type: object
+    properties:
+      apply:
+        type: boolean
+        default: false
+        description: >
+          Write the consolidation. Leave false to preview it.
+      max_groups:
+        type: number
+        minimum: 1
+        maximum: 50
+        default: 10
+  output_schema_json:
+    type: object
+    required: [outcome, apply, scanned_source_tasks, group_count, groups, unchanged_single_source, skipped]
+    properties:
+      outcome:
+        type: string
+        enum: [dry_run, applied, nothing_to_consolidate]
+      apply:
+        type: boolean
+      scanned_source_tasks:
+        type: number
+      group_count:
+        type: number
+      groups:
+        type: array
+        items:
+          type: object
+          required: [cause_key, rule_id, alert_numbers, source_task_ids, replacement_title]
+          properties:
+            cause_key:
+              type: string
+            repository:
+              type: string
+            rule_id:
+              type: string
+            message:
+              type: string
+            alert_numbers:
+              type: array
+            paths:
+              type: array
+            source_task_ids:
+              type: array
+            carried_dependencies:
+              type: array
+            replacement_title:
+              type: string
+            replacement_priority:
+              type: string
+            applied:
+              type: boolean
+            replacement_task_id:
+              type: string
+            not_applied_reason:
+              type: string
+            moved_source_task_id:
+              type: string
+            sources_not_retired:
+              type: array
+      unchanged_single_source:
+        type: array
+      skipped:
+        type: array
+        items:
+          type: object
+          required: [task_id, status, reason]
+          properties:
+            task_id:
+              type: string
+            status:
+              type: string
+            reason:
+              type: string
+              enum: [active_work, deferred, already_grouped, unparsable_evidence]
+      max_groups:
+        type: number
+      group_bounds:
+        type: object
+  action: consolidate_code_scanning_tasks
+  config: {}

--- a/crates/orbit-core/assets/activities/file_dependabot_alert_tasks.yaml
+++ b/crates/orbit-core/assets/activities/file_dependabot_alert_tasks.yaml
@@ -9,12 +9,18 @@ spec:
     Dependabot, Code scanning, and secret scanning snapshot. Preserve
     Dependabot clustering, severity filtering, and PR skips; dedupe the other
     families by repository and alert number; and enforce one max_tasks bound
-    across all families. Exact generated-key tags remain the fast path, then a
-    shared high-confidence material coverage check finds untagged still-open
-    tasks. Skips name the covering task and bounded match evidence; closed
-    historical tasks and superficial similarities do not suppress a current
-    alert. Duplicate-check failures are bounded retryable errors and happen
-    before any task is filed. Filed tasks require no tools.
+    across all families. Code scanning alerts that share scan provenance, rule
+    and scanner message are filed as one bounded remediation group carrying a
+    per-alert evidence ledger, a per-alert disposition contract, the highest
+    member severity as priority, and every member's per-alert coverage key.
+    Coverage is still decided per alert, so an alert an open task already owns
+    is left to that task and its uncovered siblings become an attributed delta
+    group rather than widening work in flight. Exact generated-key tags remain
+    the fast path, then a shared high-confidence material coverage check finds
+    untagged still-open tasks. Skips name the covering task and bounded match
+    evidence; closed historical tasks and superficial similarities do not
+    suppress a current alert. Duplicate-check failures are bounded retryable
+    errors and happen before any task is filed. Filed tasks require no tools.
   input_schema_json:
     type: object
     required: [dependabot_snapshot]
@@ -74,5 +80,10 @@ spec:
         type: array
       excluded_below_min_severity:
         type: array
+      code_scanning_group_bounds:
+        type: object
+        description: >
+          The alert and distinct-path caps that split one cause into several
+          remediation groups so each leaf task stays executable.
   action: file_dependabot_alert_tasks
   config: {}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs
@@ -1,12 +1,12 @@
 //! Turn a host-collected repository security snapshot into ordinary backlog tasks.
 
+pub(super) mod code_groups;
+pub(super) mod consolidate;
 mod duplicates;
 
 use std::collections::BTreeMap;
-use std::path::Path;
 
 use orbit_common::OrbitError;
-use orbit_common::fs::selector::{canonical_selector_in_workspace, exists_in_workspace};
 use orbit_types::task::{TaskComplexity, TaskPriority, TaskStatus, TaskType};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -17,6 +17,10 @@ use crate::adapter::engine_host::v2_host::duplicate_tasks::{
 };
 use crate::application::task::TaskAddParams;
 
+use self::code_groups::{
+    CodeGroupTaskRequest, CoveredAlert, alert_key, cause_key, code_group_task_params,
+    group_alert_numbers, group_code_alerts, group_paths,
+};
 use self::duplicates::{
     code_duplicate_candidate, dependabot_duplicate_candidate, duplicate_lookup_error,
     secret_duplicate_candidate,
@@ -28,6 +32,7 @@ const DEPENDABOT_KEY_PREFIX: &str = "dependabot:";
 const DEPENDABOT_TITLE_PREFIX: &str = "[dependabot-sweep] ";
 const CODE_TAG: &str = "code-scanning-sweep";
 const CODE_KEY_PREFIX: &str = "code-scanning:";
+const CODE_GROUP_KEY_PREFIX: &str = "code-scanning-group:";
 const CODE_TITLE_PREFIX: &str = "[code-scanning-sweep] ";
 const SECRET_TAG: &str = "secret-scanning-sweep";
 const SECRET_KEY_PREFIX: &str = "secret-scanning:";
@@ -233,9 +238,14 @@ where
         .pointer("/repository/full_name")
         .and_then(Value::as_str)
         .unwrap_or("unknown repository");
+    // Code scanning: one lookup per alert decides coverage, then the alerts
+    // nobody owns are grouped by shared cause into bounded remediation tasks.
+    // Coverage stays per alert, so an existing per-alert task keeps covering
+    // its alert and a newly reported sibling becomes explicit delta work.
     let mut code_alerts = family_alerts(snapshot, "code_scanning");
     code_alerts.sort_by_key(alert_number);
-    candidate_count += code_alerts.len();
+    let mut uncovered_code_alerts = Vec::new();
+    let mut covered_by_cause: BTreeMap<String, Vec<CoveredAlert>> = BTreeMap::new();
     for alert in code_alerts {
         let number = alert_number(&alert);
         if number == 0 {
@@ -258,7 +268,7 @@ where
             }));
             continue;
         }
-        let key = digest(&["code-scanning", repository, &number.to_string()]);
+        let key = alert_key(repository, &alert);
         if let Some(DuplicateTaskMatch {
             task_id,
             match_kind,
@@ -266,6 +276,13 @@ where
         }) = find_covering_task(lookup, &code_duplicate_candidate(&key, &alert))
             .map_err(|error| duplicate_lookup_error("code_scanning", &key, &error))?
         {
+            covered_by_cause
+                .entry(cause_key(repository, &alert))
+                .or_default()
+                .push(CoveredAlert {
+                    number,
+                    task_id: task_id.clone(),
+                });
             skipped_existing.push(json!({
                 "family": "code_scanning", "key": key, "task_id": task_id,
                 "alert_number": number,
@@ -273,48 +290,42 @@ where
             }));
             continue;
         }
+        uncovered_code_alerts.push(alert);
+    }
+
+    let code_groups = group_code_alerts(repository, uncovered_code_alerts);
+    // A Code scanning candidate is one unit of work the sweep judged: a group
+    // it can file, or an alert it found an owner for.
+    candidate_count += code_groups.len() + covered_by_cause.values().map(Vec::len).sum::<usize>();
+    let no_siblings: Vec<CoveredAlert> = Vec::new();
+    for group in &code_groups {
+        let alert_numbers = group_alert_numbers(group);
         if pending_tasks.len() >= max_tasks {
             skipped_over_cap.push(json!({
-                "family": "code_scanning", "key": key, "alert_number": number,
+                "family": "code_scanning", "key": group.cause_key,
+                "alert_numbers": alert_numbers,
             }));
             continue;
         }
-        let rule = field(&alert, "rule_id");
-        let path = field(&alert, "path");
-        let rank = rank.unwrap_or(floor);
-        let params = TaskAddParams {
-            title: code_task_title(&rule, &path),
-            description: code_task_description(snapshot, &alert),
-            acceptance_criteria: vec![
-                format!(
-                    "Remediate Code scanning rule `{}` at `{}`{} with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.",
-                    display(&rule),
-                    display(&path),
-                    line_suffix(&alert),
-                ),
-                "Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.".to_string(),
-                "Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.".to_string(),
-            ],
-            tags: vec![
-                CODE_TAG.to_string(),
-                format!("{CODE_KEY_PREFIX}{key}"),
-                "security".to_string(),
-            ],
-            context_files: code_context_files(&alert, &runtime.paths().repo_root),
-            required_tools: Vec::new(),
+        let covered_siblings = covered_by_cause
+            .get(&group.cause_key)
+            .unwrap_or(&no_siblings);
+        let params = code_group_task_params(&CodeGroupTaskRequest {
+            snapshot,
+            group,
+            covered_siblings,
+            workspace_root: &runtime.paths().repo_root,
             crew: system_crew.clone(),
-            priority: priority_for_rank(rank),
-            complexity: TaskComplexity::Unassessed,
-            task_type: Some(TaskType::Bug),
-            status: Some(TaskStatus::Backlog),
-            system_created: true,
-            ..TaskAddParams::default()
-        };
+        });
         pending_tasks.push(PendingTask {
             params,
             result: json!({
-                "family": "code_scanning", "key": key,
-                "alert_number": number, "rule_id": rule, "path": path,
+                "family": "code_scanning", "key": group.cause_key,
+                "rule_id": field(&group.alerts[0], "rule_id"),
+                "paths": group_paths(group),
+                "alert_numbers": alert_numbers,
+                "alert_count": group.alerts.len(),
+                "delta_covered_by": covered_alert_owners(covered_siblings),
             }),
         });
     }
@@ -428,7 +439,19 @@ where
         "min_severity": floor_name,
         "skip_when_dependabot_pr_open": skip_pr,
         "max_tasks": max_tasks,
+        "code_scanning_group_bounds": code_groups::group_bounds(),
     }))
+}
+
+/// The open tasks that already own same-cause alerts left out of a group, as
+/// the sweep reports them alongside the delta task it filed instead.
+fn covered_alert_owners(covered: &[CoveredAlert]) -> Value {
+    json!(
+        covered
+            .iter()
+            .map(|sibling| json!({"alert_number": sibling.number, "task_id": sibling.task_id}))
+            .collect::<Vec<_>>()
+    )
 }
 
 fn family_alerts(snapshot: &Value, family: &str) -> Vec<Value> {
@@ -495,12 +518,6 @@ fn dependabot_task_title(package: &str, manifest_path: &str) -> String {
     format!("{DEPENDABOT_TITLE_PREFIX}{}", truncate_chars(&body, budget))
 }
 
-fn code_task_title(rule: &str, path: &str) -> String {
-    let budget = 120usize.saturating_sub(CODE_TITLE_PREFIX.chars().count());
-    let body = format!("Fix {} in {}", display(rule), display(path));
-    format!("{CODE_TITLE_PREFIX}{}", truncate_chars(&body, budget))
-}
-
 fn secret_task_title(secret_type: &str, number: u64) -> String {
     let budget = 120usize.saturating_sub(SECRET_TITLE_PREFIX.chars().count());
     let body = format!(
@@ -554,31 +571,6 @@ fn dependabot_task_description(
     }
     append_collection_bounds(&mut out, snapshot.get("truncation"));
     out.push_str("\nUpdate the dependency and regenerate the lockfile through the repository's normal package-manager workflow. Verify that the manifest and lockfile agree and run the documented pre-handoff checks.\n");
-    out
-}
-
-fn code_task_description(snapshot: &Value, alert: &Value) -> String {
-    let mut out = format!(
-        "This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.\n\n## Alert evidence\n\n- Repository: `{}`\n- Alert: `#{}`\n- Rule: `{}` ({})\n- Security severity: `{}`\n- Tool: `{}` (version `{}`, guid `{}`)\n- Message: {}\n- Ref: `{}`\n- Commit: `{}`\n- Location: `{}`{}\n- Created: `{}`\n- Updated: `{}`\n- Alert URL: {}\n",
-        repository_name(snapshot),
-        field(alert, "number"),
-        display(&field(alert, "rule_id")),
-        display(&field(alert, "rule_name")),
-        display(&field(alert, "security_severity")),
-        display(&field(alert, "tool_name")),
-        display(&field(alert, "tool_version")),
-        display(&field(alert, "tool_guid")),
-        display(&field(alert, "message")),
-        display(&field(alert, "ref")),
-        display(&field(alert, "commit_sha")),
-        display(&field(alert, "path")),
-        line_suffix(alert),
-        display(&field(alert, "created_at")),
-        display(&field(alert, "updated_at")),
-        display(&field(alert, "html_url")),
-    );
-    append_collection_bounds(&mut out, snapshot.pointer("/code_scanning/truncation"));
-    out.push_str("\nRemediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.\n");
     out
 }
 
@@ -653,34 +645,6 @@ fn location_url(location: &Value) -> String {
         }
     }
     "no location URL".to_string()
-}
-
-/// Scope a Code scanning repair task to the alert's remediation target, read
-/// from the alert's structured `path` rather than the rendered evidence.
-///
-/// The path GitHub reports is repository-relative and may not name anything in
-/// this checkout — the alert can predate a rename or deletion, or describe a
-/// path that escapes the workspace. Emit a selector only when it canonicalizes
-/// and still resolves inside the workspace, so an unusable location yields no
-/// scope instead of an invented one, and one bad alert cannot fail the sweep.
-///
-/// Line numbers stay in the alert evidence: `context_files` selectors address
-/// whole files, and a line suffix would not canonicalize as a `file:` anchor.
-fn code_context_files(alert: &Value, workspace_root: &Path) -> Vec<String> {
-    let path = field(alert, "path");
-    if path.is_empty() {
-        return Vec::new();
-    }
-
-    let Ok(selector) = canonical_selector_in_workspace(&format!("file:{path}"), workspace_root)
-    else {
-        return Vec::new();
-    };
-    if exists_in_workspace(&selector, workspace_root) {
-        vec![selector]
-    } else {
-        Vec::new()
-    }
 }
 
 fn line_suffix(value: &Value) -> String {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks/code_groups.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks/code_groups.rs
@@ -1,0 +1,488 @@
+//! Bounded logical remediation groups for Code scanning alerts.
+//!
+//! GitHub reports one alert per location, so a single repair — one tainted
+//! source, one unsafe construct — arrives as several alerts at sibling line
+//! offsets or across several files. One task per alert produced dozens of
+//! records for one edit and sent executors to reconcile work another task had
+//! already landed (F2026-09-097, F2026-09-105).
+//!
+//! Alerts join one group when their *scan provenance* (tool identity and
+//! analyzed ref), their *rule* and their *scanner message* all agree. No one
+//! of those carries the decision: the same rule twice in one file with
+//! different messages describes two findings and stays split, and the same
+//! message under a different rule or from a different analysis stays split
+//! too. Line and column offsets are deliberately absent from the signature —
+//! that is what lets sibling locations of one data flow collapse into one
+//! repair.
+//!
+//! Coverage stays per alert. Every alert keeps the generated key it has always
+//! had, a group task carries the key of every member, and the sweep asks the
+//! shared duplicate check once per alert. Existing per-alert tasks therefore
+//! keep covering their alert with no migration, and an alert that appears
+//! after a group was filed becomes explicit delta work instead of silently
+//! widening a task somebody may already be running.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use orbit_common::fs::selector::{canonical_selector_in_workspace, exists_in_workspace};
+use orbit_types::task::{TaskComplexity, TaskRelation, TaskRelationType, TaskStatus, TaskType};
+use serde_json::{Value, json};
+
+use crate::application::task::TaskAddParams;
+
+use super::{
+    CODE_GROUP_KEY_PREFIX, CODE_KEY_PREFIX, CODE_TAG, CODE_TITLE_PREFIX, alert_number,
+    append_collection_bounds, digest, display, field, line_suffix, priority_for_rank,
+    repository_name, severity_rank, truncate_chars,
+};
+
+/// One leaf task has to stay executable, so a group is bounded both by how
+/// many alerts it carries and by how many distinct files it spans. A cause
+/// that exceeds either bound splits into consecutive groups rather than
+/// growing into a task nobody can finish in one pass.
+const MAX_GROUP_ALERTS: usize = 12;
+const MAX_GROUP_PATHS: usize = 5;
+
+/// How many alert locations an acceptance criterion names inline before it
+/// defers to the ledger in the description.
+const MAX_INLINE_LOCATIONS: usize = 5;
+
+/// A set of Code scanning alerts that the collected evidence says share one
+/// repair.
+pub(super) struct CodeAlertGroup {
+    pub(super) cause_key: String,
+    pub(super) alerts: Vec<Value>,
+}
+
+/// An alert of the same cause that an open task already owns.
+pub(super) struct CoveredAlert {
+    pub(super) number: u64,
+    pub(super) task_id: String,
+}
+
+/// Everything the sweep and the consolidation path both need to render one
+/// group task through the same builder.
+pub(super) struct CodeGroupTaskRequest<'a> {
+    /// A snapshot-shaped value: `repository.full_name` names the repository
+    /// and `code_scanning.truncation`, when present, records collection bounds.
+    pub(super) snapshot: &'a Value,
+    pub(super) group: &'a CodeAlertGroup,
+    /// Same-cause alerts left out of this task because open work owns them.
+    pub(super) covered_siblings: &'a [CoveredAlert],
+    pub(super) workspace_root: &'a Path,
+    pub(super) crew: Option<String>,
+}
+
+/// The generated per-alert coverage key. This is the identity the sweep has
+/// always deduplicated on, so a group task carrying it covers exactly the
+/// alerts it lists and nothing else.
+pub(super) fn alert_key(repository: &str, alert: &Value) -> String {
+    digest(&[
+        "code-scanning",
+        repository,
+        &alert_number(alert).to_string(),
+    ])
+}
+
+/// The shared-repair identity: scan provenance, rule, and canonical scanner
+/// message together. Every component must agree for two alerts to group.
+pub(super) fn cause_key(repository: &str, alert: &Value) -> String {
+    digest(&[
+        "code-scanning-cause",
+        repository,
+        &field(alert, "tool_name").to_ascii_lowercase(),
+        &field(alert, "tool_guid").to_ascii_lowercase(),
+        &field(alert, "ref"),
+        &field(alert, "rule_id"),
+        &canonical_message(&field(alert, "message")),
+    ])
+}
+
+/// Partition `alerts` into bounded groups, ordered by their lowest alert
+/// number so a snapshot and its reordering produce the same sequence.
+pub(super) fn group_code_alerts(repository: &str, alerts: Vec<Value>) -> Vec<CodeAlertGroup> {
+    let mut by_cause: BTreeMap<String, Vec<Value>> = BTreeMap::new();
+    for alert in alerts {
+        by_cause
+            .entry(cause_key(repository, &alert))
+            .or_default()
+            .push(alert);
+    }
+
+    let mut groups = by_cause
+        .into_iter()
+        .flat_map(|(cause_key, alerts)| split_within_bounds(cause_key, alerts))
+        .collect::<Vec<_>>();
+    groups.sort_by_key(lowest_alert_number);
+    groups
+}
+
+/// The bounds a caller can report so an operator can see why a cause split.
+pub(super) fn group_bounds() -> Value {
+    json!({"max_alerts": MAX_GROUP_ALERTS, "max_paths": MAX_GROUP_PATHS})
+}
+
+pub(super) fn group_paths(group: &CodeAlertGroup) -> Vec<String> {
+    distinct_paths(&group.alerts)
+}
+
+pub(super) fn group_alert_numbers(group: &CodeAlertGroup) -> Vec<u64> {
+    let mut numbers = group.alerts.iter().map(alert_number).collect::<Vec<_>>();
+    numbers.sort_unstable();
+    numbers
+}
+
+pub(super) fn code_group_task_params(request: &CodeGroupTaskRequest<'_>) -> TaskAddParams {
+    let repository = repository_name(request.snapshot);
+    let alerts = &request.group.alerts;
+    let rule = field(&alerts[0], "rule_id");
+
+    let mut tags = vec![CODE_TAG.to_string()];
+    tags.extend(
+        alerts
+            .iter()
+            .map(|alert| format!("{CODE_KEY_PREFIX}{}", alert_key(repository, alert))),
+    );
+    tags.push(format!(
+        "{CODE_GROUP_KEY_PREFIX}{}",
+        request.group.cause_key
+    ));
+    tags.push("security".to_string());
+
+    TaskAddParams {
+        title: group_title(&rule, request.group),
+        description: group_description(request),
+        acceptance_criteria: group_acceptance_criteria(&rule, request.group),
+        tags,
+        context_files: group_context_files(alerts, request.workspace_root),
+        relations: covering_relations(request.covered_siblings),
+        required_tools: Vec::new(),
+        crew: request.crew.clone(),
+        priority: priority_for_rank(highest_severity_rank(alerts)),
+        complexity: TaskComplexity::Unassessed,
+        task_type: Some(TaskType::Bug),
+        status: Some(TaskStatus::Backlog),
+        system_created: true,
+        ..TaskAddParams::default()
+    }
+}
+
+/// Locations of one cause are ordered file by file so a bound-forced split
+/// lands on a file boundary whenever the bounds allow it.
+fn split_within_bounds(cause_key: String, mut alerts: Vec<Value>) -> Vec<CodeAlertGroup> {
+    alerts.sort_by_key(|alert| (field(alert, "path"), start_line(alert), alert_number(alert)));
+
+    let mut groups = Vec::new();
+    let mut members: Vec<Value> = Vec::new();
+    let mut paths: BTreeSet<String> = BTreeSet::new();
+    for alert in alerts {
+        let path = field(&alert, "path");
+        let bound_reached = members.len() >= MAX_GROUP_ALERTS
+            || (paths.len() >= MAX_GROUP_PATHS && !paths.contains(&path));
+        if bound_reached {
+            groups.push(CodeAlertGroup {
+                cause_key: cause_key.clone(),
+                alerts: std::mem::take(&mut members),
+            });
+            paths.clear();
+        }
+        paths.insert(path);
+        members.push(alert);
+    }
+    if !members.is_empty() {
+        groups.push(CodeAlertGroup {
+            cause_key,
+            alerts: members,
+        });
+    }
+    groups
+}
+
+fn lowest_alert_number(group: &CodeAlertGroup) -> u64 {
+    group
+        .alerts
+        .iter()
+        .map(alert_number)
+        .min()
+        .unwrap_or_default()
+}
+
+fn highest_severity_rank(alerts: &[Value]) -> u8 {
+    alerts
+        .iter()
+        .filter_map(|alert| severity_rank(&field(alert, "security_severity").to_ascii_lowercase()))
+        .max()
+        .unwrap_or(1)
+}
+
+fn distinct_paths(alerts: &[Value]) -> Vec<String> {
+    let mut paths = alerts
+        .iter()
+        .map(|alert| field(alert, "path"))
+        .filter(|path| !path.is_empty())
+        .collect::<Vec<_>>();
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+fn start_line(alert: &Value) -> u64 {
+    alert
+        .get("start_line")
+        .and_then(Value::as_u64)
+        .unwrap_or_default()
+}
+
+/// Lowercase the scanner message into a token sequence. Punctuation and
+/// spacing vary between analyses of one finding; the words do not. Digits are
+/// kept, so `CWE-79` and `CWE-89` remain distinct causes.
+fn canonical_message(message: &str) -> String {
+    let mut out = String::with_capacity(message.len());
+    let mut separated = true;
+    for character in message.chars().flat_map(char::to_lowercase) {
+        if character.is_alphanumeric() {
+            out.push(character);
+            separated = false;
+        } else if !separated {
+            out.push(' ');
+            separated = true;
+        }
+    }
+    out.trim_end().to_string()
+}
+
+fn group_title(rule: &str, group: &CodeAlertGroup) -> String {
+    let budget = 120usize.saturating_sub(CODE_TITLE_PREFIX.chars().count());
+    let paths = distinct_paths(&group.alerts);
+    let count = group.alerts.len();
+    let body = match paths.as_slice() {
+        _ if count == 1 => format!(
+            "Fix {} in {}",
+            display(rule),
+            display(&field(&group.alerts[0], "path"))
+        ),
+        [path] => format!("Fix {} at {count} locations in {path}", display(rule)),
+        paths => format!(
+            "Fix {} at {count} locations across {} files",
+            display(rule),
+            paths.len()
+        ),
+    };
+    format!("{CODE_TITLE_PREFIX}{}", truncate_chars(&body, budget))
+}
+
+fn group_acceptance_criteria(rule: &str, group: &CodeAlertGroup) -> Vec<String> {
+    let remediate = if let [alert] = group.alerts.as_slice() {
+        format!(
+            "Remediate Code scanning rule `{}` at `{}`{} with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.",
+            display(rule),
+            display(&field(alert, "path")),
+            line_suffix(alert),
+        )
+    } else {
+        format!(
+            "Remediate Code scanning rule `{}` at every alert location listed in the task description ({}) with a real code or configuration fix; do not suppress, dismiss, or exclude any of them.",
+            display(rule),
+            inline_locations(&group.alerts),
+        )
+    };
+
+    vec![
+        remediate,
+        "Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.".to_string(),
+        "Record one disposition for every alert listed in the task description: `fixed`, `already-covered`, or `not-reproducible-in-source`. An `already-covered` disposition must name the covering commit, show that commit is an ancestor of the HEAD you validated, and cite the current source carrying the repair; never present another task's commit as this task's own change.".to_string(),
+        "Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected locations. Report source-side coverage and hosted alert closure separately: do not record a hosted alert as closed without a hosted rescan.".to_string(),
+    ]
+}
+
+fn inline_locations(alerts: &[Value]) -> String {
+    let mut rendered = alerts
+        .iter()
+        .take(MAX_INLINE_LOCATIONS)
+        .map(|alert| format!("`{}`{}", display(&field(alert, "path")), line_suffix(alert)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    if alerts.len() > MAX_INLINE_LOCATIONS {
+        rendered.push_str(&format!(
+            ", and {} more in the ledger",
+            alerts.len() - MAX_INLINE_LOCATIONS
+        ));
+    }
+    rendered
+}
+
+fn group_description(request: &CodeGroupTaskRequest<'_>) -> String {
+    let alerts = &request.group.alerts;
+    let mut out = "This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.\n\n".to_string();
+
+    if let [alert] = alerts.as_slice() {
+        append_single_alert_evidence(&mut out, request.snapshot, alert);
+    } else {
+        append_shared_cause(&mut out, request.snapshot, alerts);
+        append_alert_ledger(&mut out, alerts);
+    }
+
+    append_disposition_contract(&mut out);
+    append_covered_siblings(&mut out, request.covered_siblings);
+    append_collection_bounds(
+        &mut out,
+        request.snapshot.pointer("/code_scanning/truncation"),
+    );
+
+    out.push_str(if alerts.len() == 1 {
+        "\nRemediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.\n"
+    } else {
+        "\nRemediate the shared cause once, confirm every location in the ledger, and run the repository's normal validation.\n"
+    });
+    out
+}
+
+/// The single-alert record. Its `- Key: value` bullets are also the format the
+/// consolidation path reads back out of an existing per-alert task, so the
+/// keys and their order are a parsed contract, not presentation.
+fn append_single_alert_evidence(out: &mut String, snapshot: &Value, alert: &Value) {
+    out.push_str(&format!(
+        "## Alert evidence\n\n- Repository: `{}`\n- Alert: `#{}`\n- Rule: `{}` ({})\n- Security severity: `{}`\n- Tool: `{}` (version `{}`, guid `{}`)\n- Message: {}\n- Ref: `{}`\n- Commit: `{}`\n- Location: `{}`{}\n- Created: `{}`\n- Updated: `{}`\n- Alert URL: {}\n",
+        repository_name(snapshot),
+        field(alert, "number"),
+        display(&field(alert, "rule_id")),
+        display(&field(alert, "rule_name")),
+        display(&field(alert, "security_severity")),
+        display(&field(alert, "tool_name")),
+        display(&field(alert, "tool_version")),
+        display(&field(alert, "tool_guid")),
+        display(&field(alert, "message")),
+        display(&field(alert, "ref")),
+        display(&field(alert, "commit_sha")),
+        display(&field(alert, "path")),
+        line_suffix(alert),
+        display(&field(alert, "created_at")),
+        display(&field(alert, "updated_at")),
+        display(&field(alert, "html_url")),
+    ));
+}
+
+fn append_shared_cause(out: &mut String, snapshot: &Value, alerts: &[Value]) {
+    let lead = &alerts[0];
+    let paths = distinct_paths(alerts);
+    let severity = severity_name(highest_severity_rank(alerts));
+    out.push_str(&format!(
+        "## Shared cause\n\n- Repository: `{}`\n- Rule: `{}` ({})\n- Highest open security severity: `{severity}`\n- Tool: `{}` (version `{}`, guid `{}`)\n- Ref: `{}`\n- Message: {}\n- Grouped because: {} alerts across {} report this rule with this message from the same analysis, so the evidence puts them behind one repair. Their line and column offsets differ; the construct to repair does not.\n",
+        repository_name(snapshot),
+        display(&field(lead, "rule_id")),
+        display(&field(lead, "rule_name")),
+        display(&field(lead, "tool_name")),
+        display(&field(lead, "tool_version")),
+        display(&field(lead, "tool_guid")),
+        display(&field(lead, "ref")),
+        display(&field(lead, "message")),
+        alerts.len(),
+        match paths.len() {
+            0 => "an unreported location".to_string(),
+            1 => format!("`{}`", paths[0]),
+            count => format!("{count} files"),
+        },
+    ));
+}
+
+fn append_alert_ledger(out: &mut String, alerts: &[Value]) {
+    out.push_str("\n## Per-alert evidence ledger\n\n");
+    for alert in alerts {
+        out.push_str(&format!(
+            "- **Alert `#{}`** — location `{}`{}; security severity `{}`; analyzed commit `{}`; created `{}`; updated `{}`; alert URL: {}\n",
+            field(alert, "number"),
+            display(&field(alert, "path")),
+            line_suffix(alert),
+            display(&field(alert, "security_severity")),
+            display(&field(alert, "commit_sha")),
+            display(&field(alert, "created_at")),
+            display(&field(alert, "updated_at")),
+            display(&field(alert, "html_url")),
+        ));
+    }
+}
+
+/// The reconciliation contract. A clean checkout whose repair already landed
+/// is a real outcome; manufacturing a commit for it, or claiming another
+/// task's commit, is not (F2026-09-097, F2026-09-101, F2026-09-105).
+fn append_disposition_contract(out: &mut String) {
+    out.push_str(
+        "\n## Per-alert disposition\n\n\
+         Record one outcome for every alert listed above before handoff:\n\n\
+         - `fixed` — this task changed the source and the rule no longer reports at that location.\n\
+         - `already-covered` — the repair already landed. Name the covering commit, show it is an ancestor of the HEAD you validated, and cite the current source that carries it. Do not present another task's commit as this task's own change, and do not manufacture an empty or unrelated commit to satisfy delivery.\n\
+         - `not-reproducible-in-source` — the reported location does not match the current source (a stale path, line, or message). Record what that location holds today.\n\n\
+         Source-side coverage and hosted alert closure are separate outcomes: do not record a hosted alert as closed without a hosted rescan.\n",
+    );
+}
+
+fn append_covered_siblings(out: &mut String, covered: &[CoveredAlert]) {
+    if covered.is_empty() {
+        return;
+    }
+    out.push_str(
+        "\n## Already covered elsewhere\n\n\
+         Open work already owns these alerts of the same cause. Leave them to their owner: do not repeat the repair here, and do not widen that task.\n\n",
+    );
+    for sibling in covered {
+        out.push_str(&format!(
+            "- Alert `#{}` — owned by {}\n",
+            sibling.number, sibling.task_id
+        ));
+    }
+}
+
+fn covering_relations(covered: &[CoveredAlert]) -> Vec<TaskRelation> {
+    let mut targets = covered
+        .iter()
+        .map(|sibling| sibling.task_id.clone())
+        .collect::<Vec<_>>();
+    targets.sort();
+    targets.dedup();
+    targets
+        .into_iter()
+        .map(|target| TaskRelation {
+            relation_type: TaskRelationType::RelatedTo,
+            target,
+        })
+        .collect()
+}
+
+fn severity_name(rank: u8) -> &'static str {
+    match rank {
+        4.. => "critical",
+        3 => "high",
+        2 => "moderate",
+        _ => "low",
+    }
+}
+
+/// Scope a group to its alerts' remediation targets, read from each alert's
+/// structured `path` rather than the rendered evidence.
+///
+/// The path GitHub reports is repository-relative and may not name anything in
+/// this checkout — the alert can predate a rename or deletion, or describe a
+/// path that escapes the workspace. Emit a selector only when it canonicalizes
+/// and still resolves inside the workspace, so an unusable location yields no
+/// scope instead of an invented one, and one bad alert cannot fail the sweep.
+///
+/// Line numbers stay in the alert evidence: `context_files` selectors address
+/// whole files, and a line suffix would not canonicalize as a `file:` anchor.
+fn group_context_files(alerts: &[Value], workspace_root: &Path) -> Vec<String> {
+    let mut selectors = alerts
+        .iter()
+        .filter_map(|alert| resolved_selector(&field(alert, "path"), workspace_root))
+        .collect::<Vec<_>>();
+    selectors.sort();
+    selectors.dedup();
+    selectors
+}
+
+fn resolved_selector(path: &str, workspace_root: &Path) -> Option<String> {
+    if path.is_empty() {
+        return None;
+    }
+    let selector = canonical_selector_in_workspace(&format!("file:{path}"), workspace_root).ok()?;
+    exists_in_workspace(&selector, workspace_root).then_some(selector)
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks/consolidate.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks/consolidate.rs
@@ -1,0 +1,429 @@
+//! Preview and apply consolidation of unstarted per-alert Code scanning tasks
+//! into the bounded remediation groups the sweep now files.
+//!
+//! Sweeps that ran before grouping left one task per alert, so a backlog can
+//! hold a dozen records for one repair. This action folds those records into
+//! one group task per shared cause. It previews by default: an operator sees
+//! the exact source task IDs and the replacement before anything is written.
+//!
+//! Three rules keep it safe to re-run against a live backlog. Only *unstarted*
+//! tasks (proposed or backlog) are candidates — work someone has started,
+//! deferred, or already grouped is reported and left exactly as it is. Every
+//! source is re-read before the group is minted, and the group is abandoned if
+//! any of them moved, so a task that started between preview and apply is not
+//! rewritten. And the replacement carries each member's per-alert coverage key
+//! while the sources are rejected with a covering-task comment — the evidence
+//! both the sweep's exact-key path and its confirmed-duplicate path already
+//! understand, so a second run finds nothing left to consolidate.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use orbit_common::OrbitError;
+use orbit_types::task::{Task, TaskRelation, TaskRelationType, TaskStatus};
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+use crate::application::task::TaskAddParams;
+
+use super::code_groups::{
+    CodeAlertGroup, CodeGroupTaskRequest, cause_key, code_group_task_params, group_alert_numbers,
+    group_bounds, group_code_alerts, group_paths,
+};
+use super::{CODE_KEY_PREFIX, CODE_TAG, SYSTEM_CREW, bounded_u64, field};
+
+const DEFAULT_MAX_GROUPS: u64 = 10;
+const MAX_GROUPS: u64 = 50;
+
+/// A per-alert task the consolidation can fold into a group.
+struct SourceTask {
+    id: String,
+    repository: String,
+    alert: Value,
+    dependencies: Vec<String>,
+    context_files: Vec<String>,
+}
+
+/// A replacement group and the exact tasks it would replace.
+struct Consolidation {
+    group: CodeAlertGroup,
+    repository: String,
+    source_ids: Vec<String>,
+    dependencies: Vec<String>,
+    context_files: Vec<String>,
+}
+
+pub(crate) fn consolidate_code_scanning_tasks(
+    runtime: &OrbitRuntime,
+    input: &Value,
+) -> Result<Value, OrbitError> {
+    let apply = input
+        .get("apply")
+        .and_then(Value::as_bool)
+        .unwrap_or_default();
+    let max_groups = bounded_u64(input, "max_groups", DEFAULT_MAX_GROUPS, MAX_GROUPS)? as usize;
+
+    let mut tasks = runtime.list_tasks_by_tags(&[CODE_TAG.to_string()])?;
+    tasks.sort_by(|left, right| left.id.cmp(&right.id));
+
+    let mut skipped = Vec::new();
+    let mut sources = Vec::new();
+    for task in &tasks {
+        match classify(task) {
+            Ok(Some(source)) => sources.push(source),
+            Ok(None) => {}
+            Err(reason) => skipped.push(json!({
+                "task_id": task.id, "status": task.status.to_string(), "reason": reason,
+            })),
+        }
+    }
+    let scanned = sources.len();
+    let (consolidations, unchanged) = plan(sources);
+
+    let crew = runtime
+        .validate_crew_name(Some(SYSTEM_CREW))
+        .is_ok()
+        .then(|| SYSTEM_CREW.to_string());
+    let mut groups = Vec::new();
+    for consolidation in consolidations.iter().take(max_groups) {
+        let params = replacement_params(runtime, consolidation, crew.clone());
+        let mut entry = describe(consolidation, &params);
+        if apply {
+            apply_one(runtime, consolidation, params, &mut entry)?;
+        }
+        groups.push(entry);
+    }
+
+    let outcome = match (apply, groups.is_empty()) {
+        (_, true) => "nothing_to_consolidate",
+        (true, false) => "applied",
+        (false, false) => "dry_run",
+    };
+
+    Ok(json!({
+        "outcome": outcome,
+        "apply": apply,
+        "scanned_source_tasks": scanned,
+        "group_count": groups.len(),
+        "groups": groups,
+        "unchanged_single_source": unchanged,
+        "skipped": skipped,
+        "max_groups": max_groups,
+        "group_bounds": group_bounds(),
+    }))
+}
+
+/// Decide what a swept Code scanning task is to this action: a candidate, an
+/// untouchable record with a stated reason, or closed history to ignore.
+///
+/// The status arm is exhaustive on purpose. Whether a status may be rewritten
+/// is the whole safety question here, so a new one has to be answered rather
+/// than defaulted. Proposed and backlog are the unstarted statuses, and both
+/// are statuses [`OrbitRuntime::reject_task`] retires under a compare-and-set.
+fn classify(task: &Task) -> Result<Option<SourceTask>, &'static str> {
+    match task.status {
+        TaskStatus::Proposed | TaskStatus::Backlog => {}
+        TaskStatus::Done | TaskStatus::Archived | TaskStatus::Rejected => return Ok(None),
+        TaskStatus::Someday => return Err("deferred"),
+        TaskStatus::InProgress | TaskStatus::Review | TaskStatus::Blocked => {
+            return Err("active_work");
+        }
+    }
+    if alert_key_count(task) != 1 {
+        return Err("already_grouped");
+    }
+    let Some((repository, alert)) = parse_alert_evidence(&task.description) else {
+        return Err("unparsable_evidence");
+    };
+    Ok(Some(SourceTask {
+        id: task.id.clone(),
+        repository,
+        alert,
+        dependencies: task.dependencies(),
+        context_files: task.context_files.clone(),
+    }))
+}
+
+fn alert_key_count(task: &Task) -> usize {
+    task.tags
+        .iter()
+        .filter(|tag| tag.starts_with(CODE_KEY_PREFIX))
+        .count()
+}
+
+/// Group the candidates by shared cause. A group replaces work only when it
+/// folds at least two distinct source tasks; a lone task is already the
+/// smallest record for its cause and is reported unchanged.
+fn plan(sources: Vec<SourceTask>) -> (Vec<Consolidation>, Vec<Value>) {
+    let mut by_repository: BTreeMap<String, Vec<SourceTask>> = BTreeMap::new();
+    for source in sources {
+        by_repository
+            .entry(source.repository.clone())
+            .or_default()
+            .push(source);
+    }
+
+    let mut consolidations = Vec::new();
+    let mut unchanged = Vec::new();
+    for (repository, sources) in by_repository {
+        let mut owners: BTreeMap<String, SourceTask> = BTreeMap::new();
+        let mut alerts = Vec::new();
+        for source in sources {
+            alerts.push(source.alert.clone());
+            owners.insert(cause_alert_id(&repository, &source.alert), source);
+        }
+
+        for group in group_code_alerts(&repository, alerts) {
+            let members = group
+                .alerts
+                .iter()
+                .filter_map(|alert| owners.get(&cause_alert_id(&repository, alert)))
+                .collect::<Vec<_>>();
+            let source_ids = members
+                .iter()
+                .map(|source| source.id.clone())
+                .collect::<BTreeSet<_>>();
+            if source_ids.len() < 2 {
+                unchanged.extend(source_ids.into_iter().map(
+                    |task_id| json!({"task_id": task_id, "reason": "sole_task_for_its_cause"}),
+                ));
+                continue;
+            }
+            consolidations.push(Consolidation {
+                repository: repository.clone(),
+                source_ids: source_ids.into_iter().collect(),
+                dependencies: union_of(members.iter().map(|source| &source.dependencies)),
+                context_files: union_of(members.iter().map(|source| &source.context_files)),
+                group,
+            });
+        }
+    }
+    (consolidations, unchanged)
+}
+
+/// Cause plus alert number: the identity that maps a grouped alert back to the
+/// task it came from, without assuming alert numbers are unique across causes.
+fn cause_alert_id(repository: &str, alert: &Value) -> String {
+    format!(
+        "{}#{}",
+        cause_key(repository, alert),
+        field(alert, "number")
+    )
+}
+
+fn union_of<'a>(values: impl Iterator<Item = &'a Vec<String>>) -> Vec<String> {
+    values
+        .flatten()
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn describe(consolidation: &Consolidation, params: &TaskAddParams) -> Value {
+    let lead = &consolidation.group.alerts[0];
+    json!({
+        "cause_key": consolidation.group.cause_key,
+        "repository": consolidation.repository,
+        "rule_id": field(lead, "rule_id"),
+        "message": field(lead, "message"),
+        "alert_numbers": group_alert_numbers(&consolidation.group),
+        "paths": group_paths(&consolidation.group),
+        "source_task_ids": consolidation.source_ids,
+        "carried_dependencies": consolidation.dependencies,
+        "replacement_title": params.title,
+        "replacement_priority": params.priority.to_string(),
+    })
+}
+
+/// Mint the replacement, then retire each source with a covering-task comment.
+///
+/// Every source is re-read and re-classified first, and a group whose sources
+/// no longer qualify is abandoned whole rather than partially applied, so
+/// running work is never rewritten and no alert ends up owned twice. A source
+/// that slips past that check and refuses the rejection is reported rather
+/// than failing the run:
+/// the replacement is already correct, and the next pass sees the leftover as
+/// the sole task for its cause and leaves it alone.
+fn apply_one(
+    runtime: &OrbitRuntime,
+    consolidation: &Consolidation,
+    params: TaskAddParams,
+    entry: &mut Value,
+) -> Result<(), OrbitError> {
+    for source_id in &consolidation.source_ids {
+        let source = runtime.get_task(source_id)?;
+        if !matches!(classify(&source), Ok(Some(_))) {
+            entry["applied"] = json!(false);
+            entry["not_applied_reason"] = json!("source_task_started");
+            entry["moved_source_task_id"] = json!(source_id);
+            return Ok(());
+        }
+    }
+
+    let replacement = runtime.add_task(params)?;
+    let mut not_retired = Vec::new();
+    for source_id in &consolidation.source_ids {
+        let outcome = runtime.reject_task(
+            source_id,
+            format!("Consolidated into covering task {}", replacement.id),
+            Some(format!(
+                "Consolidated into covering task {}: the same rule, scanner message, and analysis cover every alert in that group, so one task now owns the shared repair. This task's per-alert evidence and dependencies were carried over.",
+                replacement.id
+            )),
+        );
+        if let Err(error) = outcome {
+            not_retired.push(json!({"task_id": source_id, "error": error.to_string()}));
+        }
+    }
+
+    entry["applied"] = json!(true);
+    entry["replacement_task_id"] = json!(replacement.id);
+    entry["sources_not_retired"] = json!(not_retired);
+    Ok(())
+}
+
+fn replacement_params(
+    runtime: &OrbitRuntime,
+    consolidation: &Consolidation,
+    crew: Option<String>,
+) -> TaskAddParams {
+    let snapshot = json!({"repository": {"full_name": consolidation.repository}});
+    let mut params = code_group_task_params(&CodeGroupTaskRequest {
+        snapshot: &snapshot,
+        group: &consolidation.group,
+        covered_siblings: &[],
+        workspace_root: &runtime.paths().repo_root,
+        crew,
+    });
+
+    // The sources' own selectors are kept alongside the ones the alert paths
+    // resolve to: a task-pilot pass may have widened a source's scope to the
+    // file that actually carries the repair, and that judgment outlives the
+    // record it was made on.
+    params.context_files =
+        union_of([&params.context_files, &consolidation.context_files].into_iter());
+    params.dependencies = consolidation.dependencies.clone();
+    params.relations = consolidation
+        .source_ids
+        .iter()
+        .map(|target| TaskRelation {
+            relation_type: TaskRelationType::Supersedes,
+            target: target.clone(),
+        })
+        .collect();
+    params
+}
+
+/// Read a swept per-alert task's `## Alert evidence` block back into the alert
+/// shape the group builder consumes.
+///
+/// Only that section is read, so a later section cannot inject a key, and
+/// every field the cause signature depends on is required — a record edited
+/// past recognition is reported as unparsable instead of being grouped on
+/// partial evidence.
+fn parse_alert_evidence(description: &str) -> Option<(String, Value)> {
+    let fields = evidence_fields(description);
+    let text = |key: &str| fields.get(key).cloned();
+    let quoted = |key: &str| fields.get(key).and_then(|value| backticks(value));
+
+    let repository = quoted("Repository")?;
+    let number = quoted("Alert")?
+        .trim_start_matches('#')
+        .parse::<u64>()
+        .ok()?;
+    let (rule_id, rule_name) = split_name_and_parenthetical(&text("Rule")?)?;
+    let [tool_name, tool_version, tool_guid] =
+        <[String; 3]>::try_from(backtick_segments(&text("Tool")?)).ok()?;
+    let (path, lines) = parse_location(&text("Location")?)?;
+
+    Some((
+        repository,
+        json!({
+            "number": number,
+            "rule_id": rule_id,
+            "rule_name": rule_name,
+            "security_severity": quoted("Security severity")?,
+            "tool_name": tool_name,
+            "tool_version": tool_version,
+            "tool_guid": tool_guid,
+            "message": text("Message")?,
+            "ref": quoted("Ref")?,
+            "commit_sha": quoted("Commit")?,
+            "path": path,
+            "start_line": lines.map(|(start, _)| start),
+            "end_line": lines.map(|(_, end)| end),
+            "created_at": quoted("Created").unwrap_or_default(),
+            "updated_at": quoted("Updated").unwrap_or_default(),
+            "html_url": text("Alert URL").unwrap_or_default(),
+        }),
+    ))
+}
+
+fn evidence_fields(description: &str) -> BTreeMap<String, String> {
+    let mut fields = BTreeMap::new();
+    let mut inside = false;
+    for line in description.lines() {
+        let line = line.trim();
+        if let Some(heading) = line.strip_prefix("## ") {
+            if inside {
+                break;
+            }
+            inside = heading == "Alert evidence";
+            continue;
+        }
+        if !inside {
+            continue;
+        }
+        if let Some(entry) = line.strip_prefix("- ")
+            && let Some((key, value)) = entry.split_once(": ")
+        {
+            fields
+                .entry(key.trim().to_string())
+                .or_insert_with(|| value.trim().to_string());
+        }
+    }
+    fields
+}
+
+fn backticks(value: &str) -> Option<String> {
+    backtick_segments(value).into_iter().next()
+}
+
+fn backtick_segments(value: &str) -> Vec<String> {
+    value
+        .split('`')
+        .skip(1)
+        .step_by(2)
+        .map(str::to_string)
+        .collect()
+}
+
+/// `` `rust/sql-injection` (SQL injection) `` — the rendered rule ID and name.
+fn split_name_and_parenthetical(value: &str) -> Option<(String, String)> {
+    let name = backticks(value)?;
+    let parenthetical = value
+        .split_once('(')
+        .and_then(|(_, rest)| rest.rsplit_once(')'))
+        .map(|(inside, _)| inside.trim().to_string())
+        .unwrap_or_default();
+    Some((name, parenthetical))
+}
+
+/// `` `src/db.rs` lines 17-19 ``, `` `src/db.rs` line 426 ``, or a backticked
+/// path with no line suffix — an alert GitHub reported without a location
+/// range. Absent lines stay absent rather than becoming line zero.
+fn parse_location(value: &str) -> Option<(String, Option<(u64, u64)>)> {
+    let path = backticks(value)?;
+    let suffix = value.rsplit('`').next().unwrap_or_default().trim();
+    let Some(range) = suffix
+        .strip_prefix("lines ")
+        .or_else(|| suffix.strip_prefix("line "))
+    else {
+        return Some((path, None));
+    };
+    let (start, end) = range.split_once('-').unwrap_or((range, range));
+    Some((
+        path,
+        Some((start.trim().parse().ok()?, end.trim().parse().ok()?)),
+    ))
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
@@ -229,6 +229,13 @@ pub(crate) fn run_deterministic(
                 }
             })
         }
+        CoreDeterministicAction::ConsolidateCodeScanningTasks => {
+            dependabot_alert_tasks::consolidate::consolidate_code_scanning_tasks(runtime, input)
+                .map_err(|error| DispatchError::DeterministicActionFailed {
+                    action: action.to_string(),
+                    message: error.to_string(),
+                })
+        }
         CoreDeterministicAction::FileDependabotAlertTasks => {
             dependabot_alert_tasks::file_dependabot_alert_tasks(runtime, input).map_err(|error| {
                 DispatchError::DeterministicActionFailed {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/code_scanning_consolidation.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/code_scanning_consolidation.rs
@@ -1,0 +1,331 @@
+//! Folding a pre-grouping backlog of per-alert tasks into remediation groups.
+//!
+//! The source tasks here are minted by the sweep itself, one alert at a time,
+//! which is exactly the shape a backlog swept before grouping still holds.
+
+use orbit_engine::RuntimeHost;
+use orbit_tools::ToolContext;
+use orbit_types::task::{TaskPriority, TaskStatus};
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+use crate::adapter::engine_host::v2_host::test_support::{
+    runtime_with_workspace_layout, write_workspace_file,
+};
+use crate::application::task::{TaskAddParams, TaskUpdateParams};
+
+use super::dependabot_alert_tasks::{code_alert, expanded_snapshot, file};
+
+const RECONCILE: &str = "crates/orbit-core/src/runtime/reconcile.rs";
+const SALT: &str = "The hard-coded value is used as a salt for this hash.";
+
+fn hash_alert(number: u64, line: u64) -> Value {
+    let mut alert = code_alert(number, "high");
+    alert["rule_id"] = json!("rust/hard-coded-cryptographic-value");
+    alert["rule_name"] = json!("Hard-coded cryptographic value");
+    alert["message"] = json!(SALT);
+    alert["path"] = json!(RECONCILE);
+    alert["start_line"] = json!(line);
+    alert["end_line"] = json!(line);
+    alert
+}
+
+/// Sweep one alert at a time so each lands as its own per-alert task, the way
+/// the sweep filed them before it grouped by shared cause.
+fn seed_per_alert_tasks(runtime: &OrbitRuntime, alerts: &[Value]) -> Vec<String> {
+    alerts
+        .iter()
+        .map(|alert| {
+            let output = file(
+                runtime,
+                expanded_snapshot(Vec::new(), vec![alert.clone()], Vec::new()),
+                json!({}),
+            );
+            assert_eq!(output["filed_count"], json!(1));
+            output["filed"][0]["task_id"]
+                .as_str()
+                .expect("task id")
+                .to_string()
+        })
+        .collect()
+}
+
+fn consolidate(runtime: &OrbitRuntime, input: Value) -> Value {
+    runtime
+        .run_deterministic(
+            "consolidate_code_scanning_tasks",
+            &json!({}),
+            &input,
+            ToolContext::default(),
+        )
+        .expect("consolidate code scanning tasks")
+}
+
+fn seeded_reconcile_backlog() -> (tempfile::TempDir, OrbitRuntime, Vec<String>) {
+    let (root, runtime, repo) = runtime_with_workspace_layout();
+    write_workspace_file(&repo, RECONCILE);
+    let sources = seed_per_alert_tasks(
+        &runtime,
+        &[
+            hash_alert(101, 118),
+            hash_alert(102, 246),
+            hash_alert(103, 426),
+        ],
+    );
+    (root, runtime, sources)
+}
+
+#[test]
+fn a_dry_run_names_the_exact_source_tasks_and_writes_nothing() {
+    let (_root, runtime, sources) = seeded_reconcile_backlog();
+    let before = runtime.list_tasks().expect("tasks").len();
+
+    let preview = consolidate(&runtime, json!({}));
+
+    assert_eq!(preview["outcome"], "dry_run");
+    assert_eq!(preview["group_count"], json!(1));
+    assert_eq!(preview["scanned_source_tasks"], json!(3));
+    assert_eq!(preview["groups"][0]["source_task_ids"], json!(sources));
+    assert_eq!(
+        preview["groups"][0]["alert_numbers"],
+        json!([101, 102, 103])
+    );
+    assert_eq!(preview["groups"][0]["paths"], json!([RECONCILE]));
+    assert_eq!(
+        preview["groups"][0]["rule_id"],
+        "rust/hard-coded-cryptographic-value"
+    );
+    assert_eq!(preview["groups"][0]["replacement_priority"], "high");
+    assert!(
+        preview["groups"][0]["replacement_title"]
+            .as_str()
+            .expect("replacement title")
+            .contains("3 locations")
+    );
+
+    assert_eq!(runtime.list_tasks().expect("tasks").len(), before);
+    for source in &sources {
+        assert_eq!(
+            runtime.get_task(source).expect("source").status,
+            TaskStatus::Backlog
+        );
+    }
+}
+
+#[test]
+fn apply_replaces_the_sources_and_carries_their_traceability_and_dependencies() {
+    let (_root, runtime, sources) = seeded_reconcile_backlog();
+    let blocker = runtime
+        .add_task(TaskAddParams {
+            title: "Land the shared salt helper".to_string(),
+            status: Some(TaskStatus::Backlog),
+            ..TaskAddParams::default()
+        })
+        .expect("seed blocker")
+        .id;
+    runtime
+        .update_task(
+            &sources[1],
+            TaskUpdateParams {
+                dependencies: Some(vec![blocker.clone()]),
+                ..TaskUpdateParams::default()
+            },
+        )
+        .expect("record a dependency on a source task");
+
+    let applied = consolidate(&runtime, json!({"apply": true}));
+
+    assert_eq!(applied["outcome"], "applied");
+    assert_eq!(applied["groups"][0]["applied"], json!(true));
+    assert_eq!(applied["groups"][0]["sources_not_retired"], json!([]));
+    assert_eq!(
+        applied["groups"][0]["carried_dependencies"],
+        json!([blocker])
+    );
+
+    let replacement_id = applied["groups"][0]["replacement_task_id"]
+        .as_str()
+        .expect("replacement task id");
+    let replacement = runtime.get_task(replacement_id).expect("replacement");
+    assert_eq!(replacement.status, TaskStatus::Backlog);
+    assert_eq!(replacement.priority, TaskPriority::High);
+    assert_eq!(replacement.dependencies(), vec![blocker]);
+    assert_eq!(replacement.context_files, vec![format!("file:{RECONCILE}")]);
+    for number in ["#101", "#102", "#103"] {
+        assert!(
+            replacement.description.contains(number),
+            "alert {number} lost from the ledger"
+        );
+    }
+    assert_eq!(
+        replacement
+            .tags
+            .iter()
+            .filter(|tag| tag.starts_with("code-scanning:"))
+            .count(),
+        3
+    );
+    assert!(
+        replacement
+            .relations
+            .iter()
+            .filter(|relation| relation.relation_type
+                == orbit_types::task::TaskRelationType::Supersedes)
+            .map(|relation| relation.target.clone())
+            .eq(sources.iter().cloned()),
+        "the replacement must supersede every source: {:?}",
+        replacement.relations
+    );
+
+    for source in &sources {
+        let retired = runtime.get_task(source).expect("source");
+        assert_eq!(retired.status, TaskStatus::Rejected);
+        let comments = runtime.get_task_comments(source).expect("comments");
+        assert!(
+            comments
+                .iter()
+                .any(|comment| comment.message.contains("covering task")
+                    && comment.message.contains(replacement_id)),
+            "a retired source must name its covering task: {comments:?}"
+        );
+    }
+}
+
+#[test]
+fn applying_twice_changes_nothing_and_the_next_sweep_files_nothing() {
+    let (_root, runtime, _sources) = seeded_reconcile_backlog();
+    let first = consolidate(&runtime, json!({"apply": true}));
+    assert_eq!(first["outcome"], "applied");
+    let after_first = runtime.list_tasks().expect("tasks").len();
+
+    let second = consolidate(&runtime, json!({"apply": true}));
+    assert_eq!(second["outcome"], "nothing_to_consolidate");
+    assert_eq!(second["groups"], json!([]));
+    assert_eq!(runtime.list_tasks().expect("tasks").len(), after_first);
+    assert!(
+        second["skipped"]
+            .as_array()
+            .expect("skipped")
+            .iter()
+            .any(|entry| entry["reason"] == "already_grouped")
+    );
+
+    let resweep = file(
+        &runtime,
+        expanded_snapshot(
+            Vec::new(),
+            vec![
+                hash_alert(101, 118),
+                hash_alert(102, 246),
+                hash_alert(103, 426),
+            ],
+            Vec::new(),
+        ),
+        json!({}),
+    );
+    assert_eq!(resweep["filed_count"], json!(0));
+    assert_eq!(
+        resweep["skipped_existing"]
+            .as_array()
+            .expect("skipped")
+            .len(),
+        3
+    );
+}
+
+#[test]
+fn started_deferred_and_unreadable_records_are_reported_and_left_alone() {
+    let (_root, runtime, sources) = seeded_reconcile_backlog();
+    runtime
+        .update_task(
+            &sources[0],
+            TaskUpdateParams {
+                status: Some(TaskStatus::InProgress),
+                ..TaskUpdateParams::default()
+            },
+        )
+        .expect("start a source task");
+    let running = runtime.get_task(&sources[0]).expect("running source");
+
+    let deferred = seed_per_alert_tasks(&runtime, &[hash_alert(104, 501)]).remove(0);
+    runtime
+        .update_task(
+            &deferred,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Someday),
+                ..TaskUpdateParams::default()
+            },
+        )
+        .expect("defer a source task");
+
+    let unreadable = runtime
+        .add_task(TaskAddParams {
+            title: "[code-scanning-sweep] Hand-edited record".to_string(),
+            description: "Somebody rewrote this record and dropped the evidence block.".to_string(),
+            tags: vec![
+                "code-scanning-sweep".to_string(),
+                "code-scanning:0123456789abcdef".to_string(),
+            ],
+            status: Some(TaskStatus::Backlog),
+            ..TaskAddParams::default()
+        })
+        .expect("seed an unreadable record")
+        .id;
+
+    let applied = consolidate(&runtime, json!({"apply": true}));
+
+    let reasons = applied["skipped"]
+        .as_array()
+        .expect("skipped")
+        .iter()
+        .map(|entry| {
+            (
+                entry["task_id"].as_str().unwrap_or_default().to_string(),
+                entry["reason"].as_str().unwrap_or_default().to_string(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert!(reasons.contains(&(sources[0].clone(), "active_work".to_string())));
+    assert!(reasons.contains(&(deferred.clone(), "deferred".to_string())));
+    assert!(reasons.contains(&(unreadable.clone(), "unparsable_evidence".to_string())));
+
+    // Only the two untouched backlog records were folded.
+    assert_eq!(
+        applied["groups"][0]["source_task_ids"],
+        json!([sources[1], sources[2]])
+    );
+    assert_eq!(applied["groups"][0]["alert_numbers"], json!([102, 103]));
+
+    let after = runtime.get_task(&sources[0]).expect("running source");
+    assert_eq!(after.status, TaskStatus::InProgress);
+    assert_eq!(after.description, running.description);
+    assert_eq!(after.tags, running.tags);
+    assert_eq!(
+        runtime.get_task(&deferred).expect("deferred").status,
+        TaskStatus::Someday
+    );
+    assert_eq!(
+        runtime.get_task(&unreadable).expect("unreadable").status,
+        TaskStatus::Backlog
+    );
+}
+
+#[test]
+fn a_lone_task_for_its_cause_is_reported_unchanged() {
+    let (_root, runtime, repo) = runtime_with_workspace_layout();
+    write_workspace_file(&repo, RECONCILE);
+    let mut other = hash_alert(200, 12);
+    other["message"] = json!("The hard-coded value is used as a key for this cipher.");
+    let sources = seed_per_alert_tasks(&runtime, &[hash_alert(101, 118), other]);
+
+    let preview = consolidate(&runtime, json!({}));
+
+    assert_eq!(preview["outcome"], "nothing_to_consolidate");
+    let unchanged = preview["unchanged_single_source"]
+        .as_array()
+        .expect("unchanged")
+        .iter()
+        .map(|entry| entry["task_id"].as_str().unwrap_or_default().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(unchanged, sources);
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/code_scanning_groups.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/code_scanning_groups.rs
@@ -1,0 +1,533 @@
+//! Code scanning alerts that share one repair become one bounded task.
+//!
+//! The fixtures are the incidents that motivated grouping: the three
+//! `reconcile.rs` hash/salt alerts one commit covered (F2026-09-105), the
+//! Antigravity and bootstrap alerts that both named the same
+//! `validate_trusted_host_activity` flow (F2026-09-093, F2026-09-097,
+//! F2026-09-101), and sibling scoreboard reads behind one path check.
+
+use orbit_types::task::{Task, TaskPriority, TaskStatus};
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+use crate::adapter::engine_host::v2_host::test_support::{
+    runtime_with_workspace_layout, write_workspace_file,
+};
+use crate::application::task::TaskUpdateParams;
+
+use super::dependabot_alert_tasks::{code_alert, expanded_snapshot, file};
+
+const RECONCILE: &str = "crates/orbit-core/src/runtime/reconcile.rs";
+const ANTIGRAVITY: &str = "crates/orbit-agent/src/providers/antigravity/antigravity_cli.rs";
+const BOOTSTRAP: &str = "crates/orbit-core/src/bootstrap/activity.rs";
+const SCOREBOARD: &str = "crates/orbit-core/src/runtime/scoreboard.rs";
+
+const SALT: &str = "The hard-coded value is used as a salt for this hash.";
+const TRUSTED_HOST: &str = "This expression logs sensitive data returned by validate_trusted_host_activity(...) as clear text.";
+const SCOREBOARD_READ: &str =
+    "This path depends on a user-provided value read from the scoreboard record.";
+
+/// One Code scanning alert with the rule, message and location that decide
+/// which repair it belongs to.
+fn scan_alert(number: u64, rule: &str, message: &str, path: &str, line: u64) -> Value {
+    severity_alert(number, rule, message, path, line, "high")
+}
+
+fn severity_alert(
+    number: u64,
+    rule: &str,
+    message: &str,
+    path: &str,
+    line: u64,
+    severity: &str,
+) -> Value {
+    let mut alert = code_alert(number, severity);
+    alert["rule_id"] = json!(rule);
+    alert["rule_name"] = json!(rule);
+    alert["message"] = json!(message);
+    alert["path"] = json!(path);
+    alert["start_line"] = json!(line);
+    alert["end_line"] = json!(line);
+    alert
+}
+
+fn sweep(runtime: &OrbitRuntime, alerts: Vec<Value>) -> Value {
+    file(
+        runtime,
+        expanded_snapshot(Vec::new(), alerts, Vec::new()),
+        json!({}),
+    )
+}
+
+fn filed_code_tasks(runtime: &OrbitRuntime, output: &Value) -> Vec<Task> {
+    output["filed"]
+        .as_array()
+        .expect("filed")
+        .iter()
+        .filter(|entry| entry["family"] == "code_scanning")
+        .map(|entry| {
+            let task_id = entry["task_id"].as_str().expect("task id");
+            runtime.get_task(task_id).expect("filed task")
+        })
+        .collect()
+}
+
+fn reconcile_hash_alerts() -> Vec<Value> {
+    vec![
+        scan_alert(
+            101,
+            "rust/hard-coded-cryptographic-value",
+            SALT,
+            RECONCILE,
+            118,
+        ),
+        scan_alert(
+            102,
+            "rust/hard-coded-cryptographic-value",
+            SALT,
+            RECONCILE,
+            246,
+        ),
+        scan_alert(
+            103,
+            "rust/hard-coded-cryptographic-value",
+            SALT,
+            RECONCILE,
+            426,
+        ),
+    ]
+}
+
+#[test]
+fn one_shared_cause_across_line_offsets_files_a_single_task_naming_every_alert() {
+    let (_root, runtime, repo) = runtime_with_workspace_layout();
+    write_workspace_file(&repo, RECONCILE);
+
+    let output = sweep(&runtime, reconcile_hash_alerts());
+
+    assert_eq!(output["filed_count"], json!(1));
+    assert_eq!(output["filed"][0]["alert_numbers"], json!([101, 102, 103]));
+    assert_eq!(output["filed"][0]["alert_count"], json!(3));
+    assert_eq!(output["filed"][0]["paths"], json!([RECONCILE]));
+
+    let task = filed_code_tasks(&runtime, &output).remove(0);
+    for alert in ["#101", "#102", "#103"] {
+        assert!(
+            task.description.contains(alert),
+            "alert {alert} missing from the ledger: {}",
+            task.description
+        );
+    }
+    for line in ["line 118", "line 246", "line 426"] {
+        assert!(task.description.contains(line), "location {line} missing");
+    }
+    // Coverage stays per alert: the group carries each member's generated key.
+    assert_eq!(
+        task.tags
+            .iter()
+            .filter(|tag| tag.starts_with("code-scanning:"))
+            .count(),
+        3
+    );
+    assert_eq!(task.context_files, vec![format!("file:{RECONCILE}")]);
+}
+
+#[test]
+fn one_cause_reported_in_two_files_is_still_one_repair() {
+    let (_root, runtime, repo) = runtime_with_workspace_layout();
+    write_workspace_file(&repo, ANTIGRAVITY);
+    write_workspace_file(&repo, BOOTSTRAP);
+
+    let output = sweep(
+        &runtime,
+        vec![
+            scan_alert(15, "rust/cleartext-logging", TRUSTED_HOST, ANTIGRAVITY, 162),
+            scan_alert(16, "rust/cleartext-logging", TRUSTED_HOST, BOOTSTRAP, 238),
+        ],
+    );
+
+    assert_eq!(output["filed_count"], json!(1));
+    assert_eq!(output["filed"][0]["alert_numbers"], json!([15, 16]));
+
+    let task = filed_code_tasks(&runtime, &output).remove(0);
+    assert!(
+        task.title.contains("2 locations across 2 files"),
+        "{}",
+        task.title
+    );
+    assert_eq!(
+        task.context_files,
+        vec![format!("file:{ANTIGRAVITY}"), format!("file:{BOOTSTRAP}")]
+    );
+}
+
+#[test]
+fn sibling_reads_behind_one_check_group_and_take_the_highest_severity() {
+    let (_root, runtime, repo) = runtime_with_workspace_layout();
+    write_workspace_file(&repo, SCOREBOARD);
+
+    let output = sweep(
+        &runtime,
+        vec![
+            severity_alert(
+                20,
+                "rust/path-injection",
+                SCOREBOARD_READ,
+                SCOREBOARD,
+                44,
+                "high",
+            ),
+            severity_alert(
+                21,
+                "rust/path-injection",
+                SCOREBOARD_READ,
+                SCOREBOARD,
+                51,
+                "critical",
+            ),
+        ],
+    );
+
+    assert_eq!(output["filed_count"], json!(1));
+    let task = filed_code_tasks(&runtime, &output).remove(0);
+    assert_eq!(task.priority, TaskPriority::Critical);
+    assert!(
+        task.description
+            .contains("Highest open security severity: `critical`")
+    );
+}
+
+#[test]
+fn unrelated_findings_in_one_file_and_similar_messages_stay_separate() {
+    let (_root, runtime, repo) = runtime_with_workspace_layout();
+    write_workspace_file(&repo, RECONCILE);
+
+    let output = sweep(
+        &runtime,
+        vec![
+            // Same file, same rule, but a different construct to repair.
+            scan_alert(
+                30,
+                "rust/hard-coded-cryptographic-value",
+                SALT,
+                RECONCILE,
+                118,
+            ),
+            scan_alert(
+                31,
+                "rust/hard-coded-cryptographic-value",
+                "The hard-coded value is used as a key for this cipher.",
+                RECONCILE,
+                140,
+            ),
+            // The same sentence under a different rule is a different repair.
+            scan_alert(32, "rust/insecure-hash", SALT, RECONCILE, 118),
+        ],
+    );
+
+    assert_eq!(output["filed_count"], json!(3));
+    let numbers = output["filed"]
+        .as_array()
+        .expect("filed")
+        .iter()
+        .map(|entry| entry["alert_numbers"].clone())
+        .collect::<Vec<_>>();
+    assert_eq!(numbers, vec![json!([30]), json!([31]), json!([32])]);
+}
+
+#[test]
+fn a_different_analysis_of_the_same_rule_and_message_is_not_grouped() {
+    let (_root, runtime, repo) = runtime_with_workspace_layout();
+    write_workspace_file(&repo, RECONCILE);
+
+    let mut other_tool = scan_alert(
+        41,
+        "rust/hard-coded-cryptographic-value",
+        SALT,
+        RECONCILE,
+        246,
+    );
+    other_tool["tool_guid"] = json!("a-different-analysis");
+
+    let output = sweep(
+        &runtime,
+        vec![
+            scan_alert(
+                40,
+                "rust/hard-coded-cryptographic-value",
+                SALT,
+                RECONCILE,
+                118,
+            ),
+            other_tool,
+        ],
+    );
+
+    assert_eq!(output["filed_count"], json!(2));
+}
+
+#[test]
+fn repeating_and_reordering_a_snapshot_files_nothing_further() {
+    let (_root, runtime, repo) = runtime_with_workspace_layout();
+    write_workspace_file(&repo, RECONCILE);
+
+    let first = sweep(&runtime, reconcile_hash_alerts());
+    assert_eq!(first["filed_count"], json!(1));
+    let before = runtime.list_tasks().expect("tasks").len();
+
+    let repeated = sweep(&runtime, reconcile_hash_alerts());
+    assert_eq!(repeated["filed_count"], json!(0));
+
+    let mut reordered = reconcile_hash_alerts();
+    reordered.reverse();
+    let out_of_order = sweep(&runtime, reordered);
+    assert_eq!(out_of_order["filed_count"], json!(0));
+    assert_eq!(
+        out_of_order["skipped_existing"]
+            .as_array()
+            .expect("skipped")
+            .len(),
+        3
+    );
+
+    assert_eq!(runtime.list_tasks().expect("tasks").len(), before);
+}
+
+#[test]
+fn a_new_alert_on_a_covered_cause_is_attributed_delta_work() {
+    let (_root, runtime, repo) = runtime_with_workspace_layout();
+    write_workspace_file(&repo, RECONCILE);
+
+    let mut alerts = reconcile_hash_alerts();
+    let late = alerts.pop().expect("third alert");
+    let first = sweep(&runtime, alerts.clone());
+    assert_eq!(first["filed_count"], json!(1));
+    let covering_id = first["filed"][0]["task_id"]
+        .as_str()
+        .expect("covering task id")
+        .to_string();
+
+    // Somebody picked the covering task up before the next scan landed.
+    runtime
+        .update_task(
+            &covering_id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::InProgress),
+                ..TaskUpdateParams::default()
+            },
+        )
+        .expect("start the covering task");
+    let running = runtime.get_task(&covering_id).expect("covering task");
+
+    alerts.push(late);
+    let delta = sweep(&runtime, alerts);
+
+    assert_eq!(delta["filed_count"], json!(1));
+    assert_eq!(delta["filed"][0]["alert_numbers"], json!([103]));
+    assert_eq!(
+        delta["filed"][0]["delta_covered_by"],
+        json!([
+            {"alert_number": 101, "task_id": covering_id},
+            {"alert_number": 102, "task_id": covering_id},
+        ])
+    );
+
+    // The running task is reported, not rewritten.
+    let after = runtime.get_task(&covering_id).expect("covering task");
+    assert_eq!(after.description, running.description);
+    assert_eq!(after.tags, running.tags);
+    assert_eq!(after.acceptance_criteria, running.acceptance_criteria);
+
+    let delta_task = filed_code_tasks(&runtime, &delta).remove(0);
+    assert!(delta_task.description.contains("Already covered elsewhere"));
+    assert!(delta_task.description.contains(&covering_id));
+    assert!(
+        delta_task
+            .tags
+            .iter()
+            .filter(|tag| tag.starts_with("code-scanning:"))
+            .count()
+            == 1,
+        "a delta task must claim only the alerts it owns: {:?}",
+        delta_task.tags
+    );
+}
+
+#[test]
+fn a_partial_fix_leaves_the_still_reported_alert_visible() {
+    let (_root, runtime, repo) = runtime_with_workspace_layout();
+    write_workspace_file(&repo, RECONCILE);
+
+    let first = sweep(&runtime, reconcile_hash_alerts());
+    let group_id = first["filed"][0]["task_id"]
+        .as_str()
+        .expect("group task id")
+        .to_string();
+    runtime
+        .update_task(
+            &group_id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Done),
+                ..TaskUpdateParams::default()
+            },
+        )
+        .expect("close the group task");
+
+    // Two locations are gone from the next scan; one is still real.
+    let remaining = sweep(
+        &runtime,
+        vec![scan_alert(
+            103,
+            "rust/hard-coded-cryptographic-value",
+            SALT,
+            RECONCILE,
+            426,
+        )],
+    );
+
+    assert_eq!(
+        remaining["filed_count"],
+        json!(1),
+        "a completed group must not suppress an alert the scanner still reports"
+    );
+    assert_eq!(remaining["filed"][0]["alert_numbers"], json!([103]));
+}
+
+#[test]
+fn every_group_carries_bounded_scope_and_a_per_alert_disposition_contract() {
+    let (_root, runtime, repo) = runtime_with_workspace_layout();
+    write_workspace_file(&repo, RECONCILE);
+
+    let output = sweep(&runtime, reconcile_hash_alerts());
+    assert_eq!(
+        output["code_scanning_group_bounds"],
+        json!({"max_alerts": 12, "max_paths": 5})
+    );
+
+    let task = filed_code_tasks(&runtime, &output).remove(0);
+    let disposition = task
+        .acceptance_criteria
+        .iter()
+        .find(|criterion| criterion.contains("already-covered"))
+        .expect("per-alert disposition criterion");
+    assert!(disposition.contains("ancestor of the HEAD you validated"));
+    assert!(disposition.contains("never present another task's commit as this task's own change"));
+
+    let validation = task
+        .acceptance_criteria
+        .iter()
+        .find(|criterion| criterion.contains("hosted rescan"))
+        .expect("hosted closure criterion");
+    assert!(validation.contains("Report source-side coverage and hosted alert closure separately"));
+
+    assert!(
+        task.acceptance_criteria
+            .iter()
+            .any(|criterion| criterion.contains("do not suppress"))
+    );
+}
+
+#[test]
+fn a_cause_larger_than_the_bounds_splits_into_executable_groups() {
+    let (_root, runtime, _repo) = runtime_with_workspace_layout();
+
+    let by_alert_count = (1..=14)
+        .map(|index| {
+            scan_alert(
+                index,
+                "rust/hard-coded-cryptographic-value",
+                SALT,
+                RECONCILE,
+                100 + index,
+            )
+        })
+        .collect::<Vec<_>>();
+    let output = sweep(&runtime, by_alert_count);
+    assert_eq!(output["filed_count"], json!(2));
+    assert_eq!(output["filed"][0]["alert_count"], json!(12));
+    assert_eq!(output["filed"][1]["alert_count"], json!(2));
+
+    let (_root, runtime, _repo) = runtime_with_workspace_layout();
+    let by_path_count = (1..=6)
+        .map(|index| {
+            scan_alert(
+                index,
+                "rust/cleartext-logging",
+                TRUSTED_HOST,
+                &format!("crates/orbit-core/src/file_{index}.rs"),
+                10,
+            )
+        })
+        .collect::<Vec<_>>();
+    let output = sweep(&runtime, by_path_count);
+    assert_eq!(output["filed_count"], json!(2));
+    assert_eq!(
+        output["filed"][0]["paths"].as_array().expect("paths").len(),
+        5
+    );
+    assert_eq!(
+        output["filed"][1]["paths"].as_array().expect("paths").len(),
+        1
+    );
+}
+
+/// The before/after count grouping exists to move: one representative
+/// snapshot of seven alerts that today's per-alert sweep would file as seven
+/// tasks.
+#[test]
+fn a_representative_snapshot_files_three_tasks_instead_of_seven() {
+    let (_root, runtime, repo) = runtime_with_workspace_layout();
+    for path in [RECONCILE, ANTIGRAVITY, BOOTSTRAP, SCOREBOARD] {
+        write_workspace_file(&repo, path);
+    }
+
+    let mut alerts = reconcile_hash_alerts();
+    alerts.push(scan_alert(
+        15,
+        "rust/cleartext-logging",
+        TRUSTED_HOST,
+        ANTIGRAVITY,
+        162,
+    ));
+    alerts.push(scan_alert(
+        16,
+        "rust/cleartext-logging",
+        TRUSTED_HOST,
+        BOOTSTRAP,
+        238,
+    ));
+    alerts.push(scan_alert(
+        20,
+        "rust/path-injection",
+        SCOREBOARD_READ,
+        SCOREBOARD,
+        44,
+    ));
+    alerts.push(scan_alert(
+        21,
+        "rust/path-injection",
+        SCOREBOARD_READ,
+        SCOREBOARD,
+        51,
+    ));
+    let alert_count = alerts.len();
+
+    assert_eq!(runtime.list_tasks().expect("tasks").len(), 0);
+    let output = sweep(&runtime, alerts);
+
+    assert_eq!(alert_count, 7);
+    assert_eq!(output["filed_count"], json!(3));
+    assert_eq!(runtime.list_tasks().expect("tasks").len(), 3);
+    assert_eq!(
+        filed_code_tasks(&runtime, &output)
+            .iter()
+            .map(|task| task
+                .tags
+                .iter()
+                .filter(|tag| tag.starts_with("code-scanning:"))
+                .count())
+            .sum::<usize>(),
+        alert_count,
+        "every alert must remain covered by exactly one group"
+    );
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dependabot_alert_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dependabot_alert_tasks.rs
@@ -434,7 +434,7 @@ fn code_scanning_severity_floor_excludes_lower_severity_alerts() {
     );
 
     assert_eq!(output["filed_count"], json!(1));
-    assert_eq!(output["filed"][0]["alert_number"], json!(11));
+    assert_eq!(output["filed"][0]["alert_numbers"], json!([11]));
     assert_eq!(
         output["excluded_below_min_severity"],
         json!([{

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
@@ -4,6 +4,8 @@ mod ci_failure_admission;
 mod ci_failure_cancelled;
 mod ci_failure_tasks;
 mod cli_executor;
+mod code_scanning_consolidation;
+mod code_scanning_groups;
 mod dependabot_alert_tasks;
 mod dispatch;
 mod leaf_occupancy;

--- a/crates/orbit-core/src/runtime/assets.rs
+++ b/crates/orbit-core/src/runtime/assets.rs
@@ -34,6 +34,10 @@ pub(crate) const DEFAULT_ACTIVITY_FILES: &[(&str, &str)] = &[
         include_str!("../../assets/activities/collect_dependabot_alerts.yaml"),
     ),
     (
+        "consolidate_code_scanning_tasks",
+        include_str!("../../assets/activities/consolidate_code_scanning_tasks.yaml"),
+    ),
+    (
         "drain_window",
         include_str!("../../assets/activities/drain_window.yaml"),
     ),

--- a/crates/orbit-types/src/workflow/activity_job/mod.rs
+++ b/crates/orbit-types/src/workflow/activity_job/mod.rs
@@ -22,6 +22,7 @@ macro_rules! deterministic_action_catalog {
                 ApplyTriageDispositions => "apply_triage_dispositions",
                 ApplyTaskPilotResults => "apply_task_pilot_results",
                 ClassifyWorkspaceAutoTasks => "classify_workspace_auto_tasks",
+                ConsolidateCodeScanningTasks => "consolidate_code_scanning_tasks",
                 ContextConflictCheck => "context_conflict_check",
                 DrainWindow => "drain_window",
                 FileCiFailureTasks => "file_ci_failure_tasks",


### PR DESCRIPTION
## Task

[ORB-11975](https://orbit-cli.com/tasks/ORB-11975) — Group code-scanning alerts into bounded remediation tasks with per-alert coverage

### Description

## Problem and evidence
The sweep creates one task per alert even when multiple locations share one repair. F2026-09-105 describes three reconcile.rs HashSet alerts covered by ORB-11940; Antigravity reports point to the same TrustedHostActivityError repair in ORB-11826; scoreboard findings span related reads. Current dependabot_alert_tasks/duplicates.rs fingerprints code findings by alert number plus rule/path/location, so changed alert instances are not grouped by repair. Existing open records include numerous separate sibling findings. Daniel explicitly prefers logical chunks instead of hundreds of per-alert tasks.

Source frictions: F2026-09-084, F2026-09-086, F2026-09-087, F2026-09-088, F2026-09-089, F2026-09-090, F2026-09-091, F2026-09-092, F2026-09-093, F2026-09-094, F2026-09-095, F2026-09-097, F2026-09-098, F2026-09-101, F2026-09-105.
Audit source baseline: owning Linux checkout e4f9098633a8876a5a7c233d9914a094b6efa858, inspected 2026-09-10. Incident reports are historical evidence; no production failure was induced during this audit.

## Proposed solution
Replace per-alert task minting for code scanning with bounded logical remediation groups. Group by evidence-supported shared data flow/root cause and a coherent code owner or repair surface, using stable alert/fingerprint identities and scan provenance. Rule/path/message similarity alone is a candidate signal, not proof of common repair. Preserve a per-alert evidence ledger (repository, alert ID/URL, rule, severity, analyzed commit, source/sink, location) and an explicit per-alert disposition/check. Bound group size and scope so one leaf task remains executable; split unrelated causes even in the same file. Derive priority from the highest unresolved severity. Compare against pending groups and delivered covering tasks, including current ancestry/scan evidence, before creating or admitting another group. Represent new alerts as explicit delta work without silently widening an in-flight task. Provide a safe, idempotent consolidation preview/apply path for existing unstarted per-alert tasks that preserves IDs/evidence/relations; active work is never silently cancelled or rewritten. A clean checkout already covered by another task needs an explicit provenance-checked reconciliation outcome, not a synthetic commit or a claim that every open alert is fixed. Keep hosted scan closure distinct from source coverage. This task implements the grouping behavior and migration mechanism; do not bulk-mutate the live backlog during implementation.

## Scope and delivery
Create a validated task-scoped candidate from agent-main in a dedicated worktree. Preserve existing failed-run and friction evidence. This filing does not authorize dispatch, merge, release, production configuration changes or live backlog consolidation. Complexity hard; crew sol follows the configured lane. Existing task inventory and targeted searches were checked for covering work.

### Acceptance Criteria

- A fixture containing multiple alert IDs/line offsets for one validated shared cause yields one remediation task with every alert represented; unrelated findings in the same file and unrelated causes with similar messages remain separate.
- Repeated identical and reordered snapshots are idempotent; a new scan/alert delta is attributed and does not create another task for already covered work or silently expand a running task.
- Tests cover same-cause Antigravity/trusted-host, reconcile HashSet and scoreboard sibling-read examples, including a partial fix where one alert remains real and must not be suppressed.
- Each group has bounded scope, severity-derived priority and per-alert evidence/acceptance outcomes. A no-change reconciliation verifies covering task/commit ancestry and current evidence without forging same-task ownership or marking unverified hosted alerts closed.
- A dry-run consolidation lists exact pending source tasks and replacement groups; explicit apply preserves traceability and dependencies, is repeat-safe, and leaves running tasks untouched.
- Run sweep/dedup/admission regressions and normal repository gates; include before/after task counts for a deterministic representative alert snapshot.

## Execution Summary

<details>
<summary>Click to expand</summary>

Code scanning alerts now file as bounded logical remediation groups with per-alert coverage, plus a preview/apply consolidation path for the pre-grouping backlog. Changes are uncommitted in worktree orbit-jrun-20260910-0322-24 at HEAD 00f35560b660e7fc510504fba0609abb3ae04bac.

## What changed

- New `dependabot_alert_tasks/code_groups.rs`. A cause signature is the conjunction of scan provenance (tool name + guid + analyzed ref), `rule_id`, and the canonicalized scanner message; no single one of those decides. Line/column offsets are excluded, which is what collapses sibling locations of one data flow. Groups are bounded at 12 alerts and 5 distinct paths and split deterministically (ordered by path, then line, then alert number) so one leaf task stays executable. Priority is the highest member severity; scope is the union of resolvable alert paths.
- `dependabot_alert_tasks.rs` code-scanning loop: coverage is still decided one alert at a time through the unchanged `code_duplicate_candidate` / `find_covering_task` path and the unchanged generated key, so existing per-alert tasks keep covering their alert with no migration. Only uncovered alerts are grouped. A group task carries every member's per-alert key. All duplicate lookups still complete before the first write.
- Delta attribution: covered alerts are removed before grouping, so a newly reported sibling of a covered cause files a task scoped to just the new alerts, related to the covering task, with `filed[].delta_covered_by`. No existing task is mutated by the sweep.
- Per-alert contract in minted tasks: a per-alert evidence ledger (repository, alert id/URL, rule, severity, tool, ref, analyzed commit, location, message) and acceptance criteria requiring one disposition per alert — `fixed`, `already-covered` (must name the covering commit, show ancestry from the validated HEAD and cite current source; must not present another task's commit as its own or manufacture a commit), or `not-reproducible-in-source` — plus a criterion keeping hosted alert closure distinct from source coverage. This is the direct answer to F2026-09-097/101/105.
- New `consolidate_code_scanning_tasks` deterministic action (`dependabot_alert_tasks/consolidate.rs`, activity asset, catalog, assets table, dispatch). Dry run by default. Only proposed/backlog tasks with exactly one parseable `## Alert evidence` record are candidates; active, deferred, already-grouped and unreadable records are reported with a reason and untouched. Apply mints the replacement (per-alert keys, union of dependencies and scope, `supersedes` to each source) and retires each source via `reject_task` with a "covering task <id>" comment the existing confirmed-duplicate path already reads. Sources are re-classified immediately before minting and a group whose sources moved is abandoned whole.

## Criteria

1. Multiple alert IDs/offsets for one cause -> one task with every alert: `one_shared_cause_across_line_offsets_files_a_single_task_naming_every_alert` (3 reconcile.rs hash/salt alerts -> 1 task, 3 alert keys, all three lines in the ledger). Separation: `unrelated_findings_in_one_file_and_similar_messages_stay_separate` (same file+rule, different message -> split; same message, different rule -> split) and `a_different_analysis_of_the_same_rule_and_message_is_not_grouped`.
2. Idempotent/reordered + attributed delta: `repeating_and_reordering_a_snapshot_files_nothing_further` (0 filed both times, task count unchanged) and `a_new_alert_on_a_covered_cause_is_attributed_delta_work` (covering task moved to in-progress, delta task claims only alert 103, and the running task's description/tags/criteria are byte-identical afterwards).
3. Antigravity/trusted-host (`one_cause_reported_in_two_files_is_still_one_repair`), reconcile HashSet (above), scoreboard sibling reads (`sibling_reads_behind_one_check_group_and_take_the_highest_severity`), partial fix (`a_partial_fix_leaves_the_still_reported_alert_visible` — a Done group does not suppress the alert still reported).
4. Bounds/priority/disposition: `every_group_carries_bounded_scope_and_a_per_alert_disposition_contract`, `a_cause_larger_than_the_bounds_splits_into_executable_groups` (14 alerts -> 12+2; 6 paths -> 5+1), severity-derived priority asserted in the scoreboard test. The no-change reconciliation is delivered as the minted task's disposition contract (ancestry-checked `already-covered`, no forged same-task ownership, no unverified hosted closure), not as a change to the pipeline's already-landed artifact contract — see deviations.
5. `a_dry_run_names_the_exact_source_tasks_and_writes_nothing`, `apply_replaces_the_sources_and_carries_their_traceability_and_dependencies`, `applying_twice_changes_nothing_and_the_next_sweep_files_nothing`, `started_deferred_and_unreadable_records_are_reported_and_left_alone`.
6. Counts below; commands below.

## Before/after counts (deterministic representative snapshot)

`a_representative_snapshot_files_three_tasks_instead_of_seven`: 7 code-scanning alerts (3 reconcile.rs hash/salt, 2 trusted-host across two files, 2 scoreboard reads) filed 7 tasks before this change and file 3 now, with all 7 alerts still covered by exactly one group each (asserted). Consolidation fixture: 3 pending per-alert tasks -> 1 replacement plus 3 rejected sources, and the following sweep files 0.

## Validation

- `cargo test -p orbit-core` — passed (1296 + 55 across integration binaries; 0 failed). Includes the 18 `sweep_duplicate_tasks` dedupe regressions, the 16 existing sweep tests, the activity-catalog tests, and `every_declared_deterministic_action_reaches_an_implementation` (covers the new action).
- `make ci-fast` — passed (exit 0), including the activity-asset mirror, error-translation, orphan-module and redaction guards. `test-compiler-cache-namespaces` self-skips: bwrap cannot create a user namespace on this kernel; unrelated to this change.
- `make ci-lint` — passed (exit 0), workspace-wide all-target clippy with warnings denied.
- `cargo check --workspace --all-targets` — passed.
- `git diff --check` clean; `git status --short` shows only the 7 modified and 5 new files listed in context_files. No build artifacts in the patch.
- Not run: `make ci` (per workspace policy it is the PR merge gate, not a per-task local run). No live backlog was consolidated — the task explicitly forbids it, and every consolidation test runs against a temp-dir runtime.

## Deviations and risks

- One assertion in an existing test changed: `filed[0].alert_number` became `filed[0].alert_numbers` for the code-scanning family, since a filed entry now describes a group. Dependabot and secret-scanning entries are unchanged.
- Single-alert groups keep the existing `## Alert evidence` block verbatim; the consolidation parser depends on that shape, so those bullet keys are now a parsed contract and are documented as such next to the renderer. The four new acceptance criteria and the disposition section are additive.
- Sweep suppression still comes only from open tasks: delivered (done) covering tasks deliberately do not suppress a current alert, which the existing `a_done_manual_repair_does_not_hide_a_later_recurrence` regression pins. Rather than reverse that invariant, the "current ancestry/scan evidence" requirement is carried into the minted task's `already-covered` disposition. Making the execution pipeline accept a cross-task covering commit (the other half of F2026-09-105) is out of this task's scope and remains open.
- Cause grouping errs toward splitting: a scanner that words the same finding differently across instances yields separate tasks, i.e. today's behavior, rather than risking a false merge of unrelated repairs.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11975-6aa22286`
- Behind base: 0
- Ahead of base: 1