### PR TITLE
[ci-failure-sweep] Fix red CI: macOS Platform / macOS Sandbox / Run orbit-exec sandbox tests (real sandbox-exec)

### DIFF
--- a/crates/orbit-exec/src/linux_landlock/mod.rs
+++ b/crates/orbit-exec/src/linux_landlock/mod.rs
@@ -124,8 +124,44 @@ impl LandlockPathGrant {
 
 /// Whether any compiled grant lets the child read `path`.
 pub fn grants_read(grants: &[LandlockPathGrant], path: &Path) -> bool {
-    let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let path = canonicalize_with_missing_tail(path);
     grants.iter().any(|grant| grant.reads(&path))
+}
+
+/// Resolve the existing part of a path before appending any missing names.
+///
+/// Workspace grants are compiled from canonical paths. A query for a file
+/// that has not been created yet cannot itself be canonicalized, so falling
+/// back to its original spelling makes an existing symlink alias (such as
+/// macOS's `/var` → `/private/var`) look unrelated to the grant. Preserve the
+/// same canonical identity for both existing and not-yet-existing paths.
+fn canonicalize_with_missing_tail(path: &Path) -> PathBuf {
+    let mut missing = Vec::new();
+    let mut current = path;
+
+    loop {
+        if let Ok(canonical) = current.canonicalize() {
+            let mut canonical = canonical;
+            for component in missing.iter().rev() {
+                canonical.push(component);
+            }
+            return canonical;
+        }
+
+        let Some(name) = current.file_name() else {
+            return path.to_path_buf();
+        };
+        missing.push(name.to_os_string());
+
+        let Some(parent) = current.parent() else {
+            return path.to_path_buf();
+        };
+        current = if parent.as_os_str().is_empty() {
+            Path::new(".")
+        } else {
+            parent
+        };
+    }
 }
 
 /// Result of asking the running kernel whether it can enforce a ruleset.

--- a/crates/orbit-exec/src/linux_landlock/tests/workspace.rs
+++ b/crates/orbit-exec/src/linux_landlock/tests/workspace.rs
@@ -181,6 +181,23 @@ fn a_directory_out_of_reach_keeps_its_tree_grant() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn a_missing_child_uses_the_canonical_identity_of_its_parent() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let alias_parent = tempfile::tempdir().expect("alias parent");
+    fs::create_dir(workspace.path().join("src")).expect("mkdir src");
+
+    let alias_root = alias_parent.path().join("workspace-alias");
+    std::os::unix::fs::symlink(workspace.path(), &alias_root).expect("symlink workspace");
+    let grants = compile(&alias_root, &profile(&["**"], &[]));
+
+    assert!(
+        grants_read(&grants, &alias_root.join("src/generated.out")),
+        "{grants:?}"
+    );
+}
+
 /// A `*` cannot cross a separator, so it narrows the reach to one level rather
 /// than opening the whole subtree.
 #[test]


### PR DESCRIPTION
## Task

