### PR TITLE
Isolate recovery authority from leaf-writable run storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2233,6 +2233,7 @@ name = "orbit-core"
 version = "0.20.0"
 dependencies = [
  "base64 0.22.1",
+ "blake3",
  "chrono",
  "croner",
  "fs2",

--- a/crates/orbit-core/Cargo.toml
+++ b/crates/orbit-core/Cargo.toml
@@ -18,6 +18,7 @@ clap = ["orbit-types/clap"]
 getrandom.workspace = true
 orbit-automation = { path = "../orbit-automation" }
 base64.workspace = true
+blake3.workspace = true
 chrono.workspace = true
 croner.workspace = true
 fs2.workspace = true

--- a/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
@@ -33,6 +33,7 @@ use crate::application::task::{
     SYSTEM_ACTOR_LABEL, TaskAttributionInput, TaskUpdateParams, assemble_task_attribution,
 };
 use crate::runtime::engine::paths::{codex_workspace_write_writable_dirs, current_repo_root};
+use crate::runtime::recovery_authority::RecoveryAuthority;
 
 impl RuntimeHost for OrbitRuntime {
     fn record_direct_landing_intent(
@@ -595,12 +596,26 @@ impl RuntimeHost for OrbitRuntime {
             })
     }
 
+    /// Certify the host's completion first, then persist the advisory copy.
+    ///
+    /// The certificate lives outside every leaf write grant; the run-state
+    /// entry that follows it is progress data a leaf can rewrite. Either half
+    /// failing leaves the run without usable evidence rather than with
+    /// unauthenticated evidence, so both orders are fail-closed.
     fn checkpoint_rebase_recovery(
         &self,
         run_id: &str,
         step_id: &str,
         output: &Value,
     ) -> Result<(), DispatchError> {
+        RecoveryAuthority::open(&self.global_root())
+            .and_then(|authority| authority.issue(run_id, step_id, output))
+            .map_err(|error| {
+                DispatchError::JobExecution(format!(
+                    "certify rebase recovery (run {run_id}, step `{step_id}`): {error}"
+                ))
+            })?;
+
         self.stores()
             .jobs()
             .update_run_state(run_id, &mut |run_state, state| {
@@ -629,6 +644,15 @@ impl RuntimeHost for OrbitRuntime {
                     "persist rebase recovery checkpoint (run {run_id}, step `{step_id}`): {error}"
                 ))
             })
+    }
+
+    fn verify_rebase_recovery(
+        &self,
+        run_id: &str,
+        step_id: &str,
+        checkpoint: &Value,
+    ) -> Result<bool, OrbitError> {
+        RecoveryAuthority::open(&self.global_root())?.verify(run_id, step_id, checkpoint)
     }
 
     fn tool_context_for_activity(

--- a/crates/orbit-core/src/adapter/engine_host/tests/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/tests/runtime_host.rs
@@ -1364,6 +1364,9 @@ fn recovered_rebase_checkpoint_survives_restart_without_completing_the_step() {
         .unwrap();
     let output = json!({
         "run_id": run.run_id,
+        "step_id": "sync_base",
+        "task_ids": ["T-recovery"],
+        "workspace_path": root.path().join("repo"),
         "head_sha_before": "before",
         "head_sha": "after",
         "base_sha": "target",
@@ -1391,5 +1394,33 @@ fn recovered_rebase_checkpoint_survives_restart_without_completing_the_step() {
         reopened
             .checkpoint_rebase_recovery("missing-run", "sync_base", &output)
             .is_err()
+    );
+
+    // The certificate is durable too, and it is what authenticates the run-row
+    // copy after the restart.
+    assert!(
+        RuntimeHost::verify_rebase_recovery(&reopened, &run.run_id, "sync_base", &output).unwrap(),
+    );
+
+    // Rewrite the run row the way a leaf holding the `orbit.db` grant would.
+    // The store accepts the bytes; the authority does not accept the claim.
+    let mut forged = durable.clone();
+    forged
+        .rebase_recovery_checkpoints
+        .get_mut("sync_base")
+        .unwrap()["head_sha"] = json!("leaf-authored");
+    reopened
+        .stores()
+        .jobs()
+        .write_run_state(&run.run_id, &forged)
+        .unwrap();
+    let stored = RuntimeHost::read_run_state(&reopened, &run.run_id)
+        .unwrap()
+        .unwrap();
+    let stored = &stored.rebase_recovery_checkpoints["sync_base"];
+    assert_eq!(stored["head_sha"], json!("leaf-authored"));
+    assert!(
+        !RuntimeHost::verify_rebase_recovery(&reopened, &run.run_id, "sync_base", stored).unwrap(),
+        "a leaf-authored run-store row carries no certificate",
     );
 }

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
@@ -70,6 +70,7 @@ pub(crate) fn resolve_executor_sandbox(
                 append_codex_side_write_roots(runtime, provider, &mut resolved)?;
                 append_orbit_child_runtime_write_roots(runtime, &mut resolved);
                 append_active_worktree_root(runtime, subprocess_cwd, &mut resolved);
+                append_recovery_authority_deny(runtime, &mut resolved)?;
                 Ok(Some(ResolvedSandbox {
                     kind,
                     fs_profile: resolved,
@@ -113,6 +114,7 @@ pub(crate) fn resolve_executor_sandbox(
                     &mut resolved,
                 )?;
                 append_linux_provider_state_roots(provider, &mut resolved)?;
+                append_recovery_authority_deny(runtime, &mut resolved)?;
                 // Host Git state is never a provider convenience grant. Append
                 // these last so even a side root inside metadata stays denied.
                 crate::runtime::git_sandbox::append_linux_git_denies(
@@ -278,6 +280,22 @@ fn append_orbit_child_runtime_write_roots(
     ] {
         append_unique_modify_root(resolved, root);
     }
+}
+
+/// Deny the host-only recovery authority store, after every convenience grant.
+///
+/// No grant above names this root, so the rule is a tripwire that keeps a
+/// future broadening of the `<global>` grants from reopening it. Both sandbox
+/// kinds get it: the boundary is a property of the store, not of one OS.
+fn append_recovery_authority_deny(
+    runtime: &OrbitRuntime,
+    resolved: &mut ResolvedFsProfile,
+) -> Result<(), DispatchError> {
+    crate::runtime::recovery_authority::append_recovery_authority_denies(
+        &runtime.paths().global_dir,
+        resolved,
+    )
+    .map_err(|error| DispatchError::CliInvocationPermanent(error.to_string()))
 }
 
 fn append_unique_modify_root(resolved: &mut ResolvedFsProfile, root: String) {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
@@ -10,6 +10,8 @@ mod dependabot_alert_tasks;
 mod dispatch;
 mod leaf_occupancy;
 mod pipeline_actions;
+#[cfg(target_os = "linux")]
+mod recovery_authority_sandbox;
 mod required_tools;
 mod sandbox;
 mod sandbox_nested;

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/recovery_authority_sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/recovery_authority_sandbox.rs
@@ -1,0 +1,250 @@
+//! Live Bubblewrap checks that a managed leaf cannot reach the recovery
+//! authority through any path shape it can actually construct.
+//!
+//! These run a real sandbox rather than inspecting rules, because the four
+//! vectors below are enforced by mount semantics, not by glob matching: a
+//! read-only bind (`EROFS`), a mountpoint that cannot be renamed aside
+//! (`EBUSY`), and symlink resolution landing back on the same mount.
+//!
+//! Bubblewrap needs unprivileged user namespaces, which some hosts disable.
+//! When the probe reports the capability missing, the live test says so and
+//! returns instead of passing, so a skip is never mistaken for enforcement.
+//! [`the_compiled_sandbox_mounts_the_authority_read_only`] covers the same
+//! mounts at the plan level and needs no such capability.
+#![allow(clippy::print_stdout)]
+
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::process::Stdio;
+
+use orbit_engine::RuntimeHost;
+use orbit_exec::{
+    LINUX_STABLE_WORKSPACE_MOUNT, LinuxBwrapSpawnRequest, compile_linux_bwrap_argv,
+    prepare_linux_bwrap_write_grants, probe_bwrap, spawn_under_linux_bwrap,
+};
+use serde_json::json;
+
+use crate::adapter::engine_host::v2_host::test_support::{
+    runtime_with_workspace_layout, seed_executor,
+};
+use crate::runtime::recovery_authority::RecoveryAuthority;
+
+/// Each probe writes one `<name>=<outcome>` line so a failure names the vector
+/// that got through instead of only the exit status.
+const PROBE_SCRIPT: &str = r#"
+probe() {
+  if : > "$2" 2>/dev/null; then echo "$1=WRITABLE"; else echo "$1=denied"; fi
+}
+rename() {
+  if mv "$2" "$2.moved" 2>/dev/null; then echo "$1=REPLACED"; else echo "$1=denied"; fi
+}
+probe original "$AUTHORITY/authority.db"
+probe wal_sidecar "$AUTHORITY/authority.db-wal"
+probe shm_sidecar "$AUTHORITY/authority.db-shm"
+probe stable_alias "$ALIAS/authority.db"
+rename authority_root "$AUTHORITY"
+rename authority_parent "$GLOBAL/state"
+probe leaf_task "$GLOBAL/tasks/leaf-write.json"
+probe leaf_audit "$GLOBAL/state/audit/leaf-write.jsonl"
+"#;
+
+#[test]
+fn a_leaf_cannot_reach_the_recovery_authority_through_any_path_it_can_build() {
+    let probe = probe_bwrap();
+    if !probe.available {
+        println!(
+            "skipping live recovery authority sandbox test: {}",
+            probe.detail
+        );
+        return;
+    }
+
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    seed_executor(
+        &runtime,
+        "claude",
+        Some(orbit_types::workflow::ExecutorSandboxKind::LinuxBwrap),
+    );
+    let worktree = repo_root.join(".orbit/state/worktrees/orbit-jrun-authority");
+    fs::create_dir_all(&worktree).expect("managed worktree");
+
+    // Hold a certified record open so the database and both SQLite sidecars
+    // exist on disk while the leaf probes them.
+    let global = runtime
+        .paths()
+        .global_dir
+        .canonicalize()
+        .unwrap_or_else(|_| runtime.paths().global_dir.clone());
+    let authority = RecoveryAuthority::open(&global).expect("open authority");
+    authority
+        .issue(
+            "jrun-authority-1",
+            "sync_base",
+            &json!({
+                "run_id": "jrun-authority-1",
+                "step_id": "sync_base",
+                "workspace_path": worktree,
+                "head_sha": "aaaa",
+                "base_sha": "bbbb",
+            }),
+        )
+        .expect("issue certificate");
+    let authority_root = global.join("state/recovery-authority");
+
+    // The alias a leaf can actually build: a symlink inside its own writable
+    // worktree, reached through the stable workspace mount rather than the
+    // real path.
+    symlink(&authority_root, worktree.join("authority-alias")).expect("alias symlink");
+
+    let resolved = runtime
+        .resolve_executor_sandbox("claude", None, Some(&worktree))
+        .expect("resolve Linux sandbox")
+        .expect("descriptor");
+    assert!(
+        resolved.managed_worktree,
+        "the stable alias mount only exists for a managed worktree",
+    );
+    prepare_linux_bwrap_write_grants(&resolved.fs_profile, &worktree).expect("prepare grants");
+    let plan = compile_linux_bwrap_argv(
+        &resolved.fs_profile,
+        "/bin/sh",
+        &["-c".to_string(), PROBE_SCRIPT.to_string()],
+        Some(&worktree),
+        resolved.managed_worktree,
+    )
+    .expect("compile bwrap argv");
+
+    let env = [
+        ("PATH".to_string(), "/usr/bin:/bin".to_string()),
+        (
+            "AUTHORITY".to_string(),
+            authority_root.display().to_string(),
+        ),
+        ("GLOBAL".to_string(), global.display().to_string()),
+        (
+            "ALIAS".to_string(),
+            format!("{LINUX_STABLE_WORKSPACE_MOUNT}/authority-alias"),
+        ),
+    ];
+    let child = spawn_under_linux_bwrap(LinuxBwrapSpawnRequest {
+        plan: &plan,
+        env: &env,
+        cwd: Some(&worktree),
+        stdin: Stdio::null(),
+        stdout: Stdio::piped(),
+        stderr: Stdio::piped(),
+    })
+    .expect("spawn probe");
+    let output = child.wait_with_output().expect("probe output");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    assert!(
+        output.status.success(),
+        "probe script failed: {stdout}\n{stderr}"
+    );
+
+    for vector in [
+        "original",
+        "wal_sidecar",
+        "shm_sidecar",
+        "stable_alias",
+        "authority_root",
+        "authority_parent",
+    ] {
+        assert!(
+            stdout.contains(&format!("{vector}=denied")),
+            "leaf reached the recovery authority through `{vector}`: {stdout}"
+        );
+    }
+    for admitted in ["leaf_task", "leaf_audit"] {
+        assert!(
+            stdout.contains(&format!("{admitted}=WRITABLE")),
+            "admitted leaf write `{admitted}` regressed: {stdout}\n{stderr}"
+        );
+    }
+
+    // Denial has to mean the host record is intact, and admission has to mean
+    // the bytes actually landed outside the sandbox rather than on its tmpfs.
+    assert!(authority_root.join("authority.db").is_file());
+    assert!(!authority_root.with_extension("moved").exists());
+    assert!(global.join("tasks/leaf-write.json").is_file());
+    assert!(global.join("state/audit/leaf-write.jsonl").is_file());
+}
+
+/// Plan-level counterpart to the live probe, for hosts that cannot create a
+/// user namespace. It asserts the mounts the kernel would enforce: the
+/// authority root is bound read-only — which is what makes its contents
+/// unwritable and the directory itself unrenameable — and no read-write bind
+/// covers it, while the admitted leaf write roots are still bound read-write.
+#[test]
+fn the_compiled_sandbox_mounts_the_authority_read_only() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    seed_executor(
+        &runtime,
+        "claude",
+        Some(orbit_types::workflow::ExecutorSandboxKind::LinuxBwrap),
+    );
+    let worktree = repo_root.join(".orbit/state/worktrees/orbit-jrun-authority");
+    fs::create_dir_all(&worktree).expect("managed worktree");
+
+    let global = runtime
+        .paths()
+        .global_dir
+        .canonicalize()
+        .unwrap_or_else(|_| runtime.paths().global_dir.clone());
+    let authority_root = global.join("state/recovery-authority");
+
+    let resolved = runtime
+        .resolve_executor_sandbox("claude", None, Some(&worktree))
+        .expect("resolve Linux sandbox")
+        .expect("descriptor");
+    prepare_linux_bwrap_write_grants(&resolved.fs_profile, &worktree).expect("prepare grants");
+    let plan = compile_linux_bwrap_argv(
+        &resolved.fs_profile,
+        "/bin/true",
+        &[],
+        Some(&worktree),
+        resolved.managed_worktree,
+    )
+    .expect("compile bwrap argv");
+
+    let mounts = plan
+        .args
+        .windows(3)
+        .filter(|args| matches!(args[0].as_str(), "--bind" | "--ro-bind"))
+        .map(|args| (args[0].clone(), args[1].clone(), args[2].clone()))
+        .collect::<Vec<_>>();
+    let authority = authority_root.display().to_string();
+
+    assert!(
+        mounts
+            .iter()
+            .any(|(kind, source, target)| kind == "--ro-bind"
+                && source == &authority
+                && target == &authority),
+        "the authority root must be a read-only mountpoint: {mounts:?}"
+    );
+    assert!(
+        !mounts.iter().any(|(kind, _, target)| kind == "--bind"
+            && (authority.starts_with(target.as_str()) || target.starts_with(&authority))
+            && target != "/"),
+        "no read-write bind may cover the authority root: {mounts:?}"
+    );
+    for admitted in ["tasks", "state/audit"] {
+        let path = global.join(admitted).display().to_string();
+        assert!(
+            mounts.iter().any(|(kind, source, target)| kind == "--bind"
+                && source == &path
+                && target == &path),
+            "admitted leaf write root `{admitted}` must stay read-write: {mounts:?}"
+        );
+    }
+    assert!(
+        !plan
+            .dropped_grants
+            .iter()
+            .any(|grant| grant.anchor.starts_with(&authority_root)),
+        "the authority is denied outright, never a dropped grant: {:?}",
+        plan.dropped_grants
+    );
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
@@ -129,6 +129,63 @@ fn linux_child_runtime_grants_do_not_include_global_workspace_layout() {
     }
 }
 
+/// The recovery authority is the one durable record a resume trusts, so it
+/// must sit outside every grant the leaf receives — including the run store
+/// the leaf legitimately writes through `orbit.task.*` and audit tools.
+#[cfg(target_os = "linux")]
+#[test]
+fn linux_leaf_keeps_run_store_grants_but_never_reaches_the_recovery_authority() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    seed_executor(
+        &runtime,
+        "claude",
+        Some(orbit_types::workflow::ExecutorSandboxKind::LinuxBwrap),
+    );
+
+    let resolved = runtime
+        .resolve_executor_sandbox("claude", None, Some(&repo_root))
+        .expect("resolve Linux sandbox")
+        .expect("descriptor");
+    let global = runtime
+        .paths()
+        .global_dir
+        .canonicalize()
+        .unwrap_or_else(|_| runtime.paths().global_dir.clone());
+    let authority = global.join("state/recovery-authority");
+
+    // The database and both SQLite sidecars: a writer holding any one of them
+    // could inject rows, so the deny has to cover the whole root.
+    for name in ["authority.db", "authority.db-wal", "authority.db-shm"] {
+        let denied =
+            linux_bwrap_write_grant_diagnostic(&resolved.fs_profile, &authority.join(name))
+                .expect("diagnose authority path")
+                .expect("authority path must be attributably denied");
+        assert!(
+            denied.contains(name) && denied.contains("denyModify rule"),
+            "the deny must name the path and the rule that shadows it: {denied}"
+        );
+    }
+
+    // Removing the run-store grants is not the fix and must not be the effect:
+    // admitted leaf tool writes keep working.
+    for granted in [
+        global.join("orbit.db"),
+        global.join("orbit.db-wal"),
+        global.join("orbit.db-shm"),
+        global.join("tasks"),
+        global.join("state/audit"),
+    ] {
+        assert!(
+            linux_bwrap_write_grant_diagnostic(&resolved.fs_profile, &granted)
+                .expect("diagnose granted path")
+                .is_none(),
+            "admitted leaf write {} must stay granted: {:?}",
+            granted.display(),
+            resolved.fs_profile.modify
+        );
+    }
+}
+
 /// [ORB-11259] Implementer sandboxes receive a language-neutral host cache
 /// write root; reviewer profiles do not. The global registry root itself
 /// stays denied.

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod friction;
 #[cfg(target_os = "linux")]
 pub(crate) mod git_sandbox;
 pub mod mutation;
+pub(crate) mod recovery_authority;
 mod resolve;
 pub mod run_audit;
 pub(crate) mod run_input;

--- a/crates/orbit-core/src/runtime/recovery_authority.rs
+++ b/crates/orbit-core/src/runtime/recovery_authority.rs
@@ -1,0 +1,340 @@
+//! Host-only authority for rebase-recovery evidence.
+//!
+//! A managed leaf is granted modify access to the shared run store
+//! (`<global>/orbit.db` and its WAL/SHM sidecars) so that `orbit.task.*` and
+//! audit tools keep working inside the sandbox. That grant also covers the run
+//! row holding `PipelineState::rebase_recovery_checkpoints`, so those bytes are
+//! progress data, not authority: a leaf can rewrite them.
+//!
+//! This module owns the separate durable record that *is* authority. It lives
+//! in its own SQLite database under a root that appears in no leaf write grant,
+//! and [`append_recovery_authority_denies`] appends an explicit deny for that
+//! root after every convenience grant, the same shape
+//! [`crate::runtime::git_sandbox`] uses for Git metadata.
+//!
+//! Confinement here is by *location*, not by a secret. Bubblewrap mounts the
+//! host filesystem `--ro-bind / /` and enforces only write boundaries, so a key
+//! file would be readable by every leaf and a keyed MAC would buy nothing.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use orbit_common::OrbitError;
+use orbit_types::policy::ResolvedFsProfile;
+use rusqlite::{Connection, OptionalExtension, params};
+use serde_json::Value;
+
+/// Directory holding the authority database, relative to the global root.
+const AUTHORITY_DIR: &str = "state/recovery-authority";
+
+/// Database file name. Its `-wal` and `-shm` sidecars are created beside it and
+/// are covered by the same protected root.
+const AUTHORITY_DB: &str = "authority.db";
+
+/// Owner-only permissions for the authority root and its database. These do not
+/// confine a same-UID leaf on their own; they keep the record off any shared or
+/// group-readable path.
+#[cfg(unix)]
+const AUTHORITY_DIR_MODE: u32 = 0o700;
+#[cfg(unix)]
+const AUTHORITY_FILE_MODE: u32 = 0o600;
+
+/// The durable record a host writes when it completes a rebase recovery, and
+/// the only evidence a later resume will accept.
+pub(crate) struct RecoveryAuthority {
+    connection: Connection,
+}
+
+/// The identity a certificate binds. Every field is re-derived from the
+/// candidate checkpoint at verification time, so a payload that was edited,
+/// moved to another run or step, or pointed at another workspace no longer
+/// matches the record the host wrote.
+#[derive(Debug, PartialEq, Eq)]
+struct CertificateBinding {
+    run_id: String,
+    step_id: String,
+    workspace_path: String,
+    head_sha: String,
+    base_sha: String,
+    payload_digest: String,
+}
+
+impl RecoveryAuthority {
+    /// Open (creating on first use) the authority for `global_root`.
+    pub(crate) fn open(global_root: &Path) -> Result<Self, OrbitError> {
+        let root = authority_root(global_root)?;
+        let connection = Connection::open(root.join(AUTHORITY_DB))
+            .map_err(|error| authority_error("open recovery authority database", error))?;
+
+        // WAL keeps the sidecars inside the protected root rather than beside
+        // the shared store, and matches how every other Orbit database runs.
+        connection
+            .pragma_update(None, "journal_mode", "WAL")
+            .map_err(|error| authority_error("enable WAL on recovery authority", error))?;
+        connection
+            .pragma_update(None, "synchronous", "FULL")
+            .map_err(|error| authority_error("harden recovery authority durability", error))?;
+        connection
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS rebase_recovery_certificate (
+                     run_id         TEXT NOT NULL,
+                     step_id        TEXT NOT NULL,
+                     workspace_path TEXT NOT NULL,
+                     head_sha       TEXT NOT NULL,
+                     base_sha       TEXT NOT NULL,
+                     payload_digest TEXT NOT NULL,
+                     issued_at      TEXT NOT NULL,
+                     PRIMARY KEY (run_id, step_id)
+                 ) WITHOUT ROWID;",
+            )
+            .map_err(|error| authority_error("create recovery authority schema", error))?;
+        restrict_permissions(&root)?;
+
+        Ok(Self { connection })
+    }
+
+    /// Record the host's completion of `step_id` in `run_id`.
+    ///
+    /// Certificates are immutable: re-issuing the identical payload succeeds so
+    /// a retried write is harmless, while a different payload for an already
+    /// certified step is refused rather than replacing the accepted record.
+    pub(crate) fn issue(
+        &self,
+        run_id: &str,
+        step_id: &str,
+        checkpoint: &Value,
+    ) -> Result<(), OrbitError> {
+        let binding = CertificateBinding::derive(run_id, step_id, checkpoint)?;
+
+        if let Some(recorded) = self.read(run_id, step_id)? {
+            if recorded == binding {
+                return Ok(());
+            }
+            return Err(OrbitError::Execution(format!(
+                "rebase recovery for run {run_id} step `{step_id}` is already certified with \
+                 different evidence; the accepted certificate is immutable"
+            )));
+        }
+
+        self.connection
+            .execute(
+                "INSERT INTO rebase_recovery_certificate
+                     (run_id, step_id, workspace_path, head_sha, base_sha, payload_digest, issued_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    binding.run_id,
+                    binding.step_id,
+                    binding.workspace_path,
+                    binding.head_sha,
+                    binding.base_sha,
+                    binding.payload_digest,
+                    Utc::now().to_rfc3339(),
+                ],
+            )
+            .map_err(|error| authority_error("record rebase recovery certificate", error))?;
+        Ok(())
+    }
+
+    /// Whether `checkpoint` is exactly the evidence this host certified for
+    /// `run_id` / `step_id`. An absent record means the checkpoint predates the
+    /// authority boundary or was authored by something other than the host;
+    /// both are unusable, and neither is blessed here.
+    pub(crate) fn verify(
+        &self,
+        run_id: &str,
+        step_id: &str,
+        checkpoint: &Value,
+    ) -> Result<bool, OrbitError> {
+        let Ok(binding) = CertificateBinding::derive(run_id, step_id, checkpoint) else {
+            return Ok(false);
+        };
+        Ok(self.read(run_id, step_id)? == Some(binding))
+    }
+
+    fn read(&self, run_id: &str, step_id: &str) -> Result<Option<CertificateBinding>, OrbitError> {
+        self.connection
+            .query_row(
+                "SELECT workspace_path, head_sha, base_sha, payload_digest
+                 FROM rebase_recovery_certificate
+                 WHERE run_id = ?1 AND step_id = ?2",
+                params![run_id, step_id],
+                |row| {
+                    Ok(CertificateBinding {
+                        run_id: run_id.to_string(),
+                        step_id: step_id.to_string(),
+                        workspace_path: row.get(0)?,
+                        head_sha: row.get(1)?,
+                        base_sha: row.get(2)?,
+                        payload_digest: row.get(3)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(|error| authority_error("read rebase recovery certificate", error))
+    }
+}
+
+impl CertificateBinding {
+    fn derive(run_id: &str, step_id: &str, checkpoint: &Value) -> Result<Self, OrbitError> {
+        // The payload names its own run and step. Certifying a payload under a
+        // different identity would leave the two disagreeing, so refuse it at
+        // the point the record is derived instead of storing the mismatch.
+        let payload_run_id = bound_field(checkpoint, "run_id")?;
+        let payload_step_id = bound_field(checkpoint, "step_id")?;
+        if payload_run_id != run_id || payload_step_id != step_id {
+            return Err(OrbitError::Execution(format!(
+                "rebase recovery evidence names run {payload_run_id} step `{payload_step_id}`, \
+                 not run {run_id} step `{step_id}`"
+            )));
+        }
+
+        Ok(Self {
+            run_id: run_id.to_string(),
+            step_id: step_id.to_string(),
+            workspace_path: bound_field(checkpoint, "workspace_path")?,
+            head_sha: bound_field(checkpoint, "head_sha")?,
+            base_sha: bound_field(checkpoint, "base_sha")?,
+            payload_digest: payload_digest(checkpoint),
+        })
+    }
+}
+
+fn bound_field(checkpoint: &Value, field: &str) -> Result<String, OrbitError> {
+    checkpoint
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            OrbitError::Execution(format!(
+                "rebase recovery evidence is missing its `{field}` binding"
+            ))
+        })
+}
+
+/// BLAKE3 over a key-sorted rendering of the whole payload, so any edit to any
+/// field — including ones the bound columns do not name, such as `task_ids` or
+/// `rewritten` — changes the digest.
+fn payload_digest(checkpoint: &Value) -> String {
+    blake3::hash(canonical_json(checkpoint).as_bytes())
+        .to_hex()
+        .to_string()
+}
+
+/// Render `value` with object keys in a stable order. `serde_json` map ordering
+/// depends on a feature flag and on how a value was built, and this digest has
+/// to survive a round trip through the run store either way.
+fn canonical_json(value: &Value) -> String {
+    match value {
+        Value::Object(fields) => {
+            let sorted = fields
+                .iter()
+                .map(|(key, value)| (key.as_str(), canonical_json(value)))
+                .collect::<BTreeMap<_, _>>();
+            let rendered = sorted
+                .into_iter()
+                .map(|(key, value)| format!("{}:{value}", Value::String(key.to_string())))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("{{{rendered}}}")
+        }
+        Value::Array(items) => {
+            let rendered = items
+                .iter()
+                .map(canonical_json)
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("[{rendered}]")
+        }
+        other => other.to_string(),
+    }
+}
+
+/// The protected root, created and validated on demand.
+///
+/// A symlink anywhere in the path would let a writable location stand in for
+/// the authority, so refuse that layout outright rather than deny a pointer
+/// that can be replaced.
+fn authority_root(global_root: &Path) -> Result<PathBuf, OrbitError> {
+    let root = global_root.join(AUTHORITY_DIR);
+    fs::create_dir_all(&root)
+        .map_err(|error| path_error("create recovery authority root", &root, error))?;
+    let root = root
+        .canonicalize()
+        .map_err(|error| path_error("canonicalize recovery authority root", &root, error))?;
+    refuse_symlinked_path(&root)?;
+    Ok(root)
+}
+
+fn refuse_symlinked_path(path: &Path) -> Result<(), OrbitError> {
+    for ancestor in path.ancestors() {
+        let metadata = fs::symlink_metadata(ancestor)
+            .map_err(|error| path_error("inspect recovery authority path", ancestor, error))?;
+        if metadata.file_type().is_symlink() {
+            return Err(OrbitError::PolicyDenied(format!(
+                "recovery authority refuses symlinked path `{}`",
+                ancestor.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn restrict_permissions(root: &Path) -> Result<(), OrbitError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(root, fs::Permissions::from_mode(AUTHORITY_DIR_MODE))
+        .map_err(|error| path_error("restrict recovery authority root", root, error))?;
+    for name in [
+        AUTHORITY_DB.to_string(),
+        format!("{AUTHORITY_DB}-wal"),
+        format!("{AUTHORITY_DB}-shm"),
+    ] {
+        let file = root.join(name);
+        if file.exists() {
+            fs::set_permissions(&file, fs::Permissions::from_mode(AUTHORITY_FILE_MODE))
+                .map_err(|error| path_error("restrict recovery authority file", &file, error))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn restrict_permissions(_root: &Path) -> Result<(), OrbitError> {
+    Ok(())
+}
+
+/// Deny the authority root to a sandboxed leaf.
+///
+/// No convenience grant names this root today, so this is a tripwire rather
+/// than the only barrier: appended after every other grant, it keeps a future
+/// broadening of `<global>` grants from silently reopening the store. The
+/// subtree form covers `authority.db` together with its `-wal` and `-shm`
+/// sidecars, and Bubblewrap binds each writable ancestor of a deny so the
+/// directory cannot be renamed aside and replaced.
+pub(crate) fn append_recovery_authority_denies(
+    global_root: &Path,
+    resolved: &mut ResolvedFsProfile,
+) -> Result<(), OrbitError> {
+    let root = authority_root(global_root)?;
+    let deny = format!("!{}/**", root.display());
+    if !resolved.modify.iter().any(|rule| rule == &deny) {
+        resolved.modify.push(deny);
+    }
+    Ok(())
+}
+
+fn authority_error(action: &str, error: rusqlite::Error) -> OrbitError {
+    OrbitError::Execution(format!("{action}: {error}"))
+}
+
+fn path_error(action: &str, path: &Path, error: std::io::Error) -> OrbitError {
+    OrbitError::Execution(format!("{action} `{}`: {error}", path.display()))
+}
+
+#[cfg(test)]
+#[path = "tests/recovery_authority.rs"]
+mod tests;

--- a/crates/orbit-core/src/runtime/tests/recovery_authority.rs
+++ b/crates/orbit-core/src/runtime/tests/recovery_authority.rs
@@ -1,0 +1,299 @@
+//! Forge fixtures for the host-only recovery authority.
+//!
+//! Every attack here models the same capability the sandbox actually grants a
+//! managed leaf: arbitrary bytes in the shared run store. The certificate the
+//! host wrote lives elsewhere, so the fixture edits the *checkpoint* and
+//! asserts the record no longer matches.
+
+use std::path::Path;
+
+use orbit_types::policy::ResolvedFsProfile;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use super::{RecoveryAuthority, append_recovery_authority_denies};
+
+const RUN_ID: &str = "jrun-20260910-0001-1";
+const OTHER_RUN_ID: &str = "jrun-20260910-0002-1";
+const STEP_ID: &str = "sync_base";
+
+fn checkpoint(run_id: &str, step_id: &str, workspace: &Path) -> Value {
+    json!({
+        "run_id": run_id,
+        "step_id": step_id,
+        "task_ids": ["ORB-11977"],
+        "workspace_path": workspace,
+        "head": "orbit/ORB-11977",
+        "head_sha_before": "1111111111111111111111111111111111111111",
+        "original_base_sha": "2222222222222222222222222222222222222222",
+        "base_ref": "refs/remotes/origin/agent-main",
+        "base_sha": "3333333333333333333333333333333333333333",
+        "remote_sha_before": Value::Null,
+        "head_sha": "4444444444444444444444444444444444444444",
+        "rewritten": true,
+    })
+}
+
+fn fixture() -> (TempDir, TempDir, Value) {
+    let global = TempDir::new().expect("global root");
+    let workspace = TempDir::new().expect("workspace");
+    let accepted = checkpoint(RUN_ID, STEP_ID, workspace.path());
+    let authority = RecoveryAuthority::open(global.path()).expect("open authority");
+    authority
+        .issue(RUN_ID, STEP_ID, &accepted)
+        .expect("issue certificate");
+    (global, workspace, accepted)
+}
+
+#[test]
+fn certified_evidence_verifies_and_every_leaf_edit_does_not() {
+    let (global, workspace, accepted) = fixture();
+    let authority = RecoveryAuthority::open(global.path()).expect("reopen authority");
+
+    assert!(
+        authority
+            .verify(RUN_ID, STEP_ID, &accepted)
+            .expect("verify accepted"),
+        "the host's own evidence must verify",
+    );
+
+    // A leaf owns the run row, so it can change any field in it. Each edit
+    // below is a distinct forgery shape and each must be rejected.
+    for (label, forged) in [
+        ("rewritten head", {
+            let mut forged = accepted.clone();
+            forged["head_sha"] = json!("5555555555555555555555555555555555555555");
+            forged
+        }),
+        ("pinned base", {
+            let mut forged = accepted.clone();
+            forged["base_sha"] = json!("6666666666666666666666666666666666666666");
+            forged
+        }),
+        ("owning tasks", {
+            let mut forged = accepted.clone();
+            forged["task_ids"] = json!(["ORB-00000"]);
+            forged
+        }),
+        ("rewritten flag", {
+            let mut forged = accepted.clone();
+            forged["rewritten"] = json!(false);
+            forged
+        }),
+        ("added field", {
+            let mut forged = accepted.clone();
+            forged["injected"] = json!("leaf");
+            forged
+        }),
+        ("removed field", {
+            let mut forged = accepted.clone();
+            forged
+                .as_object_mut()
+                .expect("object payload")
+                .remove("remote_sha_before");
+            forged
+        }),
+    ] {
+        assert!(
+            !authority
+                .verify(RUN_ID, STEP_ID, &forged)
+                .expect("verify forged"),
+            "a forged `{label}` must not verify",
+        );
+    }
+
+    // Cross-run and cross-step substitution: the payload names its own run and
+    // step, so a copy into another run's row disagrees with the record.
+    let other_workspace = TempDir::new().expect("other workspace");
+    for (label, run_id, step_id, forged) in [
+        (
+            "another run",
+            OTHER_RUN_ID,
+            STEP_ID,
+            checkpoint(OTHER_RUN_ID, STEP_ID, workspace.path()),
+        ),
+        (
+            "another step",
+            RUN_ID,
+            "complete_pr",
+            checkpoint(RUN_ID, "complete_pr", workspace.path()),
+        ),
+        (
+            "another workspace",
+            RUN_ID,
+            STEP_ID,
+            checkpoint(RUN_ID, STEP_ID, other_workspace.path()),
+        ),
+    ] {
+        assert!(
+            !authority
+                .verify(run_id, step_id, &forged)
+                .expect("verify substituted"),
+            "evidence rebound to `{label}` must not verify",
+        );
+    }
+
+    // A leaf may also leave the payload alone and relabel where it is stored.
+    // Reading the record under the relabelled identity finds nothing.
+    assert!(
+        !authority
+            .verify(OTHER_RUN_ID, STEP_ID, &accepted)
+            .expect("verify relabelled run"),
+        "the accepted payload must not verify under another run's identity",
+    );
+    assert!(
+        !authority
+            .verify(RUN_ID, "complete_pr", &accepted)
+            .expect("verify relabelled step"),
+        "the accepted payload must not verify under another step's identity",
+    );
+}
+
+#[test]
+fn evidence_survives_restart_and_stays_bound_to_its_run() {
+    let (global, workspace, accepted) = fixture();
+
+    // Reopening from disk is the host restart: the authority is durable, and a
+    // replayed copy is still refused under any other identity.
+    let restarted = RecoveryAuthority::open(global.path()).expect("reopen after restart");
+    assert!(
+        restarted
+            .verify(RUN_ID, STEP_ID, &accepted)
+            .expect("verify after restart"),
+    );
+
+    let replayed = checkpoint(OTHER_RUN_ID, STEP_ID, workspace.path());
+    assert!(
+        !restarted
+            .verify(OTHER_RUN_ID, STEP_ID, &replayed)
+            .expect("verify replay"),
+        "a replayed payload has no certificate of its own",
+    );
+}
+
+#[test]
+fn an_accepted_certificate_cannot_be_replaced() {
+    let (global, _workspace, accepted) = fixture();
+    let authority = RecoveryAuthority::open(global.path()).expect("reopen authority");
+
+    // Re-issuing identical evidence is a harmless retry.
+    authority
+        .issue(RUN_ID, STEP_ID, &accepted)
+        .expect("idempotent reissue");
+
+    let mut replacement = accepted.clone();
+    replacement["head_sha"] = json!("7777777777777777777777777777777777777777");
+    let error = authority
+        .issue(RUN_ID, STEP_ID, &replacement)
+        .expect_err("replacing accepted evidence must fail");
+    assert!(error.to_string().contains("immutable"), "{error}");
+
+    assert!(
+        authority
+            .verify(RUN_ID, STEP_ID, &accepted)
+            .expect("verify original"),
+        "the original certificate survives the refused replacement",
+    );
+    assert!(
+        !authority
+            .verify(RUN_ID, STEP_ID, &replacement)
+            .expect("verify replacement"),
+    );
+}
+
+#[test]
+fn evidence_must_name_the_run_and_step_it_is_certified_under() {
+    let global = TempDir::new().expect("global root");
+    let workspace = TempDir::new().expect("workspace");
+    let authority = RecoveryAuthority::open(global.path()).expect("open authority");
+
+    let error = authority
+        .issue(
+            OTHER_RUN_ID,
+            STEP_ID,
+            &checkpoint(RUN_ID, STEP_ID, workspace.path()),
+        )
+        .expect_err("mismatched identity must not be certified");
+    assert!(error.to_string().contains("not run"), "{error}");
+
+    let mut incomplete = checkpoint(RUN_ID, STEP_ID, workspace.path());
+    incomplete
+        .as_object_mut()
+        .expect("object payload")
+        .remove("base_sha");
+    let error = authority
+        .issue(RUN_ID, STEP_ID, &incomplete)
+        .expect_err("unbound evidence must not be certified");
+    assert!(error.to_string().contains("`base_sha`"), "{error}");
+    assert!(
+        !authority
+            .verify(RUN_ID, STEP_ID, &incomplete)
+            .expect("verify unbound"),
+    );
+}
+
+/// An uncertified run-store row is exactly the shape a pre-boundary checkpoint
+/// has. Nothing blesses it: the authority reports no record, and the resume
+/// path turns that into a refusal.
+#[test]
+fn checkpoints_written_before_the_boundary_have_no_record() {
+    let global = TempDir::new().expect("global root");
+    let workspace = TempDir::new().expect("workspace");
+    let authority = RecoveryAuthority::open(global.path()).expect("open authority");
+
+    assert!(
+        !authority
+            .verify(
+                RUN_ID,
+                STEP_ID,
+                &checkpoint(RUN_ID, STEP_ID, workspace.path())
+            )
+            .expect("verify legacy row"),
+    );
+}
+
+/// Rule *shape*: the deny lands last and is a subtree, which is what makes it
+/// cover `authority.db` together with the `-wal` and `-shm` sidecars a writer
+/// could otherwise use to inject rows. Enforcement of these rules is proven
+/// against a live sandbox in `tests/recovery_authority_linux.rs`.
+#[test]
+fn the_authority_deny_is_a_subtree_rule_appended_after_every_grant() {
+    let global = TempDir::new().expect("global root");
+    let leaf_grants = vec![
+        format!("{}/tasks", global.path().display()),
+        format!("{}/orbit.db", global.path().display()),
+        format!("{}/orbit.db-wal", global.path().display()),
+    ];
+    let mut resolved = ResolvedFsProfile {
+        name: "implementer".to_string(),
+        read: vec!["/**".to_string()],
+        modify: leaf_grants.clone(),
+    };
+    append_recovery_authority_denies(global.path(), &mut resolved).expect("append denies");
+
+    let root = global
+        .path()
+        .canonicalize()
+        .expect("canonical global root")
+        .join("state/recovery-authority");
+    assert!(root.is_dir(), "the protected root is created on demand");
+
+    let deny = format!("!{}/**", root.display());
+    assert_eq!(
+        resolved.modify.last(),
+        Some(&deny),
+        "the deny must come after every grant so a later grant cannot win",
+    );
+    assert!(
+        resolved.modify.starts_with(&leaf_grants),
+        "leaf task and run-store grants are left untouched",
+    );
+
+    // Appending twice is idempotent, so repeated resolution cannot accumulate
+    // duplicate rules.
+    append_recovery_authority_denies(global.path(), &mut resolved).expect("append denies again");
+    assert_eq!(
+        resolved.modify.iter().filter(|rule| *rule == &deny).count(),
+        1
+    );
+}

--- a/crates/orbit-engine/src/context/hosts.rs
+++ b/crates/orbit-engine/src/context/hosts.rs
@@ -630,6 +630,22 @@ pub trait RuntimeHost: Send + Sync {
         ))
     }
 
+    /// Whether `checkpoint` is exactly the recovery evidence this host
+    /// certified for `run_id` / `step_id`.
+    ///
+    /// The run store a checkpoint is read back from is writable by managed
+    /// leaves, so the stored bytes are progress data. Authority lives in a
+    /// host-only record this method consults. Hosts without one certify
+    /// nothing and therefore authenticate nothing.
+    fn verify_rebase_recovery(
+        &self,
+        _run_id: &str,
+        _step_id: &str,
+        _checkpoint: &Value,
+    ) -> Result<bool, OrbitError> {
+        Ok(false)
+    }
+
     fn tool_context_for_activity(
         &self,
         _run_id: Option<&str>,

--- a/crates/orbit-engine/src/executor/automation/vcs/freshness.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/freshness.rs
@@ -565,6 +565,13 @@ fn parse_divergence_count(
 
 /// Read only host-written provenance, authenticating the original durable run
 /// when a resume carries a copy. Advisory activity outputs never authorize HEAD.
+///
+/// The run store these entries come from is writable by managed leaves, so a
+/// matching entry is a candidate, not authority. Every candidate must also
+/// carry the host's certificate from [`RuntimeHost::verify_rebase_recovery`].
+/// A checkpoint written before that boundary existed has no certificate and is
+/// refused here; the run redoes the rebase rather than inheriting an
+/// unauthenticated HEAD.
 pub(super) fn recovered_head_checkpoint<H: RuntimeHost + ?Sized>(
     host: &H,
     run_id: &str,
@@ -584,6 +591,12 @@ pub(super) fn recovered_head_checkpoint<H: RuntimeHost + ?Sized>(
             continue;
         }
         let source_run_id = required_input_string(checkpoint, "run_id")?;
+        if !host.verify_rebase_recovery(source_run_id, step_id, checkpoint)? {
+            return Err(OrbitError::Execution(format!(
+                "recovered rebase for step `{step_id}` of run {source_run_id} carries no host \
+                 recovery certificate; rerun the rebase instead of trusting run-store evidence"
+            )));
+        }
         if source_run_id != run_id {
             let source = host.read_run_state(source_run_id)?.ok_or_else(|| {
                 OrbitError::Execution(

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_failure.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_failure.rs
@@ -261,7 +261,18 @@ impl RuntimeHost for ResumeFailureHost {
             .unwrap()
             .rebase_recovery_checkpoints
             .insert(step_id.to_string(), output.clone());
+        self.inner.certify_recovery(run_id, step_id, output);
         Ok(())
+    }
+
+    fn verify_rebase_recovery(
+        &self,
+        run_id: &str,
+        step_id: &str,
+        checkpoint: &Value,
+    ) -> Result<bool, OrbitError> {
+        self.inner
+            .verify_rebase_recovery(run_id, step_id, checkpoint)
     }
 
     fn checkpoint_failure_activity(

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_preservation.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_preservation.rs
@@ -161,6 +161,18 @@ fn resumed_recovery_requires_the_exact_immutable_source_checkpoint() {
         serde_json::from_slice(&serde_json::to_vec(&source).unwrap()).unwrap();
     resumed.run_id = SECOND_RESUME_RUN_ID.to_string();
     host.write_state(resumed.clone());
+
+    // The row exists in the run store the leaf can write, but nothing has
+    // certified it yet. That is the pre-boundary shape, and it is refused.
+    let error =
+        recovered_head_checkpoint(&host, SECOND_RESUME_RUN_ID, &workspace.repo, &head).unwrap_err();
+    assert!(
+        error.to_string().contains("no host recovery certificate"),
+        "{error}"
+    );
+
+    host.inner
+        .certify_recovery(FIRST_RESUME_RUN_ID, "sync_base", &checkpoint);
     assert_eq!(
         recovered_head_checkpoint(&host, SECOND_RESUME_RUN_ID, &workspace.repo, &head).unwrap(),
         Some(checkpoint)
@@ -174,7 +186,20 @@ fn resumed_recovery_requires_the_exact_immutable_source_checkpoint() {
         .rebase_recovery_checkpoints
         .get_mut("sync_base")
         .unwrap()["head_sha_before"] = json!("substituted-origin");
-    host.write_state(resumed);
+    host.write_state(resumed.clone());
+    let error =
+        recovered_head_checkpoint(&host, SECOND_RESUME_RUN_ID, &workspace.repo, &head).unwrap_err();
+    assert!(
+        error.to_string().contains("no host recovery certificate"),
+        "{error}"
+    );
+
+    // Certifying the substituted payload isolates the second gate, which is
+    // what keeps a resume honest even about evidence the host did write: the
+    // copy still has to equal the immutable source row.
+    let substituted = resumed.rebase_recovery_checkpoints["sync_base"].clone();
+    host.inner
+        .certify_recovery(FIRST_RESUME_RUN_ID, "sync_base", &substituted);
     let error =
         recovered_head_checkpoint(&host, SECOND_RESUME_RUN_ID, &workspace.repo, &head).unwrap_err();
     assert!(

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
@@ -41,6 +41,10 @@ pub struct VcsCall {
 
 pub struct PrOpenTestHost {
     run_states: Mutex<HashMap<String, orbit_types::workflow::PipelineState>>,
+    /// In-memory stand-in for the host-only recovery authority. Kept apart
+    /// from `run_states` on purpose: a test that edits a checkpoint the way a
+    /// leaf would must then fail verification.
+    recovery_certificates: Mutex<HashMap<(String, String), Value>>,
     tasks: Mutex<Vec<Task>>,
     job_runs: Mutex<Vec<JobRun>>,
     comments: Mutex<HashMap<String, Vec<TaskComment>>>,
@@ -64,6 +68,7 @@ impl PrOpenTestHost {
         let scoreboard_dir = data_root.join("scoreboard");
         Self {
             run_states: Mutex::new(HashMap::new()),
+            recovery_certificates: Mutex::new(HashMap::new()),
             tasks: Mutex::new(tasks),
             job_runs: Mutex::new(Vec::new()),
             comments: Mutex::new(HashMap::new()),
@@ -86,6 +91,15 @@ impl PrOpenTestHost {
     pub fn with_provider_completion(mut self) -> Self {
         self.provider_completion = true;
         self
+    }
+
+    /// Certify `output` the way a real host would, for a state a test wrote
+    /// straight into the run store.
+    pub fn certify_recovery(&self, run_id: &str, step_id: &str, output: &Value) {
+        self.recovery_certificates
+            .lock()
+            .expect("recovery certificates lock")
+            .insert((run_id.to_string(), step_id.to_string()), output.clone());
     }
 
     pub fn review_landings(&self) -> Vec<ReviewLandingRequest> {
@@ -280,7 +294,23 @@ impl RuntimeHost for PrOpenTestHost {
         state
             .rebase_recovery_checkpoints
             .insert(step_id.to_string(), output.clone());
+        drop(states);
+        self.certify_recovery(run_id, step_id, output);
         Ok(())
+    }
+
+    fn verify_rebase_recovery(
+        &self,
+        run_id: &str,
+        step_id: &str,
+        checkpoint: &Value,
+    ) -> Result<bool, OrbitError> {
+        Ok(self
+            .recovery_certificates
+            .lock()
+            .expect("recovery certificates lock")
+            .get(&(run_id.to_string(), step_id.to_string()))
+            == Some(checkpoint))
     }
 
     fn get_job_run(&self, run_id: &str) -> Result<Option<JobRun>, OrbitError> {

--- a/crates/orbit-types/src/workflow/run_state.rs
+++ b/crates/orbit-types/src/workflow/run_state.rs
@@ -131,9 +131,15 @@ pub struct PipelineState {
     /// candidate the failure activity preserved.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure_activity_checkpoint: Option<FailureActivityCheckpoint>,
-    /// Host-validated rebase completions keyed by failed step ID. These are
-    /// provenance, not successful step outputs; retries must still run the step.
-    /// Absent in older runs, whose rewritten heads remain unverified.
+    /// Rebase completions keyed by failed step ID. These are provenance, not
+    /// successful step outputs; retries must still run the step. Absent in
+    /// older runs, whose rewritten heads remain unverified.
+    ///
+    /// This map is untrusted progress data. Managed leaves hold modify grants
+    /// on the store it is persisted in, so a matching entry is a candidate
+    /// only: authority is the host-only certificate a resume checks through
+    /// `RuntimeHost::verify_rebase_recovery`. Never treat an entry here as
+    /// evidence on its own.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub rebase_recovery_checkpoints: BTreeMap<String, Value>,
     pub updated_at: DateTime<Utc>,

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -259,6 +259,53 @@ If execution stops after Git changes HEAD but before the host persists verified
 completion, there is no authenticated completed-head record: resume fails closed
 and requires inspection. It never reconstructs success from the agent's result.
 
+#### Recovery authority is host-only
+
+`PipelineState.rebase_recovery_checkpoints` lives in the run row of
+`<global>/orbit.db`, and a managed leaf holds modify grants on that database and
+its WAL/SHM sidecars so `orbit.task.*` and audit tools keep working inside the
+sandbox. Those grants also cover the recovery rows, so the rows are progress
+data, not authority: a leaf can write bytes that look exactly like a host
+checkpoint, and authenticating them against the same store proves nothing.
+
+After [F2026-09-063], the record a resume trusts is a separate certificate the
+host writes to `<global>/state/recovery-authority/authority.db`. That root
+appears in no leaf write grant, and sandbox resolution appends an explicit
+subtree deny for it after every convenience grant, alongside the Git-metadata
+denies. The subtree form covers the database together with its `-wal` and `-shm`
+sidecars, and Bubblewrap binds the root read-only, so it is unwritable through
+its own path, unreachable through a symlink alias a leaf builds in its worktree,
+and unrenameable as a mountpoint. Removing the `orbit.db` grants was rejected as
+the fix: it would break admitted leaf writes without making the remaining
+evidence authentic.
+
+Confinement here is by location, not by a secret. Bubblewrap mounts the host
+filesystem `--ro-bind / /` and enforces only write boundaries, so a key file
+would be readable by every leaf and a keyed MAC would add no authority.
+
+Each certificate binds the run ID, step ID, canonical workspace path, recovered
+`head_sha`, pinned `base_sha`, and a BLAKE3 digest over the whole checkpoint
+payload, so an edit to any field — including `task_ids` and `rewritten`, which
+the bound columns do not name — no longer matches. Certificates are immutable
+per `(run_id, step_id)`: re-issuing identical evidence is a harmless retry, and
+different evidence for an already certified step is refused rather than
+replacing the accepted record. `recovered_head_checkpoint` checks the
+certificate before it consults the source run, so a payload relabelled into
+another run or step, or replayed after a host restart, fails at the first gate;
+lineage and source-equality checks continue to apply behind it.
+
+**Migration.** Checkpoints written before this boundary have no certificate and
+are never backfilled — a row in a store the leaf can write is not evidence that
+the host wrote it, so blessing old rows would import exactly the forgery the
+boundary removes. `recovered_head_checkpoint` refuses an otherwise matching but
+uncertified checkpoint with a typed error naming the run and step, rather than
+reporting it absent. The operational consequence is bounded: an in-flight run
+resumed across the upgrade redoes its rebase from the preserved candidate
+instead of inheriting the rewritten HEAD, and a resume that has no other
+authority (no preservation commit and no successful workflow commit) fails
+closed for inspection. No durable data is discarded; the stale rows remain
+readable and inert.
+
 `step.recovery_attempted` retains a bounded, redacted `error_message` and
 `failure_phase` when authorization, input preparation, crew resolution, dispatch,
 or the recovery activity fails. These optional fields are absent from older
@@ -872,6 +919,11 @@ One subtlety: profile attachment happens at two layers.
 - A target step may override or supply one around an inlined activity spec.
 
 Readers must distinguish "profile on the reusable activity" from "profile on this call site."
+
+Host-owned state is denied after both layers resolve, so no profile or provider
+convenience grant can reopen it: Git metadata (see [ORB-11506]) and the recovery
+authority root described in §8.6 are appended as subtree denies at the end of
+the resolved modify list.
 
 ---
 


### PR DESCRIPTION
## Task

[ORB-11977](https://orbit-cli.com/tasks/ORB-11977) — Isolate recovery authority from leaf-writable run storage

### Description

## Problem and evidence
F2026-09-063 identifies recovery certificates in the same SQLite DB writable by managed leaves. Current runtime_host.rs checkpoint_rebase_recovery stores checkpoints through update_run_state, while v2_host/sandbox.rs grants modify access to orbit.db and WAL/SHM. ORB-11506 is done, but protecting Git metadata does not authenticate this separate durable replay state.

Source frictions: F2026-09-063.
Audit source baseline: owning Linux checkout e4f9098633a8876a5a7c233d9914a094b6efa858, inspected 2026-09-10. Incident reports are historical evidence; no production failure was induced during this audit.

## Proposed solution
Move authoritative recovery verification/checkpoints behind a host-only integrity boundary. Select the smallest design that prevents leaf-authored shared DB bytes being trusted as host certificates, including replay after restart. Keep authorized leaf task/audit writes working; merely removing DB grants is not a complete solution. Bind trusted evidence to run, step, workspace/repository identity and verified Git state, and reject tampering/replay/cross-run substitution. Keep untrusted progress data separate from authority. If using signatures, host keys must be inaccessible to leaves. Use only synthetic stores/worktrees for attacks; no production DB mutations.

## Scope and delivery
Create a validated task-scoped candidate from agent-main in a dedicated worktree. Preserve existing failed-run and friction evidence. This filing does not authorize dispatch, merge, release, production configuration changes or live backlog consolidation. Complexity hard; crew sol follows the configured lane. Existing task inventory and targeted searches were checked for covering work.

### Acceptance Criteria

- A deterministic fixture proves leaf-write access to the ordinary store cannot forge or replace an accepted recovery certificate, including tampered payload, wrong run/workspace/step and replay after restart.
- Legitimate host checkpoint/recovery succeeds; leaf task/audit tool writes continue under the normal admitted boundary.
- Live Linux integration verifies protected authority through original, stable alias, parent replacement and SQLite-sidecar paths; unavailable host prerequisites are reported separately from passes.
- Document migration/failure handling for existing untrusted checkpoints; never silently bless old shared-store rows.
- Run focused recovery/sandbox/store tests and repository gates.

## Execution Summary

<details>
<summary>Click to expand</summary>

## What changed

Recovery evidence is split into untrusted progress data and host-only authority.

- **New `crates/orbit-core/src/runtime/recovery_authority.rs`** — a `RecoveryAuthority`
  backed by its own SQLite database at `<global>/state/recovery-authority/authority.db`
  (WAL, dir 0700 / files 0600, symlinked ancestors refused). One immutable row per
  `(run_id, step_id)` binds run, step, canonical workspace path, `head_sha`, `base_sha`
  and a BLAKE3 digest over key-sorted canonical JSON of the whole checkpoint payload.
  `issue()` is idempotent for identical evidence and refuses different evidence for an
  already-certified step. `verify()` re-derives the binding and compares.
- **Write path** — `runtime_host.rs::checkpoint_rebase_recovery` certifies before
  persisting the run-state copy. Both halves are fatal, so either order fails closed.
- **Verify path** — new `RuntimeHost::verify_rebase_recovery` (default `Ok(false)`),
  called by `freshness.rs::recovered_head_checkpoint` right after the cheap identity
  match and before the source-run lookup. An otherwise matching but uncertified
  checkpoint is refused with a typed error, never reported absent.
- **Sandbox** — `append_recovery_authority_denies` appends `!<root>/**` to the resolved
  modify list on both Linux and macOS, after every convenience grant and before the Git
  denies (which keep their documented last position). The subtree form covers the
  database and its `-wal` / `-shm` sidecars. No `orbit.db` grant was removed.
- **`PipelineState::rebase_recovery_checkpoints`** is documented as untrusted progress.
- **Docs** — `docs/design/activity-job/2_design.md` §8.6 gains "Recovery authority is
  host-only" (threat, design, rejected alternatives, migration) and §9 records that
  host-owned state is denied after both profile layers resolve.

Design note: confinement is by *location*, not by a secret. Bubblewrap mounts
`--ro-bind / /` and enforces only write boundaries, so a key file would be readable by
every leaf and a keyed MAC would add no authority. `crates/orbit-store/.../job_run_store/backend.rs`
was in scope but needed no change — the shared store keeps holding the advisory copy.

## Acceptance criteria

1. **Deterministic forge fixture — met.** `crates/orbit-core/src/runtime/tests/recovery_authority.rs`
   (6 tests): six payload-tamper shapes (head, base, task_ids, rewritten flag, added
   field, removed field); cross-run, cross-step and cross-workspace substitution;
   relabelling a genuine payload under another identity; immutability of an accepted
   certificate; replay after reopening the database from disk; and evidence that must
   name the run/step it is certified under.
2. **Legitimate path still works — met.** `adapter/engine_host/tests/runtime_host.rs`
   certifies, restarts, verifies, then rewrites the run row the way a leaf holding the
   `orbit.db` grant would and shows the store accepts the bytes while the authority
   rejects the claim. `v2_host/tests/sandbox.rs` asserts the deny is attributable for
   all three authority files while `orbit.db`, `orbit.db-wal`, `orbit.db-shm`,
   `<global>/tasks` and `<global>/state/audit` stay granted.
3. **Live Linux integration — implemented, NOT executed on this host.**
   `v2_host/tests/recovery_authority_sandbox.rs` spawns a real Bubblewrap child probing
   the original path, both SQLite sidecars, a symlink alias reached through
   `LINUX_STABLE_WORKSPACE_MOUNT`, and renaming both the authority root and its parent,
   with positive controls for admitted leaf writes plus host-side persistence checks.
   It **skipped** here: `probe_bwrap()` reports "No permissions to create new namespace"
   because `/proc/sys/kernel/apparmor_restrict_unprivileged_userns = 1`. Clearing that
   needs root and is a host configuration change this task does not authorize; filed as
   **F2026-09-109**. A skip is printed and is not counted as enforcement. As substitute
   evidence that runs without a namespace, `the_compiled_sandbox_mounts_the_authority_read_only`
   asserts the compiled bwrap argv `--ro-bind`s the authority root, that no `--bind`
   covers it, that the admitted leaf roots stay read-write, and that the authority never
   appears as a dropped grant. **This proves the mount plan, not kernel enforcement.**
4. **Migration documented — met.** Old rows are never backfilled or blessed; an
   otherwise matching uncertified checkpoint is refused with a typed error naming run
   and step. Consequence stated: a run resumed across the upgrade redoes its rebase from
   the preserved candidate, and a resume with no other authority fails closed for
   inspection. No durable data is discarded.
5. **Tests and gates — met, with one pre-existing flake.** See below.

## Validation

| Command | Result |
|---|---|
| `cargo test -p orbit-core --lib` | **passed** — 1292 passed, 0 failed, 2 ignored |
| `cargo test -p orbit-core` (all targets) | **passed** |
| `cargo test -p orbit-engine --lib -- --test-threads=1` | **passed** — 660 passed, 0 failed |
| `cargo test -p orbit-store -p orbit-types` | **passed** — 492 + 226, 0 failed |
| `make ci-fast` | **passed** (exit 0) |
| `make ci-lint` | **passed** (exit 0) |
| live Bubblewrap probe in `recovery_authority_sandbox.rs` | **not run** — host prerequisite unavailable (see AC3) |

`cargo test -p orbit-engine --lib` under default parallelism failed 2 of 3 runs, a
*different* test each time, always `/bin/sh: 0: cannot open /tmp/.tmpXXXX/git: No such
file`. Root cause: `activity_job/tests/workspace.rs:509` mutates process-global `PATH`
to a tempdir `git` shim while sibling tests shell out to `git`. Single-threaded the
suite is fully green and each failing test passes alone. This task touches neither file
and adds no environment manipulation; filed as **F2026-09-111**.

## Risks and deviations

- Kernel-level enforcement of the sandbox denies is unverified on this host. The
  argv-level test and the existing Git-metadata precedent make the mechanism sound, but
  AC3's live evidence remains outstanding and should be collected on a host with
  unprivileged user namespaces enabled.
- Fail-closed migration is a deliberate behaviour change: a pre-upgrade in-flight resume
  that relied solely on an uncertified checkpoint now stops for inspection instead of
  inheriting the rewritten HEAD.
- `verify_rebase_recovery` opens a SQLite connection per call. Call volume is at most a
  couple of entries per resume, so no caching was added.

Changes are uncommitted; the pipeline owns commit, PR and delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11977-6aa225fb`
- Behind base: 0
- Ahead of base: 1