### PR TITLE
[qa-sweep] Flaky test blocks `cargo test -p orbit-store --lib`: export race asserts only the "disappeared" wording

### DIFF
--- a/crates/orbit-store/src/workflow/task/tests/mod.rs
+++ b/crates/orbit-store/src/workflow/task/tests/mod.rs
@@ -819,15 +819,40 @@ fn export_racing_a_deletion_is_valid_or_reports_the_disappeared_bundle() {
             .recv_timeout(Duration::from_secs(10))
             .expect("export must finish")
         {
-            Ok(_) => {
+            Ok(outcome) => {
+                assert_eq!(outcome.task_ids, vec!["ORB-00000"]);
                 let target = open_registry(dst.path());
-                import_tasks(&target, &archive, None, ImportConflictPolicy::Fail)
+                let imported = import_tasks(&target, &archive, None, ImportConflictPolicy::Fail)
                     .expect("a completed export must import cleanly");
+                assert_eq!(
+                    imported.tasks.first().map(|task| task.final_id.as_str()),
+                    Some("ORB-00000"),
+                    "a completed export must retain the deleted task bundle"
+                );
+                let imported_bundle = target
+                    .canonical_task_bundle_path(ws, "ORB-00000")
+                    .expect("canonical imported bundle path");
+                assert!(imported_bundle.is_dir());
+                let imported_bundle = read_bundle_at(&imported_bundle)
+                    .expect("a completed export must contain a readable task bundle");
+                assert_eq!(imported_bundle.envelope.id, "ORB-00000");
             }
-            Err(error) => assert!(
-                error.to_string().contains("disappeared"),
-                "concurrent deletion must be actionable: {error}"
-            ),
+            Err(error) => {
+                let message = error.to_string();
+                let bundle_path = bundle_dir.display().to_string();
+                assert!(
+                    message.contains("missing") || message.contains("disappeared"),
+                    "concurrent deletion must report the disappeared bundle: {message}"
+                );
+                assert!(
+                    message.contains("ORB-00000"),
+                    "concurrent deletion error must name the task ID: {message}"
+                );
+                assert!(
+                    message.contains(&bundle_path),
+                    "concurrent deletion error must name the bundle path: {message}"
+                );
+            }
         }
     });
 }


### PR DESCRIPTION
## Task

