### PR TITLE
[BLOCKED] [code-review] Linux sandbox setup fails when any provider state root or home ancestor is a symlink

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
@@ -428,13 +428,65 @@ fn append_linux_provider_state_roots(
     Ok(())
 }
 
+/// Reject a provider state root that would grant more than a provider directory.
+///
+/// `candidate` is the path being judged; `configured` is what the operator
+/// supplied. They differ once symlinks have been resolved, and naming both keeps
+/// a rejection traceable back to the setting that caused it.
+#[cfg(target_os = "linux")]
+fn reject_overbroad_linux_provider_state_root(
+    candidate: &Path,
+    configured: &Path,
+    home: Option<&Path>,
+) -> Result<(), DispatchError> {
+    let describe = || {
+        if candidate == configured {
+            format!("`{}`", configured.display())
+        } else {
+            format!(
+                "`{}` (resolved to `{}`)",
+                configured.display(),
+                candidate.display()
+            )
+        }
+    };
+
+    if candidate.parent().is_none() {
+        return Err(DispatchError::CliInvocationPermanent(format!(
+            "Linux provider state root {} must not be the filesystem root",
+            describe()
+        )));
+    }
+
+    if let Some(home) = home {
+        let canonical_home = home.canonicalize().unwrap_or_else(|_| home.to_path_buf());
+        if canonical_home.starts_with(candidate) {
+            return Err(DispatchError::CliInvocationPermanent(format!(
+                "Linux provider state root {} is broader than the user's home directory",
+                describe()
+            )));
+        }
+    }
+
+    Ok(())
+}
+
 /// Resolve a provider state root before creating it on behalf of a child.
 ///
 /// Provider-specific environment variables are operator-configurable, but
 /// they must not turn sandbox preparation into an arbitrary path creator.
-/// Reject relative paths, path traversal, root/home-wide targets, and symlink
-/// components. The returned path has an existing canonical ancestor and only
-/// the validated missing suffix, so the caller can safely materialize it.
+/// Reject relative paths, path traversal, and root/home-wide targets.
+///
+/// Symlinks are resolved rather than rejected. Hosts routinely reach `$HOME`
+/// through a symlinked ancestor (OSTree systems ship `/home -> /var/home`), and
+/// dotfile managers routinely make a provider directory itself a symlink; both
+/// are ordinary configurations, not attacks. [ORB-11984]
+///
+/// Following symlinks means the configured path no longer bounds the grant, so
+/// containment is enforced twice: once on what the operator supplied, and again
+/// on the resolved destination. The returned path has an existing canonical
+/// ancestor and only the validated missing suffix, so the caller can safely
+/// materialize it.
 #[cfg(target_os = "linux")]
 pub(super) fn validated_linux_provider_state_root(
     path: &Path,
@@ -446,54 +498,23 @@ pub(super) fn validated_linux_provider_state_root(
             path.display()
         )));
     }
-    if path.parent().is_none() {
-        return Err(DispatchError::CliInvocationPermanent(
-            "Linux provider state root must not be the filesystem root".to_string(),
-        ));
-    }
-    if home.is_some_and(|home| {
-        let canonical_home = home.canonicalize().unwrap_or_else(|_| home.to_path_buf());
-        path == canonical_home || canonical_home.starts_with(path)
-    }) {
-        return Err(DispatchError::CliInvocationPermanent(format!(
-            "Linux provider state root `{}` is broader than the user's home directory",
-            path.display()
-        )));
-    }
 
