### PR TITLE
Provide a provenance-safe recipe for cross-revision build validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build release run check test fmt fmt-check clippy clean install uninstall dev watch audit tree ci ci-fast ci-lint stability release-check docs-index cleanup-branches build-budget-test build-budget-bench compiler-cache-status compiler-cache-setup compiler-cache-bench
+.PHONY: help build release run check test fmt fmt-check clippy clean install uninstall dev watch audit tree ci ci-fast ci-lint stability release-check docs-index cleanup-branches build-budget-test build-budget-bench compiler-cache-status compiler-cache-setup compiler-cache-bench cross-revision-check-test
 
 # ------------------------------------------------------------
 # Config
@@ -63,6 +63,7 @@ help:
 	@echo "  make compiler-cache-status  Show whether the opt-in rustc cache would enable"
 	@echo "  make compiler-cache-setup   Create ~/.orbit/cache/compiler (SETUP_FLAGS=--install to fetch sccache)"
 	@echo "  make compiler-cache-bench   Two-worktree cold/warm/concurrent compiler-cache timings"
+	@echo "  make cross-revision-check-test  Test the provenance-safe before/after validation helper"
 	@echo "  make watch        Continuous check + test"
 
 # ------------------------------------------------------------
@@ -206,6 +207,11 @@ compiler-cache-setup:
 
 compiler-cache-bench:
 	./scripts/bench-compiler-cache.sh
+
+# Provenance-safe before/after validation across two revisions. See
+# docs/runbooks/compiler-cache.md. [ORB-11981]
+cross-revision-check-test:
+	./scripts/test-cross-revision-check.sh
 
 # ------------------------------------------------------------
 # Dev Loop

--- a/crates/orbit-core/assets/skills/orbit/references/task-execution.md
+++ b/crates/orbit-core/assets/skills/orbit/references/task-execution.md
@@ -91,13 +91,35 @@ pop can restore another session's work. Record the worktree's initial
 and linked job-run worktrees, the repository's `.git` mount is read-only and
 must not be worked around by chmod or host-side gitdir writes. Commands that
 write to `.git` fail:
-- Do not use `git worktree add` to inspect or build other revisions; use
-  `mkdir -p /tmp/base && git archive <sha> | tar -x -C /tmp/base` to extract a
-  baseline revision without touching `.git` or creating `.git/worktrees/*`,
-  then build with a separate build cache/target directory.
+- Do not use `git worktree add` to inspect or build other revisions. Extract
+  each revision into its own scratch directory outside the checkout:
+  `mkdir -p /tmp/base && git archive <sha> | tar -x -C /tmp/base`. That reads
+  `.git` without writing it or creating `.git/worktrees/*`.
 - When `git checkout -- <path>` fails because it cannot acquire `index.lock`,
   revert the tracked file with `git show HEAD:<path> > <path>`.
 - Read-only inspection commands succeed with `GIT_OPTIONAL_LOCKS=0 git status --short`.
+
+**A bare extract is not yet before/after evidence.** Each step below answers a
+recorded false result, not a hypothetical one. Before comparing two revisions:
+
+- Give each revision its own build/output directory. Sharing one lets the
+  second arm reuse the first arm's artifacts and embedded fixture paths, so it
+  never exercises the revision it names.
+- Refresh timestamps after extracting (`find <dir> -exec touch {} +`).
+  `git archive` and `tar` write the archive's own mtimes, so an extract placed
+  beside an existing build can look up to date and rerun a stale binary.
+- Turn off compiler caches and wrappers for both arms. A cached baseline has
+  been observed producing a binary that contained the *other* tree's tests.
+- Verify provenance in the output instead of assuming it: require a string only
+  the intended revision can emit, and treat the sibling revision's string
+  appearing in an arm as a failed comparison.
+- Capture the producer's exit status before trimming output. Redirect to a log,
+  record the status, then read the tail. A filter at the end of a pipeline
+  reports the filter's success, not the build's failure — this turns a compile
+  error into a green validation line.
+
+If the workspace ships a helper for this comparison, use it rather than
+hand-rolling the steps; check the workspace's build and CI instructions.
 
 ## Step 5 — Summarize and hand off
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -25,7 +25,7 @@ CLI behavior, state layout, or recovery semantics change.
 | --- | --- |
 | [Inspect the Audit Trail](./runbooks/audit-trail.md) | Query and interpret Orbit invocation, run, step, and activity audit history. |
 | [Bound Concurrent Orbit Repository Builds](./runbooks/build-budget.md) | Run Cargo builds within Orbit's host-wide cross-worktree admission and compiler-job budget. |
-| [Share Rust dependency compilation across worker worktrees](./runbooks/compiler-cache.md) | Opt in, measure, and remove the host Rust compiler cache shared across Orbit worker worktrees. |
+| [Share Rust dependency compilation across worker worktrees](./runbooks/compiler-cache.md) | Opt in, measure, and remove the host Rust compiler cache shared across Orbit worker worktrees, and validate before/after builds with it off. |
 | [Recover a Corrupted Database](./runbooks/database-recovery.md) | Recover a corrupted Orbit SQLite database from backup, salvage, or regeneration. |
 | [Onboard an Executor](./runbooks/executor-onboarding.md) | Add and validate a CLI-agent or deterministic local-shell executor without changing existing users' routing or state. |
 | [Check Orbit Health](./runbooks/health-checks.md) | Check Orbit workspace, database, dashboard, log-sink, job-run, and routine-clock health. |

--- a/docs/runbooks/compiler-cache.md
+++ b/docs/runbooks/compiler-cache.md
@@ -1,11 +1,11 @@
 ---
 type: runbook
-summary: Opt in, measure, and remove the host Rust compiler cache shared across Orbit worker worktrees.
+summary: Opt in, measure, and remove the host Rust compiler cache shared across Orbit worker worktrees, and validate before/after builds with it off.
 tags: [operations, rust, cache, worktrees, sandbox, linux]
-paths: ["scripts/rustc-compiler-cache.sh", "scripts/compiler-cache.sh", "scripts/test-compiler-cache.sh", "scripts/test-compiler-cache-namespaces.sh", "scripts/bench-compiler-cache.sh", ".cargo/config.toml"]
+paths: ["scripts/rustc-compiler-cache.sh", "scripts/compiler-cache.sh", "scripts/test-compiler-cache.sh", "scripts/test-compiler-cache-namespaces.sh", "scripts/bench-compiler-cache.sh", "scripts/cross-revision-check.sh", "scripts/test-cross-revision-check.sh", ".cargo/config.toml"]
 related_features: [policy-sandbox, executors]
