### PR TITLE
[auto-task] Remediate current GitHub Actions failures

### DIFF
--- a/crates/orbit-core/src/application/automation/source.rs
+++ b/crates/orbit-core/src/application/automation/source.rs
@@ -12,19 +12,18 @@ use std::{
 };
 
 #[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
-
-#[cfg(test)]
-static LS_TREE_INVOCATIONS: AtomicUsize = AtomicUsize::new(0);
+thread_local! {
+    static LS_TREE_INVOCATIONS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
 
 #[cfg(test)]
 pub(super) fn reset_ls_tree_invocations() {
-    LS_TREE_INVOCATIONS.store(0, Ordering::SeqCst);
+    LS_TREE_INVOCATIONS.with(|count| count.set(0));
 }
 
 #[cfg(test)]
 pub(super) fn ls_tree_invocations() -> usize {
-    LS_TREE_INVOCATIONS.load(Ordering::SeqCst)
+    LS_TREE_INVOCATIONS.with(std::cell::Cell::get)
 }
 
 pub(crate) struct Source<'a> {
@@ -44,7 +43,7 @@ impl<'a> Source<'a> {
     fn command(&self, program: &str, args: &[&str]) -> Result<String, AutomationError> {
         #[cfg(test)]
         if program == "git" && args.first() == Some(&"ls-tree") {
-            LS_TREE_INVOCATIONS.fetch_add(1, Ordering::SeqCst);
+            LS_TREE_INVOCATIONS.with(|count| count.set(count.get() + 1));
         }
 
         if self.started.elapsed() > Duration::from_secs(30) {


### PR DESCRIPTION
## Task

[ORB-11893](https://orbit-cli.com/tasks/ORB-11893) — [auto-task] Remediate current GitHub Actions failures

### Description

Investigate and remediate current GitHub Actions failures for this
repository. This task may legitimately finish with no diff: if no
current, reproducible, repository-owned failure remains, persist the
evidence described below and report a successful no-current-failure or
transient-only outcome.

## Discovery and duplicate safety

1. Enumerate this repository's workflows and recent runs with GitHub's API
   or `gh`, and enumerate open pull requests with their current head SHAs.
   Cover failures for the current heads of `agent-main`, `main`, and every
   open pull request, including informational jobs such as coverage rather
   than looking only at required checks or the main `ci` job.
2. The fail-open CI failure report in `.github/workflows/ci.yml` records
   runner provenance only; it never creates Orbit tasks. Durable filing is
   owned by the host-side `ci_failure_sweep_pipeline`. Search open Orbit
   tasks for the report's run URL, job, SHAs, and failure signature.
   Reference matching tasks in the execution summary; do not create
   another task for the same run or root cause. This remediation task owns
   the repair and must not fan a red-run cluster out into more failure
   tasks.
3. For every candidate run, record the run and job URLs, workflow, event,
   branch or PR, run-attempt number, reported head SHA, and the current
   branch/PR head SHA. Query the failed jobs and steps and inspect the
   exact failed-step logs.
4. Independently verify the commit that Actions actually checked out from
   the checkout step/log (`HEAD is now at`, checkout ref/SHA, or equivalent
   unambiguous evidence). Keep the event's reported head SHA, the current
   ref head, and the tested checkout commit distinct; PR merge SHAs are not
   interchangeable with PR head SHAs.
5. Ignore a failed run as stale when its branch or PR has advanced and the
   failure does not reproduce at the current head, or when a newer
   successful run of the same workflow/check at the relevant current
   commit supersedes it. Cite the advancing or superseding run and SHAs;
   age alone is not evidence that a failure is stale.

## Diagnosis and remediation

Cluster repeated runs by root cause before editing. Use the failing
command, job/step, exact error signature, tested commit, and causal
dependency between failures to distinguish one regression repeated across
push/PR runs from independent failures. Repair each current root cause
once, while retaining a mapping from every affected run/job to that
cluster.

Reproduce every current candidate at the current repository head using
the exact command or the narrowest faithful local equivalent. A
deterministic repository-owned failure is in scope and must be fixed in
this task's worktree. Classify a GitHub service, network, hosted-runner, or
other infrastructure failure as transient only with concrete evidence,
such as a successful retry at the same SHA plus logs showing the
infrastructure fault. Do not call a failure transient merely because it
fails to reproduce once.

Fix the underlying repository-owned cause. Do not disable a workflow,
weaken an assertion or lint level, add a broad allow/ignore rule, mark a
failing gate `continue-on-error`, remove an affected target from coverage,
or otherwise obtain green CI by hiding the failure. Informational checks
remain informational, but they must execute successfully.

## Validation and handoff

For each fixed root cause, rerun the exact command that formerly failed.
Then run the repository pre-handoff gate, `make ci-fast`. After the
candidate commit is published through the repository's normal workflow,
inspect its GitHub Actions runs and require a green rerun for every
affected workflow/check. This includes affected informational jobs even
though they remain non-required. Do not declare a repair validated while
an affected run is missing, queued, in progress, cancelled, or red.

Persist an `execution_summary` that maps every investigated run/job URL,
reported head SHA, actual checkout commit, and current ref head to its
root-cause cluster, disposition (fixed, stale, superseded, or transient),
change, local reproduction, exact formerly failing validation, pre-handoff
result, and green GitHub rerun URL. Also map any matching PR-hook-created
Orbit task. For a successful no-diff pass, list the queries, current heads,
superseding successes or transient evidence, and why no repository-owned
failure remained.

## Historical validation fixture

Use run 30232696219 as the calibration example for the evidence model, not
as proof of a current failure:

- `Check / Clippy / Test` → `Run CI guardrails` reported Clippy's needless
  borrow at
  `crates/orbit-store/src/file/task_store/v2_bundle/bundle_io/mod.rs:172`,
  `sync_parent_dir(&staging_dir)`.
- `Coverage (informational)` reported that
  `command::skill::tests::plugin_skill_symlinks_resolve_to_assets` found
  `plugin/skills/orbit-task/SKILL.md` different from
  `crates/orbit-core/assets/skills/orbit-task/SKILL.md`.
- The run metadata reported head
  `49a2871a480b927bb31dc7a315f5ff5d130d15d0`, while the checkout log showed
  `5cec12c53211fad3f4ca940a0565bef87787958d`. A valid investigation preserves
  that discrepancy, clusters adjacent runs by the two root causes, and
  tests whether either failure still exists at the relevant current head
  before editing.


### Acceptance Criteria

- Current-head failures across agent-main, main, and open pull requests were enumerated for every repository workflow, including informational jobs.
- Every investigated run records its reported SHA, actual checkout commit, current ref head, failed job/step, exact log evidence, and stale or superseding evidence where applicable.
- Repeated red runs are clustered by root cause, and every current repository-owned failure is reproduced and fixed without weakening or bypassing a check.
- Transient-only classifications cite infrastructure evidence and a successful same-SHA retry; a single non-reproduction is not treated as sufficient evidence.
- Each fixed cause passes the exact formerly failing validation and make ci-fast, and every affected required or informational GitHub Actions check executes successfully on the candidate commit.
- The persisted execution_summary maps each run/job URL and SHA to its root cause, disposition, change, validations, green rerun, and any matching PR-hook task.
- A no-current-failure or transient-only investigation is a successful no-diff outcome when its current-head queries and superseding or transient evidence are persisted.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: implementation complete; changes remain uncommitted for the managed delivery pipeline.

Baseline and scope:
- Worktree validation passed: pwd -P and git rev-parse --show-toplevel both resolved to ~/workspace/constellation/codebases/orbit/.orbit/state/worktrees/orbit-jrun-20260910-0344-2. Starting HEAD was 4151b09bb0e0fcf2ded58ab89c5a42791b5e0e8a and the initial worktree was clean.
- GitHub workflow inventory covered .github/workflows/ci.yml, ci-macos.yml, codeql.yml, publish-mcp-registry.yml, release.yml, smoke-npm-install.yml, and website.yml, plus gh workflow list --all. gh pr list --state open returned no open pull requests.
- At final discovery, origin/agent-main was 923bd085af7569d133a93bb11fdbbefa7cc8e0fa and origin/main was 0151090d31900d946fe42c2124d5d26b0eb801de. The checkout intentionally remains at the injected task base; reported, tested, and current-ref SHAs are kept distinct below.

Root-cause clusters and changes:
1. Workspace-init registry-root creation. Current-main CI run 34318686833 reported/tested 0151090d31900d946fe42c2124d5d26b0eb801de, current main was the same SHA, and its failed coverage job 102360318946 (https://github.com/constellation-works/orbit/actions/runs/34318686833/job/102360318946) failed at Collect workspace coverage with 477 passed and 13 failures. The exact repeated error was Io("canonicalize /tmp/.tmp.../.orbit: No such file or directory (os error 2)") for workspace-init tests, including custom-root and shared-root cases. Its Check / Clippy / Test job 102360318863 (https://github.com/constellation-works/orbit/actions/runs/34318686833/job/102360318863) failed at Run CI guardrails with the same workspace-init cluster. The runner checkout evidence reported tested_sha=0151090d31900d946fe42c2124d5d26b0eb801de. The owning fix is already present in this candidate base from commit 152dfe639: validate the registry parent before canonicalizing/locking the registry path and creating the fresh global root. Exact local validation passed: cargo test -p orbit-cli --bin orbit command::workspace::tests::init -- --test-threads=1 (40 passed).
2. Website dependency compatibility. The js-yaml 4.3.2 override and lockfile entries are already present in website/package.json and website/package-lock.json from landed dependency fixes. This prevents the Astro default-import break observed after the dependency update. npm validation could not run because npm is not installed in this executor (npm ci --ignore-scripts -> exit 127); GitHub Website validation remains the authoritative environment.
3. Parallel-test instrumentation isolation. Full workspace coverage reproduced a repository-owned race: the test-only LS_TREE_INVOCATIONS counter in crates/orbit-core/src/application/automation/source.rs was process-global, so parallel tests could increment it after another test reset it. Changed only the cfg(test) counter to a thread-local Cell; production behavior is unchanged. Exact validations passed: cargo test -p orbit-core --lib application::automation::tests::members::preparation_page_lists_instructions_once_for_all_eligible_tasks -- --exact --nocapture (1 passed), and cargo test -p orbit-core --lib application::automation::tests::members -- --test-threads=1 (6 passed).
4. Concurrent export/deletion diagnostics. The canonical-bundle disappearance message and test marker are already present in the owning archive boundary from landed commit 98a0b8c3d; no duplicate edit was made.

Run and supersession evidence:
- Current-main CI run 34318686833 (https://github.com/constellation-works/orbit/actions/runs/34318686833), push main, attempt 1, reported/tested SHA 0151090d31900d946fe42c2124d5d26b0eb801de, current main SHA the same: MSRV and Linux Sandbox succeeded; Check / Clippy / Test failed at Run CI guardrails (job URL above); informational Coverage failed at Collect workspace coverage (job URL above). This is the current red main evidence; the registry fix exists on agent-main but no new main run has published it.
- Agent-main CI run 34434536467 (https://github.com/constellation-works/orbit/actions/runs/34434536467), push agent-main, reported/tested SHA 467ec5566e20ff1ffd2b7b6612c1da0c8406ab54; by final query it was completed success for MSRV job https://github.com/constellation-works/orbit/actions/runs/34434536467/job/102736765039, informational Coverage job https://github.com/constellation-works/orbit/actions/runs/34434536467/job/102736765172, Check / Clippy / Test job https://github.com/constellation-works/orbit/actions/runs/34434536467/job/102736765191, and Linux Sandbox job https://github.com/constellation-works/orbit/actions/runs/34434536467/job/102736765277. This successful run is superseded as a ref-head observation by the later agent-main SHA 923bd085af7569d133a93bb11fdbbefa7cc8e0fa, not a candidate-patch validation.
- Agent-main CI run 34323509694 (https://github.com/constellation-works/orbit/actions/runs/34323509694) was a completed success at tested SHA 79fa18679adb391ffa7f8f501ba5012292b772ef, and is superseded by later agent-main heads.
- Website run 34195398040 (https://github.com/constellation-works/orbit/actions/runs/34195398040), push main, reported/tested SHA 5c4245aeb9e34251e2170a6508b4d898e9ae24ee, failed job 101962006802 (https://github.com/constellation-works/orbit/actions/runs/34195398040/job/101962006802) at Verify deployment and custom domain. Its exact evidence was deployment 19def95c.orbit-website-3zi.pages.dev and the message that the expected homepage, setup explorer, install route, and source revision did not reach the deployment URL. Main later advanced to 0151090d..., so this run is stale, not transient.
- Scheduled smoke run 34148361933 (https://github.com/constellation-works/orbit/actions/runs/34148361933), reported/tested SHA a93caa13890764380e184d996fa709b1bcbe278c, checked out that same SHA on both Linux and macOS, and failed Run npm install smoke in jobs 101825152713 and 101825152872 with ETARGET: No matching version found for @orbit-tools/cli@0.19.2. Main later advanced to 0151090d..., so it is stale, not transient.
- CodeQL run 34434536458 (https://github.com/constellation-works/orbit/actions/runs/34434536458) and macOS Platform run 34434536447 (https://github.com/constellation-works/orbit/actions/runs/34434536447) completed successfully at reported/tested agent-main SHA 467ec5566e20ff1ffd2b7b6612c1da0c8406ab54. No open PR heads existed to inspect.
- Search for current run IDs, SHA 0151090d..., and distinctive failure text found no separate PR-hook task for run 34318686833. Related durable records were ORB-11892 (done, prior CI sweep for the canonicalize failure), ORB-11825 (rejected website sweep task), and ORB-11856 (done duplicate auto-task for the website investigation); no new task was created.

Validation:
- Passed: the two focused Rust test commands above; make ci-fast (including formatter/guardrail fast checks); git diff --check.
- ./scripts/ci-guardrails.sh ran through compilation, clippy, workspace nextest, documentation, and doc tests successfully, then the overall command failed at cargo-deny before dependency evaluation because ~/.cargo/advisory-dbs/db.lock is on a read-only path: failed to acquire advisory database lock. This is recorded as an environment/tooling limitation, not relabeled as a pass.
- Not run: website npm checks, because npm is unavailable; macOS/Cloudflare behavior, because this Linux executor cannot exercise those environments; candidate-commit GitHub reruns, because this managed run leaves changes uncommitted and no candidate PR exists yet.
- Final worktree contains only the intended source change in crates/orbit-core/src/application/automation/source.rs; generated Cargo output is ignored. Final status was checked with git status --short.

Acceptance mapping:
1. Workflows, agent-main/main heads, no open PRs, required and informational jobs were enumerated.
2. Investigated runs retain run/job URLs, event/ref, reported SHA, checked-out/tested SHA, current ref head, failed step, and exact log evidence; stale/superseding distinctions are listed above.
3. Repeated workspace-init and test-isolation causes were clustered; repository-owned causes were reproduced and fixed or confirmed already fixed in the candidate base without weakening checks.
4. Website and smoke classifications are stale due ref advancement, not transient-only; no transient classification relies on a single non-reproduction.
5. Formerly failing Rust validations and make ci-fast passed, and the affected agent-main required/informational run 34434536467 is green at its tested SHA. Candidate-patch GitHub validation is pending managed publication; website local validation is unavailable because npm is missing.
6. This summary maps each investigated run/job to cause, disposition, change, local validation, green/superseding evidence, and matching Orbit records.
7. This is not a no-diff outcome because the test-isolation repair is an intentional one-file change. Remaining risk is candidate GitHub validation, especially the current main red run and unavailable local website toolchain.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11893-6aa227a5`
- Behind base: 0
- Ahead of base: 1