-    let mut prefix = PathBuf::new();
     for component in path.components() {
-        match component {
-            std::path::Component::RootDir => prefix.push(component),
-            std::path::Component::Normal(name) => {
-                prefix.push(name);
-                match std::fs::symlink_metadata(&prefix) {
-                    Ok(metadata) if metadata.file_type().is_symlink() => {
-                        return Err(DispatchError::CliInvocationPermanent(format!(
-                            "Linux provider state root `{}` must not contain symlink `{}`",
-                            path.display(),
-                            prefix.display()
-                        )));
-                    }
-                    Ok(_) => {}
-                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => break,
-                    Err(error) => {
-                        return Err(DispatchError::CliInvocationPermanent(format!(
-                            "inspect Linux provider state root `{}`: {error}",
-                            path.display()
-                        )));
-                    }
-                }
-            }
-            _ => {
-                return Err(DispatchError::CliInvocationPermanent(format!(
-                    "Linux provider state root `{}` must not contain traversal components",
-                    path.display()
-                )));
-            }
+        if !matches!(
+            component,
+            std::path::Component::RootDir | std::path::Component::Normal(_)
+        ) {
+            return Err(DispatchError::CliInvocationPermanent(format!(
+                "Linux provider state root `{}` must not contain traversal components",
+                path.display()
+            )));
         }
     }
+    reject_overbroad_linux_provider_state_root(path, path, home)?;
 
+    // Walk up to the deepest path that already exists. `exists` follows
+    // symlinks, so a provider directory that is itself a symlink to an existing
+    // directory counts as existing and canonicalizes to its real destination.
     let mut existing = path.to_path_buf();
     let mut missing = Vec::<OsString>::new();
     while !existing.exists() {
@@ -517,6 +538,8 @@ pub(super) fn validated_linux_provider_state_root(
     for component in missing.iter().rev() {
         validated.push(component);
     }
+
+    reject_overbroad_linux_provider_state_root(&validated, path, home)?;
 
     Ok(validated)
 }

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
@@ -946,6 +946,7 @@ mod copilot_state_roots {
 
 #[cfg(target_os = "linux")]
 mod provider_state_root_validation {
+    use std::os::unix::fs::symlink;
     use std::path::Path;
 
     use crate::adapter::engine_host::v2_host::sandbox::{
@@ -975,7 +976,80 @@ mod provider_state_root_validation {
         let validated = validated_linux_provider_state_root(&custom, Some(parent.path()))
             .expect("validate custom provider root");
 
-        assert_eq!(validated, custom);
+        assert_eq!(
+            validated,
+            parent
+                .path()
+                .canonicalize()
+                .expect("canonical parent")
+                .join("provider")
+                .join("state")
+        );
+    }
+
+    /// OSTree hosts ship `/home -> /var/home`, so a symlinked ancestor is an
+    /// ordinary host layout rather than a redirected root. [ORB-11984]
+    #[test]
+    fn accepts_a_missing_root_beneath_a_symlinked_ancestor() {
+        let parent = tempfile::tempdir().expect("parent");
+        let real = parent.path().join("real");
+        std::fs::create_dir_all(&real).expect("create real ancestor");
+        let linked = parent.path().join("linked");
+        symlink(&real, &linked).expect("create ancestor symlink");
+        let custom = linked.join("provider").join("state");
+
+        let validated = validated_linux_provider_state_root(&custom, Some(parent.path()))
+            .expect("validate root beneath a symlinked ancestor");
+
+        assert_eq!(
+            validated,
+            real.canonicalize()
+                .expect("canonical real ancestor")
+                .join("provider")
+                .join("state")
+        );
+    }
+
+    /// Dotfile managers relocate provider directories through a symlink, so an
+    /// existing symlinked target resolves to its destination. [ORB-11984]
+    #[test]
+    fn resolves_a_symlinked_root_target_to_its_destination() {
+        let parent = tempfile::tempdir().expect("parent");
+        let target = parent.path().join("target");
+        std::fs::create_dir_all(&target).expect("create symlink target");
+        let symlinked_root = parent.path().join("symlink_root");
+        symlink(&target, &symlinked_root).expect("create root symlink");
+        let canonical_target = target.canonicalize().expect("canonical target");
+
+        assert_eq!(
+            validated_linux_provider_state_root(&symlinked_root, Some(parent.path()))
+                .expect("validate symlinked provider root"),
+            canonical_target
+        );
+        assert_eq!(
+            ensure_linux_provider_directory(&symlinked_root, Some(parent.path()))
+                .expect("create symlinked provider root"),
+            canonical_target
+        );
+    }
+
+    /// Following symlinks must not let one widen the grant: containment is
+    /// re-checked against the resolved destination. [ORB-11984]
+    #[test]
+    fn rejects_a_symlinked_root_that_resolves_into_the_home_directory() {
+        let parent = tempfile::tempdir().expect("parent");
+        let home = parent.path().join("home");
+        std::fs::create_dir_all(&home).expect("create home");
+        let escaping_root = home.join("provider");
+        symlink(&home, &escaping_root).expect("create escaping root symlink");
+
+        let error = validated_linux_provider_state_root(&escaping_root, Some(&home))
+            .expect_err("reject a symlink resolving onto home");
+
+        assert!(
+            error.to_string().contains("broader than the user's home"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]
@@ -1020,15 +1094,31 @@ mod runtime_root_validation {
     }
 
     #[test]
-    fn rejects_missing_relative_and_symlinked_runtime_roots() {
+    fn rejects_missing_and_relative_runtime_roots() {
         let parent = tempfile::tempdir().expect("runtime parent");
         let missing = parent.path().join("missing");
-        let link = parent.path().join("link");
-        symlink(parent.path(), &link).expect("create runtime-root symlink");
 
         assert!(validated_linux_runtime_root(&missing).is_err());
         assert!(validated_linux_runtime_root(Path::new("runtime-root")).is_err());
-        assert!(validated_linux_runtime_root(&link).is_err());
+    }
+
+    /// Runtime roots live under `$HOME`, so they hit the same symlinked-ancestor
+    /// host layouts as provider state roots. [ORB-11984]
+    #[test]
+    fn resolves_a_symlinked_runtime_root_to_its_canonical_directory() {
+        let parent = tempfile::tempdir().expect("runtime parent");
+        let real = parent.path().join("real");
+        std::fs::create_dir_all(&real).expect("create runtime directory");
+        let link = parent.path().join("link");
+        symlink(&real, &link).expect("create runtime-root symlink");
+
+        let validated =
+            validated_linux_runtime_root(&link).expect("validate symlinked runtime root");
+
+        assert_eq!(
+            validated,
+            real.canonicalize().expect("canonical runtime root")
+        );
     }
 }
 


### PR DESCRIPTION
## Delivery failure handoff

Orbit preserved and pushed this task's candidate after the shipment pipeline failed. This PR is intentionally blocked; inspect the recorded failure before retrying delivery.

- Task: `ORB-11984`
- Run: `jrun-20260910-0421-3`
- Failed step: `prepare_branch`
- Error code: `pipeline_step_failed`
- Original base: `6f785c0a94c9063327b91010589e4bb226596fe8`
- Target base: `1cadc8b6487f71b83e349d99765328030f9ee7c3`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
deterministic action `pr_prepare` failed: execution failed: git fetch origin +refs/heads/agent-main:refs/remotes/origin/agent-main timed out after 60000ms in '/home/daniel/workspace/constellation/codebases/orbit/.orbit/state/worktrees/orbit-jrun-20260910-0421-3': process timed out
```