### PR TITLE
Close the remaining dynamic denyRead gap after Landlock integration

### DIFF
--- a/crates/orbit-exec/src/lib.rs
+++ b/crates/orbit-exec/src/lib.rs
@@ -49,8 +49,8 @@ mod supervision;
 
 pub use linux_landlock::{
     HOST_READ_ENV_VARS, LandlockGrant, LandlockPathGrant, LandlockProbeOutcome,
-    MINIMUM_LANDLOCK_ABI, grants_read, landlock_unavailable_message, linux_landlock_grants,
-    probe_landlock, spawn_under_linux_landlock,
+    LandlockReadBoundary, MINIMUM_LANDLOCK_ABI, grants_read, landlock_unavailable_message,
+    linux_landlock_read_boundary, probe_landlock, spawn_under_linux_landlock,
 };
 pub use linux_sandbox::{
     BwrapProbeOutcome, LINUX_STABLE_BUILD_MOUNT, LINUX_STABLE_WORKSPACE_MOUNT, LinuxBwrapPlan,

--- a/crates/orbit-exec/src/linux_landlock/mod.rs
+++ b/crates/orbit-exec/src/linux_landlock/mod.rs
@@ -25,11 +25,22 @@
 //! move a denied file into a fully readable sibling directory and read it
 //! there. See [`workspace`] for how denied paths are carved out.
 //!
-//! # Limits
-//! Landlock rules bind to the inodes that exist when the ruleset is compiled.
-//! A file that appears *later* under an already-granted directory inherits
-//! that directory's access. See [`workspace::grant_read_tree`] for exactly
-//! what that does and does not expose.
+//! # What the ruleset does not cover
+//! Landlock rules bind to inodes, so the ruleset cannot single out a *name*
+//! that does not exist yet. The compiler answers that by asking what the
+//! profile's exclusions can name rather than what they currently match: a
+//! directory a bounded exclusion reaches into is granted list-only, so a name
+//! created there afterwards has no readable ancestor. An exclusion whose reach
+//! crosses directories (`**/.env`) reaches every directory in the workspace,
+//! and carving that out would leave the run unable to read the files it
+//! produces itself. Those rules are reported on
+//! [`LandlockReadBoundary::unenforced_exclusions`] instead of being enforced
+//! or quietly dropped. [`workspace`] carries the full reasoning.
+//!
+//! The boundary also governs acquisition rather than naming: an inode the
+//! ruleset already grants keeps that grant through a rename or hard link into
+//! a denied name, and bytes already read, mapped, or held on an open
+//! descriptor cannot be withdrawn by any later rule.
 
 mod host;
 mod workspace;
@@ -42,6 +53,7 @@ use std::path::{Path, PathBuf};
 use std::process::Child;
 
 use orbit_common::OrbitError;
+use orbit_common::tracing;
 use orbit_types::policy::ResolvedFsProfile;
 
 use crate::runner::{EnvironmentMode, ExecRequest};
@@ -153,17 +165,32 @@ pub fn landlock_unavailable_message(probe: &LandlockProbeOutcome) -> String {
     )
 }
 
+/// The compiled read boundary for one profile: what the child may read, and
+/// which of the profile's exclusions the kernel is not holding for it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LandlockReadBoundary {
+    /// Every path grant the ruleset will carry.
+    pub grants: Vec<LandlockPathGrant>,
+    /// Read exclusions this backend cannot enforce for a path that does not
+    /// exist yet, as written in the profile.
+    ///
+    /// Reported rather than dropped so no layer describes the boundary as
+    /// whole-contract enforcement. These rules keep their full effect in the
+    /// request-time policy check, which decides a concrete path.
+    pub unenforced_exclusions: Vec<String>,
+}
+
 /// Compile every path grant a confined child needs: the host paths its own
 /// runtime requires, and the workspace paths the resolved profile allows.
 ///
 /// `environment` is the child's own environment, which is what names the tool
 /// state directories in [`HOST_READ_ENV_VARS`]. Nothing outside those grants
 /// is readable.
