### PR TITLE
[qa-sweep] cross-revision-check.sh reuses a --workdir extract, so a rerun validates the previous revision's files

### DIFF
--- a/docs/runbooks/compiler-cache.md
+++ b/docs/runbooks/compiler-cache.md
@@ -221,6 +221,7 @@ scripts/cross-revision-check.sh \
 | Guarantee | False result it prevents |
 | --- | --- |
 | A scratch extract and a private `CARGO_TARGET_DIR` per arm | An arm reusing the sibling revision's build output or embedded fixture paths |
+| Reused `--workdir` arm trees and targets are reset at the start of each invocation | Files or build artifacts from an earlier revision surviving into a rerun |
 | Every extracted mtime reset to now | A build skipped because archive timestamps predate an existing target dir |
 | `ORBIT_COMPILER_CACHE=0`, empty `RUSTC_WRAPPER` / `CARGO_BUILD_RUSTC_WRAPPER`, `CARGO_INCREMENTAL=0` | A baseline compiled through the host cache picking up the other tree's artifacts |
 | Producer status captured from a redirect, then `--tail` reads the log file | A filter's success replacing the build's failure |

--- a/scripts/cross-revision-check.sh
+++ b/scripts/cross-revision-check.sh
@@ -199,6 +199,12 @@ run_arm() {
   ARM_TARGET="$WORKDIR/$arm-target"
   ARM_LOG="$WORKDIR/$arm.log"
 
+  # A caller may intentionally reuse --workdir to retain logs. The extract and
+  # target are per-invocation state, so clear both arm-specific paths before
+  # rebuilding them; otherwise files and build artifacts from an older
+  # revision can survive into this arm.
+  rm -rf -- "$ARM_TREE" "$ARM_TARGET"
+
   extract_revision "$sha" "$ARM_TREE"
   mkdir -p "$ARM_TARGET"
 

--- a/scripts/test-cross-revision-check.sh
+++ b/scripts/test-cross-revision-check.sh
@@ -12,11 +12,13 @@ HELPER="$ROOT/scripts/cross-revision-check.sh"
 TMP="$(mktemp -d)"
 SRC="$TMP/src"
 START_EPOCH="$(date +%s)"
+PRESERVED_WORK=""
 
 # The read-only-.git case leaves the fixture unwritable; restore it before rm.
 cleanup() {
   chmod -R u+w "$TMP" 2>/dev/null || true
   rm -rf "$TMP"
+  [[ -z "$PRESERVED_WORK" ]] || rm -rf -- "$PRESERVED_WORK"
 }
 trap cleanup EXIT
 
@@ -104,12 +106,15 @@ EOF
 chmod +x "$SRC/leak.sh"
 
 printf 'MARKER_BASELINE\n' >"$SRC/marker.txt"
+printf 'baseline-only\n' >"$SRC/baseline-only.txt"
 git_fixture add probe.sh leak.sh marker.txt
+git_fixture add baseline-only.txt
 GIT_AUTHOR_DATE="$ARCHIVE_DATE" GIT_COMMITTER_DATE="$ARCHIVE_DATE" \
   git_fixture commit -q -m "baseline revision"
 BASELINE_SHA="$(git_fixture rev-parse HEAD)"
 
 printf 'MARKER_CANDIDATE\n' >"$SRC/marker.txt"
+git_fixture rm -q baseline-only.txt
 git_fixture add marker.txt
 GIT_AUTHOR_DATE="$ARCHIVE_DATE" GIT_COMMITTER_DATE="$ARCHIVE_DATE" \
   git_fixture commit -q -m "candidate revision"
@@ -118,8 +123,14 @@ CANDIDATE_SHA="$(git_fixture rev-parse HEAD)"
 run_helper() {
   local out="$1"
   shift
+  run_helper_revisions "$out" "$BASELINE_SHA" "$CANDIDATE_SHA" "$@"
+}
+
+run_helper_revisions() {
+  local out="$1" baseline="$2" candidate="$3"
+  shift 3
   local status=0
-  "$HELPER" --repo "$SRC" --baseline "$BASELINE_SHA" --candidate "$CANDIDATE_SHA" \
+  "$HELPER" --repo "$SRC" --baseline "$baseline" --candidate "$candidate" \
     "$@" >"$out" 2>&1 || status=$?
   printf '%s' "$status"
 }
@@ -166,7 +177,32 @@ done
 
 assert_contains "$out" "provenance=ok" "helper should report verified provenance"
 
-# --- 2. A failing producer stays a failure behind bounded output -------------
+# --- 2. Reusing a workdir refreshes trees and targets ------------------------
+
+work="$TMP/work-reuse"
+out="$TMP/reuse-first.out"
+status="$(run_helper_revisions "$out" "$BASELINE_SHA" "$CANDIDATE_SHA" \
+  --workdir "$work" --expect-baseline pass --expect-candidate fail \
+  -- sh -c 'touch "$CARGO_TARGET_DIR/stale-target-marker"; test -e baseline-only.txt')"
+assert_eq "$status" "0" "the first reused-workdir run should match its revision contents"
+[[ -e "$work/baseline/baseline-only.txt" ]] \
+  || fail "the baseline revision should contain its baseline-only file"
+[[ ! -e "$work/candidate/baseline-only.txt" ]] \
+  || fail "the candidate revision should not contain the baseline-only file"
+
+out="$TMP/reuse-second.out"
+status="$(run_helper_revisions "$out" "$CANDIDATE_SHA" "$CANDIDATE_SHA" \
+  --workdir "$work" \
+  -- sh -c 'test ! -e baseline-only.txt && test ! -e "$CARGO_TARGET_DIR/stale-target-marker"')"
+assert_eq "$status" "0" "a reused workdir must not retain prior tree or target state"
+for arm in baseline candidate; do
+  [[ ! -e "$work/$arm/baseline-only.txt" ]] \
+    || fail "$arm tree retained a file absent from the current revision"
+  [[ ! -e "$work/$arm-target/stale-target-marker" ]] \
+    || fail "$arm target retained an artifact from the prior invocation"
+done
+
+# --- 3. A failing producer stays a failure behind bounded output -------------
 
 work="$TMP/work-exit"
 out="$TMP/exit.out"
@@ -206,7 +242,7 @@ status=0
   >"$out" 2>&1 || status=$?
 assert_eq "$status" "0" "before-fails/after-passes is the regression-proof shape"
 
-# --- 3. Provenance failures are detected, not assumed absent -----------------
+# --- 4. Provenance failures are detected, not assumed absent -----------------
 
 work="$TMP/work-missing-marker"
 out="$TMP/missing-marker.out"
@@ -222,7 +258,7 @@ assert_eq "$status" "1" "a sibling marker in an arm's log must fail the run"
 assert_contains "$out" "contains the sibling revision marker" "the helper should name the contamination"
 assert_contains "$out" "provenance=contaminated" "the report should mark the arm contaminated"
 
-# --- 4. Read-only Git metadata and an unmodified source checkout -------------
+# --- 5. Read-only Git metadata and an unmodified source checkout -------------
 
 before="$TMP/snapshot-before"
 after="$TMP/snapshot-after"
@@ -241,7 +277,7 @@ diff -u "$before" "$after" \
   || fail "the helper must not modify the source checkout (including .git mtimes)"
 [[ ! -e "$SRC/.git/index.lock" ]] || fail "the helper must not leave a Git index lock behind"
 
-# --- 5. Scratch state stays outside the checkout and outside Orbit state -----
+# --- 6. Scratch state stays outside the checkout and outside Orbit state -----
 
 out="$TMP/inside-repo.out"
 status="$(run_helper "$out" --workdir "$SRC/scratch" -- ./probe.sh)"
@@ -254,7 +290,19 @@ status="$(run_helper "$out" --workdir "$TMP/.orbit/state/scratch" -- ./probe.sh)
 assert_eq "$status" "1" "a workdir inside .orbit must be refused"
 assert_contains "$out" "must not be inside Orbit state" "the refusal should name Orbit state"
 
-# --- 6. The cache opt-out is a default, not a hard-coded policy --------------
+# A failed run with an auto-created workdir must retain its logs for diagnosis.
+out="$TMP/auto-workdir-failure.out"
+status=0
+PROBE_EXIT=9 "$HELPER" --repo "$SRC" --baseline "$BASELINE_SHA" --candidate "$CANDIDATE_SHA" \
+  -- ./probe.sh >"$out" 2>&1 || status=$?
+assert_eq "$status" "1" "an unexpected producer failure should fail the helper"
+PRESERVED_WORK="$(sed -n 's/^cross-revision-check: logs preserved at //p' "$out")"
+[[ -n "$PRESERVED_WORK" && -d "$PRESERVED_WORK" ]] \
+  || fail "a failed auto-workdir run should preserve its scratch root"
+[[ -f "$PRESERVED_WORK/baseline.log" && -f "$PRESERVED_WORK/candidate.log" ]] \
+  || fail "a failed auto-workdir run should preserve both arm logs"
+
+# --- 7. The cache opt-out is a default, not a hard-coded policy --------------
 
 work="$TMP/work-keep-cache"
 out="$TMP/keep-cache.out"


### PR DESCRIPTION
## Task

[ORB-12006](https://orbit-cli.com/tasks/ORB-12006) — [qa-sweep] cross-revision-check.sh reuses a --workdir extract, so a rerun validates the previous revision's files

### Description

## Summary

`scripts/cross-revision-check.sh` (added by ORB-11981, commit `923bd085af7569d133a93bb11fdbbefa7cc8e0fa`) extracts each revision with `mkdir -p "$tree"` + `git archive | tar -x` **over whatever is already there**. When the same `--workdir` is reused across invocations, files that existed in the earlier run's revision but not in the current one survive in the arm tree. The arm then compiles and tests a source set that is not the revision it reports.

This is precisely the class of false before/after result the helper exists to prevent (its header cites F2026-09-064, F2026-09-081, F2026-09-082, F2026-09-077), and the marker/provenance check cannot catch it: markers only inspect the arm's log text, so a leftover file that produces no distinctive output is invisible.

## Evidence (reproduced on this workspace, HEAD `e3dcc364086dc759e06f69e3702a4eac6a699904`, Linux)

`scripts/cross-revision-check.sh` was itself added in `923bd085a`, so `923bd085a^` (= `f93c17b16aa46524acefdf8dc2a2c9537c774541`) does not contain it:

```
$ GIT_OPTIONAL_LOCKS=0 git ls-tree '923bd085a^' scripts/cross-revision-check.sh
        (empty — file absent in that revision)
```

Reproduction:

```bash
rm -rf /tmp/crc-reuse

# Run 1: baseline revision DOES contain scripts/cross-revision-check.sh
./scripts/cross-revision-check.sh \
  --baseline 923bd085a --candidate HEAD \
  --workdir /tmp/crc-reuse --tail 2 \
  -- bash -c 'ls scripts/cross-revision-check.sh 2>&1'

# Run 2: SAME workdir, baseline revision does NOT contain that file
./scripts/cross-revision-check.sh \
  --baseline '923bd085a^' --candidate HEAD \
  --workdir /tmp/crc-reuse --tail 3 \
  -- bash -c 'ls scripts/cross-revision-check.sh 2>&1'
```

Observed output of run 2's baseline arm:

```
==> baseline  rev=f93c17b16aa46524acefdf8dc2a2c9537c774541
    tree=/tmp/crc-reuse/baseline
    target=/tmp/crc-reuse/baseline-target
    exit_code=0  outcome=pass  expected=pass
    provenance=skipped
    --- last 3 log lines (/tmp/crc-reuse/baseline.log) ---
    scripts/cross-revision-check.sh
```

The arm reports `rev=f93c17b16…` and exits 0 having "found" a file that revision does not contain. Direct filesystem confirmation:

```
$ test -f /tmp/crc-reuse/baseline/scripts/cross-revision-check.sh && echo YES-STALE
YES-STALE
```

The per-arm `CARGO_TARGET_DIR` (`$WORKDIR/<arm>-target`) is reused across invocations for the same reason, reintroducing the F2026-09-064 shared-target hazard between sequential runs that share a `--workdir`.

## Scope

- The auto-created `mktemp -d` workdir (no `--workdir`) is unaffected: it is fresh each run and removed on success.
- Only the documented `--workdir <dir>` option is affected. That option's help text says only "scratch root; must live outside the source checkout" — nothing warns that reuse is unsafe, and the runbook does not either.
- Impact: a maintainer who reruns a before/after check into a stable scratch dir (the natural way to keep logs and avoid re-extracting) can get a silently wrong verdict about whether a regression test detects the original fault.

## Test coverage gap

`scripts/test-cross-revision-check.sh` passes (`test-cross-revision-check: ok`, and `make ci-fast` is green at this HEAD). Every one of its cases allocates a fresh `work` directory; no case invokes the helper twice against the same `--workdir` with different revisions, which is why the defect ships green.

## Suggested direction

Make each arm's tree and target directory authoritative for the revision being run — for example, remove `$WORKDIR/<arm>` and `$WORKDIR/<arm>-target` at the start of `run_arm` before extracting (with the same "must live outside the checkout / outside `.orbit`" guards already enforced on `--workdir`), or refuse a non-empty reused workdir unless an explicit opt-in flag is given. Whichever is chosen, add a regression case to `scripts/test-cross-revision-check.sh` that runs the helper twice into one `--workdir` across two revisions that differ by a file's existence, and asserts the second run does not see the first run's file.

### Acceptance Criteria

- Running scripts/cross-revision-check.sh twice into the same --workdir with different revisions makes each arm's tree contain exactly the files of the revision it reports; a file present only in a previously-extracted revision is gone.
- The per-arm CARGO_TARGET_DIR is not silently reused across invocations that share a --workdir.
- scripts/test-cross-revision-check.sh gains a case that fails against the current implementation and passes after the fix, exercising two sequential runs sharing one --workdir across revisions that differ by a file's existence.
- Existing guards are preserved: a --workdir inside the source checkout or inside .orbit is still refused and still not created, and the auto-created mktemp workdir still survives a failed run for its logs.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Reset each arm's extract tree and per-arm CARGO_TARGET_DIR before every run, so a reused --workdir cannot retain files or build artifacts from an earlier revision while preserving log files and existing workdir guards.
- Extended the shell regression harness with two sequential runs sharing one workdir across revisions that differ by baseline-only.txt, asserting both stale source files and target markers are absent on the rerun.
- Added coverage that an auto-created workdir and both arm logs survive an unexpected failed run.
- Documented the reused-workdir reset guarantee in docs/runbooks/compiler-cache.md.

Acceptance criteria:
- Reused workdir trees contain only the current revision: verified by the new sequential-run regression case.
- Per-arm target directories are refreshed per invocation: verified by creating and then rejecting a stale target marker on the second run.
- Regression case fails with stale tree/target state and passes with the fix: covered by the new assertions and final focused harness pass.
- Existing checkout/.orbit guards and failed auto-workdir log retention: verified by the existing guard cases and the added auto-workdir failure case.
- make ci-fast: passed.

Validation:
- `scripts/test-cross-revision-check.sh` — passed (`test-cross-revision-check: ok`).
- `make ci-fast` — passed; the namespace-dependent compiler-cache test reported its documented environment skip because unprivileged bubblewrap namespaces are unavailable.
- `git diff --check` — passed.
- `GIT_OPTIONAL_LOCKS=0 git status --short` — inspected; only the three task-scoped files are modified.

Assessment: The fix is narrowly scoped to per-arm scratch-state refresh, keeps logs available for reused workdirs and failures, and has boundary-level shell coverage. No known remaining risk beyond the existing platform-specific namespace-test skip.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12006-6aa23af9`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra