### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/friction_store/mod.rs

### DIFF
--- a/crates/orbit-store/src/driver/file/friction_store/mod.rs
+++ b/crates/orbit-store/src/driver/file/friction_store/mod.rs
@@ -12,7 +12,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use chrono::Utc;
 use orbit_common::OrbitError;
@@ -364,25 +364,37 @@ fn split_frontmatter(raw: &str) -> Option<(&str, &str)> {
 /// its canonical directory prevents a configured path from redirecting the
 /// import outside the selected legacy tree.
 pub(crate) fn validated_friction_root(frictions_root: &Path) -> Result<PathBuf, OrbitError> {
-    let metadata = fs::symlink_metadata(frictions_root).map_err(|error| {
-        OrbitError::Io(format!(
-            "inspect friction corpus root {}: {error}",
-            frictions_root.display()
-        ))
-    })?;
-    if metadata.file_type().is_symlink() || !metadata.is_dir() {
-        return Err(OrbitError::InvalidInput(format!(
-            "friction corpus root must be a regular directory: {}",
-            frictions_root.display()
-        )));
-    }
-
     let canonical_root = fs::canonicalize(frictions_root).map_err(|error| {
         OrbitError::Io(format!(
             "canonicalize friction corpus root {}: {error}",
             frictions_root.display()
         ))
     })?;
+
+    // Compare the resolved path with a purely lexical absolute path. This
+    // rejects symlinked roots without sending the unvalidated path through a
+    // second filesystem operation.
+    let absolute_root = if frictions_root.is_absolute() {
+        frictions_root.to_path_buf()
+    } else {
+        let current_dir = std::env::current_dir()
+            .map_err(|error| OrbitError::Io(format!("resolve current directory: {error}")))?;
+        let canonical_current_dir = fs::canonicalize(&current_dir).map_err(|error| {
+            OrbitError::Io(format!(
+                "canonicalize current directory {}: {error}",
+                current_dir.display()
+            ))
+        })?;
+        canonical_current_dir.join(frictions_root)
+    };
+    let normalized_root = normalize_path_components(&absolute_root);
+    if canonical_root != normalized_root {
+        return Err(OrbitError::InvalidInput(format!(
+            "friction corpus root must be a regular directory and must not resolve through a symlink: {}",
+            frictions_root.display()
+        )));
+    }
+
     if !canonical_root.is_dir() {
         return Err(OrbitError::InvalidInput(format!(
             "canonical friction corpus root must be a directory: {}",
@@ -391,6 +403,20 @@ pub(crate) fn validated_friction_root(frictions_root: &Path) -> Result<PathBuf, 
     }
 
     Ok(canonical_root)
+}
+
+fn normalize_path_components(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
 }
 
 pub(crate) fn friction_record_paths(frictions_root: &Path) -> Result<Vec<PathBuf>, OrbitError> {


### PR DESCRIPTION
## Task

[ORB-12003](https://orbit-cli.com/tasks/ORB-12003) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/friction_store/mod.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#405`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.27.0`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided
- Ref: `refs/heads/agent-main`
- Commit: `8e1acf49022b8e867e031296b6416bdc35b27dbc`
- Location: `crates/orbit-store/src/driver/file/friction_store/mod.rs` line 367
- Created: `2026-09-10T03:44:28Z`
- Updated: `2026-09-10T03:44:29Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/405

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-store/src/driver/file/friction_store/mod.rs` line 367 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Reworked validated_friction_root so the configured root is canonicalized before any metadata/read-directory operation.
- Compared the canonical result with a lexically normalized absolute path, preserving rejection of symlinked roots without passing the unvalidated path to symlink_metadata.
- Preserved regular-directory validation and existing friction-record enumeration behavior. No CodeQL suppression, dismissal, exclusion, or extension change was added.

Criteria:
- rust/path-injection: addressed in crates/orbit-store/src/driver/file/friction_store/mod.rs; the affected flow now starts with fs::canonicalize and no longer calls symlink_metadata on the configured path.
- Intended behavior: focused friction-store tests pass, including rejection of a symlinked root and ignoring symlinked month/record entries.
- Validation/security: repository guardrails and schema validation pass; static inspection confirms the affected call flow and existing barrier model. Live CodeQL execution was not available on this lane (codeql binary absent and the task explicitly does not require agent-side GitHub access).

Validation:
- PASSED: cargo fmt --all -- --check
- PASSED: cargo test -p orbit-store --lib driver::file::friction_store::tests::friction_store (10 tests)
- PASSED: make ci-fast (the environment-only compiler-cache namespace probe reported its documented bwrap/EPERM skip)
- PASSED: make ci-lint
- PASSED: python3 scripts/check-codeql-extension-schema.py
- PASSED: git diff --check
- FAILED once: cargo test -p orbit-store --lib had one unrelated concurrent-deletion test failure; the exact failing test was rerun and passed.
- NOT RUN: live CodeQL analysis because codeql is unavailable on this execution lane.

Assessment: The change is scoped to the reported store boundary, preserves the existing symlink rejection contract, and leaves one modified source file. Remaining risk is limited to live CodeQL confirmation in CI.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12003-6aa23678`
- Behind base: 0
- Ahead of base: 1