-related_artifacts: [ORB-11259, ORB-11755]
-last_validated: 2026-09-08
+related_artifacts: [ORB-11259, ORB-11755, ORB-11981]
+last_validated: 2026-09-10
 ---
 
 # Share Rust dependency compilation across worker worktrees
@@ -190,6 +190,68 @@ stays in the client tree. Do not advertise command-tree CPU as total compiler
 CPU when using server-side mode.
 
 Practical opt-out, no uninstall: `ORBIT_COMPILER_CACHE=0`.
+
+## Cross-revision before/after validation
+
+Comparing two revisions is the one workflow where the cache must be **off**, and
+where reused build state is the main source of false evidence. Recorded
+observations, all of them ordinary consequences of reusing state across source
+trees rather than defects in Cargo or sccache:
+
+- An archived baseline compiled under the configured rustc wrapper produced a
+  test binary listing the *current* worktree's newly added tests.
+- Two extracts sharing one `CARGO_TARGET_DIR` ran the first extract's embedded
+  fixture paths, so the second arm never exercised the revision it named.
+- `git archive` and `tar` write the commit's timestamps, so an extract placed
+  beside an existing build can look up to date and skip the rebuild.
+- A build piped into `tail` reported `tail`'s exit status, turning a compile
+  error into a green result.
+
+Use the maintained helper instead of hand-rolling `git archive | tar -x`:
+
+```bash
+scripts/cross-revision-check.sh \
+  --baseline <pre-fix-sha> --candidate <post-fix-sha> \
+  --expect-baseline fail --expect-candidate pass \
+  --baseline-marker 'test result: FAILED' \
+  --candidate-marker 'test result: ok' \
+  -- cargo test -p orbit-core --lib
+```
+
+| Guarantee | False result it prevents |
+| --- | --- |
+| A scratch extract and a private `CARGO_TARGET_DIR` per arm | An arm reusing the sibling revision's build output or embedded fixture paths |
+| Every extracted mtime reset to now | A build skipped because archive timestamps predate an existing target dir |
+| `ORBIT_COMPILER_CACHE=0`, empty `RUSTC_WRAPPER` / `CARGO_BUILD_RUSTC_WRAPPER`, `CARGO_INCREMENTAL=0` | A baseline compiled through the host cache picking up the other tree's artifacts |
+| Producer status captured from a redirect, then `--tail` reads the log file | A filter's success replacing the build's failure |
+| `--expect-baseline` / `--expect-candidate` | An unexpected failure reported as an ordinary arm result |
+| Per-arm marker required, sibling marker rejected | A stale or foreign test set passing as this revision's |
+| Read-only Git access (`rev-parse`, `archive`, `GIT_OPTIONAL_LOCKS=0`) | Writes to a managed read-only `.git`, or a mutated source checkout |
+| `--workdir` refused inside the checkout or under `.orbit/` | Scratch trees landing in the state being validated |
+
+Limits worth stating in a validation summary:
+
+- Marker verification is a literal substring match on each arm's log. A marker
+  both revisions can print proves nothing; pick text only one arm can emit.
+- The helper compares whatever the two revisions contain. It does not establish
+  that they differ only in the change under test.
+- Uncached arms are slower than a warm worktree build. That is the cost of an
+  independent baseline, not a regression; do not re-enable the cache for the
+  baseline arm to speed it up. `--keep-compiler-cache` exists for deliberate
+  cache experiments, not for before/after evidence.
+- Arm wall time is not a cache measurement. Use
+  [`scripts/bench-compiler-cache.sh`](#measure) for that.
+- The helper cannot recover a status you discard inside your own pipeline. Pass
+  the producer directly and let `--tail` do the bounding.
+
+Regression fixtures for the helper — arm isolation, mtime normalization, cache
+opt-out, producer exit code through bounded output, read-only `.git`, and
+workdir containment — run in CI and locally:
+
+```bash
+make cross-revision-check-test
+# equivalent: scripts/test-cross-revision-check.sh
+```
 
 ## Measure
 

--- a/plugin/skills/orbit/references/task-execution.md
+++ b/plugin/skills/orbit/references/task-execution.md
@@ -91,13 +91,35 @@ pop can restore another session's work. Record the worktree's initial
 and linked job-run worktrees, the repository's `.git` mount is read-only and
 must not be worked around by chmod or host-side gitdir writes. Commands that
 write to `.git` fail:
-- Do not use `git worktree add` to inspect or build other revisions; use
-  `mkdir -p /tmp/base && git archive <sha> | tar -x -C /tmp/base` to extract a
-  baseline revision without touching `.git` or creating `.git/worktrees/*`,
-  then build with a separate build cache/target directory.
+- Do not use `git worktree add` to inspect or build other revisions. Extract
+  each revision into its own scratch directory outside the checkout:
+  `mkdir -p /tmp/base && git archive <sha> | tar -x -C /tmp/base`. That reads
+  `.git` without writing it or creating `.git/worktrees/*`.
 - When `git checkout -- <path>` fails because it cannot acquire `index.lock`,
   revert the tracked file with `git show HEAD:<path> > <path>`.
 - Read-only inspection commands succeed with `GIT_OPTIONAL_LOCKS=0 git status --short`.
+
+**A bare extract is not yet before/after evidence.** Each step below answers a
+recorded false result, not a hypothetical one. Before comparing two revisions:
+
+- Give each revision its own build/output directory. Sharing one lets the
+  second arm reuse the first arm's artifacts and embedded fixture paths, so it
+  never exercises the revision it names.
+- Refresh timestamps after extracting (`find <dir> -exec touch {} +`).
+  `git archive` and `tar` write the archive's own mtimes, so an extract placed
+  beside an existing build can look up to date and rerun a stale binary.
+- Turn off compiler caches and wrappers for both arms. A cached baseline has
+  been observed producing a binary that contained the *other* tree's tests.
+- Verify provenance in the output instead of assuming it: require a string only
+  the intended revision can emit, and treat the sibling revision's string
+  appearing in an arm as a failed comparison.
+- Capture the producer's exit status before trimming output. Redirect to a log,
+  record the status, then read the tail. A filter at the end of a pipeline
+  reports the filter's success, not the build's failure — this turns a compile
+  error into a green validation line.
+
+If the workspace ships a helper for this comparison, use it rather than
+hand-rolling the steps; check the workspace's build and CI instructions.
 
 ## Step 5 — Summarize and hand off
 

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -74,3 +74,4 @@ fi
 "$repo_root/scripts/test-build-budget.sh"
 "$repo_root/scripts/test-compiler-cache.sh"
 "$repo_root/scripts/test-compiler-cache-namespaces.sh"
+"$repo_root/scripts/test-cross-revision-check.sh"

--- a/scripts/cross-revision-check.sh
+++ b/scripts/cross-revision-check.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+# Provenance-safe before/after validation across two immutable revisions [ORB-11981].
+#
+# Runs the same command once per revision in an independent scratch extract with
+# its own build target directory, then reports each arm's producer exit status
+# and a bounded tail of its log. Each guard below answers a measured false
+# before/after result, not a suspected cache defect:
+#
+#   F2026-09-064  a shared CARGO_TARGET_DIR let the second arm reuse the first
+#                 extract's embedded fixture paths     -> per-arm target dirs
+#   F2026-09-081  archive/tar mtimes are older than an existing build, so the
+#                 build skipped and reran a stale binary -> mtime normalization
+#   F2026-09-082  an archived baseline compiled under the configured rustc
+#                 wrapper and listed current-worktree tests -> cache opt-out
+#   F2026-09-077  `cargo ... | tail` reported tail's success -> status captured
+#                 from a redirect before any bounded display
+#
+# Git metadata is read-only (rev-parse + archive under GIT_OPTIONAL_LOCKS=0).
+# The source checkout is never written and no Orbit state is touched.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+REPO="$ROOT"
+BASELINE_REV=""
+CANDIDATE_REV=""
+BASELINE_MARKER=""
+CANDIDATE_MARKER=""
+EXPECT_BASELINE="pass"
+EXPECT_CANDIDATE="pass"
+WORKDIR=""
+TAIL_LINES="40"
+KEEP_COMPILER_CACHE=0
+COMMAND=()
+OWNED_WORKDIR=0
+
+usage() {
+  cat <<'EOF'
+usage: scripts/cross-revision-check.sh --baseline <rev> --candidate <rev> [options] -- <command> [args...]
+
+Runs <command> once per revision in an isolated extract and reports both arms.
+
+Required:
+  --baseline <rev>            revision validated as "before"
+  --candidate <rev>           revision validated as "after"
+
+Options:
+  --repo <dir>                source checkout to read revisions from (default: this repository)
+  --baseline-marker <text>    literal text the baseline log must contain
+  --candidate-marker <text>   literal text the candidate log must contain
+  --expect-baseline <pass|fail>   intended baseline outcome (default: pass)
+  --expect-candidate <pass|fail>  intended candidate outcome (default: pass)
+  --workdir <dir>             scratch root; must live outside the source checkout
+  --tail <n>                  log lines to display per arm (default: 40)
+  --keep-compiler-cache       do not force the compiler-cache opt-out
+  -h, --help                  show this help
+
+When both markers are given, each arm's log must contain its own marker and must
+not contain the other arm's. That is how a stale binary or a reused fixture path
+from the sibling revision is detected rather than assumed absent.
+
+Proving a regression test detects the original fault:
+
+  scripts/cross-revision-check.sh \
+    --baseline <pre-fix-sha> --candidate <post-fix-sha> \
+    --expect-baseline fail --expect-candidate pass \
+    --baseline-marker 'test result: FAILED' \
+    --candidate-marker 'test result: ok' \
+    -- cargo test -p orbit-core --lib
+
+Pass the producer directly. Do not wrap it in a pipeline: a filter at the end of
+your own pipeline replaces the producer's exit status, which is the failure this
+helper exists to prevent. Bounding is already handled by --tail.
+EOF
+}
+
+die() {
+  printf 'cross-revision-check: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --baseline) BASELINE_REV="${2:-}"; shift 2 ;;
+    --candidate) CANDIDATE_REV="${2:-}"; shift 2 ;;
+    --repo) REPO="${2:-}"; shift 2 ;;
+    --baseline-marker) BASELINE_MARKER="${2:-}"; shift 2 ;;
+    --candidate-marker) CANDIDATE_MARKER="${2:-}"; shift 2 ;;
+    --expect-baseline) EXPECT_BASELINE="${2:-}"; shift 2 ;;
+    --expect-candidate) EXPECT_CANDIDATE="${2:-}"; shift 2 ;;
+    --workdir) WORKDIR="${2:-}"; shift 2 ;;
+    --tail) TAIL_LINES="${2:-}"; shift 2 ;;
+    --keep-compiler-cache) KEEP_COMPILER_CACHE=1; shift ;;
+    -h | --help) usage; exit 0 ;;
+    --) shift; COMMAND=("$@"); break ;;
+    *) die "unknown argument: $1 (use -- before the command)" ;;
+  esac
+done
+
+[[ -n "$BASELINE_REV" ]] || die "--baseline is required"
+[[ -n "$CANDIDATE_REV" ]] || die "--candidate is required"
+[[ "${#COMMAND[@]}" -gt 0 ]] || die "no command given; put it after --"
+[[ "$TAIL_LINES" =~ ^[0-9]+$ ]] || die "--tail expects a number, got '$TAIL_LINES'"
+
+for expectation in "$EXPECT_BASELINE" "$EXPECT_CANDIDATE"; do
+  case "$expectation" in
+    pass | fail) ;;
+    *) die "--expect-baseline/--expect-candidate accept pass or fail, got '$expectation'" ;;
+  esac
+done
+
+[[ -d "$REPO" ]] || die "--repo is not a directory: $REPO"
+REPO="$(cd "$REPO" && pwd -P)"
+
+# All Git access is read-only. GIT_OPTIONAL_LOCKS=0 keeps a managed read-only
+# .git mount from failing on an index refresh it never needed.
+git_ro() {
+  GIT_OPTIONAL_LOCKS=0 git -C "$REPO" "$@"
+}
+
+git_ro rev-parse --git-dir >/dev/null 2>&1 || die "not a Git repository: $REPO"
+
+resolve_rev() {
+  local rev="$1"
+  git_ro rev-parse --verify --quiet "${rev}^{commit}" \
+    || die "cannot resolve revision '$rev' in $REPO"
+}
+
+BASELINE_SHA="$(resolve_rev "$BASELINE_REV")"
+CANDIDATE_SHA="$(resolve_rev "$CANDIDATE_REV")"
+
+# Canonicalize a path that need not exist yet, by resolving its closest existing
+# ancestor. A refused --workdir must not have been created first.
+abs_path() {
+  local path="$1" suffix=""
+  case "$path" in
+    /*) ;;
+    *) path="$PWD/$path" ;;
+  esac
+  while [[ ! -d "$path" ]]; do
+    suffix="/$(basename "$path")$suffix"
+    path="$(dirname "$path")"
+    [[ "$path" != "/" ]] || break
+  done
+  printf '%s%s\n' "$(cd "$path" && pwd -P)" "$suffix"
+}
+
+if [[ -n "$WORKDIR" ]]; then
+  WORKDIR="$(abs_path "$WORKDIR")"
+  # Writing scratch trees or build output into the checkout would mutate the
+  # very state under validation, and .orbit is canonical Orbit state.
+  case "$WORKDIR" in
+    "$REPO" | "$REPO"/*)
+      die "--workdir must live outside the source checkout ($WORKDIR is inside $REPO)"
+      ;;
+    */.orbit | */.orbit/*)
+      die "--workdir must not be inside Orbit state: $WORKDIR"
+      ;;
+  esac
+  mkdir -p "$WORKDIR"
+else
+  WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/orbit-cross-revision-XXXXXX")"
+  OWNED_WORKDIR=1
+fi
+
+# A self-made scratch root is disposable only when every check held; otherwise
+# the logs are the evidence and must outlive the run.
+RUN_FAILED=1
+
+cleanup() {
+  [[ "$OWNED_WORKDIR" -eq 1 ]] || return 0
+  if [[ "$RUN_FAILED" -eq 0 ]]; then
+    rm -rf "$WORKDIR"
+  else
+    printf 'cross-revision-check: logs preserved at %s\n' "$WORKDIR" >&2
+  fi
+}
+trap cleanup EXIT
+
+# Extract a revision into its own tree. `git archive` embeds the commit time in
+# the entries it writes, so a tree restored beside an older build can look
+# up-to-date; normalize every extracted mtime to now (F2026-09-081).
+extract_revision() {
+  local sha="$1" tree="$2"
+  mkdir -p "$tree"
+  git_ro archive "$sha" | tar -x -C "$tree"
+  find "$tree" \( -type f -o -type d \) -exec touch {} +
+}
+
+# Report fields for the arm just executed.
+ARM_STATUS=0
+ARM_LOG=""
+ARM_TREE=""
+ARM_TARGET=""
+
+run_arm() {
+  local arm="$1" sha="$2"
+  ARM_TREE="$WORKDIR/$arm"
+  ARM_TARGET="$WORKDIR/$arm-target"
+  ARM_LOG="$WORKDIR/$arm.log"
+
+  extract_revision "$sha" "$ARM_TREE"
+  mkdir -p "$ARM_TARGET"
+
+  local arm_env=(
+    "CARGO_TARGET_DIR=$ARM_TARGET"
+    "CARGO_INCREMENTAL=0"
+    # The extract has no .git. Stop any git the command runs from walking out of
+    # the scratch root and describing an unrelated repository as this revision.
+    "GIT_CEILING_DIRECTORIES=$WORKDIR"
+  )
+  if [[ "$KEEP_COMPILER_CACHE" -eq 0 ]]; then
+    # The repository's .cargo/config.toml sets build.rustc-wrapper, and the
+    # extract carries it. An empty RUSTC_WRAPPER overrides that config key;
+    # ORBIT_COMPILER_CACHE=0 makes the committed wrapper exec plain rustc if
+    # some other path still reaches it (F2026-09-082).
+    arm_env+=(
+      "ORBIT_COMPILER_CACHE=0"
+      "RUSTC_WRAPPER="
+      "CARGO_BUILD_RUSTC_WRAPPER="
+    )
+  fi
+
+  # Redirect, then capture. A filter here would report its own success
+  # (F2026-09-077); the bounded display reads the file afterwards instead.
+  ARM_STATUS=0
+  (
+    cd "$ARM_TREE"
+    env "${arm_env[@]}" "${COMMAND[@]}"
+  ) >"$ARM_LOG" 2>&1 || ARM_STATUS=$?
+}
+
+outcome_of() {
+  [[ "$1" -eq 0 ]] && printf 'pass' || printf 'fail'
+}
+
+# Marker verification is the provenance check: an arm that never printed its own
+# marker, or that printed its sibling's, did not run the source set it claims.
+verify_markers() {
+  local arm="$1" log="$2" own="$3" other="$4"
+  local result="skipped"
+
+  if [[ -n "$own" ]]; then
+    if grep -Fq -- "$own" "$log"; then
+      result="ok"
+    else
+      printf 'cross-revision-check: %s log is missing its own marker: %s\n' "$arm" "$own" >&2
+      printf 'unverified'
+      return 1
+    fi
+  fi
+
+  if [[ -n "$other" ]] && grep -Fq -- "$other" "$log"; then
+    printf 'cross-revision-check: %s log contains the sibling revision marker: %s\n' "$arm" "$other" >&2
+    printf 'contaminated'
+    return 1
+  fi
+
+  printf '%s' "$result"
+}
+
+cache_mode="disabled (ORBIT_COMPILER_CACHE=0, empty RUSTC_WRAPPER)"
+[[ "$KEEP_COMPILER_CACHE" -eq 0 ]] || cache_mode="enabled by --keep-compiler-cache"
+
+printf 'cross-revision-check\n'
+printf '  repo=%s\n' "$REPO"
+printf '  baseline=%s (%s)\n' "$BASELINE_SHA" "$BASELINE_REV"
+printf '  candidate=%s (%s)\n' "$CANDIDATE_SHA" "$CANDIDATE_REV"
+printf '  command=%s\n' "${COMMAND[*]}"
+printf '  workdir=%s\n' "$WORKDIR"
+printf '  compiler_cache=%s\n' "$cache_mode"
+
+failures=0
+
+report_arm() {
+  local arm="$1" sha="$2" expectation="$3" own_marker="$4" other_marker="$5"
+
+  run_arm "$arm" "$sha"
+
+  local status="$ARM_STATUS" log="$ARM_LOG"
+  local actual
+  actual="$(outcome_of "$status")"
+
+  local marker_result marker_ok=1
+  marker_result="$(verify_markers "$arm" "$log" "$own_marker" "$other_marker")" || marker_ok=0
+
+  printf '\n==> %s  rev=%s\n' "$arm" "$sha"
+  printf '    tree=%s\n' "$ARM_TREE"
+  printf '    target=%s\n' "$ARM_TARGET"
+  printf '    exit_code=%s  outcome=%s  expected=%s\n' "$status" "$actual" "$expectation"
+  printf '    provenance=%s\n' "$marker_result"
+  printf '    --- last %s log lines (%s) ---\n' "$TAIL_LINES" "$log"
+  tail -n "$TAIL_LINES" "$log" | sed 's/^/    /'
+
+  if [[ "$actual" != "$expectation" ]]; then
+    printf 'cross-revision-check: %s expected to %s but exited %s\n' "$arm" "$expectation" "$status" >&2
+    failures=$((failures + 1))
+  fi
+  if [[ "$marker_ok" -eq 0 ]]; then
+    failures=$((failures + 1))
+  fi
+}
+
+report_arm baseline "$BASELINE_SHA" "$EXPECT_BASELINE" "$BASELINE_MARKER" "$CANDIDATE_MARKER"
+report_arm candidate "$CANDIDATE_SHA" "$EXPECT_CANDIDATE" "$CANDIDATE_MARKER" "$BASELINE_MARKER"
+
+printf '\n'
+if [[ "$failures" -ne 0 ]]; then
+  printf 'cross-revision-check: FAILED (%s check(s) did not hold)\n' "$failures" >&2
+  exit 1
+fi
+
+RUN_FAILED=0
+printf 'cross-revision-check: ok (both arms matched their expected outcome)\n'

--- a/scripts/test-cross-revision-check.sh
+++ b/scripts/test-cross-revision-check.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+# Regression fixtures for scripts/cross-revision-check.sh [ORB-11981].
+#
+# The fixture is a throwaway Git repository with ancient commit dates and a
+# different marker per revision, so each guard is proved against the shape of
+# the failure that motivated it rather than asserted in prose. No Rust compile:
+# the helper is command-agnostic and the probe reports the environment it ran in.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="$ROOT/scripts/cross-revision-check.sh"
+TMP="$(mktemp -d)"
+SRC="$TMP/src"
+START_EPOCH="$(date +%s)"
+
+# The read-only-.git case leaves the fixture unwritable; restore it before rm.
+cleanup() {
+  chmod -R u+w "$TMP" 2>/dev/null || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+# 2020-01-01: far enough back that a preserved archive mtime is unmistakable.
+ARCHIVE_EPOCH=1577836800
+ARCHIVE_DATE="@$ARCHIVE_EPOCH +0000"
+
+fail() {
+  printf 'test-cross-revision-check: FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local got="$1" want="$2" msg="$3"
+  [[ "$got" == "$want" ]] || fail "$msg: got '$got' want '$want'"
+}
+
+assert_contains() {
+  local file="$1" needle="$2" msg="$3"
+  grep -Fq -- "$needle" "$file" || fail "$msg: '$needle' not found in $file"
+}
+
+assert_absent() {
+  local file="$1" needle="$2" msg="$3"
+  grep -Fq -- "$needle" "$file" && fail "$msg: '$needle' unexpectedly found in $file"
+  return 0
+}
+
+file_mtime() {
+  if stat -c '%Y' "$1" >/dev/null 2>&1; then
+    stat -c '%Y' "$1"
+  else
+    stat -f '%m' "$1"
+  fi
+}
+
+# Recursive path + mtime listing, used to prove the source checkout is untouched.
+snapshot() {
+  local root="$1" path
+  (
+    cd "$root"
+    find . -print | sort | while IFS= read -r path; do
+      printf '%s %s\n' "$path" "$(file_mtime "$path")"
+    done
+  )
+}
+
+git_fixture() {
+  git -c user.name=orbit-test -c user.email=orbit-test@example.invalid \
+    -c init.defaultBranch=main -C "$SRC" "$@"
+}
+
+# --- fixture repository -------------------------------------------------------
+
+mkdir -p "$SRC"
+git -c init.defaultBranch=main init -q "$SRC"
+
+cat >"$SRC/probe.sh" <<'EOF'
+#!/bin/sh
+# Reports the provenance and environment of the arm that ran it.
+printf 'marker=%s\n' "$(cat marker.txt)"
+printf 'target=%s\n' "$CARGO_TARGET_DIR"
+printf 'cache=%s\n' "${ORBIT_COMPILER_CACHE-unset}"
+printf 'wrapper=[%s]\n' "${RUSTC_WRAPPER-unset}"
+printf 'build_wrapper=[%s]\n' "${CARGO_BUILD_RUSTC_WRAPPER-unset}"
+printf 'incremental=%s\n' "${CARGO_INCREMENTAL-unset}"
+printf 'source_mtime=%s\n' "$(stat -c '%Y' marker.txt 2>/dev/null || stat -f '%m' marker.txt)"
+i=0
+while [ "$i" -lt "${PROBE_NOISE_LINES:-0}" ]; do
+  printf 'noise %s\n' "$i"
+  i=$((i + 1))
+done
+exit "${PROBE_EXIT:-0}"
+EOF
+chmod +x "$SRC/probe.sh"
+
+# Prints its own revision's marker and then, unconditionally, the candidate
+# marker: the shape of a stale binary or reused fixture leaking a sibling
+# revision's identity into an arm's output.
+cat >"$SRC/leak.sh" <<'EOF'
+#!/bin/sh
+printf 'marker=%s\n' "$(cat marker.txt)"
+printf 'leaked=MARKER_CANDIDATE\n'
+EOF
+chmod +x "$SRC/leak.sh"
+
+printf 'MARKER_BASELINE\n' >"$SRC/marker.txt"
+git_fixture add probe.sh leak.sh marker.txt
+GIT_AUTHOR_DATE="$ARCHIVE_DATE" GIT_COMMITTER_DATE="$ARCHIVE_DATE" \
+  git_fixture commit -q -m "baseline revision"
+BASELINE_SHA="$(git_fixture rev-parse HEAD)"
+
+printf 'MARKER_CANDIDATE\n' >"$SRC/marker.txt"
+git_fixture add marker.txt
+GIT_AUTHOR_DATE="$ARCHIVE_DATE" GIT_COMMITTER_DATE="$ARCHIVE_DATE" \
+  git_fixture commit -q -m "candidate revision"
+CANDIDATE_SHA="$(git_fixture rev-parse HEAD)"
+
+run_helper() {
+  local out="$1"
+  shift
+  local status=0
+  "$HELPER" --repo "$SRC" --baseline "$BASELINE_SHA" --candidate "$CANDIDATE_SHA" \
+    "$@" >"$out" 2>&1 || status=$?
+  printf '%s' "$status"
+}
+
+# --- 0. The fixture really does carry stale archive mtimes --------------------
+# Without this control, the mtime-normalization assertion below could pass
+# against a fixture that was never stale to begin with.
+
+mkdir -p "$TMP/raw-archive"
+git -C "$SRC" archive "$BASELINE_SHA" | tar -x -C "$TMP/raw-archive"
+assert_eq "$(file_mtime "$TMP/raw-archive/marker.txt")" "$ARCHIVE_EPOCH" \
+  "plain git-archive extraction should preserve the ancient commit mtime"
+
+# --- 1. Arm isolation, provenance, mtime normalization, cache opt-out ---------
+
+work="$TMP/work-isolation"
+out="$TMP/isolation.out"
+status="$(run_helper "$out" --workdir "$work" \
+  --baseline-marker MARKER_BASELINE --candidate-marker MARKER_CANDIDATE \
+  -- ./probe.sh)"
+assert_eq "$status" "0" "matching arms should succeed"
+
+assert_contains "$work/baseline.log" "marker=MARKER_BASELINE" "baseline ran its own source set"
+assert_contains "$work/candidate.log" "marker=MARKER_CANDIDATE" "candidate ran its own source set"
+assert_absent "$work/baseline.log" "MARKER_CANDIDATE" "baseline must not see the candidate source set"
+assert_absent "$work/candidate.log" "MARKER_BASELINE" "candidate must not see the baseline source set"
+
+assert_contains "$work/baseline.log" "target=$work/baseline-target" "baseline uses a private target dir"
+assert_contains "$work/candidate.log" "target=$work/candidate-target" "candidate uses a private target dir"
+[[ -d "$work/baseline-target" && -d "$work/candidate-target" ]] \
+  || fail "each arm should get its own target directory"
+
+for arm in baseline candidate; do
+  assert_contains "$work/$arm.log" "cache=0" "$arm must force ORBIT_COMPILER_CACHE=0"
+  assert_contains "$work/$arm.log" "wrapper=[]" "$arm must clear RUSTC_WRAPPER"
+  assert_contains "$work/$arm.log" "build_wrapper=[]" "$arm must clear CARGO_BUILD_RUSTC_WRAPPER"
+  assert_contains "$work/$arm.log" "incremental=0" "$arm must pin CARGO_INCREMENTAL=0"
+
+  arm_mtime="$(sed -n 's/^source_mtime=//p' "$work/$arm.log")"
+  [[ -n "$arm_mtime" ]] || fail "$arm probe did not report a source mtime"
+  [[ "$arm_mtime" -ge "$START_EPOCH" ]] \
+    || fail "$arm source mtime $arm_mtime was not normalized past run start $START_EPOCH"
+done
+
+assert_contains "$out" "provenance=ok" "helper should report verified provenance"
+
+# --- 2. A failing producer stays a failure behind bounded output -------------
+
+work="$TMP/work-exit"
+out="$TMP/exit.out"
+status="$(
+  export PROBE_EXIT=7 PROBE_NOISE_LINES=200
+  run_helper "$out" --workdir "$work" --tail 40 \
+    --baseline-marker MARKER_BASELINE --candidate-marker MARKER_CANDIDATE \
+    -- ./probe.sh
+)"
+assert_eq "$status" "1" "a failing producer must fail the helper by default"
+assert_contains "$out" "exit_code=7" "the producer exit code must survive the bounded display"
+assert_contains "$out" "baseline expected to pass but exited 7" "the helper must name the unmet expectation"
+
+# The bounded tail displays only the trailing noise, yet provenance still holds:
+# marker verification reads the full log, and the status came from the producer
+# rather than from whatever wrote last.
+assert_absent "$out" "marker=MARKER_BASELINE" "tail -40 should have bounded the marker out of the display"
+assert_contains "$out" "noise 199" "the bounded display should show the trailing lines"
+assert_contains "$out" "provenance=ok" "provenance must be verified against the full log, not the tail"
+
+# The same failing producer is a success only when the operator declared it.
+work="$TMP/work-expected-fail"
+out="$TMP/expected-fail.out"
+status="$(
+  export PROBE_EXIT=7
+  run_helper "$out" --workdir "$work" --expect-baseline fail --expect-candidate fail -- ./probe.sh
+)"
+assert_eq "$status" "0" "an explicitly expected failure should pass"
+
+# The regression-proof shape: baseline fails, candidate passes.
+work="$TMP/work-ab"
+out="$TMP/ab.out"
+status=0
+"$HELPER" --repo "$SRC" --baseline "$BASELINE_SHA" --candidate "$CANDIDATE_SHA" \
+  --workdir "$work" --expect-baseline fail --expect-candidate pass \
+  -- sh -c 'marker=$(cat marker.txt); echo "marker=$marker"; [ "$marker" = MARKER_CANDIDATE ]' \
+  >"$out" 2>&1 || status=$?
+assert_eq "$status" "0" "before-fails/after-passes is the regression-proof shape"
+
+# --- 3. Provenance failures are detected, not assumed absent -----------------
+
+work="$TMP/work-missing-marker"
+out="$TMP/missing-marker.out"
+status="$(run_helper "$out" --workdir "$work" --baseline-marker NOT_IN_ANY_LOG -- ./probe.sh)"
+assert_eq "$status" "1" "a missing own marker must fail the run"
+assert_contains "$out" "missing its own marker" "the helper should name the missing marker"
+
+work="$TMP/work-contaminated"
+out="$TMP/contaminated.out"
+status="$(run_helper "$out" --workdir "$work" \
+  --baseline-marker MARKER_BASELINE --candidate-marker MARKER_CANDIDATE -- ./leak.sh)"
+assert_eq "$status" "1" "a sibling marker in an arm's log must fail the run"
+assert_contains "$out" "contains the sibling revision marker" "the helper should name the contamination"
+assert_contains "$out" "provenance=contaminated" "the report should mark the arm contaminated"
+
+# --- 4. Read-only Git metadata and an unmodified source checkout -------------
+
+before="$TMP/snapshot-before"
+after="$TMP/snapshot-after"
+snapshot "$SRC" >"$before"
+
+chmod -R a-w "$SRC/.git"
+work="$TMP/work-readonly"
+out="$TMP/readonly.out"
+readonly_status="$(run_helper "$out" --workdir "$work" \
+  --baseline-marker MARKER_BASELINE --candidate-marker MARKER_CANDIDATE -- ./probe.sh)"
+chmod -R u+w "$SRC/.git"
+assert_eq "$readonly_status" "0" "the helper must work with read-only Git metadata: $(cat "$out")"
+
+snapshot "$SRC" >"$after"
+diff -u "$before" "$after" \
+  || fail "the helper must not modify the source checkout (including .git mtimes)"
+[[ ! -e "$SRC/.git/index.lock" ]] || fail "the helper must not leave a Git index lock behind"
+
+# --- 5. Scratch state stays outside the checkout and outside Orbit state -----
+
+out="$TMP/inside-repo.out"
+status="$(run_helper "$out" --workdir "$SRC/scratch" -- ./probe.sh)"
+assert_eq "$status" "1" "a workdir inside the source checkout must be refused"
+assert_contains "$out" "must live outside the source checkout" "the refusal should explain itself"
+[[ ! -e "$SRC/scratch" ]] || fail "a refused workdir must not be created inside the checkout"
+
+out="$TMP/orbit-state.out"
+status="$(run_helper "$out" --workdir "$TMP/.orbit/state/scratch" -- ./probe.sh)"
+assert_eq "$status" "1" "a workdir inside .orbit must be refused"
+assert_contains "$out" "must not be inside Orbit state" "the refusal should name Orbit state"
+
+# --- 6. The cache opt-out is a default, not a hard-coded policy --------------
+
+work="$TMP/work-keep-cache"
+out="$TMP/keep-cache.out"
+status="$(
+  export ORBIT_COMPILER_CACHE=inherited RUSTC_WRAPPER=/inherited/wrapper
+  run_helper "$out" --workdir "$work" --keep-compiler-cache -- ./probe.sh
+)"
+assert_eq "$status" "0" "--keep-compiler-cache should still run both arms"
+assert_contains "$work/baseline.log" "cache=inherited" "--keep-compiler-cache must not force the opt-out"
+assert_contains "$work/baseline.log" "wrapper=[/inherited/wrapper]" "--keep-compiler-cache must keep the wrapper"
+assert_contains "$out" "enabled by --keep-compiler-cache" "the report should disclose the opt-in"
+
+# --- 7. Argument handling ----------------------------------------------------
+
+"$HELPER" --help >/dev/null || fail "--help should succeed"
+
+status=0
+"$HELPER" --repo "$SRC" --baseline "$BASELINE_SHA" --candidate "$CANDIDATE_SHA" \
+  >"$TMP/no-command.out" 2>&1 || status=$?
+assert_eq "$status" "1" "a missing command must be rejected"
+assert_contains "$TMP/no-command.out" "no command given" "the helper should name the missing command"
+
+status=0
+"$HELPER" --repo "$SRC" --baseline "$BASELINE_SHA" --candidate no-such-revision \
+  -- ./probe.sh >"$TMP/bad-rev.out" 2>&1 || status=$?
+assert_eq "$status" "1" "an unresolvable revision must be rejected"
+assert_contains "$TMP/bad-rev.out" "cannot resolve revision" "the helper should name the bad revision"
+
+status=0
+"$HELPER" --repo "$SRC" --baseline "$BASELINE_SHA" --candidate "$CANDIDATE_SHA" \
+  --expect-baseline maybe -- ./probe.sh >"$TMP/bad-expect.out" 2>&1 || status=$?
+assert_eq "$status" "1" "an unknown expectation must be rejected"
+
+printf 'test-cross-revision-check: ok\n'


### PR DESCRIPTION
## Task

[ORB-11981](https://orbit-cli.com/tasks/ORB-11981) — Provide a provenance-safe recipe for cross-revision build validation

### Description

## Problem and evidence
Repeated records show false before/after evidence: shared Cargo targets reuse embedded fixture paths (064), tar restores stale mtimes (081), an archived baseline ran current-worktree tests under the configured wrapper (082), and cargo piped into tail reports tail's success (077). These observations do not establish a specific Cargo or sccache root-cause defect.

Source frictions: F2026-09-064, F2026-09-077, F2026-09-081, F2026-09-082.
Audit source baseline: owning Linux checkout e4f9098633a8876a5a7c233d9914a094b6efa858, inspected 2026-09-10. Incident reports are historical evidence; no production failure was induced during this audit.

## Proposed solution
Add one maintained repository validation recipe/helper for independent extracted revisions: isolated per-revision targets, explicit compiler-cache opt-out for baseline comparisons, expected test/fixture provenance verification, and producer exit-status capture before bounded log display. Document the measured limitations without blaming an unproven cache algorithm. Use scratch copies and preserve Git metadata safety. Do not alter the production cache defaults or disable useful caching globally.

## Scope and delivery
Create a validated task-scoped candidate from agent-main in a dedicated worktree. Preserve existing failed-run and friction evidence. This filing does not authorize dispatch, merge, release, production configuration changes or live backlog consolidation. Complexity medium; crew terra follows the configured lane. Existing task inventory and targeted searches were checked for covering work.

### Acceptance Criteria

- A fixture with distinct baseline/candidate marker tests and preserved mtimes proves each arm runs its own source/test set with separate targets and explicit cache opt-out.
- A failing producer followed by a successful output filter is still reported as failure; bounded output retains the producer exit code.
- The documented commands work with read-only managed Git metadata and do not modify the real checkout or canonical Orbit state.
- Update the existing validation/compiler-cache runbook and relevant QA recipe rather than adding competing instructions; run the helper's meaningful regression fixtures and documentation checks.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

## Changes

Added one maintained recipe/helper for before/after validation across two
immutable revisions, plus its regression fixtures, and folded the corrected
procedure into the existing runbook and the shipped QA recipe rather than
creating a competing instruction site.

- **`scripts/cross-revision-check.sh`** (new). Runs one command per revision in
  an independent scratch extract. Guards, each answering a recorded false
  result rather than a suspected cache defect:
  - per-arm extract and per-arm `CARGO_TARGET_DIR` (F2026-09-064)
  - every extracted mtime reset to now, because `git archive`/`tar` write the
    commit's timestamps (F2026-09-081)
  - compiler-cache opt-out by default: `ORBIT_COMPILER_CACHE=0`, empty
    `RUSTC_WRAPPER` and `CARGO_BUILD_RUSTC_WRAPPER`, `CARGO_INCREMENTAL=0`;
    `--keep-compiler-cache` for a deliberate opt-in (F2026-09-082)
  - producer status captured from a redirect, never a pipe, before `--tail`
    reads the log file (F2026-09-077); `--expect-baseline`/`--expect-candidate`
    make an unmet outcome a helper failure
  - output provenance: each arm must print its own marker and must not print
    the sibling's
  - read-only Git only (`rev-parse`, `archive`, `GIT_OPTIONAL_LOCKS=0`);
    `GIT_CEILING_DIRECTORIES` keeps a command's git from escaping the scratch
    root; `--workdir` is refused inside the checkout or under `.orbit/`, and is
    validated before any directory is created
- **`scripts/test-cross-revision-check.sh`** (new). Throwaway Git fixture with
  ancient commit dates and distinct per-revision markers. Includes a negative
  control proving a plain `git archive` extract really does carry the stale
  1577836800 mtime, so the normalization assertion is not vacuous. Covers arm
  isolation/provenance, mtime normalization, cache opt-out, failing producer
  through bounded output, the regression-proof `fail`/`pass` shape, missing and
  contaminated markers, read-only `.git` plus an unchanged source checkout,
  workdir containment refusals, `--keep-compiler-cache`, and argument handling.
- **`scripts/ci-guardrails.sh`**, **`Makefile`**: regression registered in CI
  and exposed as `make cross-revision-check-test` with a help line.
- **`docs/runbooks/compiler-cache.md`**: new "Cross-revision before/after
  validation" section (guarantee/false-result table, stated limits, regression
  command), extended frontmatter `paths`/`related_artifacts`, `last_validated`
  2026-09-10. `docs/INDEX.md` regenerated for the changed summary.
- **`crates/orbit-core/assets/skills/orbit/references/task-execution.md`**: the
  bare `git archive | tar -x` bullet was the incomplete recipe behind these
  frictions. Replaced with the corrected, domain-neutral steps (own build dir
  per arm, refresh mtimes, disable compiler caches/wrappers, verify provenance
  in output, capture status before trimming) and a pointer to use a
  workspace-shipped helper when one exists. No repo-specific paths and no
  internal IDs in shipped skill text. `plugin/skills/**` re-synced via
  `scripts/sync-plugin-skills.sh`.

## Acceptance criteria

1. *Fixture with distinct baseline/candidate markers and preserved mtimes* —
   met. `scripts/test-cross-revision-check.sh` section 1 asserts each arm logs
   only its own marker, uses `<workdir>/<arm>-target`, and reports `cache=0`,
   `wrapper=[]`, `build_wrapper=[]`, `incremental=0`; section 0 first proves the
   raw archive extract preserves mtime 1577836800, then section 1 requires both
   arms' source mtime >= run start.
2. *Failing producer behind a successful filter still fails* — met. Section 2
   runs a producer that emits 200 noise lines and exits 7: helper exits 1,
   report shows `exit_code=7`, the 40-line tail contains only trailing noise
   while provenance still verifies against the full log. The same failure is a
   pass only under `--expect-baseline fail`.
3. *Read-only managed Git metadata, no checkout or Orbit-state mutation* — met.
   Section 4 chmods the fixture `.git` unwritable, runs the helper (exit 0),
   and diffs a full path+mtime snapshot of the checkout before/after; section 5
   asserts a `--workdir` inside the checkout or under `.orbit/` is refused and
   never created. Confirmed live: two runs against this managed worktree
   (linked read-only gitdir) succeeded and left `git status --short` clean.
4. *Update the existing runbook and QA recipe; run regression and doc checks* —
   met, as listed above.

## Validation

Commands run in this worktree at HEAD dccdff692da1ab6bb14f8293a97a70054ccecd58,
each with output redirected and the exit status captured separately:

- `scripts/test-cross-revision-check.sh` — passed
- `make cross-revision-check-test` — passed
- `make ci-fast` — passed (includes the new regression, `test-compiler-cache`,
  `sync-plugin-skills --check`, `generate-doc-indexes --check`)
- `make ci-lint` — passed (1m26s)
- `scripts/generate-doc-indexes.sh` then `--check` — passed
- `scripts/sync-plugin-skills.sh` then `--check` — passed
- Real-repo smoke, HEAD~1 vs HEAD, markers `NO_CARGO_DENY_SCRIPT` /
  `HAS_CARGO_DENY_SCRIPT` — exit 0, `provenance=ok` on both arms
- Real-repo Cargo smoke, `cargo metadata --offline --no-deps --format-version 1`
  — exit 0 on both arms, package IDs rooted in each arm's own extract
- Mechanism check for the cache opt-out: a probe crate whose
  `.cargo/config.toml` sets `build.rustc-wrapper` to a script that exits 1
  fails `cargo check` (exit 101, wrapper ran); the same command with empty
  `RUSTC_WRAPPER`/`CARGO_BUILD_RUSTC_WRAPPER` succeeds and the wrapper never
  runs. cargo 1.96.0.
- Mutation checks on the regression fixture: dropping mtime normalization,
  sharing one target dir, removing the cache opt-out, losing the producer
  status through a filter (with `pipefail` also removed), and removing the
  cross-arm marker check are each detected with a specific failure message.

Not run: `make ci` (workspace policy runs the full gate on the PR);
`scripts/bench-compiler-cache.sh` (a timing benchmark, unrelated to this
change); `shellcheck` (not installed here, and not part of this repository's
CI). `scripts/test-compiler-cache-namespaces.sh` reports its usual skip inside
`make ci-fast` — this sandbox cannot create user namespaces. That skip is
pre-existing and unrelated to this change.

## Risks and deviations

- Marker verification is a literal substring match on an arm's log. A marker
  both revisions can emit proves nothing; the runbook and `--help` say so.
- macOS was not exercised. The helper uses portable `git archive`, `tar`,
  `find -exec touch {} +` and `tail`, and the fixture handles BSD `stat`, but
  the only evidence here is Linux.
- The helper drives real Cargo, proven with `cargo metadata` on both arms and
  with the wrapper-override mechanism check above. A full two-arm `cargo check`
  of a workspace crate was not run: that is two cold uncached dependency
  compiles under the shared build budget, and the documented behavior it would
  demonstrate is already covered by those two checks.
- No AGENTS.md entry was added. Acceptance criterion 4 asks for one place, so
  the runbook plus the generic skill recipe is the whole instruction surface.

## Recommended follow-ups

- Resolve F2026-09-064, F2026-09-077, F2026-09-081 and F2026-09-082 once this
  lands; each records a hazard this helper now enforces against.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11981-6aa22a6a`
- Behind base: 0
- Ahead of base: 1