-pub fn linux_landlock_grants(
+pub fn linux_landlock_read_boundary(
     workspace_root: &Path,
     profile: &ResolvedFsProfile,
     environment: &[(String, String)],
-) -> Result<Vec<LandlockPathGrant>, OrbitError> {
+) -> Result<LandlockReadBoundary, OrbitError> {
     let workspace_root = workspace_root.canonicalize().map_err(|error| {
         OrbitError::InvalidInput(format!(
             "landlock workspace `{}` must exist and resolve canonically: {error}",
@@ -171,9 +198,14 @@ pub fn linux_landlock_grants(
         ))
     })?;
 
+    let workspace = workspace::workspace_read_grants(&workspace_root, profile)?;
     let mut grants = host::host_read_grants(environment);
-    grants.extend(workspace::workspace_read_grants(&workspace_root, profile)?);
-    Ok(dedupe(grants))
+    grants.extend(workspace.grants);
+
+    Ok(LandlockReadBoundary {
+        grants: dedupe(grants),
+        unenforced_exclusions: workspace.unenforced_exclusions,
+    })
 }
 
 /// Spawn `req` with the child restricted to the compiled ruleset.
@@ -193,9 +225,30 @@ pub fn spawn_under_linux_landlock(
     }
 
     let environment = child_environment(req);
-    let mut grants = linux_landlock_grants(workspace_root, profile, &environment)?;
+    let boundary = linux_landlock_read_boundary(workspace_root, profile, &environment)?;
+    report_unenforced_exclusions(profile, &boundary);
+
+    let mut grants = boundary.grants;
     grants.extend(host::program_grants(&req.program, &environment));
     spawn_restricted(req, &dedupe(grants))
+}
+
+/// Record the part of the profile the kernel is not holding for this child.
+///
+/// A boundary that quietly enforces less than the profile asks for is the
+/// failure this module exists to avoid, so the gap is stated once per spawn
+/// where an operator reading the run can see it.
+fn report_unenforced_exclusions(profile: &ResolvedFsProfile, boundary: &LandlockReadBoundary) {
+    if boundary.unenforced_exclusions.is_empty() {
+        return;
+    }
+    tracing::warn!(
+        target: "orbit.sandbox.landlock",
+        profile = profile.name.as_str(),
+        exclusions = boundary.unenforced_exclusions.join(" ").as_str(),
+        "landlock cannot enforce these read exclusions for paths that do not exist yet; \
+         they remain enforced at request time",
+    );
 }
 
 /// The environment the child will actually run with, which decides the tool

--- a/crates/orbit-exec/src/linux_landlock/tests/workspace.rs
+++ b/crates/orbit-exec/src/linux_landlock/tests/workspace.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 
 use orbit_types::policy::ResolvedFsProfile;
 
-use crate::linux_landlock::{LandlockPathGrant, grants_read, linux_landlock_grants};
+use crate::linux_landlock::{LandlockPathGrant, grants_read, linux_landlock_read_boundary};
 
 const DEFAULT_DENY_READ: &[&str] = &["**/.env", "**/.env.*", "**/*.env", "**/*.env.*"];
 
@@ -24,7 +24,9 @@ fn profile(read: &[&str], denies: &[&str]) -> ResolvedFsProfile {
 }
 
 fn compile(workspace: &Path, profile: &ResolvedFsProfile) -> Vec<LandlockPathGrant> {
-    linux_landlock_grants(workspace, profile, &[]).expect("compile grants")
+    linux_landlock_read_boundary(workspace, profile, &[])
+        .expect("compile grants")
+        .grants
 }
 
 #[test]
@@ -136,4 +138,127 @@ fn grant_compilation_stays_within_budget_on_a_large_workspace() {
         "compiling grants for {} files took {elapsed:?}, over the {BUDGET:?} budget",
         DIRECTORIES * FILES_PER_DIRECTORY
     );
+}
+
+/// The gap this module closed: a bounded exclusion has to shape the ruleset
+/// even when nothing matches it yet, or the same profile enforces a secret
+/// that already exists and hands over the identical secret written a moment
+/// after the ruleset was compiled. [F2026-09-054]
+#[test]
+fn a_directory_a_deny_rule_can_still_name_into_is_not_granted_as_a_tree() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    fs::create_dir(workspace.path().join("src")).expect("mkdir src");
+    fs::write(workspace.path().join("src/main.rs"), "code").expect("write allowed");
+
+    let grants = compile(workspace.path(), &profile(&["**"], &["secrets/**"]));
+
+    // `secrets/` does not exist, so nothing is carved out of the tree that
+    // exists — but the root can still gain it.
+    let appears_later = workspace.path().join("secrets/token.txt");
+    assert!(!grants_read(&grants, &appears_later), "{grants:?}");
+    assert!(
+        !grants_read(&grants, &workspace.path().join("root-generated.txt")),
+        "{grants:?}"
+    );
+}
+
+/// The cost of that carve-out has to stay where the rule points. A directory
+/// the exclusion cannot name into keeps its whole-tree grant, which is what
+/// lets a build read the files it produces.
+#[test]
+fn a_directory_out_of_reach_keeps_its_tree_grant() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    fs::create_dir(workspace.path().join("src")).expect("mkdir src");
+    fs::write(workspace.path().join("src/main.rs"), "code").expect("write allowed");
+
+    let grants = compile(workspace.path(), &profile(&["**"], &["secrets/**"]));
+
+    let generated = workspace.path().join("src/build.out");
+    assert!(grants_read(&grants, &generated), "{grants:?}");
+    assert!(
+        grants_read(&grants, &workspace.path().join("src/main.rs")),
+        "{grants:?}"
+    );
+}
+
+/// A `*` cannot cross a separator, so it narrows the reach to one level rather
+/// than opening the whole subtree.
+#[test]
+fn a_segment_wildcard_reaches_only_the_directory_it_names() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    fs::create_dir_all(workspace.path().join("config/nested")).expect("mkdir config/nested");
+    fs::write(workspace.path().join("config/nested/app.key"), "k").expect("write nested");
+
+    let grants = compile(workspace.path(), &profile(&["**"], &["config/*.key"]));
+
+    assert!(
+        !grants_read(&grants, &workspace.path().join("config/app.key")),
+        "{grants:?}"
+    );
+    assert!(
+        grants_read(&grants, &workspace.path().join("config/nested/app.key")),
+        "{grants:?}"
+    );
+}
+
+/// An exclusion whose `**` crosses directories can name a path beneath every
+/// directory in the workspace. Carving that out would withdraw read access
+/// from every generated file, so it is reported instead of enforced — and
+/// reporting it is what stops another layer describing this boundary as
+/// whole-contract enforcement.
+#[test]
+fn an_unbounded_exclusion_is_reported_rather_than_silently_dropped() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    fs::create_dir(workspace.path().join("src")).expect("mkdir src");
+    fs::write(workspace.path().join("src/main.rs"), "code").expect("write allowed");
+
+    let boundary =
+        linux_landlock_read_boundary(workspace.path(), &profile(&["**"], DEFAULT_DENY_READ), &[])
+            .expect("compile boundary");
+
+    assert_eq!(boundary.unenforced_exclusions, DEFAULT_DENY_READ);
+    assert!(
+        grants_read(&boundary.grants, &workspace.path().join("src/build.out")),
+        "{:?}",
+        boundary.grants
+    );
+}
+
+/// A bounded exclusion in the same profile is still enforced; the two classes
+/// are decided per rule rather than per profile.
+#[test]
+fn a_bounded_exclusion_is_enforced_alongside_an_unbounded_one() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    fs::create_dir(workspace.path().join("src")).expect("mkdir src");
+    fs::write(workspace.path().join("src/main.rs"), "code").expect("write allowed");
+
+    let mut denies = DEFAULT_DENY_READ.to_vec();
+    denies.push("vault/**");
+    let boundary = linux_landlock_read_boundary(workspace.path(), &profile(&["**"], &denies), &[])
+        .expect("compile boundary");
+
+    assert_eq!(boundary.unenforced_exclusions, DEFAULT_DENY_READ);
+    assert!(
+        !grants_read(&boundary.grants, &workspace.path().join("vault/token")),
+        "{:?}",
+        boundary.grants
+    );
+    assert!(
+        grants_read(&boundary.grants, &workspace.path().join("src/main.rs")),
+        "{:?}",
+        boundary.grants
+    );
+}
+
+/// A profile with no exclusion at all reports none, and pays nothing for the
+/// analysis.
+#[test]
+fn a_profile_without_exclusions_reports_nothing_unenforced() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    fs::write(workspace.path().join("visible.txt"), "ok").expect("write file");
+
+    let boundary = linux_landlock_read_boundary(workspace.path(), &profile(&["**"], &[]), &[])
+        .expect("compile boundary");
+
+    assert!(boundary.unenforced_exclusions.is_empty());
 }

--- a/crates/orbit-exec/src/linux_landlock/workspace.rs
+++ b/crates/orbit-exec/src/linux_landlock/workspace.rs
@@ -3,63 +3,180 @@
 //! The profile is a last-match-wins list of globs; a Landlock ruleset is a set
 //! of inodes. Translating one into the other means walking the workspace once
 //! and deciding, per path, whether the child may read it.
+//!
+//! The translation is driven by what the exclusion *rules* can name, not by
+//! which denied paths happen to exist when the walk runs. A ruleset compiled
+//! from the second would hand out a whole directory whenever today's tree
+//! contained no match, and a name created in it afterwards — by the child or
+//! by anyone else sharing the workspace — would inherit that grant. See
+//! [`DenyReach`].
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use orbit_common::OrbitError;
-use orbit_types::policy::{CompiledFsRules, FsOperation, ResolvedFsProfile};
+use orbit_types::policy::{CompiledFsRules, FsOperation, GlobReach, ResolvedFsProfile};
 
 use super::LandlockPathGrant;
+
+/// The workspace half of a compiled ruleset, and the exclusions it leaves to
+/// another layer.
+#[derive(Debug, Default)]
+pub(super) struct WorkspaceReadGrants {
+    pub(super) grants: Vec<LandlockPathGrant>,
+    /// Exclusions whose reach no inode ruleset can carve out ahead of time.
+    /// See [`DenyReach::compile`] for why they are reported rather than
+    /// enforced.
+    pub(super) unenforced_exclusions: Vec<String>,
+}
 
 /// Compile the workspace half of the ruleset for `profile`.
 pub(super) fn workspace_read_grants(
     workspace_root: &Path,
     profile: &ResolvedFsProfile,
-) -> Result<Vec<LandlockPathGrant>, OrbitError> {
+) -> Result<WorkspaceReadGrants, OrbitError> {
     let rules = profile.compile(FsOperation::Read)?;
     if rules.grants_nothing() {
-        return Ok(Vec::new());
+        return Ok(WorkspaceReadGrants::default());
     }
 
-    if rules.allows(".")? {
-        return grant_read_tree(workspace_root, workspace_root, &rules);
-    }
-    allowed_subtrees(workspace_root, workspace_root, &rules)
+    let reach = DenyReach::compile(workspace_root, &rules)?;
+    let grants = if rules.allows(".")? {
+        grant_read_tree(workspace_root, workspace_root, &rules, &reach)?
+    } else {
+        allowed_subtrees(workspace_root, workspace_root, &rules, &reach)?
+    };
+
+    Ok(WorkspaceReadGrants {
+        grants,
+        unenforced_exclusions: reach.unenforced,
+    })
 }
 