[ORB-11999](https://orbit-cli.com/tasks/ORB-11999) — [ci-failure-sweep] Fix red CI: macOS Platform / macOS Sandbox / Run orbit-exec sandbox tests (real sandbox-exec)

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `macOS Platform`
- Failing job: `macOS Sandbox`
- Failing step: `Run orbit-exec sandbox tests (real sandbox-exec)`
- Commit the runner actually checked out: `035a3b0cf617411473cf80447703ac6db735a5d7`
- Normalized error signature (the dedupe identity, not a quote): `test linux_landlock::tests::workspace::a_directory_out_of_reach_keeps_its_tree_grant ... failed`
- Repository: `constellation-works/orbit`
- Release branch as GitHub reports it: `agent-main`
- Evidence collected at: 2026-09-10T04:22:16.990744134+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/constellation-works/orbit/actions/runs/34436647617 run `34436647617` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `035a3b0cf617411473cf80447703ac6db735a5d7`
  - current head of that ref: `6f785c0a94c9063327b91010589e4bb226596fe8`
  - commit actually checked out: `035a3b0cf617411473cf80447703ac6db735a5d7`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/opt/homebrew/bin/git checkout --progress --force -B agent-main refs/remotes/origin/agent-main`
  - checkout evidence: `/opt/homebrew/bin/git log -1 --format=%H`
  - failed job `macOS Sandbox` (id `102742987438`): https://github.com/constellation-works/orbit/actions/runs/34436647617/job/102742987438
  - failing step(s): `Run orbit-exec sandbox tests (real sandbox-exec)`

## Failed-step log excerpt

```
[...]
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.0835130Z test linux_landlock::tests::platform::an_unenforceable_host_explains_what_it_needs ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.0835830Z test linux_landlock::tests::host::the_loader_and_system_binaries_are_granted_so_a_program_can_start ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.0840870Z test linux_landlock::tests::host::every_documented_variable_actually_widens_the_grants ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.0841670Z test linux_landlock::tests::workspace::a_directory_a_deny_rule_can_still_name_into_is_not_granted_as_a_tree ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.0842400Z test linux_landlock::tests::workspace::a_denied_file_keeps_no_readable_ancestor ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.0843240Z test linux_landlock::tests::workspace::a_bounded_exclusion_is_enforced_alongside_an_unbounded_one ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.0844060Z test linux_landlock::tests::workspace::a_directory_out_of_reach_keeps_its_tree_grant ... FAILED
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.0845160Z test linux_landlock::tests::workspace::a_profile_that_reads_one_subtree_grants_nothing_beside_it ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.0845980Z test linux_landlock::tests::workspace::a_profile_without_exclusions_reports_nothing_unenforced ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.0846760Z test linux_landlock::tests::workspace::a_symlink_leaving_the_workspace_is_not_granted ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.0847650Z test linux_landlock::tests::workspace::a_workspace_profile_grants_the_workspace_and_not_a_host_sibling ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.0848540Z test linux_landlock::tests::workspace::an_empty_read_profile_grants_no_workspace_path ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.0849210Z test linux_landlock::tests::workspace::a_segment_wildcard_reaches_only_the_directory_it_names ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.0849970Z test linux_sandbox::tests::capture_skips_absent_deny_whose_nested_reallow_will_create_the_root ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.0850720Z test linux_sandbox::tests::capture_watches_absent_denies_through_a_symlinked_workspace_path ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.0919880Z test linux_landlock::tests::workspace::an_unbounded_exclusion_is_reported_rather_than_silently_dropped ... FAILED
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.1101850Z test linux_sandbox::tests::managed_aliases_replay_denies_and_pin_replaceable_parents ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.1195080Z test linux_sandbox::tests::capture_watches_absent_exact_and_subtree_denies ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-10T04:19:59.1199630Z test linux_sandbox::tests::walk_lists_every_path_once ... ok
```

_The collection display was truncated. Selected evidence is used for diagnosis; its retention limits are independent of that display._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `macOS Platform` run https://github.com/constellation-works/orbit/actions/runs/34436223026 — superseded_by_newer_workflow_run: newer relevant run 34436647617 at 2026-09-10T04:18:04Z is completed with conclusion failure
- `macOS Platform` run https://github.com/constellation-works/orbit/actions/runs/34436038872 — superseded_by_newer_workflow_run: newer relevant run 34436647617 at 2026-09-10T04:18:04Z is completed with conclusion failure
- `macOS Platform` run https://github.com/constellation-works/orbit/actions/runs/34436023140 — superseded_by_newer_workflow_run: newer relevant run 34436647617 at 2026-09-10T04:18:04Z is completed with conclusion failure
- `macOS Platform` run https://github.com/constellation-works/orbit/actions/runs/34436018687 — ref_no_longer_exists: branch 'orbit/ORB-11978-6aa22283' has no head on origin: its pull request was merged or the branch was deleted, so this run describes code that is either already landed — where the landing branch's own runs are the current evidence — or abandoned

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 1,
  "current_failures_discovered": 1,
  "current_failures_investigated": 1,
  "current_failures_investigation_attempted": 6,
  "inconclusive": 0,
  "investigation_cursor": 496948,
  "job_log_reads": 1,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_job_log_reads": 6,
  "max_pull_requests": 10,
  "max_retired_ref_probes": 20,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely",
    "11 of 17 current or mixed-state runs were listed but not investigated (max_investigated_runs=6); their run URLs are still present, and the rotating slot reaches a different overflow candidate on the next sweep"
  ],
  "pull_requests_scanned": 0,
  "refs_scanned": 1,
  "retired_refs": [
    "orbit/ORB-11903-6aa21f28",
    "orbit/ORB-11961-6aa22282",
    "orbit/ORB-11978-6aa22283",
    "orbit/ORB-11987-6aa22285"
  ],
  "runs_listed": 100,
  "unverified_refs": []
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `macOS Platform` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Fixed `grants_read` to canonicalize the deepest existing ancestor and append missing path components, keeping not-yet-created path queries consistent with canonical Landlock grants on symlinked filesystems such as macOS `/var` → `/private/var`.
- Added `a_missing_child_uses_the_canonical_identity_of_its_parent`, which exercises an external symlink alias and a missing child; the test fails with the pre-fix fallback and passes with the fix.

Acceptance criteria:
- macOS Platform failure root cause fixed in repository: passed. The change affects path identity only; no workflow, assertion, lint level, or blocking behavior was weakened.
- Failing test reproduced and passing: passed. The focused workspace equivalent failed with the original implementation (exit 101) and passed after the fix; the exact CI command `cargo test --no-fail-fast -p orbit-exec --locked` passed locally.
- Documented pre-handoff gate: passed. `make ci-fast` and `make ci-lint` both exited 0. `ci-fast` reported its pre-existing environment limitation: the compiler-cache namespace test skipped because unprivileged Bubblewrap namespaces are unavailable.
- Infrastructure assessment: repository-owned defect, not infrastructure-only. The regression test failed against the original implementation and passed after canonicalizing the existing ancestor. Native macOS execution was not available in this Linux worktree, so the real `sandbox-exec` apply layer remains for PR CI verification.

Validation:
- `cargo test -p orbit-exec linux_landlock::tests::workspace -- --nocapture`: passed, 13 tests.
- `cargo test --no-fail-fast -p orbit-exec --locked`: passed, 81 unit + 18 Landlock integration + 20 sandbox + 3 signal tests and doctests.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
- `make ci-fast`: passed with the namespace-test skip noted above.
- `make ci-lint`: passed.

Assessment: Small, platform-correct fix at the shared grant-query boundary with a regression test that preserves the original access assertion and explicitly covers missing paths through an external symlink alias.

Remaining risk: The macOS runner's native `sandbox-exec` behavior cannot be exercised in this Linux environment; PR CI must confirm the platform-specific job.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11999-6aa23163`
- Behind base: 0
- Ahead of base: 1