### PR TITLE
Check task validation tool requirements before implementation admission

### DIFF
--- a/.orbit/resources/activities/task_pilot.yaml
+++ b/.orbit/resources/activities/task_pilot.yaml
@@ -177,7 +177,21 @@ spec:
        a wrong dependency requirement, a broken manifest, a packaging script
        bug — is ordinary work, so return its selectors and leave
        `release_action_required` null.
-    5. Report recommendations only; do not apply them:
+    5. Check the task's acceptance criteria against the lane that would run
+       them. A criterion is infeasible when it requires a tool over a transport
+       that does not advertise it (an MCP session reaches only MCP-advertised
+       tools, so `proc.spawn` is CLI-only), when it names a tool outside the
+       implementation activity's allowlist that the task's immutable
+       `required_tools` never declared, or when it requires an
+       operator-reserved governed operation an implementing agent cannot
+       perform. Report each contradiction in `utility_warnings`, naming the
+       tool and the repair — declare it at creation, restate the transport, or
+       hand that validation to an operator. Never recommend widening the MCP
+       surface, relaxing an allowlist, or setting an authority environment
+       variable to make a criterion reachable. A criterion that expects a
+       refusal is a correct negative test, and a tool name inside a quoted
+       example is not a requirement; report neither.
+    6. Report recommendations only; do not apply them:
        `recommended_crew`, `recommended_complexity`, real `blocked_by` task IDs,
        `duplicate_of`, `already_landed`, `release_action_required`,
        `adr_conflicts` (a legacy output field name kept for consumer

--- a/crates/orbit-core/assets/activities/task_pilot.yaml
+++ b/crates/orbit-core/assets/activities/task_pilot.yaml
@@ -177,7 +177,21 @@ spec:
        a wrong dependency requirement, a broken manifest, a packaging script
        bug — is ordinary work, so return its selectors and leave
        `release_action_required` null.
-    5. Report recommendations only; do not apply them:
+    5. Check the task's acceptance criteria against the lane that would run
+       them. A criterion is infeasible when it requires a tool over a transport
+       that does not advertise it (an MCP session reaches only MCP-advertised
+       tools, so `proc.spawn` is CLI-only), when it names a tool outside the
+       implementation activity's allowlist that the task's immutable
+       `required_tools` never declared, or when it requires an
+       operator-reserved governed operation an implementing agent cannot
+       perform. Report each contradiction in `utility_warnings`, naming the
+       tool and the repair — declare it at creation, restate the transport, or
+       hand that validation to an operator. Never recommend widening the MCP
+       surface, relaxing an allowlist, or setting an authority environment
+       variable to make a criterion reachable. A criterion that expects a
+       refusal is a correct negative test, and a tool name inside a quoted
+       example is not a requirement; report neither.
+    6. Report recommendations only; do not apply them:
        `recommended_crew`, `recommended_complexity`, real `blocked_by` task IDs,
        `duplicate_of`, `already_landed`, `release_action_required`,
        `adr_conflicts` (a legacy output field name kept for consumer

--- a/crates/orbit-core/assets/skills/orbit/references/task-authoring.md
+++ b/crates/orbit-core/assets/skills/orbit/references/task-authoring.md
@@ -98,7 +98,10 @@ job fills them from real inspection. → [orchestration.md](orchestration.md)
   any agent activity's baseline. Use only exact, active, agent-facing registered
   names; wildcards and prefixes are rejected at dispatch. The list is normalized,
   sorted, and deduplicated at creation. It is immutable afterward, and every
-  existing-task update surface rejects `required_tools`.
+  existing-task update surface rejects `required_tools` — so declare every tool
+  your acceptance criteria name **at creation**, because setting it later
+  cannot widen an already-dispatched activity. → [Validation your lane can
+  actually run](#validation-your-lane-can-actually-run)
   Inclusion grants only activity allowlist membership: caller role, host
   capability, tool policy, filesystem/subprocess policy, and external
   authentication can still deny execution. A task that names exactly
@@ -109,6 +112,37 @@ job fills them from real inspection. → [orchestration.md](orchestration.md)
   `github.auth.status` can still yield a structured `available: false` or
   `authenticated: false` capability-unavailable result when the lane has no
   GitHub client or credentials; that is not a clean CI pass.
+
+## Validation your lane can actually run
+
+A criterion that names a tool is a promise about the lane that will run it, and
+`required_tools` is the only field that can keep that promise — which is why it
+has to be right at creation. Task-pilot preparation reads each criterion
+against the registered tool surface, the canonical MCP tool list, the
+implementation activity's allowlist, and the governed-operation registry, and
+reports one `validation_tool_warnings` finding per contradiction before the
+task is admitted. A finding never rejects a task; it names the repair.
+
+- **Transport.** An MCP session reaches only MCP-advertised tools. `proc.spawn`
+  is registered CLI-only, so a criterion that requires it over MCP can never
+  pass — drive it through `orbit tool run proc.spawn` instead. Never ask for
+  the MCP surface to be widened to match a criterion's wording.
+- **Allowlist.** A tool outside the implementation activity's baseline has to
+  be in `required_tools`, or the criterion is unreachable from the lane.
+- **Operator capability.** Governed operations — workflow run observation and
+  resume, the operation grants, `orbit.command.exec`, `orbit.agent.invoke`,
+  and the other destructive surfaces — are reserved for an operator.
+  `required_tools` grants allowlist membership, not capability, and an
+  implementing agent must never set an authority environment variable to get
+  past that gate. Write the criterion as an explicit operator handoff, or scope
+  it to the registered dispatch path an agent can reach.
+- **External credentials.** `github.*` reads depend on authentication the lane
+  may not hold, so state that precondition instead of treating a
+  capability-unavailable result as a pass.
+
+A criterion that *expects* a refusal is a correct negative test, and a tool
+name inside a quoted example is a copied observation, not a requirement.
+Neither is reported, and neither grants anything.
 
 ## Quality bar
 

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_admission.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_admission.rs
@@ -78,11 +78,16 @@ pub(super) fn assess(
         }
     }
 
+    // `validation_tool_warnings` is the deterministic boundary's own finding
+    // rather than the pilot's, but it withholds admission for the same reason
+    // the others do: the repair would be admitted with an acceptance check the
+    // implementation lane cannot run [ORB-11980].
     let warning_fields = [
         "blocked_by",
         "adr_conflicts",
         "utility_warnings",
         "surface_warnings",
+        super::task_pilot::VALIDATION_TOOL_WARNINGS,
     ];
     let warnings = warning_fields
         .iter()

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
@@ -24,9 +24,11 @@ use crate::application::task::TaskListFilter;
 
 mod apply;
 mod source;
+mod validation_tools;
 
 pub(super) use apply::apply;
 use source::{GitPathKind, SourceSnapshot, requested_base_branch, resolve_source_snapshot};
+use validation_tools::ImplementationLane;
 
 const DEFAULT_MAX_PARTITION_SIZE: usize = 5;
 const HARD_MAX_PARTITION_SIZE: usize = 5;
@@ -39,6 +41,10 @@ const TASK_PILOT_JOB_ID: &str = "task_pilot_pipeline";
 /// only the per-task sample so evidence size stops scaling with terminal
 /// workspace history [ORB-11244].
 const MAX_EXCLUDED_SAMPLE: usize = 20;
+/// Field carrying the deterministic validation-tool feasibility findings, on
+/// both a prepared task snapshot and the assessment apply reports for it
+/// [ORB-11980].
+pub(super) const VALIDATION_TOOL_WARNINGS: &str = "validation_tool_warnings";
 
 pub(super) fn prepare(
     runtime: &OrbitRuntime,
@@ -200,25 +206,33 @@ pub(super) fn prepare(
         ));
     }
 
-    if let Some(source) = &source {
-        for snapshot in &mut task_snapshots {
-            let task = runtime
-                .get_task(snapshot["task_id"].as_str().unwrap_or_default())
-                .map_err(|error| action_failed(action, error.to_string()))?;
-            let fingerprint = crate::application::automation::preparation::fingerprint(
-                runtime,
-                &task,
-                &source.source_revision,
-            )
+    // One hydration per selected task feeds both the state-automation
+    // fingerprint and the validation-tool feasibility check. Discovery above
+    // deliberately works from envelopes, which carry no acceptance criteria,
+    // and the selection is already bounded by `max_tasks` at this point.
+    let lane = ImplementationLane::resolve(runtime);
+    for (task_id, snapshot) in task_ids.iter().zip(task_snapshots.iter_mut()) {
+        let task = runtime
+            .get_task(task_id)
             .map_err(|error| action_failed(action, error.to_string()))?;
-            if claim
-                .as_ref()
-                .is_some_and(|claim| claim.member.fingerprint != fingerprint)
-            {
-                return Err(action_failed(action, "state-trigger task meaning changed"));
-            }
-            snapshot["material_fingerprint"] = json!(fingerprint);
+        snapshot[VALIDATION_TOOL_WARNINGS] = json!(lane.validation_warnings(&task));
+
+        let Some(source) = &source else {
+            continue;
+        };
+        let fingerprint = crate::application::automation::preparation::fingerprint(
+            runtime,
+            &task,
+            &source.source_revision,
+        )
+        .map_err(|error| action_failed(action, error.to_string()))?;
+        if claim
+            .as_ref()
+            .is_some_and(|claim| claim.member.fingerprint != fingerprint)
+        {
+            return Err(action_failed(action, "state-trigger task meaning changed"));
         }
+        snapshot["material_fingerprint"] = json!(fingerprint);
     }
 
     let partitions = task_ids
@@ -496,9 +510,20 @@ fn validate_after_selectors(
 /// not sufficient: any finding that names other work, or an action outside
 /// what this repository owns — a duplicate, a repair that already landed, or
 /// an operator-reserved release action — keeps that decision with a human
-/// [ORB-11517].
+/// [ORB-11517]. A validation criterion the implementation lane cannot satisfy
+/// does the same, because promoting it admits work whose acceptance check is
+/// already known to be unreachable [ORB-11980].
 pub(super) fn member_ready(assessment: &Value) -> bool {
-    assessment["disposition"] == "selectors"
+    // Unlike the agent's own findings below, this field is injected by the
+    // deterministic apply boundary, so an assessment that predates the
+    // injection reads as "no finding" rather than as "not ready".
+    let validation_tools_feasible = assessment
+        .get(VALIDATION_TOOL_WARNINGS)
+        .and_then(Value::as_array)
+        .is_none_or(Vec::is_empty);
+
+    validation_tools_feasible
+        && assessment["disposition"] == "selectors"
         && [
             "blocked_by",
             "adr_conflicts",

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs
@@ -14,8 +14,9 @@ use crate::application::task::TaskUpdateParams;
 
 use super::source::SourceSnapshot;
 use super::{
-    action_failed, member_ready, requested_workspace_root, required_string, required_string_array,
-    string_array_value, validate_after_selectors, validate_recommendations,
+    VALIDATION_TOOL_WARNINGS, action_failed, member_ready, requested_workspace_root,
+    required_string, required_string_array, string_array, string_array_value,
+    validate_after_selectors, validate_recommendations,
 };
 
 #[derive(Clone)]
@@ -25,6 +26,9 @@ struct PreparedTaskSnapshot {
     title: String,
     tags: Vec<String>,
     material: Option<(String, String)>,
+    /// Deterministic feasibility findings for the tools this task's acceptance
+    /// criteria require, computed at preparation [ORB-11980].
+    validation_tool_warnings: Vec<String>,
 }
 
 struct ValidatedTask {
@@ -106,6 +110,11 @@ pub(in super::super) fn apply(
                     status,
                     title,
                     tags,
+                    validation_tool_warnings: string_array(
+                        entry,
+                        VALIDATION_TOOL_WARNINGS,
+                        action,
+                    )?,
                     material: entry
                         .get("material_fingerprint")
                         .and_then(Value::as_str)
@@ -360,13 +369,25 @@ pub(in super::super) fn apply(
                 stale.push(stale_task(task_id, reason.0, reason.1));
                 continue;
             }
+            // The pilot never sees the deterministic feasibility findings, so
+            // apply attaches them here: every downstream readiness and
+            // admission rule then reads one assessment that carries both the
+            // agent's findings and the lane's [ORB-11980].
+            let mut assessment = (*assessment).clone();
+            if let Value::Object(fields) = &mut assessment {
+                fields.insert(
+                    VALIDATION_TOOL_WARNINGS.to_string(),
+                    json!(snapshot.validation_tool_warnings),
+                );
+            }
+
             let admission = match ci_sweep_filing
                 .map(|filing| {
                     ci_failure_admission::assess(
                         action,
                         task_id,
                         &current,
-                        assessment,
+                        &assessment,
                         &after,
                         filing,
                         promotion_authorized,
@@ -386,7 +407,7 @@ pub(in super::super) fn apply(
             validated.push(ValidatedTask {
                 task_id: task_id.clone(),
                 after,
-                assessment: (*assessment).clone(),
+                assessment,
                 admission,
                 promote,
             });

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/validation_tools.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/validation_tools.rs
@@ -1,0 +1,340 @@
+//! Feasibility check for the tools a task's acceptance criteria name [ORB-11980].
+//!
+//! Acceptance criteria routinely name the exact tool and transport a
+//! validation must use. Nothing compared that wording against the lane that
+//! would run the work, so a criterion could demand an MCP call for a CLI-only
+//! tool (F2026-09-065) or an operator-reserved tool the implementation
+//! allowlist never grants (F2026-09-066). Both contradictions surfaced only
+//! after an implementing agent had spent most of a run discovering them, and
+//! `required_tools` — the one field that could have granted the tool — is
+//! immutable after creation, so by then nothing could repair it in place.
+//!
+//! This check reads the same canonical data the runtime enforces with: the
+//! registered tool surface, the MCP exposure set from
+//! [`orbit_tools::canonical_builtin_mcp_tool_definitions`], the implementation
+//! activity's tool allowlist, and the governed-operation registry.
+//!
+//! It is advisory in both directions, on purpose:
+//!
+//! - Prose never grants. A tool named in a criterion stays ungranted;
+//!   `required_tools` remains the only grant, and this check merely reports
+//!   when the two disagree.
+//! - A mention never rejects. Every finding is a warning, so a criterion that
+//!   quotes an expected denial, or a fixture that names a tool it expects to
+//!   be refused, cannot fail preparation.
+//!
+//! Nothing here proposes widening the MCP surface, relaxing an allowlist, or
+//! setting an authority environment variable. The actionable repair for an
+//! operator-reserved validation is an operator handoff, not a wider lane.
+
+use std::collections::BTreeSet;
+
+use orbit_common::governance::authorization::governed_tool;
+use orbit_types::task::Task;
+use orbit_types::tool::McpCapability;
+use orbit_types::workflow::activity_job::{ActivityV2Spec, tool_allowed};
+
+use crate::OrbitRuntime;
+
+/// Activity that implements a task. Its tool allowlist is the baseline a
+/// task's `required_tools` extends, so it is the lane a validation criterion
+/// has to be feasible in.
+const IMPLEMENTATION_ACTIVITY: &str = "agent_implement";
+
+/// Cap on findings reported for one task. A criterion set that contradicts the
+/// lane this many times needs rewriting, not a longer list.
+const MAX_FINDINGS_PER_TASK: usize = 8;
+
+/// Tool families whose execution depends on credentials Orbit neither holds
+/// nor can grant, paired with the precondition to state.
+const EXTERNAL_CREDENTIALS: &[(&str, &str)] = &[("github.", "GitHub authentication")];
+
+/// Lowercase wording that marks a sentence as expecting a refusal rather than
+/// requiring a call. A negative test names the tool it expects to be denied,
+/// which is a correct criterion, not a contradiction.
+const DENIAL_MARKERS: &[&str] = &[
+    "deny",
+    "denie",
+    "denial",
+    "reject",
+    "refus",
+    "unavailable",
+    "not granted",
+    "not in the allowlist",
+    "must not",
+    "cannot",
+];
+
+/// Lowercase wording that names the MCP transport specifically.
+const MCP_TRANSPORT_MARKERS: &[&str] = &["mcp", "tools/call", "tools/list"];
+
+/// The execution lane a task's validation criteria have to be feasible in.
+///
+/// Each source is optional because none of them may fail preparation: when a
+/// catalog or the registry cannot be read, the dimension it feeds reports
+/// nothing rather than guessing.
+pub(super) struct ImplementationLane {
+    /// Active, agent-facing registered tool names, sorted so findings are
+    /// reported in a stable order.
+    registered: Vec<String>,
+    /// Canonical MCP-advertised names, or `None` when the definition set is
+    /// invalid.
+    mcp_exposed: Option<BTreeSet<String>>,
+    /// The implementation activity's declared allowlist, or `None` when the
+    /// activity catalog is unavailable.
+    baseline: Option<Vec<String>>,
+}
+
+impl ImplementationLane {
+    pub(super) fn resolve(runtime: &OrbitRuntime) -> Self {
+        let mut registered = runtime.allowlist_known_tool_names();
+        registered.sort();
+
+        let mcp_exposed = orbit_tools::canonical_builtin_mcp_tool_definitions()
+            .ok()
+            .map(|definitions| {
+                definitions
+                    .into_iter()
+                    .map(|definition| definition.schema.name)
+                    .collect()
+            });
+
+        let baseline = runtime.v2_activity_catalog().ok().and_then(|catalog| {
+            match &catalog.get(IMPLEMENTATION_ACTIVITY)?.spec {
+                ActivityV2Spec::AgentLoop(spec) => Some(spec.tools.clone()),
+                ActivityV2Spec::Deterministic(_) => None,
+            }
+        });
+
+        Self {
+            registered,
+            mcp_exposed,
+            baseline,
+        }
+    }
+
+    /// Findings for every tool this task's acceptance criteria positively
+    /// require.
+    ///
+    /// Only acceptance criteria are read. They are the task's validation
+    /// contract; a tool named in the problem statement describes what broke,
+    /// not what the implementing agent has to call.
+    pub(super) fn validation_warnings(&self, task: &Task) -> Vec<String> {
+        let granted = self.baseline.as_ref().map(|baseline| {
+            baseline
+                .iter()
+                .chain(task.required_tools.iter())
+                .cloned()
+                .collect::<Vec<_>>()
+        });
+
+        let mut findings = Findings::default();
+        for criterion in &task.acceptance_criteria {
+            for sentence in sentences(&blank_quoted_regions(criterion)) {
+                if expects_denial(sentence) {
+                    continue;
+                }
+                for tool in self.tools_named_in(sentence) {
+                    self.report(tool, sentence, granted.as_deref(), &mut findings);
+                    if findings.is_full() {
+                        return findings.ordered;
+                    }
+                }
+            }
+        }
+        findings.ordered
+    }
+
+    /// Matching walks the registered surface rather than scanning for
+    /// dotted-looking words, so a name this Orbit does not expose to agents is
+    /// simply not a tool mention. That keeps prose from inventing a tool, at
+    /// the cost of staying silent on a name only dispatch can resolve — where
+    /// `required_tools` admission already rejects it.
+    fn tools_named_in<'a>(&'a self, sentence: &str) -> Vec<&'a str> {
+        self.registered
+            .iter()
+            .map(String::as_str)
+            .filter(|tool| names_tool(sentence, tool))
+            .collect()
+    }
+
+    /// Emit one finding per way the lane refuses this tool, so the author sees
+    /// which repair applies: restate the transport, declare the tool, or hand
+    /// the validation to an operator.
+    fn report(
+        &self,
+        tool: &str,
+        sentence: &str,
+        granted: Option<&[String]>,
+        findings: &mut Findings,
+    ) {
+        if names_mcp_transport(sentence)
+            && self
+                .mcp_exposed
+                .as_ref()
+                .is_some_and(|exposed| !exposed.contains(tool))
+        {
+            findings.push(format!(
+                "acceptance criterion validates `{tool}` over MCP, but `{tool}` is registered CLI-only and is absent from Orbit's canonical MCP tool list; drive it through `orbit tool run {tool}` or restate the criterion — do not widen the MCP surface to match the wording"
+            ));
+        }
+
+        if granted.is_some_and(|granted| !tool_allowed(tool, granted)) {
+            findings.push(format!(
+                "acceptance criterion requires `{tool}`, which the `{IMPLEMENTATION_ACTIVITY}` allowlist does not grant and this task's `required_tools` does not declare; declare it in `required_tools` at creation, because that field is immutable once the task exists"
+            ));
+        }
+
+        if let Some(operation) = governed_tool(tool)
+            && !operation.allowed.contains(&McpCapability::Agent)
+        {
+            findings.push(format!(
+                "acceptance criterion requires `{tool}`, a governed operation reserved for the {} capability; `required_tools` grants allowlist membership only, so route this validation to an explicit operator handoff instead of expecting the implementing agent to perform it",
+                capability_label(operation.allowed)
+            ));
+        }
+
+        if let Some((_, credential)) = EXTERNAL_CREDENTIALS
+            .iter()
+            .find(|(family, _)| tool.starts_with(family))
+        {
+            findings.push(format!(
+                "acceptance criterion requires `{tool}`, whose result depends on {credential} in the executing lane; `required_tools` cannot supply credentials, so state that precondition or hand the check to an operator"
+            ));
+        }
+    }
+}
+
+/// Deduplicated, order-preserving, bounded findings for one task.
+#[derive(Default)]
+struct Findings {
+    seen: BTreeSet<String>,
+    ordered: Vec<String>,
+}
+
+impl Findings {
+    fn push(&mut self, finding: String) {
+        if !self.is_full() && self.seen.insert(finding.clone()) {
+            self.ordered.push(finding);
+        }
+    }
+
+    fn is_full(&self) -> bool {
+        self.ordered.len() >= MAX_FINDINGS_PER_TASK
+    }
+}
+
+fn capability_label(allowed: &[McpCapability]) -> String {
+    allowed
+        .iter()
+        .map(McpCapability::to_string)
+        .collect::<Vec<_>>()
+        .join(" or ")
+}
+
+/// Blank the regions a criterion uses to quote something rather than to
+/// require it: fenced code blocks and double-quoted strings.
+///
+/// A tool name inside a copied transcript or an expected error message is an
+/// example of what the work will observe, not a call the lane has to support.
+/// Inline single backticks are deliberately left alone: canonical tool names
+/// are conventionally written that way, so masking them would blind the check
+/// to nearly every real criterion.
+///
+/// Blanking preserves length and line structure so the sentence split below
+/// still sees the surrounding prose as the author wrote it.
+fn blank_quoted_regions(text: &str) -> String {
+    const FENCE: &str = "```";
+
+    let mut blanked = String::with_capacity(text.len());
+    let mut quoting = Quoting::None;
+    let mut chars = text.char_indices();
+    while let Some((index, character)) = chars.next() {
+        if matches!(quoting, Quoting::None | Quoting::Fence) && text[index..].starts_with(FENCE) {
+            blanked.push_str("   ");
+            // The scanner already consumed the first backtick.
+            chars.next();
+            chars.next();
+            quoting = match quoting {
+                Quoting::Fence => Quoting::None,
+                _ => Quoting::Fence,
+            };
+            continue;
+        }
+        match (quoting, character) {
+            (Quoting::None, '"') => {
+                quoting = Quoting::Double;
+                blanked.push(' ');
+            }
+            // An unterminated quote ends at the line break, so a stray `"`
+            // cannot blank the rest of the criterion.
+            (Quoting::Double, '"' | '\n') => {
+                quoting = Quoting::None;
+                blanked.push(blank(character));
+            }
+            (Quoting::None, _) => blanked.push(character),
+            _ => blanked.push(blank(character)),
+        }
+    }
+    blanked
+}
+
+#[derive(Clone, Copy)]
+enum Quoting {
+    None,
+    Fence,
+    Double,
+}
+
+fn blank(character: char) -> char {
+    if character == '\n' { '\n' } else { ' ' }
+}
+
+/// Split into sentences at a terminator followed by whitespace, or at a line
+/// break. Requiring the trailing whitespace keeps a canonical tool name's own
+/// dots inside one sentence.
+fn sentences(text: &str) -> Vec<&str> {
+    let mut split = Vec::new();
+    let mut start = 0;
+    for (index, character) in text.char_indices() {
+        let terminates = matches!(character, '.' | ';' | '!' | '?')
+            && text[index + character.len_utf8()..]
+                .chars()
+                .next()
+                .is_none_or(char::is_whitespace);
+        if character == '\n' || terminates {
+            split.push(&text[start..index]);
+            start = index + character.len_utf8();
+        }
+    }
+    split.push(&text[start..]);
+    split.retain(|sentence| !sentence.trim().is_empty());
+    split
+}
+
+fn expects_denial(sentence: &str) -> bool {
+    let lowered = sentence.to_ascii_lowercase();
+    DENIAL_MARKERS.iter().any(|marker| lowered.contains(marker))
+}
+
+fn names_mcp_transport(sentence: &str) -> bool {
+    let lowered = sentence.to_ascii_lowercase();
+    MCP_TRANSPORT_MARKERS
+        .iter()
+        .any(|marker| lowered.contains(marker))
+}
+
+/// Whether `sentence` names exactly `tool`, rather than containing it inside a
+/// longer dotted name. Dots count as name characters so `orbit.task.artifact`
+/// does not match inside `orbit.task.artifact.get`.
+fn names_tool(sentence: &str, tool: &str) -> bool {
+    sentence.match_indices(tool).any(|(index, _)| {
+        let before = sentence[..index].chars().next_back();
+        let after = sentence[index + tool.len()..].chars().next();
+        !before.is_some_and(is_tool_name_char) && !after.is_some_and(is_tool_name_char)
+    })
+}
+
+fn is_tool_name_char(character: char) -> bool {
+    character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.')
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
@@ -18,6 +18,7 @@ mod sweep_duplicate_tasks;
 mod task_context;
 mod task_pilot;
 mod task_pilot_source;
+mod task_pilot_validation_tools;
 mod triage;
 mod v2_host;
 mod workspace_auto;

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_validation_tools.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_validation_tools.rs
@@ -1,0 +1,444 @@
+//! Preparation and admission coverage for the validation-tool feasibility
+//! check [ORB-11980], driven by the two frictions that motivated it:
+//! F2026-09-065 (a criterion requiring `proc.spawn` over MCP, which is
+//! CLI-only) and F2026-09-066 (a criterion requiring live workflow observation
+//! the implementation lane neither allowlists nor has the capability for).
+
+use std::collections::BTreeSet;
+
+use orbit_types::task::{Task, TaskPriority, TaskStatus, TaskType};
+use serde_json::{Value, json};
+
+use super::super::task_pilot::{apply, member_ready, prepare};
+use crate::OrbitRuntime;
+use crate::adapter::engine_host::v2_host::test_support::{
+    runtime_with_workspace_layout, write_workspace_file,
+};
+use crate::application::task::TaskAddParams;
+
+/// The lane a validation criterion has to be feasible in is the shipped
+/// implementation activity, so fixtures seed the real asset rather than a
+/// hand-written allowlist that could drift from it.
+fn seed_implementation_activity(root: &tempfile::TempDir) {
+    let activities = root.path().join("home/.orbit/resources/activities");
+    std::fs::create_dir_all(&activities).expect("global activities dir");
+    let &(_, yaml) = crate::runtime::assets::DEFAULT_ACTIVITY_FILES
+        .iter()
+        .find(|(name, _)| *name == "agent_implement")
+        .expect("shipped agent_implement asset");
+    std::fs::write(activities.join("agent_implement.yaml"), yaml)
+        .expect("seed the implementation activity");
+}
+
+fn seed_task(
+    runtime: &OrbitRuntime,
+    title: &str,
+    acceptance_criteria: &[&str],
+    required_tools: &[&str],
+) -> Task {
+    runtime
+        .add_task(TaskAddParams {
+            title: title.to_string(),
+            description: format!("Fixture task: {title}"),
+            acceptance_criteria: acceptance_criteria
+                .iter()
+                .map(|criterion| (*criterion).to_string())
+                .collect(),
+            required_tools: required_tools
+                .iter()
+                .map(|tool| (*tool).to_string())
+                .collect(),
+            plan: "Inspect and update the fixture.".to_string(),
+            workspace_path: Some(".".to_string()),
+            priority: TaskPriority::Medium,
+            task_type: Some(TaskType::Chore),
+            status: Some(TaskStatus::Backlog),
+            ..TaskAddParams::default()
+        })
+        .expect("seed task")
+}
+
+fn prepared(runtime: &OrbitRuntime, repo_root: &std::path::Path, task_ids: &[String]) -> Value {
+    prepare(
+        runtime,
+        "prepare_task_pilot",
+        &json!({
+            "task_ids": task_ids,
+            "workspace_path": repo_root,
+        }),
+    )
+    .expect("prepare explicit task-pilot selection")
+}
+
+/// Findings prepared for `task_id`, as plain strings.
+fn findings(prepared: &Value, task_id: &str) -> Vec<String> {
+    prepared["tasks"]
+        .as_array()
+        .expect("prepared tasks")
+        .iter()
+        .find(|snapshot| snapshot["task_id"] == json!(task_id))
+        .expect("prepared snapshot for task")["validation_tool_warnings"]
+        .as_array()
+        .expect("validation_tool_warnings array")
+        .iter()
+        .map(|finding| finding.as_str().expect("finding is a string").to_string())
+        .collect()
+}
+
+fn canonical_mcp_tool_names() -> BTreeSet<String> {
+    orbit_tools::canonical_builtin_mcp_tool_definitions()
+        .expect("canonical MCP tool definitions")
+        .into_iter()
+        .map(|definition| definition.schema.name)
+        .collect()
+}
+
+/// F2026-09-065 and F2026-09-066, side by side: both criteria are infeasible
+/// in the implementation lane, and preparation — which runs before any pilot
+/// worker launches — has to say so for distinct, actionable reasons.
+#[test]
+fn preparation_reports_distinct_reasons_for_mcp_transport_and_ungranted_observation() {
+    let (root, runtime, repo_root) = runtime_with_workspace_layout();
+    seed_implementation_activity(&root);
+
+    let mcp_transport = seed_task(
+        &runtime,
+        "signal handling",
+        &[
+            "Start `orbit mcp listen`, call `proc.spawn` over that MCP session with a 30-second sleep, SIGTERM the server, and confirm it exits inside the grace period.",
+        ],
+        &[],
+    );
+    let live_observation = seed_task(
+        &runtime,
+        "run observability",
+        &["Verify the installed run through `orbit.workflow.run.show` against the live workspace."],
+        &[],
+    );
+
+    let prepared = prepared(
+        &runtime,
+        &repo_root,
+        &[mcp_transport.id.clone(), live_observation.id.clone()],
+    );
+
+    let transport = findings(&prepared, &mcp_transport.id);
+    assert_eq!(transport.len(), 1, "unexpected findings: {transport:?}");
+    assert!(
+        transport[0].contains("`proc.spawn`")
+            && transport[0].contains("over MCP")
+            && transport[0].contains("orbit tool run proc.spawn"),
+        "transport finding must name the tool and the lane that can run it: {transport:?}"
+    );
+
+    let observation = findings(&prepared, &live_observation.id);
+    assert_eq!(observation.len(), 2, "unexpected findings: {observation:?}");
+    assert!(
+        observation.iter().any(
+            |finding| finding.contains("`required_tools` does not declare")
+                && finding.contains("immutable")
+        ),
+        "one finding must name the missing declaration: {observation:?}"
+    );
+    assert!(
+        observation
+            .iter()
+            .any(|finding| finding.contains("operator") && finding.contains("operator handoff")),
+        "one finding must route operator-reserved validation to a handoff: {observation:?}"
+    );
+
+    // The two tasks fail for different reasons, so neither finding may be a
+    // generic "this tool is a problem" message reused for both.
+    assert!(
+        observation
+            .iter()
+            .all(|finding| !transport.contains(finding)),
+        "findings must be distinct: {transport:?} vs {observation:?}"
+    );
+}
+
+/// A tool the lane really supports — whether from the activity baseline or
+/// from an explicit `required_tools` declaration — has to pass cleanly, or the
+/// check is noise. Declaration is still only allowlist membership: it supplies
+/// neither the operator capability nor an external credential.
+#[test]
+fn declaration_satisfies_the_allowlist_but_not_capability_or_credentials() {
+    let (root, runtime, repo_root) = runtime_with_workspace_layout();
+    seed_implementation_activity(&root);
+
+    // The same criterion twice, declared and undeclared, so a clean result
+    // proves the declaration carried it rather than the check overlooking the
+    // tool.
+    const AUTO_TASK_LIST: &str = "Enumerate the workspace's auto-task definitions with `orbit.auto_task.list` and confirm the seeded definition appears.";
+
+    let supported = seed_task(
+        &runtime,
+        "supported tools",
+        &[
+            "Read the task with `orbit.task.show` and confirm the plan field is populated.",
+            AUTO_TASK_LIST,
+        ],
+        &["orbit.auto_task.list"],
+    );
+    let undeclared = seed_task(&runtime, "undeclared tool", &[AUTO_TASK_LIST], &[]);
+    let operator_reserved = seed_task(
+        &runtime,
+        "declared operator tool",
+        &[
+            "List the workspace's runs with `orbit.workflow.run.list` and compare the newest run id.",
+        ],
+        &["orbit.workflow.run.list"],
+    );
+    let external_credential = seed_task(
+        &runtime,
+        "declared GitHub read",
+        &["Confirm the failing job appears in `github.run.list` output for the tested commit."],
+        &["github.run.list"],
+    );
+
+    let prepared = prepared(
+        &runtime,
+        &repo_root,
+        &[
+            supported.id.clone(),
+            undeclared.id.clone(),
+            operator_reserved.id.clone(),
+            external_credential.id.clone(),
+        ],
+    );
+
+    assert_eq!(
+        findings(&prepared, &supported.id),
+        Vec::<String>::new(),
+        "a baseline tool and a declared tool must both pass"
+    );
+
+    let missing_declaration = findings(&prepared, &undeclared.id);
+    assert_eq!(
+        missing_declaration.len(),
+        1,
+        "unexpected findings: {missing_declaration:?}"
+    );
+    assert!(
+        missing_declaration[0].contains("`orbit.auto_task.list`")
+            && missing_declaration[0].contains("`required_tools` does not declare"),
+        "the same criterion without the declaration must report it: {missing_declaration:?}"
+    );
+
+    let capability = findings(&prepared, &operator_reserved.id);
+    assert_eq!(capability.len(), 1, "unexpected findings: {capability:?}");
+    assert!(
+        capability[0].contains("operator") && capability[0].contains("allowlist membership only"),
+        "declaring an operator-reserved tool must not read as satisfied: {capability:?}"
+    );
+
+    let credential = findings(&prepared, &external_credential.id);
+    assert_eq!(credential.len(), 1, "unexpected findings: {credential:?}");
+    assert!(
+        credential[0].contains("GitHub authentication")
+            && credential[0].contains("cannot supply credentials"),
+        "a declared GitHub read must still name its credential precondition: {credential:?}"
+    );
+}
+
+/// Prose is evidence, not authority. A tool named inside a quoted example is
+/// not a requirement, a criterion that expects a refusal is a correct negative
+/// test, and neither may grant a tool or fail preparation.
+#[test]
+fn quoted_examples_and_negative_tests_neither_grant_nor_reject() {
+    let (root, runtime, repo_root) = runtime_with_workspace_layout();
+    seed_implementation_activity(&root);
+
+    let quoted_example = seed_task(
+        &runtime,
+        "quoted example",
+        &[
+            r#"The captured artifact records the string "orbit.workflow.run.show was skipped for this lane" verbatim."#,
+        ],
+        &[],
+    );
+    let negative_test = seed_task(
+        &runtime,
+        "negative test",
+        &["The lane refuses `orbit.workflow.run.show`, and the fixture asserts that refusal."],
+        &[],
+    );
+
+    let prepared = prepared(
+        &runtime,
+        &repo_root,
+        &[quoted_example.id.clone(), negative_test.id.clone()],
+    );
+
+    assert_eq!(
+        findings(&prepared, &quoted_example.id),
+        Vec::<String>::new(),
+        "a name inside a quoted example is not a validation requirement"
+    );
+    assert_eq!(
+        findings(&prepared, &negative_test.id),
+        Vec::<String>::new(),
+        "a criterion that expects a refusal is already correct"
+    );
+
+    // Neither task's `required_tools` grew, and preparation still selected
+    // both: prose can warn, but it can neither grant nor reject.
+    for task_id in [&quoted_example.id, &negative_test.id] {
+        assert_eq!(
+            runtime
+                .get_task(task_id)
+                .expect("reload fixture task")
+                .required_tools,
+            Vec::<String>::new()
+        );
+    }
+    assert_eq!(prepared["task_count"], 2);
+}
+
+/// The MCP dimension must answer from the same definition set MCP advertises
+/// from, so a tool that gains or loses exposure changes this check with it.
+#[test]
+fn mcp_findings_read_the_canonical_exposure_data() {
+    let (root, runtime, repo_root) = runtime_with_workspace_layout();
+    seed_implementation_activity(&root);
+
+    let exposed = canonical_mcp_tool_names();
+    assert!(
+        !exposed.contains("proc.spawn"),
+        "fixture assumes `proc.spawn` stays off the MCP surface"
+    );
+    assert!(
+        exposed.contains("orbit.task.show"),
+        "fixture assumes `orbit.task.show` stays on the MCP surface"
+    );
+
+    let advertised = seed_task(
+        &runtime,
+        "advertised over MCP",
+        &["Call `orbit.task.show` over the MCP session and confirm the envelope shape."],
+        &[],
+    );
+    let cli_only = seed_task(
+        &runtime,
+        "CLI-only",
+        &["Call `proc.spawn` over the MCP session and confirm the child is supervised."],
+        &[],
+    );
+
+    let prepared = prepared(
+        &runtime,
+        &repo_root,
+        &[advertised.id.clone(), cli_only.id.clone()],
+    );
+
+    assert_eq!(
+        findings(&prepared, &advertised.id),
+        Vec::<String>::new(),
+        "an MCP-advertised tool named over MCP is feasible"
+    );
+    assert_eq!(
+        findings(&prepared, &cli_only.id).len(),
+        1,
+        "a tool absent from the canonical definitions is not reachable over MCP"
+    );
+}
+
+/// Admission reads the finding, not just preparation's output: the pilot never
+/// sees it, so apply attaches it to the assessment it reports and readiness
+/// withholds the task.
+#[test]
+fn admission_withholds_a_task_whose_validation_criteria_are_infeasible() {
+    let (root, runtime, repo_root) = runtime_with_workspace_layout();
+    seed_implementation_activity(&root);
+    write_workspace_file(&repo_root, "src/listen.rs");
+
+    let task = seed_task(
+        &runtime,
+        "signal handling",
+        &["Verify the installed run through `orbit.workflow.run.show` against the live workspace."],
+        &[],
+    );
+    let task_ids = vec![task.id.clone()];
+    let prepared_snapshot = prepared(&runtime, &repo_root, &task_ids);
+
+    let output = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": prepared_snapshot,
+            "results": [json!({
+                "partition_index": 0,
+                "task_ids": task_ids,
+                "tasks": [json!({
+                    "task_id": task.id,
+                    "context_files_before": [],
+                    "context_files_after": ["file:src/listen.rs"],
+                    "disposition": "selectors",
+                    "recommended_crew": "luna",
+                    "recommended_complexity": "medium",
+                    "blocked_by": [],
+                    "duplicate_of": null,
+                    "already_landed": null,
+                    "adr_conflicts": [],
+                    "utility_warnings": [],
+                    "surface_warnings": [],
+                })],
+                "summary": "fixture partition",
+            })],
+            "workspace_path": repo_root,
+        }),
+    )
+    .expect("apply validated pilot results");
+
+    assert_eq!(output["status"], "succeeded");
+    let assessment = &output["tasks"][0];
+    assert_eq!(
+        assessment["validation_tool_warnings"]
+            .as_array()
+            .expect("reported findings")
+            .len(),
+        2,
+        "apply must report the findings the pilot could not see: {assessment:?}"
+    );
+    assert!(
+        !member_ready(assessment),
+        "a task whose acceptance check the lane cannot run is not ready for automatic promotion"
+    );
+
+    // Selectors still apply: the finding withholds promotion, it does not
+    // discard the pilot's validated work.
+    assert_eq!(
+        runtime
+            .get_task(&task.id)
+            .expect("reload task")
+            .context_files,
+        vec!["file:src/listen.rs"]
+    );
+}
+
+/// An assessment that predates the injected field reads as "no finding"
+/// rather than as "not ready", so readiness stays governed by the pilot's own
+/// findings when the deterministic one is absent.
+#[test]
+fn readiness_treats_an_absent_finding_as_feasible() {
+    let mut assessment = json!({
+        "task_id": "ORB-FIXTURE",
+        "disposition": "selectors",
+        "context_files_after": ["file:src/existing.rs"],
+        "blocked_by": [],
+        "duplicate_of": null,
+        "already_landed": null,
+        "release_action_required": null,
+        "adr_conflicts": [],
+        "utility_warnings": [],
+        "surface_warnings": [],
+    });
+    assert!(member_ready(&assessment));
+
+    assessment["validation_tool_warnings"] = json!([]);
+    assert!(member_ready(&assessment));
+
+    assessment["validation_tool_warnings"] =
+        json!(["acceptance criterion requires `orbit.workflow.run.show`"]);
+    assert!(!member_ready(&assessment));
+}

--- a/plugin/skills/orbit/references/task-authoring.md
+++ b/plugin/skills/orbit/references/task-authoring.md
@@ -98,7 +98,10 @@ job fills them from real inspection. → [orchestration.md](orchestration.md)
   any agent activity's baseline. Use only exact, active, agent-facing registered
   names; wildcards and prefixes are rejected at dispatch. The list is normalized,
   sorted, and deduplicated at creation. It is immutable afterward, and every
-  existing-task update surface rejects `required_tools`.
+  existing-task update surface rejects `required_tools` — so declare every tool
+  your acceptance criteria name **at creation**, because setting it later
+  cannot widen an already-dispatched activity. → [Validation your lane can
+  actually run](#validation-your-lane-can-actually-run)
   Inclusion grants only activity allowlist membership: caller role, host
   capability, tool policy, filesystem/subprocess policy, and external
   authentication can still deny execution. A task that names exactly
@@ -109,6 +112,37 @@ job fills them from real inspection. → [orchestration.md](orchestration.md)
   `github.auth.status` can still yield a structured `available: false` or
   `authenticated: false` capability-unavailable result when the lane has no
   GitHub client or credentials; that is not a clean CI pass.
+
+## Validation your lane can actually run
+
+A criterion that names a tool is a promise about the lane that will run it, and
+`required_tools` is the only field that can keep that promise — which is why it
+has to be right at creation. Task-pilot preparation reads each criterion
+against the registered tool surface, the canonical MCP tool list, the
+implementation activity's allowlist, and the governed-operation registry, and
+reports one `validation_tool_warnings` finding per contradiction before the
+task is admitted. A finding never rejects a task; it names the repair.
+
+- **Transport.** An MCP session reaches only MCP-advertised tools. `proc.spawn`
+  is registered CLI-only, so a criterion that requires it over MCP can never
+  pass — drive it through `orbit tool run proc.spawn` instead. Never ask for
+  the MCP surface to be widened to match a criterion's wording.
+- **Allowlist.** A tool outside the implementation activity's baseline has to
+  be in `required_tools`, or the criterion is unreachable from the lane.
+- **Operator capability.** Governed operations — workflow run observation and
+  resume, the operation grants, `orbit.command.exec`, `orbit.agent.invoke`,
+  and the other destructive surfaces — are reserved for an operator.
+  `required_tools` grants allowlist membership, not capability, and an
+  implementing agent must never set an authority environment variable to get
+  past that gate. Write the criterion as an explicit operator handoff, or scope
+  it to the registered dispatch path an agent can reach.
+- **External credentials.** `github.*` reads depend on authentication the lane
+  may not hold, so state that precondition instead of treating a
+  capability-unavailable result as a pass.
+
+A criterion that *expects* a refusal is a correct negative test, and a tool
+name inside a quoted example is a copied observation, not a requirement.
+Neither is reported, and neither grants anything.
 
 ## Quality bar
 


### PR DESCRIPTION
## Task

[ORB-11980](https://orbit-cli.com/tasks/ORB-11980) — Check task validation tool requirements before implementation admission

### Description

## Problem and evidence
F2026-09-065's criterion requires MCP proc.spawn although it is CLI-only. F2026-09-066 requires live workflow observation absent from the activity allowlist and operator capability. required_tools already exists and is immutable, but the contract mismatch reached implementation.

Source frictions: F2026-09-065, F2026-09-066.
Audit source baseline: owning Linux checkout e4f9098633a8876a5a7c233d9914a094b6efa858, inspected 2026-09-10. Incident reports are historical evidence; no production failure was induced during this audit.

## Proposed solution
Add a bounded task-preparation/admission feasibility check using the canonical tool registry, MCP exposure, effective activity allowlist and capability requirements. Check explicitly declared validation tools/transport against the actual execution lane and surface contradictions before implementation. Tool names found in prose can yield actionable warnings; do not reject quoted negative tests by naive regex or infer authority from prose. Update authoring/pilot guidance to declare required_tools at creation and route operator-only live validation to an explicit operator handoff. Never widen the baseline, expose proc.spawn over MCP or scrub authority environment variables merely to satisfy a criterion.

## Scope and delivery
Create a validated task-scoped candidate from agent-main in a dedicated worktree. Preserve existing failed-run and friction evidence. This filing does not authorize dispatch, merge, release, production configuration changes or live backlog consolidation. Complexity medium; crew terra follows the configured lane. Existing task inventory and targeted searches were checked for covering work.

### Acceptance Criteria

- Fixtures detect an MCP proc.spawn positive validation requirement and a required workflow observation lacking allowlist/capability before worker launch, with distinct actionable reasons.
- A properly declared supported tool passes, while required_tools alone does not imply operator capability or external credentials.
- Quoted examples and negative tests do not falsely grant tools or trigger unconditional rejection; deterministic registry checks share the canonical exposure data.
- Authoring guidance explains immutable required_tools and separate operator validation; run focused preparation/admission tests and repository gates.

## Execution Summary

<details>
<summary>Click to expand</summary>

Bounded, advisory validation-tool feasibility check added to task-pilot preparation, carried into admission. Changes left uncommitted on `orbit/ORB-11980-6aa22532` at HEAD 462a8f88b4815bf80b0ef5c96626b84678c49982.

## What landed

- **New** `crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/validation_tools.rs`. `ImplementationLane::resolve` reads four canonical sources: the active registered tool surface (`OrbitRuntime::allowlist_known_tool_names`), MCP exposure from `orbit_tools::canonical_builtin_mcp_tool_definitions()`, the `agent_implement` allowlist from the activity catalog, and `orbit_common::governance::authorization::governed_tool`. Each source is optional so a missing catalog or an invalid definition set silences its dimension instead of failing preparation. Per acceptance criterion it blanks fenced blocks and double-quoted spans, splits on sentence terminators followed by whitespace (so a tool name's own dots survive), skips sentences carrying refusal wording, matches only registered names at name-character boundaries, and emits one distinct finding per contradicted dimension: MCP transport, allowlist/`required_tools`, operator capability, external credential. Capped at 8 findings per task, deduplicated, deterministic order.
- `task_pilot.rs`: `prepare` now publishes `validation_tool_warnings` on every prepared task snapshot. The existing fingerprint loop and the new check were merged so each selected task is hydrated once (discovery works from envelopes, which carry no acceptance criteria); the selection is already bounded by `max_tasks` at that point. `member_ready` withholds automatic promotion on a non-empty finding, treating an absent field as "no finding".
- `task_pilot/apply.rs`: the pilot never receives the deterministic findings, so apply attaches them to the assessment it reports; `member_ready` and CI-sweep admission then read one assessment. Validated selectors still apply — the finding withholds promotion, it does not discard the pilot's work.
- `ci_failure_admission.rs`: `validation_tool_warnings` joined the warning vocabulary that withholds admission.
- Authoring guidance (`crates/orbit-core/assets/skills/orbit/references/task-authoring.md`, mirrored to `plugin/`): new "Validation your lane can actually run" section plus a `required_tools` cross-reference stating declaration must happen at creation because later updates cannot widen an already-dispatched activity. Covers transport, allowlist, operator capability (explicit handoff; never set an authority environment variable), and external credentials, and states that expected-refusal criteria and quoted examples are neither reported nor granting.
- Task-pilot instruction (`crates/orbit-core/assets/activities/task_pilot.yaml`, mirrored to `.orbit/resources/`): new step 5 telling the pilot to report a lane contradiction in `utility_warnings`, never to recommend widening the MCP surface, relaxing an allowlist, or setting an authority environment variable, and to report neither negative tests nor quoted examples. Mirrors regenerated with `scripts/sync-activity-assets.sh` and `scripts/sync-plugin-skills.sh`.

## Criteria

1. **Distinct reasons before worker launch** — met. `preparation_reports_distinct_reasons_for_mcp_transport_and_ungranted_observation` seeds F2026-09-065's criterion (`proc.spawn` over an MCP session) and F2026-09-066's (`orbit.workflow.run.show` against a live workspace) and asserts on `prepare` output, which is job step 0 and precedes the `pilots` fan-out. The first yields exactly one transport finding naming `orbit tool run proc.spawn`; the second yields two — missing declaration (naming immutability) and operator handoff — and the test asserts no finding string is shared.
2. **Declared supported tool passes; declaration is not capability or credentials** — met. `declaration_satisfies_the_allowlist_but_not_capability_or_credentials` pairs a clean task (baseline `orbit.task.show` plus declared `orbit.auto_task.list`) with a control carrying the identical criterion undeclared, which does report — so the clean result proves the declaration carried it. Declared `orbit.workflow.run.list` still reports operator capability; declared `github.run.list` still reports the credential precondition.
3. **Quoted examples and negative tests; shared exposure data** — met. `quoted_examples_and_negative_tests_neither_grant_nor_reject` covers a name reachable only inside a double-quoted span and an unquoted criterion expecting a refusal: both report nothing, preparation succeeds, and both tasks' `required_tools` stay empty. Rejection is impossible by construction — the check returns findings, never an error. `mcp_findings_read_the_canonical_exposure_data` derives its expectation from `canonical_builtin_mcp_tool_definitions()` itself, so exposure drift moves the test with the surface. `crates/orbit-tools/src/registry.rs` was consumed, not modified: sharing the canonical data meant calling its existing public function rather than restating the set.
4. **Guidance plus focused tests and gates** — met; commands below.

## Validation

| Command | Outcome |
| --- | --- |
| `cargo test -p orbit-core --lib task_pilot_validation_tools` | passed (6/6) |
| `cargo test -p orbit-core --lib task_pilot` | passed (46/46, includes existing pilot/apply/source suites) |
| `cargo test -p orbit-core --lib ci_failure` | passed (69 passed, 2 ignored — replay fixtures needing `ORBIT_CI_REPLAY_*`) |
| `cargo test -p orbit-core --lib` | passed (1286 passed, 2 ignored) |
| `make ci-fast` | passed (exit 0); `test-compiler-cache-namespaces` self-skipped — bubblewrap cannot create a user namespace on this kernel |
| `make ci-lint` | passed (exit 0) |
| `git diff --check`, `git status --short` | clean; every change accounted for, no stray artifacts |

Not run: `make ci` (per workspace policy, the merge gate runs in CI, not per task). Cross-crate suites outside orbit-core were not run; the change is confined to orbit-core plus two mirrored assets, and both sync guards pass inside `ci-fast`.

## Scope notes and risks

- Three files outside the original `context_files` were changed and appended to it: `task_pilot/apply.rs` and `ci_failure_admission.rs` (a finding nothing consumes is inert — these are the admission consumers named in the task title), and `tests/mod.rs` to register the new test module. Two new files were created and deliberately not added as selectors, since they do not exist at the source revision: `task_pilot/validation_tools.rs` and `tests/task_pilot_validation_tools.rs`. `tests/task_pilot.rs` was left unmodified — the existing file is already 918 lines, so new coverage went to a sibling file rather than growing it.
- Baseline, MCP surface, and authority environment variables were not touched, per the task's explicit prohibition.
- **Residual risk — false positives.** Detection is sentence-scoped heuristics over prose. A sentence that mentions MCP for one reason and a CLI-only tool for another can produce a spurious transport finding. Consequences are bounded: findings warn, and they withhold only *automatic* promotion.
- **Residual risk — false negatives.** Refusal wording is matched by a fixed stem list, so an unusually phrased negative test still reports, and an unusually phrased positive requirement may not. Only names on the active registered surface are matched, so a transport-synthesized name such as `orbit.workspace.list` (defined in `orbit-mcp`, not a registry builtin) is never a mention. That is deliberate: prose must not invent a tool, and `required_tools` admission in `resolve_activity_tools` already rejects an unknown or non-agent-facing declaration at dispatch.
- The check costs one `get_task` per selected task even when no source revision is pinned; previously that hydration happened only when one was. Bounded by `max_tasks` (default 50).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11980-6aa22532`
- Behind base: 0
- Ahead of base: 1