-/// Grant `root` as a readable tree, carving out every denied path beneath it.
+/// Where the profile's exclusions can still name a path that does not exist.
+///
+/// # Why a ruleset needs this
+/// Landlock rules bind to inodes, and the ruleset is fixed before the child
+/// starts. Granting a directory as a readable tree therefore grants every name
+/// that will ever appear in it. Consulting only the denied paths present at
+/// compile time makes the boundary depend on timing: the same profile enforces
+/// a secret that already exists and discloses the identical secret written a
+/// moment later.
+///
+/// Asking the rules instead removes the timing. A directory a bounded
+/// exclusion can name into is granted list-only, so a name appearing there
+/// afterwards has no readable ancestor, exactly as if it had been present all
+/// along.
+///
+/// # What stays unenforced, and why it is reported
+/// An exclusion whose reach is unbounded — a `**` that crosses directories, as
+/// in `**/.env` — can name a path beneath *every* directory in the workspace.
+/// Carving that out ahead of time means granting no directory as a tree at
+/// all, which withdraws read access from every file the run itself produces:
+/// a compiler cannot read back the object it just wrote, and the boundary
+/// stops being one any build can run under (F2026-09-054 measured exactly
+/// this). Such a rule is not silently dropped either. It is carried out on
+/// [`WorkspaceReadGrants::unenforced_exclusions`] so the spawn boundary can
+/// say which part of the profile the kernel is not holding, and it keeps its
+/// full effect in the request-time policy check, which decides a concrete path
+/// and needs no ruleset.
+struct DenyReach<'a> {
+    workspace_root: &'a Path,
+    /// Exclusions whose reach their own segments bound.
+    bounded: Vec<GlobReach>,
+    /// Exclusions reported rather than compiled, as written.
+    unenforced: Vec<String>,
+}
+
+impl<'a> DenyReach<'a> {
+    fn compile(
+        workspace_root: &'a Path,
+        rules: &CompiledFsRules,
+    ) -> Result<DenyReach<'a>, OrbitError> {
+        let mut bounded = Vec::new();
+        let mut unenforced = Vec::new();
+        for exclusion in rules.exclusions() {
+            let reach = GlobReach::compile(exclusion).map_err(|error| {
+                OrbitError::InvalidInput(format!(
+                    "landlock cannot compile read exclusion `{exclusion}`: {error}"
+                ))
+            })?;
+            if reach.is_bounded() {
+                bounded.push(reach);
+            } else {
+                unenforced.push(exclusion.to_string());
+            }
+        }
+        Ok(DenyReach {
+            workspace_root,
+            bounded,
+            unenforced,
+        })
+    }
+
+    /// A reach that names nothing, for a carve-out driven by an explicit file
+    /// list rather than by a rule set.
+    fn none(workspace_root: &'a Path) -> DenyReach<'a> {
+        DenyReach {
+            workspace_root,
+            bounded: Vec::new(),
+            unenforced: Vec::new(),
+        }
+    }
+
+    /// Whether a bounded exclusion can name a path beneath `dir`.
+    ///
+    /// A later positive rule may re-allow part of what an exclusion names.
+    /// This does not model that: re-allowing narrows a grant rather than
+    /// widening it, so treating the directory as reachable costs read access
+    /// to names that do not exist yet and never discloses one.
+    fn names_beneath(&self, dir: &Path) -> Result<bool, OrbitError> {
+        if self.bounded.is_empty() {
+            return Ok(false);
+        }
+        let relative = relative_to(self.workspace_root, dir)?;
+        Ok(self
+            .bounded
+            .iter()
+            .any(|reach| reach.names_beneath(&relative)))
+    }
+}
+
+/// Grant `root` as a readable tree, carving out every path the profile denies
+/// it — the ones present now, and the ones its exclusions can still name.
 ///
 /// A directory holding a denied path cannot be granted as a tree, because a
 /// path-beneath rule reaches every descendant. Such a directory is granted
 /// list-only and each allowed child is granted in its own right, recursively.
-/// The denied path is then left with no readable ancestor at all.
+/// The denied path is then left with no readable ancestor at all. A directory
+/// a bounded exclusion can still name into is treated the same way, so the
+/// grant does not depend on whether that name has been created yet.
 ///
 /// # What this does and does not deny
-/// The carve-out is computed from the paths that exist when the ruleset is
-/// compiled, and Landlock rules bind to inodes. Consequences, all covered by
-/// tests:
+/// Landlock rules bind to inodes, which decides the semantics at the edges.
+/// Consequences, all covered by tests:
 ///
-/// - A denied file that exists at spawn stays unreadable for the child's whole
-///   life, including after the child renames it within its directory: the
-///   inode keeps no readable ancestor.
+/// - A denied path stays unreadable for the child's whole life whether it
+///   existed at spawn or appeared afterwards, including after a rename within
+///   its directory: the inode keeps no readable ancestor.
 /// - The child cannot move a denied file into a readable directory. Landlock
 ///   refuses a rename that would give a file more access at its destination,
 ///   which is why `REFER` is handled.
-/// - A file matching a deny rule that is *created* later under an
-///   already-granted directory is readable by that child. That discloses
-///   nothing the child could not already obtain — either the child wrote those
-///   bytes, or it copied them from somewhere this ruleset already allowed.
-///   A concurrent third party writing a new secret into the workspace during
-///   the child's lifetime is the residual race, and it is why `denyRead` is
-///   also enforced at request time by the policy engine.
-pub(super) fn grant_read_tree(
+/// - The boundary governs acquisition, not naming. A file the ruleset already
+///   grants keeps its grant through a rename or a hard link into a denied
+///   name, because the grant is on the inode and the child could read those
+///   bytes before it renamed anything. Bytes already in the child's memory, an
+///   open descriptor, or a mapping are equally beyond recall.
+/// - An exclusion whose reach is unbounded is reported rather than carved out;
+///   see [`DenyReach`].
+fn grant_read_tree(
     workspace_root: &Path,
     root: &Path,
     rules: &CompiledFsRules,
+    reach: &DenyReach<'_>,
 ) -> Result<Vec<LandlockPathGrant>, OrbitError> {
     let denied = denied_paths(workspace_root, root, rules)?;
-    carve_out(root, &denied)
+    carve_out_beneath(root, &denied, reach)
 }
 
 /// Walk into a workspace whose root is not itself allowed, granting the
@@ -68,13 +185,14 @@ fn allowed_subtrees(
     workspace_root: &Path,
     dir: &Path,
     rules: &CompiledFsRules,
+    reach: &DenyReach<'_>,
 ) -> Result<Vec<LandlockPathGrant>, OrbitError> {
     let mut grants = Vec::new();
     for child in children_under(workspace_root, dir)? {
         if rules.allows(&relative_to(workspace_root, &child)?)? {
-            grants.extend(grant_read_tree(workspace_root, &child, rules)?);
+            grants.extend(grant_read_tree(workspace_root, &child, rules, reach)?);
         } else if child.is_dir() {
-            grants.extend(allowed_subtrees(workspace_root, &child, rules)?);
+            grants.extend(allowed_subtrees(workspace_root, &child, rules, reach)?);
         }
     }
     Ok(grants)
@@ -111,17 +229,28 @@ fn collect_denied(
 }
 
 /// Grant `root` while leaving every path in `denied` without a readable
-/// ancestor. Shared with the host grants, which carve credential files out of
-/// an otherwise readable tool state directory the same way.
+/// ancestor. Used by the host grants, which carve credential files out of an
+/// otherwise readable tool state directory from a fixed file list rather than
+/// from a rule set.
 pub(super) fn carve_out(
     root: &Path,
     denied: &BTreeSet<PathBuf>,
+) -> Result<Vec<LandlockPathGrant>, OrbitError> {
+    carve_out_beneath(root, denied, &DenyReach::none(root))
+}
+
+/// Grant `root` while leaving both the denied paths beneath it and the paths
+/// `reach` can still name there without a readable ancestor.
+fn carve_out_beneath(
+    root: &Path,
+    denied: &BTreeSet<PathBuf>,
+    reach: &DenyReach<'_>,
 ) -> Result<Vec<LandlockPathGrant>, OrbitError> {
     if denied.contains(root) {
         return Ok(Vec::new());
     }
     let holds_denied_path = denied.iter().any(|path| path.starts_with(root));
-    if !holds_denied_path {
+    if !holds_denied_path && !reach.names_beneath(root)? {
         return Ok(vec![whole_path_grant(root)]);
     }
     if !root.is_dir() {
@@ -130,7 +259,7 @@ pub(super) fn carve_out(
 
     let mut grants = vec![LandlockPathGrant::list_only(root.to_path_buf())];
     for child in children_under(root, root)? {
-        grants.extend(carve_out(&child, denied)?);
+        grants.extend(carve_out_beneath(&child, denied, reach)?);
     }
     Ok(grants)
 }

--- a/crates/orbit-exec/tests/linux_landlock.rs
+++ b/crates/orbit-exec/tests/linux_landlock.rs
@@ -14,7 +14,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use orbit_exec::{
-    EnvironmentMode, ExecRequest, StdinMode, linux_landlock_grants, probe_landlock,
+    EnvironmentMode, ExecRequest, StdinMode, linux_landlock_read_boundary, probe_landlock,
     spawn_under_linux_landlock,
 };
 use orbit_types::policy::ResolvedFsProfile;
@@ -82,6 +82,12 @@ impl Fixture {
     /// combined output. `sh` is on every shipped activity allowlist, so this is
     /// the shape of the bypass this change closes.
     fn run(&self, profile: &ResolvedFsProfile, script: &str) -> Output {
+        Output::of(self.spawn(profile, script))
+    }
+
+    /// Start the confined child without waiting for it, so a test can change
+    /// the workspace while the ruleset is already in force.
+    fn spawn(&self, profile: &ResolvedFsProfile, script: &str) -> std::process::Child {
         let request = ExecRequest {
             program: "/bin/sh".to_string(),
             args: vec!["-c".to_string(), script.to_string()],
@@ -91,15 +97,7 @@ impl Fixture {
             environment_mode: EnvironmentMode::ClearAndSet(self.environment.clone()),
             debug: false,
         };
-        let output = spawn_under_linux_landlock(&request, &self.root(), profile)
-            .expect("spawn confined child")
-            .wait_with_output()
-            .expect("wait for confined child");
-        Output {
-            succeeded: output.status.success(),
-            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-        }
+        spawn_under_linux_landlock(&request, &self.root(), profile).expect("spawn confined child")
     }
 }
 
@@ -110,6 +108,15 @@ struct Output {
 }
 
 impl Output {
+    fn of(child: std::process::Child) -> Self {
+        let output = child.wait_with_output().expect("wait for confined child");
+        Self {
+            succeeded: output.status.success(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        }
+    }
+
     fn assert_withheld(&self, sentinel: &str) {
         assert!(
             !self.stdout.contains(sentinel),
@@ -131,8 +138,12 @@ impl Output {
 }
 
 fn profile(read: &[&str]) -> ResolvedFsProfile {
+    profile_denying(read, DEFAULT_DENY_READ)
+}
+
+fn profile_denying(read: &[&str], denies: &[&str]) -> ResolvedFsProfile {
     let mut rules: Vec<String> = read.iter().map(ToString::to_string).collect();
-    rules.extend(DEFAULT_DENY_READ.iter().map(|rule| format!("!{rule}")));
+    rules.extend(denies.iter().map(|rule| format!("!{rule}")));
     ResolvedFsProfile {
         name: "test".to_string(),
         read: rules,
@@ -364,13 +375,284 @@ fn a_profile_that_reads_nothing_grants_no_workspace_path() {
         modify: Vec::new(),
     };
 
-    let grants =
-        linux_landlock_grants(&fixture.root(), &profile, &fixture.environment).expect("grants");
+    let boundary = linux_landlock_read_boundary(&fixture.root(), &profile, &fixture.environment)
+        .expect("compile boundary");
     assert!(
-        !orbit_exec::grants_read(&grants, &fixture.root().join("visible.txt")),
-        "an empty read profile must not grant a workspace file: {grants:?}"
+        !orbit_exec::grants_read(&boundary.grants, &fixture.root().join("visible.txt")),
+        "an empty read profile must not grant a workspace file: {:?}",
+        boundary.grants
     );
     fixture
         .run(&profile, "cat visible.txt")
         .assert_withheld("PURE_COMPUTE_SENTINEL");
+}
+
+/// The fixture the dynamic-name tests share.
+///
+/// `vault/**` and `src/secret.key` are bounded exclusions: their own segments
+/// say which directories they can name into, so the ruleset can carve those
+/// directories out before the names exist. `build/` is out of reach, which is
+/// what keeps generated files readable.
+fn dynamic_fixture() -> (Fixture, ResolvedFsProfile) {
+    let fixture = Fixture::new();
+    fixture.write("src/main.rs", "ALLOWED_SENTINEL");
+    fs::create_dir(fixture.root().join("build")).expect("create build");
+    let profile = profile_denying(&["**"], &["vault/**", "src/secret.key"]);
+    (fixture, profile)
+}
+
+/// Criterion 1, and the gap this task closed. A third party writes a secret
+/// into the workspace *after* the child has been admitted, into a directory
+/// that did not exist when the ruleset was compiled. An indirect descendant —
+/// a grandchild, which is what request-time argv checks never see — must not
+/// be able to return it, and the run must still be able to read a file it
+/// generates itself. [F2026-09-054]
+#[test]
+fn a_secret_written_after_admission_is_withheld_from_an_indirect_descendant() {
+    if unenforceable() {
+        return;
+    }
+    let (fixture, profile) = dynamic_fixture();
+
+    // The child waits for the writer, then reads the secret through a
+    // grandchild and generates a file of its own through another.
+    let child = fixture.spawn(
+        &profile,
+        "n=0; while [ ! -e go ] && [ $n -lt 200 ]; do n=$((n+1)); sleep 0.05; done; \
+         sh -c 'cat vault/secret.txt' || echo DESCENDANT_REFUSED; \
+         printf GENERATED_SENTINEL > build/out.txt; \
+         sh -c 'cat build/out.txt'",
+    );
+
+    let secret = fixture.root().join("vault/secret.txt");
+    fs::create_dir(fixture.root().join("vault")).expect("concurrent writer creates vault");
+    fs::write(&secret, "LATE_SENTINEL").expect("concurrent writer writes secret");
+    fs::write(fixture.root().join("go"), "").expect("release the child");
+
+    // The test is only meaningful if the secret really is there to be read.
+    assert_eq!(
+        fs::read_to_string(&secret).expect("read secret outside the sandbox"),
+        "LATE_SENTINEL"
+    );
+
+    let output = Output::of(child);
+    output.assert_withheld("LATE_SENTINEL");
+    output.assert_returned("DESCENDANT_REFUSED");
+    output.assert_returned("GENERATED_SENTINEL");
+}
+
+/// Criterion 2, create/read/remove. A denied name the child creates itself is
+/// no more readable than one someone else creates: the boundary is the name's
+/// directory, not who wrote the bytes. Removing it still works, because this
+/// ruleset governs reads and leaves writes to the mount namespace.
+#[test]
+fn a_denied_name_can_be_created_and_removed_but_never_read_back() {
+    if unenforceable() {
+        return;
+    }
+    let (fixture, profile) = dynamic_fixture();
+
+    fixture
+        .run(
+            &profile,
+            "mkdir -p vault && printf SELF_WRITTEN_SENTINEL > vault/key; \
+             cat vault/key || echo READ_REFUSED; \
+             rm -f vault/key && echo REMOVED",
+        )
+        .assert_withheld("SELF_WRITTEN_SENTINEL");
+
+    fixture
+        .run(
+            &profile,
+            "mkdir -p vault && printf x > vault/key; rm -f vault/key && echo REMOVED",
+        )
+        .assert_returned("REMOVED");
+}
+
+/// Criterion 2, allowed-to-denied rename, stated as the acquisition rule it
+/// is. A grant binds to an inode the child could already read, so giving that
+/// inode a denied name afterwards does not take the bytes back — the child
+/// could have copied them before it renamed anything. What the boundary does
+/// guarantee is that no *new* inode arrives at a denied name with a readable
+/// ancestor.
+#[test]
+fn renaming_an_allowed_file_to_a_denied_name_does_not_withdraw_what_was_granted() {
+    if unenforceable() {
+        return;
+    }
+    let (fixture, profile) = dynamic_fixture();
+
+    fixture
+        .run(
+            &profile,
+            "mv src/main.rs src/secret.key && cat src/secret.key",
+        )
+        .assert_returned("ALLOWED_SENTINEL");
+
+    // The other direction is the one that matters, and it is closed: a file
+    // that arrives at the denied name without a grant of its own stays unread.
+    fixture
+        .run(
+            &profile,
+            "printf FRESH_SENTINEL > src/secret.key; cat src/secret.key || echo REFUSED",
+        )
+        .assert_withheld("FRESH_SENTINEL");
+}
+
+/// Criterion 2, hard links. A hard link is another name for an inode the
+/// ruleset already decided on, so it follows the same acquisition rule as a
+/// rename — and a link that would *gain* access at its destination is refused
+/// by `REFER`.
+#[test]
+fn a_hard_link_carries_the_access_its_inode_already_had() {
+    if unenforceable() {
+        return;
+    }
+    let (fixture, profile) = dynamic_fixture();
+
+    fixture
+        .run(
+            &profile,
+            "ln src/main.rs src/secret.key && cat src/secret.key",
+        )
+        .assert_returned("ALLOWED_SENTINEL");
+
+    fixture
+        .run(
+            &profile,
+            "mkdir -p vault && printf LINKED_SENTINEL > vault/key; \
+             ln vault/key build/laundered.txt 2>/dev/null; \
+             cat build/laundered.txt || echo LINK_REFUSED",
+        )
+        .assert_withheld("LINKED_SENTINEL");
+}
+
+/// Criterion 2, aliases. A symlink is resolved where it points, so pointing one
+/// from a readable directory at a denied path grants nothing.
+#[test]
+fn a_symlink_alias_does_not_launder_a_denied_path() {
+    if unenforceable() {
+        return;
+    }
+    let (fixture, profile) = dynamic_fixture();
+
+    fixture
+        .run(
+            &profile,
+            "mkdir -p vault && printf ALIASED_SENTINEL > vault/key; \
+             ln -s ../vault/key build/alias.txt; \
+             cat build/alias.txt || echo ALIAS_REFUSED",
+        )
+        .assert_withheld("ALIASED_SENTINEL");
+}
+
+/// Criterion 2, descriptors and mappings. Both are acquisitions: once the
+/// child holds one, no later filesystem rule can revoke it. Stating this is
+/// the point — a reader who expects a rename to close an open descriptor would
+/// expect the wrong contract.
+#[test]
+fn an_open_descriptor_and_a_mapping_survive_a_later_rename_to_a_denied_name() {
+    if unenforceable() {
+        return;
+    }
+    let (fixture, profile) = dynamic_fixture();
+
+    fixture
+        .run(
+            &profile,
+            "exec 3< src/main.rs; mv src/main.rs src/secret.key; cat <&3",
+        )
+        .assert_returned("ALLOWED_SENTINEL");
+
+    if !on_path("python3", &fixture.environment) {
+        println!("skipping the mapping half: python3 is not on the child PATH");
+        return;
+    }
+    // The descriptor half already consumed `src/main.rs`, so the mapping half
+    // brings its own file and its own sentinel.
+    fixture.write("src/mapped.rs", "MAPPED_SENTINEL");
+    fixture
+        .run(
+            &profile,
+            "python3 -c \"import mmap,os,sys\n\
+             f=open('src/mapped.rs','rb')\n\
+             m=mmap.mmap(f.fileno(),0,access=mmap.ACCESS_READ)\n\
+             os.rename('src/mapped.rs','src/secret.key')\n\
+             sys.stdout.write(m[:].decode())\"",
+        )
+        .assert_returned("MAPPED_SENTINEL");
+}
+
+/// Criterion 2, paired positive operations. Carving a directory out for a
+/// bounded exclusion must not cost the run the files it already had or the
+/// ones it produces where the rule cannot reach.
+#[test]
+fn the_carve_out_leaves_the_rest_of_the_workspace_usable() {
+    if unenforceable() {
+        return;
+    }
+    let (fixture, profile) = dynamic_fixture();
+    fixture.write("build/nested/input.txt", "NESTED_SENTINEL");
+
+    fixture
+        .run(&profile, "cat src/main.rs")
+        .assert_returned("ALLOWED_SENTINEL");
+    fixture
+        .run(&profile, "cat build/nested/input.txt")
+        .assert_returned("NESTED_SENTINEL");
+    fixture
+        .run(
+            &profile,
+            "mkdir -p build/deep && printf DEEP_SENTINEL > build/deep/out.txt; \
+             sh -c 'cat build/deep/out.txt'",
+        )
+        .assert_returned("DEEP_SENTINEL");
+}
+
+/// Criterion 3. An exclusion whose `**` crosses directories can name a path
+/// beneath every directory in the workspace; enforcing it ahead of time would
+/// leave nothing readable that the run itself produced. The compiler says so
+/// on the boundary rather than letting a caller believe the kernel is holding
+/// the whole profile.
+#[test]
+fn the_boundary_names_the_exclusions_the_kernel_is_not_holding() {
+    let fixture = Fixture::new();
+    fixture.write("src/main.rs", "code");
+
+    let boundary = linux_landlock_read_boundary(
+        &fixture.root(),
+        &profile_denying(&["**"], &["vault/**", "**/*.env"]),
+        &fixture.environment,
+    )
+    .expect("compile boundary");
+
+    assert_eq!(boundary.unenforced_exclusions, vec!["**/*.env".to_string()]);
+}
+
+/// Criterion 3. A profile the backend cannot compile is a capability failure,
+/// not a reason to run the child with no boundary at all.
+#[test]
+fn a_profile_that_cannot_be_compiled_refuses_to_spawn() {
+    if unenforceable() {
+        return;
+    }
+    let fixture = Fixture::new();
+    let missing = fixture.root().join("not-a-workspace");
+
+    let request = ExecRequest {
+        program: "/bin/echo".to_string(),
+        args: vec!["MUST_NOT_RUN".to_string()],
+        current_dir: None,
+        timeout_ms: Some(1_000),
+        stdin_mode: StdinMode::Null,
+        environment_mode: EnvironmentMode::ClearAndSet(fixture.environment.clone()),
+        debug: false,
+    };
+    let error = spawn_under_linux_landlock(&request, &missing, &profile(&["**"]))
+        .expect_err("a workspace that does not resolve must not spawn");
+
+    assert!(
+        error.to_string().contains("landlock workspace"),
+        "the error must name what it could not compile: {error}"
+    );
 }

--- a/crates/orbit-types/src/policy/fs_rules.rs
+++ b/crates/orbit-types/src/policy/fs_rules.rs
@@ -60,7 +60,20 @@ impl CompiledFsRules {
     /// True when an exclusion could carve a denied path out of an allowed
     /// subtree. Without one, an allowed subtree needs no further inspection.
     pub fn has_exclusion(&self) -> bool {
-        self.rules.iter().any(|rule| rule.negated)
+        self.exclusions().next().is_some()
+    }
+
+    /// The exclusion patterns, normalized and in declaration order.
+    ///
+    /// [`Self::allows`] decides a path that exists. A caller compiling these
+    /// rules into a kernel ruleset also has to reason about paths that do not
+    /// exist yet, which needs the patterns themselves — see
+    /// [`GlobReach`](crate::policy::GlobReach).
+    pub fn exclusions(&self) -> impl Iterator<Item = &str> {
+        self.rules
+            .iter()
+            .filter(|rule| rule.negated)
+            .map(|rule| rule.pattern.as_str())
     }
 
     /// Decide `path`, reporting the rule that settled it.

--- a/crates/orbit-types/src/policy/glob.rs
+++ b/crates/orbit-types/src/policy/glob.rs
@@ -183,3 +183,106 @@ fn compile_filesystem_regex(pattern: &str) -> Result<Regex, regex::Error> {
 fn filesystem_globs_are_case_insensitive() -> bool {
     cfg!(any(target_os = "macos", windows))
 }
+
+/// Which directories a glob rule can name a not-yet-existing path into.
+///
+/// [`match_glob`] answers "does this rule match this path", which is the only
+/// question a request-time check needs. A caller compiling an inode-based
+/// kernel ruleset needs the other direction: a rule that matches nothing today
+/// may still name a path tomorrow, and the ruleset is fixed before that
+/// happens. Asking per directory is what lets such a caller decide which
+/// directories it may hand out wholesale.
+///
+/// # Bounded and unbounded reach
+/// A rule's own segments normally bound the directories it can name into:
+/// `secrets/**` and `.env` can only produce a path beneath the workspace root,
+/// `config/*.key` beneath `config`. A directory-crossing `**` removes that
+/// bound — `**/.env` names `.env` in every directory, including directories
+/// that do not exist yet — which callers with a per-directory cost need to
+/// distinguish. See [`GlobReach::is_bounded`].
+#[derive(Debug)]
+pub struct GlobReach {
+    segments: Vec<ReachSegment>,
+    bounded: bool,
+    /// `.` names the workspace root itself and nothing beneath it.
+    root_only: bool,
+}
+
+#[derive(Debug)]
+enum ReachSegment {
+    /// A trailing `**`: everything below this point, at any depth.
+    Subtree,
+    /// One path segment, matched with the segment-local operators (`*`, `?`).
+    Name(Regex),
+}
+
+impl GlobReach {
+    /// Compile `rule` — a pattern already stripped of any `!` prefix and
+    /// normalized to forward slashes — for per-directory reach questions.
+    pub fn compile(rule: &str) -> Result<Self, regex::Error> {
+        let raw: Vec<&str> = rule.split('/').filter(|part| !part.is_empty()).collect();
+        let bounded = raw
+            .iter()
+            .enumerate()
+            .all(|(index, part)| !part.contains("**") || (*part == "**" && index + 1 == raw.len()));
+
+        let mut segments = Vec::with_capacity(raw.len());
+        for part in &raw {
+            if *part == "**" {
+                segments.push(ReachSegment::Subtree);
+            } else {
+                segments.push(ReachSegment::Name(compile_filesystem_regex(&format!(
+                    "^{}$",
+                    translate_glob_body(part)
+                ))?));
+            }
+        }
+
+        Ok(Self {
+            segments,
+            bounded,
+            root_only: rule == ".",
+        })
+    }
+
+    /// Whether the rule's reach is bounded by its own segments.
+    ///
+    /// False when a `**` crosses directory boundaries, which lets the rule name
+    /// a path beneath a directory the rule text never mentions. A caller that
+    /// pays a cost per reached directory cannot enumerate that set.
+    pub fn is_bounded(&self) -> bool {
+        self.bounded
+    }
+
+    /// Whether the rule can name a path *strictly beneath* the directory
+    /// `dir`, expressed workspace-relative (`""` or `"."` for the root).
+    ///
+    /// This asks about names, not about what exists: `secrets/**` names a path
+    /// beneath the root whether or not `secrets` has ever been created. A rule
+    /// that matches `dir` itself and nothing below it does not reach beneath
+    /// it.
+    pub fn names_beneath(&self, dir: &str) -> bool {
+        if self.root_only {
+            return false;
+        }
+        let dir: Vec<&str> = dir
+            .split('/')
+            .filter(|part| !part.is_empty() && *part != ".")
+            .collect();
+        names_beneath(&self.segments, &dir)
+    }
+}
+
+fn names_beneath(pattern: &[ReachSegment], dir: &[&str]) -> bool {
+    match (pattern.split_first(), dir.split_first()) {
+        // The rule ran out of segments at or above `dir`, so everything it can
+        // name lies outside this directory.
+        (None, _) => false,
+        // The rule still has segments to spend below `dir`.
+        (Some(_), None) => true,
+        (Some((ReachSegment::Subtree, _)), Some(_)) => true,
+        (Some((ReachSegment::Name(matcher), rest)), Some((name, below))) => {
+            matcher.is_match(name) && names_beneath(rest, below)
+        }
+    }
+}

--- a/crates/orbit-types/src/policy/mod.rs
+++ b/crates/orbit-types/src/policy/mod.rs
@@ -9,7 +9,9 @@ mod role;
 pub use error::PolicyError;
 pub use fs_rules::CompiledFsRules;
 
-pub use glob::{compile_glob_regex, join_normal_components, match_glob, normalize_glob_path};
+pub use glob::{
+    GlobReach, compile_glob_regex, join_normal_components, match_glob, normalize_glob_path,
+};
 pub use policy_decision::PolicyDecision;
 pub use policy_def::{
     DEFAULT_POLICY_NAME, FsCheckResult, FsOperation, FsProfile, PolicyDef, ResolvedFsProfile,

--- a/crates/orbit-types/src/policy/tests/glob.rs
+++ b/crates/orbit-types/src/policy/tests/glob.rs
@@ -1,4 +1,4 @@
-use crate::policy::{PolicyError, compile_glob_regex, match_glob, normalize_glob_path};
+use crate::policy::{GlobReach, PolicyError, compile_glob_regex, match_glob, normalize_glob_path};
 
 #[test]
 fn glob_matching_preserves_segment_aware_wildcards() {
@@ -81,4 +81,90 @@ fn globs_match_case_variants_on_case_insensitive_platforms() {
 fn globs_remain_case_sensitive_on_case_sensitive_platforms() {
     let path = normalize_glob_path("Secret.ENV").expect("normalize");
     assert!(!match_glob("**/*.env", &path).expect("match glob"));
+}
+
+/// A rule that names a path beneath the root has to say so before that path
+/// exists — the caller compiling it into a kernel ruleset cannot re-ask later.
+#[test]
+fn a_rule_names_a_path_beneath_a_directory_it_can_still_reach() {
+    for (rule, dir) in [
+        (".env", ""),
+        ("secrets/**", ""),
+        ("secrets/**", "secrets"),
+        ("secrets/**", "secrets/nested"),
+        ("config/*.key", ""),
+        ("config/*.key", "config"),
+        ("build/*/out.log", "build"),
+        ("build/*/out.log", "build/debug"),
+    ] {
+        let reach = GlobReach::compile(rule).expect("compile reach");
+        assert!(
+            reach.names_beneath(dir),
+            "`{rule}` can name a path beneath `{dir}`"
+        );
+    }
+}
+
+#[test]
+fn a_rule_names_nothing_beneath_a_directory_it_cannot_reach() {
+    for (rule, dir) in [
+        (".env", "src"),
+        ("secrets/**", "src"),
+        ("config/*.key", "src"),
+        ("config/*.key", "config/nested"),
+        ("build/*/out.log", "build/debug/deps"),
+        // `.` is the workspace root itself, not anything inside it.
+        (".", ""),
+    ] {
+        let reach = GlobReach::compile(rule).expect("compile reach");
+        assert!(
+            !reach.names_beneath(dir),
+            "`{rule}` cannot name a path beneath `{dir}`"
+        );
+    }
+}
+
+/// The `./a/b` and `a/b` spellings of a directory are the same directory.
+#[test]
+fn reach_accepts_either_spelling_of_the_workspace_root() {
+    let reach = GlobReach::compile("secrets/**").expect("compile reach");
+
+    assert!(reach.names_beneath("."));
+    assert!(reach.names_beneath(""));
+}
+
+/// The distinction a caller with a per-directory cost needs: a rule whose own
+/// segments bound it can be carved out ahead of time, and one whose `**`
+/// crosses directories reaches everywhere, including directories that do not
+/// exist yet.
+#[test]
+fn only_a_directory_crossing_wildcard_leaves_the_reach_unbounded() {
+    for bounded in [".env", "secrets/**", "config/*.key", "**", "a/b/c"] {
+        assert!(
+            GlobReach::compile(bounded)
+                .expect("compile reach")
+                .is_bounded(),
+            "`{bounded}` is bounded by its own segments"
+        );
+    }
+
+    for unbounded in ["**/.env", "**/*.env", "**/secrets/**", "a/**/b.key"] {
+        assert!(
+            !GlobReach::compile(unbounded)
+                .expect("compile reach")
+                .is_bounded(),
+            "`{unbounded}` can name a path beneath a directory it never mentions"
+        );
+    }
+}
+
+/// A trailing `**` covers every depth beneath its prefix, so every directory
+/// inside that subtree can still gain a denied name.
+#[test]
+fn a_trailing_subtree_wildcard_reaches_every_depth_beneath_its_prefix() {
+    let reach = GlobReach::compile("secrets/**").expect("compile reach");
+
+    for dir in ["secrets", "secrets/a", "secrets/a/b/c"] {
+        assert!(reach.names_beneath(dir), "beneath `{dir}`");
+    }
 }

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -3,8 +3,8 @@ summary: "Policy & Sandboxing — Design"
 type: design
 title: "Policy & Sandboxing — Design"
 owner: claude
-last_updated: 2026-09-08
-last_validated: 2026-09-07
+last_updated: 2026-09-10
+last_validated: 2026-09-10
 status: Draft
 feature: policy-sandbox
 doc_role: design
@@ -138,18 +138,36 @@ The ruleset handles `EXECUTE | READ_FILE | READ_DIR | REFER`. Writes stay with t
 
 Grants come from three places:
 
-- **Workspace.** The resolved `read` rules are compiled once (`CompiledFsRules`, §3) and the tree is walked once. A directory holding a denied path is granted list-only and its allowed children are granted individually, so the denied path keeps no readable ancestor.
+- **Workspace.** The resolved `read` rules are compiled once (`CompiledFsRules`, §3) and the tree is walked once. A directory is granted list-only — with its allowed children granted individually, so the denied path keeps no readable ancestor — when it holds a denied path *or* when an exclusion can still name a new path beneath it. The second condition is what makes the grant independent of timing; see the dynamic-name contract below. [ORB-11978]
 - **Host runtime, resolver, and trust.** A fixed table: system binaries and libraries, the loader and its cache, the character devices a process opens on startup, the world-readable resolver files (`/etc/hosts`, `/etc/nsswitch.conf`, `/etc/resolv.conf`, `/etc/passwd`, …), and the CA stores. `/etc` is never granted as a directory, and neither is `/proc` — a tree-wide `/proc` grant would expose any same-user process's `environ`, including the launching Orbit process's credentials.
 - **Tool state.** The directories on the child's own `PATH`, plus one directory per tool named by an environment variable the operator admitted into the child environment (`CARGO_HOME`, `RUSTUP_HOME`, `GH_CONFIG_DIR`, `TMPDIR`, `ORBIT_ROOT`, …) or by that tool's documented default under `$HOME`. `$HOME` itself is refused, as is any variable naming an ancestor of it, and publish tokens such as `$CARGO_HOME/credentials.toml` are carved back out.
 
 Availability is fail-closed. `REFER` arrived in Landlock ABI 2, so a kernel below that — or any non-Linux host — makes activity-scoped `proc.spawn` return a capability error naming the requirement. There is no unconfined fallback.
 
-**Known limits, all covered by tests.** Landlock rules bind to the inodes that exist when the ruleset is compiled:
+#### Dynamic denied names
 
-- A denied file present at spawn stays unreadable for the child's whole life, including after the child renames it within its directory, and it cannot be moved into a readable directory.
-- A file matching a deny rule that is *created* later under an already-granted directory is readable by that child. That discloses nothing the child could not already obtain — either the child wrote those bytes, or it copied them from somewhere the ruleset already allowed. A concurrent third party writing a new secret into the workspace during the child's lifetime is the residual race; `denyRead` is also enforced at request time for that reason.
-- Bytes already read into the child's memory cannot be withdrawn by any later filesystem rule; the boundary governs acquisition, not recall.
-- SSH-authenticated `git` does not work through a scoped spawn, because `~/.ssh` is not granted (use HTTPS or `gh`). A toolchain whose runtime files live outside the `bin` directory on `PATH` — an `nvm`-style install — needs its tree named by the tool's own environment variable.
+Landlock rules bind to inodes, so a ruleset cannot single out a *name* that does not exist yet. Compiling the carve-out from the denied paths a walk happens to find therefore made the boundary depend on timing: the same profile withheld a secret that already existed and disclosed the identical secret written a moment after the ruleset was compiled, to the child or to any descendant it spawned. F2026-09-054 measured that on Linux 6.8.0-139-generic / Landlock ABI 4, along with the two repairs that do not work — granting files individually blocks a legitimate generated file from being read back, and a post-run scan cannot recall bytes that already left. [ORB-11978]
+
+The compiler asks the exclusion **rules** what they can name instead of asking the tree what it currently holds. `GlobReach` (`crates/orbit-types/src/policy/glob.rs`) answers, per directory, whether a rule can name a path strictly beneath it, and every such directory is granted list-only. A name created there afterwards then has no readable ancestor, exactly as if it had been present all along, and the ruleset's shape no longer depends on when the write happened.
+
+That question has an answer only when the rule's own segments bound it:
+
+- **Bounded** — `secrets/**`, `.env`, `config/*.key`. The rule names the directories it can reach (`*` and `?` cannot cross a separator), so the carve-out costs exactly those directories and every other directory keeps its whole-tree grant. This is enforced.
+- **Unbounded** — `**/.env`, `**/*.env`, `a/**/b.key`. A `**` that crosses directories can name a path beneath *every* directory in the workspace, including directories that do not exist yet. Carving that out means granting no directory as a tree at all, which withdraws read access from every file the run produces itself: a compiler cannot read back the object it just wrote. Such a rule is **not enforced at the process boundary and not silently dropped**. It is returned on `LandlockReadBoundary::unenforced_exclusions`, logged once per spawn under `orbit.sandbox.landlock`, and keeps its full effect in the request-time policy check, which decides a concrete path and needs no ruleset.
+
+The shipped default policy's `denyRead` (`**/.env`, `**/.env.*`, `**/*.env`, `**/*.env.*`) is entirely in the unbounded class, so a profile resolved from it reports all four rules as unenforced at the process boundary and keeps its previous grant shape. An operator who needs a `denyRead` rule held by the kernel against names that do not exist yet must write it in a bounded form — `secrets/**` rather than `**/secrets/**`. Closing the unbounded case needs a name-enforcing backend, which Landlock is not; no snapshot, inode census, or post-run guard substitutes for one, and none is reported as if it did.
+
+**Acquisition, not naming.** The boundary decides which inodes a child may take bytes from, at the moment it takes them. Everything downstream of that follows and is covered by tests:
+
+- A denied path stays unreadable for the child's whole life whether it existed at spawn or appeared afterwards, including after a rename within its directory, and it cannot be moved or hard-linked into a readable directory — `REFER` refuses a relocation that would gain access.
+- An inode the ruleset already granted keeps that grant through a rename or hard link into a denied name. The child could read those bytes before it renamed anything, so the name change withdraws nothing. What stays closed is the direction that matters: a *new* inode arriving at a denied name gets no readable ancestor.
+- A symlink is resolved where it points, so aliasing a denied path from a readable directory grants nothing.
+- An open descriptor, an active mapping, and bytes already in the child's memory are beyond recall; no later filesystem rule revokes them.
+- Creating and removing a denied name still work. This ruleset governs reads; writes stay with the mount namespace in §7.1.
+
+**Other known limits.** SSH-authenticated `git` does not work through a scoped spawn, because `~/.ssh` is not granted (use HTTPS or `gh`). A toolchain whose runtime files live outside the `bin` directory on `PATH` — an `nvm`-style install — needs its tree named by the tool's own environment variable.
+
+**Evidence.** `crates/orbit-exec/tests/linux_landlock.rs` exercises the real kernel: a concurrent writer creates a secret in a directory that did not exist at spawn and an indirect descendant cannot return it, while a file the run generates stays readable. It runs only where the host offers Landlock ABI 2 or later and reports a skip otherwise; `crates/orbit-exec/src/linux_landlock/tests/` covers grant compilation deterministically on any platform.
 
 `ExecutionResult { success, stdout, stderr, exit_code, duration_ms, output }` is defined in `orbit-common`. Captured bytes use `String::from_utf8_lossy`, so non-UTF-8 output becomes replacement characters instead of failing the call.
 


### PR DESCRIPTION
## Task

[ORB-11978](https://orbit-cli.com/tasks/ORB-11978) — Close the remaining dynamic denyRead gap after Landlock integration

### Description

## Problem and evidence
ORB-11514 and ORB-11546 now report done, but current linux_landlock/workspace.rs explicitly states that newly created denied names beneath granted directories remain readable and calls a concurrent third-party secret write a residual race. The original authorized contract required dynamic denied-name/alias confidentiality; request-time argv checks do not mediate indirect descendants. F2026-09-054 remains a real contract gap. REFER handling now exists, so do not repeat the separate F2026-09-056 repair.

Source frictions: F2026-09-054.
Audit source baseline: owning Linux checkout e4f9098633a8876a5a7c233d9914a094b6efa858, inspected 2026-09-10. Incident reports are historical evidence; no production failure was induced during this audit.

## Proposed solution
Implement the remaining live dynamic-name enforcement or fail closed for scoped profiles whose requested guarantee the selected backend cannot enforce. Reuse the prior ORB-11546 fixtures and measured mechanisms; preserve generated allowed files and narrow git/rg/cargo/make/gh runtime access. A spawn-time inode snapshot and post-exit scan are insufficient. Make descriptor, alias, rename and mmap semantics explicit against the original requirement. Do not silently narrow the contract to existing-at-spawn secrets or disable tools globally. Produce an exact runnable integration harness and host prerequisite when unavailable; no host-wide policy change or production probe is authorized.

## Scope and delivery
Create a validated task-scoped candidate from agent-main in a dedicated worktree. Preserve existing failed-run and friction evidence. This filing does not authorize dispatch, merge, release, production configuration changes or live backlog consolidation. Complexity hard; crew sol follows the configured lane. Existing task inventory and targeted searches were checked for covering work.

### Acceptance Criteria

- A synthetic concurrent writer creates a denied secret after child admission and an indirect descendant cannot return its bytes; allowed generated-file create/read still succeeds.
- Negative tests cover create/read/remove, allowed-to-denied rename, hardlinks, aliases and descriptor/mmap cases with explicit acquisition/later-access semantics; paired positive tool operations remain usable.
- Unsupported profiles/platforms fail with an actionable capability error before unconfined execution; no snapshot or post-run guard is reported as whole-contract enforcement.
- Reuse prior probe provenance and distinguish deterministic tests, real kernel passes and unavailable host integration; run normal repository gates.

## Execution Summary

<details>
<summary>Click to expand</summary>

Closed the enforceable half of the dynamic denyRead gap and made the remainder explicit instead of implied. Uncommitted on `orbit/ORB-11978-6aa22283`; HEAD unchanged at 00f35560b660e7fc510504fba0609abb3ae04bac.

## What changed

The carve-out no longer asks the tree what it currently holds; it asks the exclusion **rules** what they can name.

- `crates/orbit-types/src/policy/glob.rs` — new `GlobReach`: per directory, can a rule name a path strictly beneath it (`names_beneath`), and is its reach bounded by the rule's own segments or does a directory-crossing `**` let it name into directories the rule never mentions (`is_bounded`). Placed here because it is glob semantics, so there is one matcher rather than two.
- `crates/orbit-types/src/policy/fs_rules.rs` — `CompiledFsRules::exclusions()`; `has_exclusion()` now derives from it.
- `crates/orbit-exec/src/linux_landlock/workspace.rs` — `DenyReach` built from the profile's bounded exclusions; `carve_out_beneath` grants a directory list-only when it holds a denied path **or** when a bounded exclusion can still name a new path beneath it. The ruleset's shape is now independent of whether the denied path existed at spawn. Host credential carve-outs keep the rule-free `carve_out` entry point.
- `crates/orbit-exec/src/linux_landlock/mod.rs` — `linux_landlock_grants` becomes `linux_landlock_read_boundary`, returning `LandlockReadBoundary { grants, unenforced_exclusions }`; `spawn_under_linux_landlock` logs any unenforced exclusions once per spawn under `orbit.sandbox.landlock`.
- `docs/design/policy-sandbox/2_design.md` §7.3 — replaced the "residual race" paragraph with the enforced/reported split, the acquisition-vs-naming semantics, and the evidence/skip conditions.

## Criteria

1. **Concurrent writer / indirect descendant** — met. `a_secret_written_after_admission_is_withheld_from_an_indirect_descendant` spawns the confined child, then (outside the sandbox) creates `vault/` — a directory absent at spawn — writes the secret, and releases the child. A grandchild `sh -c 'cat vault/secret.txt'` is refused while the same run writes and reads back `build/out.txt` through another grandchild. The test asserts the secret is genuinely readable outside the sandbox, so it cannot pass vacuously. Regression evidence: with `DenyReach::names_beneath` forced to `false`, the test fails with `LATE_SENTINEL` in the child's stdout — the exact F2026-09-054 disclosure — and passes with it restored.
2. **Negative and paired positive cases** — met, all on the real kernel: create/read/remove of a denied name; allowed-to-denied rename; hard link (both directions, including the `REFER` refusal); symlink alias; open descriptor; `mmap` mapping surviving a rename (skips with a printed reason if `python3` is not on the child PATH — it was present here); and `the_carve_out_leaves_the_rest_of_the_workspace_usable` plus the pre-existing `allowlisted_programs_still_run_through_the_boundary` for git/rg/cargo/make/gh. Rename, hard link, descriptor and mapping are documented and asserted as **acquisition** semantics: a grant binds to an inode the child could already read, so renaming it to a denied name withdraws nothing; what stays closed is a *new* inode arriving at a denied name.
3. **Capability failure and honest reporting** — partly met, with one deliberate deviation stated below. Platform/ABI unavailability and any grant-compilation failure still return `PolicyDenied`/`InvalidInput` before a child exists, with no unconfined fallback (`a_profile_that_cannot_be_compiled_refuses_to_spawn`, plus the existing `tests/platform.rs` cases). No snapshot or post-run guard is presented as whole-contract enforcement; the doc states plainly that closing the unbounded case needs a name-enforcing backend.
4. **Provenance and gates** — met. Reuses the ORB-11546/F2026-09-054 fixture shape and the measured mechanisms rather than re-probing. Deterministic grant-compilation tests run anywhere; kernel tests ran for real on Linux 6.8.0-139-generic / Landlock ABI 4 and self-skip with a printed reason where Landlock is unavailable.

## Deviation, stated explicitly

Criterion 3 says unsupported profiles fail with a capability error. An exclusion whose `**` crosses directories (`**/.env`) can name a path beneath every directory in the workspace; enforcing it means granting no directory as a tree, which is precisely the failure F2026-09-054 measured — the run cannot read back files it produced. The shipped `default.yaml` `denyRead` is **entirely** in that class, and `proc_spawn_activity_scoped` follows `managed_run_context()`, so failing closed on it would make every managed-run activity-scoped `proc.spawn` on Linux return a capability error, and enforcing it would break builds. Editing the policy asset was not authorized. Those rules are therefore reported on `unenforced_exclusions` and logged, never silently dropped, and the boundary no longer claims to hold them. Filed as **F2026-09-108** — an owner decision on whether to anchor the shipped `denyRead` rules into a bounded form, not a code repair.

Net effect on the shipped default policy: no behavioural change (all four rules unbounded, grant shape as before) plus the new per-spawn disclosure. Operators who write a bounded rule (`secrets/**`, `.env`, `config/*.key`) now get kernel enforcement against names that do not exist yet.

## Validation

Passed:
- `make ci-fast` — exit 0 (re-run after the final cleanup edit).
- `make ci-lint` — exit 0.
- `cargo test -p orbit-types -p orbit-exec -p orbit-policy -p orbit-tools` — exit 0.
- `cargo test -p orbit-exec --test linux_landlock` — 18/18 on real Landlock ABI 4, including 8 new tests.
- `cargo test -p orbit-exec --lib linux_landlock` — 22/22, including 6 new grant-compilation tests.
- `cargo test -p orbit-types --lib policy::tests::glob` — 12/12, including 5 new reach tests.
- Fault-injection check that the criterion-1 test detects the pre-fix behaviour (described above).

Not run: full `make ci` (per workspace policy it is the CI merge gate, not a per-task local run). `test-compiler-cache-namespaces` inside `ci-fast` self-skipped — this host disallows unprivileged user namespaces, so bwrap cannot start; unrelated to this change and not something it could regress.

Limits of the evidence: the kernel assertions establish Linux/Landlock ABI 4 behaviour only. Non-Linux platforms are covered by the compile-time-gated refusal in `tests/platform.rs`, not by execution. Behaviour on ABI 2 and 3 is inferred from the ABI floor, not exercised.

## Scope note

Five files outside the original `context_files` were changed and appended to the task: the three `orbit-types` policy files and their glob test file (the reach primitive belongs with the glob matcher, not duplicated in `orbit-exec`), and `crates/orbit-exec/src/lib.rs` (the renamed re-export). No new cross-crate dependency edge: `orbit-exec` already depends on `orbit-types`.

Working tree carries only these ten files; `git diff --check` clean, no untracked artifacts, nothing committed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11978-6aa22283`
- Behind base: 0
- Ahead of base: 1

*authored by: claude*