[ORB-12007](https://orbit-cli.com/tasks/ORB-12007) — [qa-sweep] Flaky test blocks `cargo test -p orbit-store --lib`: export race asserts only the "disappeared" wording

### Description

## Summary

`workflow::task::tests::export_racing_a_deletion_is_valid_or_reports_the_disappeared_bundle` fails nondeterministically (~10% of runs on this Linux host). `export_tasks` has **two** legitimate error paths for a bundle deleted concurrently, but the test's assertion only accepts the substring `disappeared`, so whichever path the race lands on decides whether the suite is green.

## Validation impact vs production impact

- **Validation impact:** `cargo test -p orbit-store --lib` — and therefore `make ci` / the full test suite — fails intermittently. This is a real blocker for the prescribed validation command; a red run here carries no information about the change under test.
- **Production impact:** none observed. Both messages are correctly-typed, actionable `OrbitError::Store` reports naming the task ID and the bundle path. The export refuses rather than producing a truncated archive in either case. This is a test-assertion defect, not a production defect.

## Evidence (HEAD `e3dcc364086dc759e06f69e3702a4eac6a699904`, Linux 6.8.0-139-generic, x86_64)

Failing command and exact error:

```
$ cargo test -p orbit-store --lib

---- workflow::task::tests::export_racing_a_deletion_is_valid_or_reports_the_disappeared_bundle stdout ----
thread 'workflow::task::tests::export_racing_a_deletion_is_valid_or_reports_the_disappeared_bundle' (30038)
panicked at crates/orbit-store/src/workflow/task/tests/mod.rs:827:27:
concurrent deletion must be actionable: store error: canonical bundle for 'ORB-00000' is missing at
/tmp/.tmpTMV2Kp/tasks/workspaces/export-deleted-abcdef/ORB-00000

failures:
    workflow::task::tests::export_racing_a_deletion_is_valid_or_reports_the_disappeared_bundle

test result: FAILED. 493 passed; 1 failed; 7 ignored; 0 measured; 0 filtered out; finished in 19.95s
```

Reproduction — the failure is timing-dependent, so loop it:

```bash
for i in $(seq 1 10); do
  cargo test -p orbit-store --lib \
    export_racing_a_deletion_is_valid_or_reports_the_disappeared_bundle 2>&1 \
  | grep -E '^test result:'
done
```

Observed on this host: 9 × `test result: ok`, 1 × `test result: FAILED`.

## Root cause

`export_tasks` checks bundle existence twice, and the two checks word the failure differently:

1. `crates/orbit-store/src/workflow/task/mod.rs:256-262` — the pre-pass that resolves every bundle directory before building the archive:

```rust
let dir = registry.canonical_task_bundle_path(&workspace_id, id)?;
if !dir.is_dir() {
    return Err(OrbitError::Store(format!(
        "canonical bundle for '{id}' is missing at {}",
        dir.display()
    )));
}
```

2. `crates/orbit-store/src/workflow/task/archive.rs:60-67` — the per-bundle check taken under the shared file lock while writing:

```rust
if !dir.is_dir() {
    return Err(OrbitError::Store(format!(
        "canonical bundle for '{task_id}' disappeared while exporting at {}",
        dir.display()
    )));
}
```

The test at `crates/orbit-store/src/workflow/task/tests/mod.rs:824-830` accepts only the second wording:

```rust
Err(error) => assert!(
    error.to_string().contains("disappeared"),
    "concurrent deletion must be actionable: {error}"
),
```

The test spawns the deleter and the exporter concurrently and releases them from a `Barrier`, so which check observes the removal is a genuine race. When the deletion wins early, path 1 fires, the message says `is missing at` rather than `disappeared`, and the assertion fails — even though the export behaved correctly.

## Suggested direction

Assert the observable contract rather than one path's wording — for example, accept either error path (both name the task ID and the bundle path and are `OrbitError::Store`), or unify the two messages so the concurrently-deleted-bundle refusal has a single wording that both call sites emit. Prefer the assertion that would still fail if the export silently produced an archive missing the bundle.

## Related green checks at this HEAD

`make ci-fast` and `make ci-lint` both pass; `cargo test -p orbit-exec --lib` passes. The failure is isolated to this one test.

### Acceptance Criteria

- `cargo test -p orbit-store --lib export_racing_a_deletion_is_valid_or_reports_the_disappeared_bundle` passes on 20 consecutive runs on Linux.
- The test still fails if export_tasks stops refusing a concurrently deleted bundle — e.g. if it produced an archive missing that bundle, or returned a non-actionable error that does not name the task ID.
- Whichever of the two error paths in crates/orbit-store/src/workflow/task/mod.rs and crates/orbit-store/src/workflow/task/archive.rs is taken, the outcome is accepted by the test and the wording remains actionable (names the task ID and the bundle path).
- make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Strengthened `export_racing_a_deletion_is_valid_or_reports_the_disappeared_bundle` in `crates/orbit-store/src/workflow/task/tests/mod.rs`.
- Successful exports now must report the seeded task, import successfully, and produce a readable bundle with the expected task ID.
- Concurrent-deletion errors now accept either the preflight “missing” or locked-write “disappeared” path, while requiring both the task ID and canonical bundle path in the actionable error.

Assessment: The test asserts the observable export/import contract and is independent of which legitimate deletion race path wins. A silent archive omission or non-actionable error fails the test.

Criteria evidence:
1. Targeted test passed on 20 consecutive Linux runs (20/20).
2. The success branch verifies the reported task ID, imports the archive, requires the imported task, and reads its bundle; the error branch requires deletion wording, task ID, and canonical bundle path.
3. Both “missing” and “disappeared” error paths are accepted only when actionable details are present.
4. `make ci-fast` passed; `make ci-lint` passed.

Validation:
- `cargo test -p orbit-store --lib export_racing_a_deletion_is_valid_or_reports_the_disappeared_bundle` ×20: passed (20/20).
- `make ci-fast`: passed. The environment-limited compiler-cache namespace sub-check reported a skip because unprivileged bubblewrap namespaces are unavailable; the overall command passed.
- `make ci-lint`: passed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
- `git status --short`: only the scoped test file is modified.

Remaining risk: the namespace-dependent ci-fast sub-check was not executable in this environment; its skip is unrelated to the changed test.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12007-6aa23af9`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra