### PR TITLE
Fix orbit update Homebrew guidance and migration from the legacy tap

### DIFF
--- a/crates/orbit-cmd/src/update/channel.rs
+++ b/crates/orbit-cmd/src/update/channel.rs
@@ -10,11 +10,23 @@
 //! one command that actually works for them.
 
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use orbit_common::OrbitError;
 
 /// Environment variable `install.sh` reads for the managed install directory.
 pub const INSTALL_DIR_ENV: &str = "ORBIT_INSTALL_DIR";
+
+/// The formula name every current install instruction and diagnostic names.
+/// Fully qualified so `brew` never has to guess between it and a retired tap.
+pub const CANONICAL_HOMEBREW_FORMULA: &str = "constellation-works/tap/orbit";
+
+/// The formula Orbit published under before consolidating on the
+/// `constellation-works` tap. Still resolvable by `brew`, and still what a
+/// machine set up before the move has installed — its Cellar keg shares the
+/// canonical formula's short name, so the two conflict rather than
+/// coexisting.
+pub const LEGACY_HOMEBREW_FORMULA: &str = "danieljhkim/tap/orbit";
 
 /// The installer that owns the current executable.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -27,8 +39,15 @@ pub enum InstallChannel {
     },
     /// The npm package `@orbit-tools/cli` owns this binary.
     Npm,
-    /// A Homebrew formula owns this binary.
-    Homebrew,
+    /// A Homebrew formula owns this binary. `remediation` is resolved once,
+    /// against the formulae `brew` reports installed, by
+    /// [`Self::detect_with_homebrew_ownership`] — `None` until then, in which
+    /// case [`Self::unsupported_reason`] falls back to the plain qualified
+    /// upgrade rather than guessing which tap owns it.
+    Homebrew {
+        /// The exact remediation text, once resolved.
+        remediation: Option<String>,
+    },
     /// `cargo install` or `make install` owns this binary.
     Cargo,
     /// A build tree inside a checkout's `target/` directory.
@@ -43,7 +62,7 @@ impl InstallChannel {
         match self {
             Self::Managed { .. } => "managed",
             Self::Npm => "npm",
-            Self::Homebrew => "homebrew",
+            Self::Homebrew { .. } => "homebrew",
             Self::Cargo => "cargo",
             Self::LocalBuild => "local-build",
             Self::Unknown => "unknown",
@@ -69,7 +88,7 @@ impl InstallChannel {
             return Self::Npm;
         }
         if has_component(executable, "Cellar") || has_component(executable, "homebrew") {
-            return Self::Homebrew;
+            return Self::Homebrew { remediation: None };
         }
         if is_cargo_build_output(executable) {
             return Self::LocalBuild;
@@ -78,6 +97,23 @@ impl InstallChannel {
             return Self::Cargo;
         }
         Self::Unknown
+    }
+
+    /// [`Self::detect`], then — only for a bare Homebrew match — resolve
+    /// which formula owns the install by asking `inventory`, so the
+    /// remediation names an ordinary qualified upgrade or the legacy-tap
+    /// migration instead of leaving it unresolved.
+    pub fn detect_with_homebrew_ownership(
+        executable: &Path,
+        managed_install_dir: Option<&Path>,
+        inventory: &dyn HomebrewInventory,
+    ) -> Self {
+        match Self::detect(executable, managed_install_dir) {
+            Self::Homebrew { .. } => Self::Homebrew {
+                remediation: Some(homebrew_remediation(inventory.installed_full_names())),
+            },
+            other => other,
+        }
     }
 
     /// Refuse an in-place replacement, naming the command that does work.
@@ -94,10 +130,12 @@ impl InstallChannel {
                 "npm owns this installation; run `npm install -g @orbit-tools/cli@{target_version}` \
                  (or `npx -y @orbit-tools/cli@{target_version}`)"
             ),
-            Self::Homebrew => {
-                "Homebrew owns this installation; run `brew update && brew upgrade orbit`"
-                    .to_string()
-            }
+            Self::Homebrew { remediation } => remediation.clone().unwrap_or_else(|| {
+                format!(
+                    "Homebrew owns this installation; run \
+                     `brew update && brew upgrade {CANONICAL_HOMEBREW_FORMULA}`"
+                )
+            }),
             Self::Cargo => format!(
                 "cargo owns this installation; run `cargo install --git https://github.com/constellation-works/orbit --tag v{target_version} --locked orbit-cli`, \
                  or reinstall through the managed installer with `curl -sSf https://raw.githubusercontent.com/constellation-works/orbit/main/install.sh | sh`"
@@ -118,6 +156,93 @@ impl InstallChannel {
             "cannot update '{}' in place: {remediation}",
             executable.display()
         )))
+    }
+}
+
+/// Reports which Orbit formula full names Homebrew currently has installed —
+/// the signal [`InstallChannel::detect_with_homebrew_ownership`] needs to
+/// tell an ordinary canonical upgrade from a legacy-tap migration.
+pub trait HomebrewInventory {
+    /// Full names (`tap/formula`) `brew list --formula --full-name` reports.
+    fn installed_full_names(&self) -> Result<Vec<String>, OrbitError>;
+}
+
+/// Asks the real `brew` on the caller's `PATH`.
+///
+/// Tests construct this directly with `command` pointed at a fake `brew`
+/// fixture instead of touching the process's `PATH`.
+pub(crate) struct SystemHomebrewInventory {
+    pub(crate) command: PathBuf,
+}
+
+impl SystemHomebrewInventory {
+    /// Probe the real `brew` found on `PATH`.
+    pub(crate) fn system() -> Self {
+        Self {
+            command: PathBuf::from("brew"),
+        }
+    }
+}
+
+impl HomebrewInventory for SystemHomebrewInventory {
+    fn installed_full_names(&self) -> Result<Vec<String>, OrbitError> {
+        let output = Command::new(&self.command)
+            .args(["list", "--formula", "--full-name"])
+            .output()
+            .map_err(|error| {
+                OrbitError::Execution(format!(
+                    "failed to run '{} list --formula --full-name': {error}",
+                    self.command.display()
+                ))
+            })?;
+        if !output.status.success() {
+            return Err(OrbitError::Execution(format!(
+                "'{} list --formula --full-name' failed: {}",
+                self.command.display(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+        Ok(String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(str::to_string)
+            .collect())
+    }
+}
+
+/// Build the exact Homebrew remediation from the formula full names
+/// `inventory` reported, or the diagnostic if it could not be asked.
+///
+/// An installed [`LEGACY_HOMEBREW_FORMULA`] always wins the recommendation,
+/// even alongside the canonical one — Homebrew keys formulae by short name,
+/// so having both installed at once is itself the conflict this guides the
+/// operator out of. When the listing does not mention either formula, or the
+/// probe itself failed, the fallback is still the fully qualified canonical
+/// upgrade — never a bare, ambiguous `brew upgrade orbit`.
+pub fn homebrew_remediation(inventory: Result<Vec<String>, OrbitError>) -> String {
+    let legacy_installed = matches!(
+        &inventory,
+        Ok(names) if names.iter().any(|name| name == LEGACY_HOMEBREW_FORMULA)
+    );
+    if legacy_installed {
+        return format!(
+            "Homebrew owns this installation through the retired `{LEGACY_HOMEBREW_FORMULA}` \
+             formula; migrate to the canonical tap without removing unrelated packages or taps: \
+             `brew uninstall {LEGACY_HOMEBREW_FORMULA} && brew update && \
+             brew install {CANONICAL_HOMEBREW_FORMULA}`"
+        );
+    }
+    match inventory {
+        Ok(_) => format!(
+            "Homebrew owns this installation; run \
+             `brew update && brew upgrade {CANONICAL_HOMEBREW_FORMULA}`"
+        ),
+        Err(error) => format!(
+            "Homebrew owns this installation; run \
+             `brew update && brew upgrade {CANONICAL_HOMEBREW_FORMULA}` \
+             (could not confirm the installed formula: {error})"
+        ),
     }
 }
 

--- a/crates/orbit-cmd/src/update/mod.rs
+++ b/crates/orbit-cmd/src/update/mod.rs
@@ -113,9 +113,10 @@ impl UpdateEnvironment {
                 },
             );
         Ok(Self {
-            install_channel: InstallChannel::detect(
+            install_channel: InstallChannel::detect_with_homebrew_ownership(
                 &executable,
                 channel::managed_install_dir().as_deref(),
+                &channel::SystemHomebrewInventory::system(),
             ),
             executable,
             current_version: env!("CARGO_PKG_VERSION").to_string(),

--- a/crates/orbit-cmd/src/update/tests/channel.rs
+++ b/crates/orbit-cmd/src/update/tests/channel.rs
@@ -1,6 +1,11 @@
 use std::path::{Path, PathBuf};
 
-use crate::update::channel::{InstallChannel, release_archive_name, release_target_triple};
+use orbit_common::OrbitError;
+
+use crate::update::channel::{
+    CANONICAL_HOMEBREW_FORMULA, HomebrewInventory, InstallChannel, LEGACY_HOMEBREW_FORMULA,
+    SystemHomebrewInventory, homebrew_remediation, release_archive_name, release_target_triple,
+};
 
 fn detect(path: &str, managed: Option<&str>) -> InstallChannel {
     InstallChannel::detect(Path::new(path), managed.map(Path::new))
@@ -34,8 +39,8 @@ fn package_manager_installs_are_classified_and_get_their_own_command() {
         ),
         (
             "/opt/homebrew/Cellar/orbit/0.18.0/bin/orbit",
-            InstallChannel::Homebrew,
-            "brew upgrade orbit",
+            InstallChannel::Homebrew { remediation: None },
+            "brew upgrade constellation-works/tap/orbit",
         ),
         (
             "/home/dev/.cargo/bin/orbit",
@@ -83,6 +88,192 @@ fn a_cross_compiled_build_tree_is_still_a_local_build() {
         ),
         InstallChannel::LocalBuild
     );
+}
+
+#[test]
+fn homebrew_remediation_names_the_ordinary_qualified_upgrade_for_a_canonical_install() {
+    let text = homebrew_remediation(Ok(vec![CANONICAL_HOMEBREW_FORMULA.to_string()]));
+
+    assert!(
+        text.contains(&format!(
+            "brew update && brew upgrade {CANONICAL_HOMEBREW_FORMULA}"
+        )),
+        "{text}"
+    );
+    assert!(!text.contains("uninstall"), "{text}");
+}
+
+#[test]
+fn homebrew_remediation_migrates_a_legacy_only_install_off_the_retired_tap() {
+    let text = homebrew_remediation(Ok(vec![LEGACY_HOMEBREW_FORMULA.to_string()]));
+
+    assert!(
+        text.contains(&format!("brew uninstall {LEGACY_HOMEBREW_FORMULA}")),
+        "{text}"
+    );
+    assert!(
+        text.contains(&format!("brew install {CANONICAL_HOMEBREW_FORMULA}")),
+        "{text}"
+    );
+}
+
+#[test]
+fn homebrew_remediation_migrates_rather_than_upgrades_when_both_taps_are_installed() {
+    let text = homebrew_remediation(Ok(vec![
+        LEGACY_HOMEBREW_FORMULA.to_string(),
+        CANONICAL_HOMEBREW_FORMULA.to_string(),
+    ]));
+
+    // The conflict is that both are installed at once; removing the legacy
+    // one is the fix, not reinstalling the canonical one that is already there.
+    assert!(
+        text.contains(&format!("brew uninstall {LEGACY_HOMEBREW_FORMULA}")),
+        "{text}"
+    );
+}
+
+#[test]
+fn homebrew_remediation_falls_back_to_the_canonical_upgrade_when_the_formula_is_unlisted() {
+    let text = homebrew_remediation(Ok(vec!["jq".to_string()]));
+
+    assert!(
+        text.contains(&format!(
+            "brew update && brew upgrade {CANONICAL_HOMEBREW_FORMULA}"
+        )),
+        "{text}"
+    );
+    assert!(!text.contains("uninstall"), "{text}");
+}
+
+#[test]
+fn homebrew_remediation_stays_actionable_and_honest_when_brew_itself_fails() {
+    let text = homebrew_remediation(Err(OrbitError::Execution(
+        "brew: command not found".to_string(),
+    )));
+
+    assert!(
+        text.contains(&format!(
+            "brew update && brew upgrade {CANONICAL_HOMEBREW_FORMULA}"
+        )),
+        "{text}"
+    );
+    assert!(text.contains("brew: command not found"), "{text}");
+    assert!(!text.contains("uninstall"), "{text}");
+}
+
+/// A [`HomebrewInventory`] built from a fixed answer, so
+/// `detect_with_homebrew_ownership` can be exercised without a real `brew`.
+struct FakeInventory {
+    names: Option<Vec<String>>,
+    error: Option<String>,
+}
+
+impl HomebrewInventory for FakeInventory {
+    fn installed_full_names(&self) -> Result<Vec<String>, OrbitError> {
+        match &self.error {
+            Some(message) => Err(OrbitError::Execution(message.clone())),
+            None => Ok(self.names.clone().unwrap_or_default()),
+        }
+    }
+}
+
+#[test]
+fn detect_with_homebrew_ownership_resolves_the_legacy_migration() {
+    let inventory = FakeInventory {
+        names: Some(vec![LEGACY_HOMEBREW_FORMULA.to_string()]),
+        error: None,
+    };
+
+    let channel = InstallChannel::detect_with_homebrew_ownership(
+        Path::new("/opt/homebrew/Cellar/orbit/0.18.0/bin/orbit"),
+        Some(Path::new("/home/dev/.orbit/bin")),
+        &inventory,
+    );
+
+    let InstallChannel::Homebrew { remediation } = channel else {
+        panic!("expected a Homebrew channel");
+    };
+    assert!(
+        remediation
+            .as_deref()
+            .is_some_and(|text| text.contains(&format!(
+                "brew uninstall {LEGACY_HOMEBREW_FORMULA}"
+            ))),
+        "{remediation:?}"
+    );
+}
+
+#[test]
+fn detect_with_homebrew_ownership_never_probes_a_non_homebrew_channel() {
+    struct PanicsIfCalled;
+    impl HomebrewInventory for PanicsIfCalled {
+        fn installed_full_names(&self) -> Result<Vec<String>, OrbitError> {
+            panic!("must not probe brew for a non-Homebrew channel");
+        }
+    }
+
+    let channel = InstallChannel::detect_with_homebrew_ownership(
+        Path::new("/home/dev/.cargo/bin/orbit"),
+        Some(Path::new("/home/dev/.orbit/bin")),
+        &PanicsIfCalled,
+    );
+
+    assert_eq!(channel, InstallChannel::Cargo);
+}
+
+#[test]
+fn system_inventory_parses_full_names_from_a_controlled_brew_fixture() {
+    let fixture_dir = tempfile::tempdir().expect("fixture dir");
+    let brew = fixture_dir.path().join("brew");
+    std::fs::write(
+        &brew,
+        format!(
+            "#!/bin/sh\necho '{LEGACY_HOMEBREW_FORMULA}'\necho 'jq'\necho '{CANONICAL_HOMEBREW_FORMULA}'\n"
+        ),
+    )
+    .expect("write fake brew");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&brew, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+    }
+
+    let inventory = SystemHomebrewInventory { command: brew };
+    let names = inventory
+        .installed_full_names()
+        .expect("controlled brew fixture succeeds");
+
+    assert_eq!(
+        names,
+        vec![
+            LEGACY_HOMEBREW_FORMULA.to_string(),
+            "jq".to_string(),
+            CANONICAL_HOMEBREW_FORMULA.to_string(),
+        ]
+    );
+}
+
+#[test]
+fn system_inventory_reports_a_failing_brew_without_claiming_success() {
+    let fixture_dir = tempfile::tempdir().expect("fixture dir");
+    let brew = fixture_dir.path().join("brew");
+    std::fs::write(
+        &brew,
+        "#!/bin/sh\necho 'Error: Homebrew is broken' >&2\nexit 1\n",
+    )
+    .expect("write failing fake brew");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&brew, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+    }
+
+    let inventory = SystemHomebrewInventory { command: brew };
+    let error = inventory
+        .installed_full_names()
+        .expect_err("a failing brew must not report success");
+
+    assert!(error.to_string().contains("Homebrew is broken"), "{error}");
 }
 
 #[test]

--- a/crates/orbit-cmd/src/update/tests/flow.rs
+++ b/crates/orbit-cmd/src/update/tests/flow.rs
@@ -1,7 +1,9 @@
 use std::path::Path;
 use std::sync::{Arc, Barrier};
 
-use crate::update::channel::InstallChannel;
+use crate::update::channel::{
+    CANONICAL_HOMEBREW_FORMULA, InstallChannel, LEGACY_HOMEBREW_FORMULA, homebrew_remediation,
+};
 use crate::update::tests::fixture::{
     FakeBinary, Fixture, PausingLatestSource, request, tar_gz, tar_gz_named,
 };
@@ -74,7 +76,13 @@ fn check_answers_availability_even_where_a_package_manager_owns_the_install() {
     let fixture = Fixture::new("0.18.0");
     fixture.publish("0.19.0", FakeBinary::Healthy);
     let mut environment = fixture.environment();
-    environment.install_channel = InstallChannel::Homebrew;
+    environment.install_channel = InstallChannel::Homebrew {
+        remediation: Some(
+            "Homebrew owns this installation; run \
+             `brew update && brew upgrade constellation-works/tap/orbit`"
+                .to_string(),
+        ),
+    };
 
     let mut requested = request();
     requested.check = true;
@@ -86,10 +94,64 @@ fn check_answers_availability_even_where_a_package_manager_owns_the_install() {
         report
             .remediation
             .as_deref()
-            .is_some_and(|text| text.contains("brew upgrade orbit")),
+            .is_some_and(|text| text.contains("brew upgrade constellation-works/tap/orbit")),
         "{:?}",
         report.remediation
     );
+}
+
+#[test]
+fn a_legacy_tap_install_is_refused_with_a_migration_that_preserves_unrelated_taps() {
+    let fixture = Fixture::new("0.18.0");
+    fixture.publish("0.19.0", FakeBinary::Healthy);
+    let mut environment = fixture.environment();
+    environment.install_channel = InstallChannel::Homebrew {
+        remediation: Some(homebrew_remediation(Ok(vec![
+            LEGACY_HOMEBREW_FORMULA.to_string(),
+        ]))),
+    };
+
+    let error =
+        run_update(&environment, &request()).expect_err("a legacy Homebrew install is refused");
+
+    let message = error.to_string();
+    assert!(
+        message.contains(&format!("brew uninstall {LEGACY_HOMEBREW_FORMULA}")),
+        "{message}"
+    );
+    assert!(
+        message.contains(&format!("brew install {CANONICAL_HOMEBREW_FORMULA}")),
+        "{message}"
+    );
+    // Nothing was downloaded or replaced: the channel guard runs before staging.
+    assert_eq!(fixture.installed_reports(), "orbit 0.18.0");
+    assert_eq!(fixture.install_dir_entries(), vec!["orbit".to_string()]);
+}
+
+#[test]
+fn a_canonical_tap_install_is_refused_with_an_ordinary_qualified_upgrade() {
+    let fixture = Fixture::new("0.18.0");
+    fixture.publish("0.19.0", FakeBinary::Healthy);
+    let mut environment = fixture.environment();
+    environment.install_channel = InstallChannel::Homebrew {
+        remediation: Some(homebrew_remediation(Ok(vec![
+            CANONICAL_HOMEBREW_FORMULA.to_string(),
+        ]))),
+    };
+
+    let error =
+        run_update(&environment, &request()).expect_err("a canonical Homebrew install is refused");
+
+    let message = error.to_string();
+    assert!(
+        message.contains(&format!(
+            "brew update && brew upgrade {CANONICAL_HOMEBREW_FORMULA}"
+        )),
+        "{message}"
+    );
+    assert!(!message.contains("uninstall"), "{message}");
+    assert_eq!(fixture.installed_reports(), "orbit 0.18.0");
+    assert_eq!(fixture.install_dir_entries(), vec!["orbit".to_string()]);
 }
 
 #[test]

--- a/crates/orbit-core/assets/skills/orbit/references/setup/first-run.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/first-run.md
@@ -28,10 +28,15 @@ A prebuilt CLI gives you setup, dashboard, and administration commands:
 ```bash
 curl -sSf https://raw.githubusercontent.com/constellation-works/orbit/main/install.sh | sh
 # Alternative when Homebrew is the chosen package manager:
-brew install danieljhkim/tap/orbit
+brew install constellation-works/tap/orbit
 ```
 
-Choose one installation method; do not run both. Agent plugins provide the MCP
+Choose one installation method; do not run both. A machine that still has the
+retired `danieljhkim/tap/orbit` formula installed conflicts with the canonical
+one — `orbit update` on that machine detects it and reports the exact
+migration sequence (uninstall the legacy formula, then install the canonical
+one) instead of an ambiguous `brew upgrade orbit`; do not improvise a
+different migration. Agent plugins provide the MCP
 integration and bundled skill through their own package distribution, and do
 not require a source checkout. Source builds are optional for customization;
 follow the published README for toolchain and build instructions if that is

--- a/docs/runbooks/upgrades.md
+++ b/docs/runbooks/upgrades.md
@@ -4,8 +4,8 @@ summary: Install a new Orbit release with `orbit update`, then review, apply, an
 tags: [operations, upgrades, migrations, recovery]
 paths: ["crates/orbit-cmd/src/update/**", "crates/orbit-store/src/workflow/layout/**", "crates/orbit-store/src/driver/sqlite/migration/**"]
 related_features: [orbit-core]
-related_artifacts: [ORB-10014, ORB-11280, ORB-11344, ORB-11695, ORB-11753]
-last_validated: 2026-09-08
+related_artifacts: [ORB-10014, ORB-11280, ORB-11344, ORB-11695, ORB-11753, ORB-12013]
+last_validated: 2026-09-10
 ---
 
 # Upgrade Orbit Safely
@@ -28,7 +28,12 @@ orbit update --json               # machine-readable report
 1. Resolve the target version — the newest published release, or the one `--version` names.
 2. Refuse an installation Orbit's own installer does not own. An npm, Homebrew, `cargo
    install`, or checkout build is reported with the command that *does* upgrade it, before
-   anything is downloaded.
+   anything is downloaded. A Homebrew install names the fully qualified canonical formula,
+   `constellation-works/tap/orbit`, rather than an ambiguous `brew upgrade orbit`. A machine
+   that still has the retired `danieljhkim/tap/orbit` formula installed gets a tested migration
+   sequence instead — uninstall the legacy formula, then install the canonical one — because the
+   two conflict rather than coexisting; a canonical-only install gets the ordinary qualified
+   upgrade.
 3. Take an exclusive lock in the install directory, so two updates cannot interleave.
 4. Re-read the installed binary's version under that lock, and on Linux resolve a replaced
    running inode (`/path/to/orbit (deleted)`) back to the live install path. Equal, newer,

--- a/plugin/skills/orbit/references/setup/first-run.md
+++ b/plugin/skills/orbit/references/setup/first-run.md
@@ -28,10 +28,15 @@ A prebuilt CLI gives you setup, dashboard, and administration commands:
 ```bash
 curl -sSf https://raw.githubusercontent.com/constellation-works/orbit/main/install.sh | sh
 # Alternative when Homebrew is the chosen package manager:
-brew install danieljhkim/tap/orbit
+brew install constellation-works/tap/orbit
 ```
 
-Choose one installation method; do not run both. Agent plugins provide the MCP
+Choose one installation method; do not run both. A machine that still has the
+retired `danieljhkim/tap/orbit` formula installed conflicts with the canonical
+one — `orbit update` on that machine detects it and reports the exact
+migration sequence (uninstall the legacy formula, then install the canonical
+one) instead of an ambiguous `brew upgrade orbit`; do not improvise a
+different migration. Agent plugins provide the MCP
 integration and bundled skill through their own package distribution, and do
 not require a source checkout. Source builds are optional for customization;
 follow the published README for toolchain and build instructions if that is


### PR DESCRIPTION
## Task

[ORB-12013](https://orbit-cli.com/tasks/ORB-12013) — Fix orbit update Homebrew guidance and migration from the legacy tap

### Description

## Problem
Daniel reports Homebrew-installed orbit update is unusable because it needs the fully qualified formula constellation-works/tap/orbit and conflicts with the former danieljhkim/tap/orbit. Current update/channel.rs emits ambiguous brew update && brew upgrade orbit. The canonical setup skill and generated plugin mirror still advertise the old tap, despite README using the new one.

## Scope
Make the Homebrew update path actionable and consistent with package-manager ownership. Use the fully qualified canonical formula in update/check diagnostics and current installation instructions. Explain or detect the legacy installed formula and provide a safe migration path that removes only the legacy Orbit formula before installing the canonical one; distinguish an ordinary canonical upgrade from a tap migration. Do not automatically remove unrelated formulae/taps or overwrite the Homebrew executable with Orbit's self-installer. Preserve check-only and package-manager channel safety.

Verify canonical, legacy-only, both-taps, missing-formula, and failure cases using a controlled brew fixture and, where an authorized macOS host is available, actual Homebrew. Do not equate Linux mocks with macOS verification. Remove stale active install examples in the canonical skill then regenerate plugin mirror using scripts/sync-plugin-skills.sh. Historical incident URLs are not migration targets.

### Acceptance Criteria

- Homebrew-installed orbit update and --check identify the package-manager channel and name constellation-works/tap/orbit explicitly; no ambiguous brew upgrade orbit remediation remains in current update output.
- Legacy danieljhkim/tap/orbit installations receive a clear tested migration sequence that addresses formula conflicts and preserves unrelated packages/taps; canonical installations receive ordinary qualified upgrade guidance.
- Update/check do not download/overwrite a Homebrew-managed executable or unexpectedly uninstall anything. Brew failure diagnostics remain actionable and do not falsely report a successful update.
- Controlled brew fixtures exercise canonical, legacy-only, both-taps, missing-formula and command-failure behavior; any real macOS verification or unavailable platform limitation is recorded explicitly.
- Canonical setup/upgrade documentation and generated plugin skill mirror use the current tap; sync check, focused channel/flow tests, make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented and validated. Changes:

- crates/orbit-cmd/src/update/channel.rs: added `CANONICAL_HOMEBREW_FORMULA` (`constellation-works/tap/orbit`) and `LEGACY_HOMEBREW_FORMULA` (`danieljhkim/tap/orbit`) constants. `InstallChannel::Homebrew` is now a struct variant carrying `remediation: Option<String>`. New `HomebrewInventory` trait + `SystemHomebrewInventory` (invokes `brew list --formula --full-name`, injectable `command` path for tests, never touches process-wide PATH) + `homebrew_remediation(Result<Vec<String>, OrbitError>) -> String` pure classifier: legacy formula present (alone or alongside canonical) -> tested migration (`brew uninstall <legacy> && brew update && brew install <canonical>`) that touches only the Orbit formula; canonical-only, formula-not-listed, or brew-probe-failure all fall back to the fully qualified ordinary upgrade (`brew update && brew upgrade <canonical>`), with the failure case appending the diagnostic rather than claiming success. New `InstallChannel::detect_with_homebrew_ownership` wraps `detect()` (unchanged, still pure/path-only) and resolves ownership only for a Homebrew match.
- crates/orbit-cmd/src/update/mod.rs: `UpdateEnvironment::from_process` now calls `detect_with_homebrew_ownership` with the real `SystemHomebrewInventory`, so the resolved remediation flows into `UpdateReport.remediation`/`unsupported_reason` for both `--check` and mutating runs; the existing pre-lock/pre-download channel guard is unchanged, so nothing is downloaded, replaced, or uninstalled before the refusal.
- Tests (crates/orbit-cmd/src/update/tests/channel.rs, tests/flow.rs): updated the existing Homebrew detection case to the new struct variant and fully-qualified text; added unit coverage for all 5 required brew scenarios via `homebrew_remediation` (canonical, legacy-only, both-taps, formula-missing-from-listing, brew-command-failure), `detect_with_homebrew_ownership` (legacy resolution, and proof a non-Homebrew channel never probes brew), and two `SystemHomebrewInventory` tests against a controlled fake `brew` script fixture (parses full names; surfaces a failing brew honestly, not as success). Added two flow-level tests proving `run_update` refuses before staging/download for both a legacy-tap install (uninstall+install migration text, nothing replaced) and a canonical-tap install (ordinary qualified upgrade, no uninstall wording).
- Docs: crates/orbit-core/assets/skills/orbit/references/setup/first-run.md now shows `brew install constellation-works/tap/orbit` and explains the legacy-tap migration is detected/reported by `orbit update`, not to be improvised. Regenerated plugin/skills mirror via `scripts/sync-plugin-skills.sh` (verified `--check` clean before and after). docs/runbooks/upgrades.md step 2 now names the qualified formula and the legacy-vs-canonical remediation split; bumped `last_validated` and added ORB-12013 to `related_artifacts`. README.md already used the canonical tap; left unchanged (in scope but not stale).

Acceptance criteria:
1. Fully qualified formula everywhere (constants + remediation text + docs); no bare `brew upgrade orbit` remains in code, tests, or docs. Met.
2. Legacy-only and both-taps installs get the tested uninstall+install migration that names only the Orbit formula (no tap/formula removal beyond it); canonical-only gets the ordinary qualified upgrade. Met — covered by unit and flow tests.
3. The channel guard in `run_update` still runs before the update lock, staging, download, or replacement (unchanged control flow); `--check` stays read-only; a brew-probe failure is reported as a diagnostic appended to a still-actionable command, never as success. Met.
4. Controlled brew fixtures: pure-function coverage of all 5 required scenarios (canonical/legacy-only/both-taps/missing-formula/command-failure) in tests/channel.rs, plus two tests against an actual fake `brew` executable (subprocess-level, not just data-level). No macOS host was available in this environment; real Homebrew/macOS verification is not performed here and is called out as an explicit limitation — Linux fixtures exercise the parsing/classification/subprocess-invocation logic, not live Homebrew behavior.
5. Canonical skill doc updated, plugin mirror regenerated via the sync script (verified byte-identical after sync), docs/runbooks/upgrades.md updated.

Validation run (all from the task worktree):
- `cargo test -p orbit-cmd update::` — 53 passed, 1 ignored (pre-existing unrelated subprocess-fixture test), 0 failed.
- `cargo clippy -p orbit-cmd --all-targets -- -D warnings` — clean.
- `cargo clippy -p orbit-cli --all-targets -- -D warnings` — clean (orbit-cli only touches `UpdateReport`/`as_str()`, unaffected by the enum shape change).
- `make ci-fast` — passed (fmt-check + guardrail scripts, including sync-plugin-skills --check and docs/INDEX.md verification).
- `make ci-lint` — passed (workspace-wide `cargo clippy --workspace --all-targets -- -D warnings`).
- `git diff --check` — clean; `git status --short` — exactly the 7 files listed above, no stray artifacts.
- `make ci` (full) intentionally not run per workspace policy (CI is the canonical merge gate, not a per-task local step).

Deviations/risk: none beyond the explicit macOS-verification gap noted in criterion 4. `context_files` were sufficient; no scope expansion beyond the 6 files provided plus this execution summary (README.md inspected, found already correct, left untouched).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12013-6aa23cf2`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra