### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/scoreboard/common.rs

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -99,3 +99,9 @@ extensions:
           "path-injection",
           "manual",
         ]
+      - [
+          "orbit_store::driver::file::scoreboard::common::validated_scoreboard_file_path",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]

--- a/crates/orbit-store/src/driver/file/scoreboard/common.rs
+++ b/crates/orbit-store/src/driver/file/scoreboard/common.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use orbit_common::OrbitError;
 use orbit_types::identity::normalize_attribution_label;
@@ -18,6 +18,56 @@ pub(crate) type ModelScores = HashMap<String, u64>;
 /// Metric name → per-model counters — the shape of `pr.json` and
 /// `task_review.json`.
 pub(crate) type CounterScoreboard = HashMap<String, ModelScores>;
+
+fn validated_scoreboard_file_name(file_name: &str) -> Result<&'static str, OrbitError> {
+    match file_name {
+        "pr.json" => Ok("pr.json"),
+        "task_review.json" => Ok("task_review.json"),
+        _ => Err(OrbitError::InvalidInput(format!(
+            "unsupported scoreboard file: {file_name}"
+        ))),
+    }
+}
+
+/// Resolve a scoreboard file beneath its canonical directory.
+///
+/// Scoreboard filenames are an internal allow-list, not caller-selected
+/// paths. Canonicalizing the directory and rejecting a symlinked or non-file
+/// target keeps the read-modify-write cycle within the intended scoreboard
+/// directory before any filesystem access uses the result.
+fn validated_scoreboard_file_path(
+    scoreboard_dir: &Path,
+    file_name: &str,
+) -> Result<PathBuf, OrbitError> {
+    let file_name = validated_scoreboard_file_name(file_name)?;
+
+    let canonical_dir = fs::canonicalize(scoreboard_dir)
+        .map_err(|error| OrbitError::Io(format!("canonicalize scoreboard directory: {error}")))?;
+    if !canonical_dir.is_dir() {
+        return Err(OrbitError::InvalidInput(
+            "scoreboard path must be a directory".to_string(),
+        ));
+    }
+
+    let path = canonical_dir.join(file_name);
+    if !path.starts_with(&canonical_dir) {
+        return Err(OrbitError::InvalidInput(
+            "scoreboard file must remain within its directory".to_string(),
+        ));
+    }
+
+    match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(OrbitError::InvalidInput(
+            "scoreboard file must not be a symlink".to_string(),
+        )),
+        Ok(metadata) if !metadata.is_file() => Err(OrbitError::InvalidInput(
+            "scoreboard file must be a regular file".to_string(),
+        )),
+        Ok(_) => Ok(path),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(path),
+        Err(error) => Err(OrbitError::Io(format!("inspect scoreboard file: {error}"))),
+    }
+}
 
 /// Increment `metric` for the (normalized) `model` in
 /// `scoreboard_dir/<file_name>`, creating the file on first use. `migrate`
@@ -31,9 +81,11 @@ pub(crate) fn increment_model_metric(
     model: &str,
     migrate: impl FnOnce(&mut CounterScoreboard),
 ) -> Result<(), OrbitError> {
-    let path = scoreboard_dir.join(file_name);
+    let file_name = validated_scoreboard_file_name(file_name)?;
+    let lock_path = scoreboard_dir.join(file_name);
     let normalized_model = normalize_attribution_label(model, None);
-    with_exclusive_file_lock(&path, lock_label, || {
+    with_exclusive_file_lock(&lock_path, lock_label, || {
+        let path = validated_scoreboard_file_path(scoreboard_dir, file_name)?;
         let mut scoreboard: CounterScoreboard = if path.exists() {
             let content = fs::read_to_string(&path)
                 .map_err(|e| OrbitError::Io(format!("read {file_name}: {e}")))?;

--- a/crates/orbit-store/src/driver/file/scoreboard/mod.rs
+++ b/crates/orbit-store/src/driver/file/scoreboard/mod.rs
@@ -6,3 +6,6 @@
 pub(crate) mod common;
 pub(crate) mod pr_scoreboard;
 pub(crate) mod scoreboard_summary;
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-store/src/driver/file/scoreboard/tests/mod.rs
+++ b/crates/orbit-store/src/driver/file/scoreboard/tests/mod.rs
@@ -1,0 +1,60 @@
+use std::fs;
+
+use super::common::increment_model_metric;
+
+#[test]
+fn increment_creates_and_updates_a_scoreboard_file() {
+    let temp = tempfile::tempdir().expect("create scoreboard parent");
+    let scoreboard_dir = temp.path().join("scoreboard");
+
+    increment_model_metric(
+        &scoreboard_dir,
+        "pr.json",
+        "test scoreboard",
+        "pr-count",
+        "codex",
+        |_| {},
+    )
+    .expect("create scoreboard");
+    increment_model_metric(
+        &scoreboard_dir,
+        "pr.json",
+        "test scoreboard",
+        "pr-count",
+        "codex",
+        |_| {},
+    )
+    .expect("update scoreboard");
+
+    let content = fs::read_to_string(scoreboard_dir.join("pr.json")).expect("read scoreboard");
+    let scoreboard: serde_json::Value = serde_json::from_str(&content).expect("parse scoreboard");
+    assert_eq!(scoreboard["pr-count"]["codex"], 2);
+}
+
+#[cfg(unix)]
+#[test]
+fn increment_rejects_a_symlinked_scoreboard_file() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().expect("create scoreboard parent");
+    let outside = tempfile::tempdir().expect("create outside parent");
+    fs::write(outside.path().join("pr.json"), "{}").expect("write outside scoreboard");
+    symlink(outside.path().join("pr.json"), root.path().join("pr.json"))
+        .expect("create scoreboard symlink");
+
+    let error = increment_model_metric(
+        root.path(),
+        "pr.json",
+        "test scoreboard",
+        "pr-count",
+        "codex",
+        |_| {},
+    )
+    .expect_err("reject scoreboard symlink");
+
+    assert!(error.to_string().contains("must not be a symlink"));
+    assert_eq!(
+        fs::read_to_string(outside.path().join("pr.json")).expect("read outside scoreboard"),
+        "{}"
+    );
+}


### PR DESCRIPTION
## Task

[ORB-11954](https://orbit-cli.com/tasks/ORB-11954) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/scoreboard/common.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#380`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.27.0`, guid `unknown`)
- Message: This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `3fced6f6a6bcfc1d6e85aa5e876f0acbc7c85ada`
- Location: `crates/orbit-store/src/driver/file/scoreboard/common.rs` line 38
- Created: `2026-09-09T05:02:09Z`
- Updated: `2026-09-09T05:02:09Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/380

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-store/src/driver/file/scoreboard/common.rs` line 38 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added an allow-listed scoreboard filename boundary and canonical scoreboard-directory validation before the read-modify-write path is used.
- Rejected symlinked and non-regular scoreboard targets, while preserving first-use creation and counter updates.
- Added sibling unit coverage for creation/update behavior and symlink rejection.
- Registered the real validator in the Rust CodeQL path-injection barrier model; no suppression, dismissal, or path exclusion was added.

Acceptance criteria:
1. Met — the flagged common.rs read now consumes only the validated path, and the fix is implemented in production code plus the CodeQL barrier model.
2. Met — valid pr.json and task_review.json scoreboard names retain existing behavior; unsupported names, symlink targets, and non-regular targets fail closed.
3. Met with local limitation — repository validation and CodeQL extension schema checks passed, and source inspection confirms the raw path no longer reaches the read without the validator. Full CodeQL database analysis was not available in this executor; CI CodeQL re-analysis remains the external confirmation for alert #380.

Validation:
- Passed: cargo fmt --all -- --check
- Passed: cargo test -p orbit-store scoreboard --lib (29 passed, 0 failed)
- Passed: make ci-fast (exit 0; compiler-cache namespace subcheck reported the documented bubblewrap user-namespace limitation and skipped only that subcheck)
- Passed: make ci-lint (workspace all-target clippy with warnings denied)
- Passed: python3 scripts/check-codeql-extension-schema.py
- Passed: git diff --check
- Passed: git status --short showed only the four task-scoped changes
- Not run: CodeQL database analysis; codeql executable is unavailable locally and agent-side GitHub access is outside the task bounds

Assessment: The scoreboard persistence boundary now validates fixed internal filenames and canonicalizes the selected directory before reading or atomically replacing the file. Remaining risk is limited to pending CI CodeQL re-analysis and filesystem races outside the local validation window.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11954-6aa22e8b`
- Behind base: 0
- Ahead of base: 1