### PR TITLE
Validate recovery authority root before filesystem effects and close CodeQL alert 409

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -117,3 +117,9 @@ extensions:
           "path-injection",
           "manual",
         ]
+      - [
+          "orbit_core::runtime::recovery_authority::validated_authority_global_root",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/recovery_authority_sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/recovery_authority_sandbox.rs
@@ -38,12 +38,18 @@ probe() {
 rename() {
   if mv "$2" "$2.moved" 2>/dev/null; then echo "$1=REPLACED"; else echo "$1=denied"; fi
 }
+plant() {
+  if ln -s /tmp "$2" 2>/dev/null; then echo "$1=PLANTED"; else echo "$1=denied"; fi
+}
 probe original "$AUTHORITY/authority.db"
 probe wal_sidecar "$AUTHORITY/authority.db-wal"
 probe shm_sidecar "$AUTHORITY/authority.db-shm"
 probe stable_alias "$ALIAS/authority.db"
 rename authority_root "$AUTHORITY"
 rename authority_parent "$GLOBAL/state"
+probe authority_parent_entry "$GLOBAL/state/planted-file"
+plant authority_root_redirect "$GLOBAL/state/planted-link"
+plant global_child_redirect "$GLOBAL/planted-link"
 probe leaf_task "$GLOBAL/tasks/leaf-write.json"
 probe leaf_audit "$GLOBAL/state/audit/leaf-write.jsonl"
 "#;
@@ -150,6 +156,12 @@ fn a_leaf_cannot_reach_the_recovery_authority_through_any_path_it_can_build() {
         "stable_alias",
         "authority_root",
         "authority_parent",
+        // Redirection preconditions: the module refuses a symlinked component
+        // below the trusted root, and the sandbox denies a leaf the write that
+        // would let it plant one in the first place.
+        "authority_parent_entry",
+        "authority_root_redirect",
+        "global_child_redirect",
     ] {
         assert!(
             stdout.contains(&format!("{vector}=denied")),
@@ -167,6 +179,17 @@ fn a_leaf_cannot_reach_the_recovery_authority_through_any_path_it_can_build() {
     // the bytes actually landed outside the sandbox rather than on its tmpfs.
     assert!(authority_root.join("authority.db").is_file());
     assert!(!authority_root.with_extension("moved").exists());
+    for planted in [
+        global.join("state/planted-file"),
+        global.join("state/planted-link"),
+        global.join("planted-link"),
+    ] {
+        assert!(
+            planted.symlink_metadata().is_err(),
+            "leaf planted `{}` on the way to the authority",
+            planted.display(),
+        );
+    }
     assert!(global.join("tasks/leaf-write.json").is_file());
     assert!(global.join("state/audit/leaf-write.jsonl").is_file());
 }

--- a/crates/orbit-core/src/runtime/recovery_authority.rs
+++ b/crates/orbit-core/src/runtime/recovery_authority.rs
@@ -18,7 +18,7 @@
 
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use chrono::Utc;
 use orbit_common::OrbitError;
@@ -43,6 +43,7 @@ const AUTHORITY_FILE_MODE: u32 = 0o600;
 
 /// The durable record a host writes when it completes a rebase recovery, and
 /// the only evidence a later resume will accept.
+#[derive(Debug)]
 pub(crate) struct RecoveryAuthority {
     connection: Connection,
 }
@@ -65,6 +66,8 @@ impl RecoveryAuthority {
     /// Open (creating on first use) the authority for `global_root`.
     pub(crate) fn open(global_root: &Path) -> Result<Self, OrbitError> {
         let root = authority_root(global_root)?;
+        refuse_symlinked_authority_files(&root)?;
+
         let connection = Connection::open(root.join(AUTHORITY_DB))
             .map_err(|error| authority_error("open recovery authority database", error))?;
 
@@ -252,34 +255,136 @@ fn canonical_json(value: &Value) -> String {
     }
 }
 
-/// The protected root, created and validated on demand.
+/// The protected root, validated before any filesystem effect.
 ///
-/// A symlink anywhere in the path would let a writable location stand in for
-/// the authority, so refuse that layout outright rather than deny a pointer
-/// that can be replaced.
+/// Order matters: the trusted root is established first, and only then is the
+/// authority tree created beneath it. Creating first and canonicalizing
+/// afterwards would erase exactly the aliases the check is looking for, so a
+/// symlink planted below the root would be followed and then declared clean.
 fn authority_root(global_root: &Path) -> Result<PathBuf, OrbitError> {
-    let root = global_root.join(AUTHORITY_DIR);
-    fs::create_dir_all(&root)
-        .map_err(|error| path_error("create recovery authority root", &root, error))?;
-    let root = root
-        .canonicalize()
-        .map_err(|error| path_error("canonicalize recovery authority root", &root, error))?;
-    refuse_symlinked_path(&root)?;
-    Ok(root)
+    let trusted = validated_authority_global_root(global_root)?;
+    create_authority_root_under(&trusted)
 }
 
-fn refuse_symlinked_path(path: &Path) -> Result<(), OrbitError> {
-    for ancestor in path.ancestors() {
-        let metadata = fs::symlink_metadata(ancestor)
-            .map_err(|error| path_error("inspect recovery authority path", ancestor, error))?;
+/// Establish the trusted root the authority tree may be built under.
+///
+/// The configured global root reaches this module from `~/.orbit` or from a
+/// managed run's registry locator, so it is untrusted input: it is required to
+/// be an absolute, traversal-free path that already exists as a directory, and
+/// it is resolved *without writing anything*. Aliasing in the configured root
+/// itself is the operator's — a symlinked `$HOME` or a macOS `/var` prefix is a
+/// supported layout, and anyone able to redirect the global root already owns
+/// the run store the authority exists to outrank — so it is resolved once here
+/// and the canonical result becomes the trusted root every later join is
+/// anchored to.
+fn validated_authority_global_root(global_root: &Path) -> Result<PathBuf, OrbitError> {
+    if !global_root.is_absolute() {
+        return Err(OrbitError::InvalidInput(format!(
+            "recovery authority root `{}` must be absolute",
+            global_root.display()
+        )));
+    }
+    if !global_root
+        .components()
+        .all(|component| matches!(component, Component::RootDir | Component::Normal(_)))
+    {
+        return Err(OrbitError::InvalidInput(format!(
+            "recovery authority root `{}` must not contain traversal components",
+            global_root.display()
+        )));
+    }
+
+    let trusted = global_root
+        .canonicalize()
+        .map_err(|error| path_error("resolve recovery authority root", global_root, error))?;
+    if !trusted.is_dir() {
+        return Err(OrbitError::InvalidInput(format!(
+            "recovery authority root `{}` must be an existing directory",
+            global_root.display()
+        )));
+    }
+    Ok(trusted)
+}
+
+/// Create `state/recovery-authority` one component at a time under `trusted`.
+///
+/// `create_dir_all` would happily follow a symlink standing in for `state` and
+/// leave the authority in a directory the planter controls. `create_dir` never
+/// writes through an existing entry, so each component is created inside a
+/// parent this walk has already confirmed is a real directory, and is then
+/// re-inspected without following links before it becomes the next parent.
+fn create_authority_root_under(trusted: &Path) -> Result<PathBuf, OrbitError> {
+    let mut root = trusted.to_path_buf();
+    for component in Path::new(AUTHORITY_DIR).components() {
+        root.push(component);
+        match fs::create_dir(&root) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(error) => {
+                return Err(path_error("create recovery authority root", &root, error));
+            }
+        }
+
+        let Some(metadata) = unfollowed_metadata(&root)? else {
+            return Err(path_error(
+                "inspect recovery authority path",
+                &root,
+                std::io::Error::from(std::io::ErrorKind::NotFound),
+            ));
+        };
         if metadata.file_type().is_symlink() {
+            return Err(refuse_symlinked(&root));
+        }
+        if !metadata.is_dir() {
             return Err(OrbitError::PolicyDenied(format!(
-                "recovery authority refuses symlinked path `{}`",
-                ancestor.display()
+                "recovery authority refuses non-directory path `{}`",
+                root.display()
             )));
         }
     }
+    Ok(root)
+}
+
+/// Refuse the authority database and its sidecars when any of them is a link.
+///
+/// A symlinked database file would let the certificate be read from, and
+/// written to, a file outside the protected root while every directory on the
+/// way there still looks correct. A missing sidecar is ordinary: SQLite creates
+/// and removes them around each connection.
+fn refuse_symlinked_authority_files(root: &Path) -> Result<(), OrbitError> {
+    for name in authority_file_names() {
+        let file = root.join(name);
+        if unfollowed_metadata(&file)?.is_some_and(|metadata| metadata.file_type().is_symlink()) {
+            return Err(refuse_symlinked(&file));
+        }
+    }
     Ok(())
+}
+
+/// The database and the two SQLite sidecars that share its protected root.
+fn authority_file_names() -> [String; 3] {
+    [
+        AUTHORITY_DB.to_string(),
+        format!("{AUTHORITY_DB}-wal"),
+        format!("{AUTHORITY_DB}-shm"),
+    ]
+}
+
+/// `path`'s own metadata, never the metadata of a symlink's target. `None` when
+/// nothing is there.
+fn unfollowed_metadata(path: &Path) -> Result<Option<fs::Metadata>, OrbitError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(Some(metadata)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(path_error("inspect recovery authority path", path, error)),
+    }
+}
+
+fn refuse_symlinked(path: &Path) -> OrbitError {
+    OrbitError::PolicyDenied(format!(
+        "recovery authority refuses symlinked path `{}`",
+        path.display()
+    ))
 }
 
 #[cfg(unix)]
@@ -288,11 +393,7 @@ fn restrict_permissions(root: &Path) -> Result<(), OrbitError> {
 
     fs::set_permissions(root, fs::Permissions::from_mode(AUTHORITY_DIR_MODE))
         .map_err(|error| path_error("restrict recovery authority root", root, error))?;
-    for name in [
-        AUTHORITY_DB.to_string(),
-        format!("{AUTHORITY_DB}-wal"),
-        format!("{AUTHORITY_DB}-shm"),
-    ] {
+    for name in authority_file_names() {
         let file = root.join(name);
         if file.exists() {
             fs::set_permissions(&file, fs::Permissions::from_mode(AUTHORITY_FILE_MODE))

--- a/crates/orbit-core/src/runtime/tests/recovery_authority.rs
+++ b/crates/orbit-core/src/runtime/tests/recovery_authority.rs
@@ -255,7 +255,8 @@ fn checkpoints_written_before_the_boundary_have_no_record() {
 /// Rule *shape*: the deny lands last and is a subtree, which is what makes it
 /// cover `authority.db` together with the `-wal` and `-shm` sidecars a writer
 /// could otherwise use to inject rows. Enforcement of these rules is proven
-/// against a live sandbox in `tests/recovery_authority_linux.rs`.
+/// against a live sandbox in
+/// `adapter/engine_host/v2_host/tests/recovery_authority_sandbox.rs`.
 #[test]
 fn the_authority_deny_is_a_subtree_rule_appended_after_every_grant() {
     let global = TempDir::new().expect("global root");
@@ -295,5 +296,193 @@ fn the_authority_deny_is_a_subtree_rule_appended_after_every_grant() {
     assert_eq!(
         resolved.modify.iter().filter(|rule| *rule == &deny).count(),
         1
+    );
+}
+
+/// The configured global root may legitimately be reached through a symlink —
+/// a symlinked `$HOME` is a supported layout — so it is resolved to its trusted
+/// target rather than refused. What must hold is that resolution is *stable*:
+/// both spellings name one authority, so a certificate issued through the alias
+/// is the same record the canonical path reads back.
+#[cfg(unix)]
+#[test]
+fn a_symlinked_global_root_resolves_to_one_trusted_authority() {
+    use std::os::unix::fs::symlink;
+
+    let base = TempDir::new().expect("base");
+    let workspace = TempDir::new().expect("workspace");
+    let real = base.path().join("real-global");
+    let alias = base.path().join("aliased-global");
+    std::fs::create_dir(&real).expect("real global root");
+    symlink(&real, &alias).expect("global root symlink");
+
+    let accepted = checkpoint(RUN_ID, STEP_ID, workspace.path());
+    RecoveryAuthority::open(&alias)
+        .expect("open through the alias")
+        .issue(RUN_ID, STEP_ID, &accepted)
+        .expect("issue through the alias");
+
+    assert!(
+        real.join("state/recovery-authority/authority.db").is_file(),
+        "the authority must land under the trusted target, not beside the link",
+    );
+    assert!(
+        !alias.symlink_metadata().expect("alias metadata").is_dir(),
+        "the alias itself must stay a symlink rather than be replaced",
+    );
+    assert!(
+        RecoveryAuthority::open(&real)
+            .expect("open through the trusted target")
+            .verify(RUN_ID, STEP_ID, &accepted)
+            .expect("verify through the trusted target"),
+        "both spellings must resolve to the same certificate",
+    );
+}
+
+/// The same property one level up: an aliased *ancestor* of the global root
+/// resolves to the trusted target instead of forking the authority in two.
+#[cfg(unix)]
+#[test]
+fn a_symlinked_ancestor_of_the_global_root_resolves_to_the_same_authority() {
+    use std::os::unix::fs::symlink;
+
+    let base = TempDir::new().expect("base");
+    let workspace = TempDir::new().expect("workspace");
+    let real_parent = base.path().join("real-parent");
+    std::fs::create_dir_all(real_parent.join("global")).expect("global root");
+    symlink(&real_parent, base.path().join("aliased-parent")).expect("ancestor symlink");
+
+    let accepted = checkpoint(RUN_ID, STEP_ID, workspace.path());
+    RecoveryAuthority::open(&base.path().join("aliased-parent/global"))
+        .expect("open through the aliased ancestor")
+        .issue(RUN_ID, STEP_ID, &accepted)
+        .expect("issue through the aliased ancestor");
+
+    assert!(
+        real_parent
+            .join("global/state/recovery-authority/authority.db")
+            .is_file(),
+        "the authority must land under the trusted target of the aliased ancestor",
+    );
+    assert!(
+        RecoveryAuthority::open(&real_parent.join("global"))
+            .expect("open through the trusted target")
+            .verify(RUN_ID, STEP_ID, &accepted)
+            .expect("verify through the trusted target"),
+    );
+}
+
+/// The regression this module exists for. A symlink standing in for a component
+/// *below* the trusted root used to be followed by `create_dir_all` and then
+/// declared clean, because the symlink check ran on an already canonicalized
+/// path. Each layout below must be refused with nothing created at the
+/// redirection target.
+#[cfg(unix)]
+#[test]
+fn a_symlink_below_the_trusted_root_is_refused_before_anything_is_created() {
+    use std::os::unix::fs::symlink;
+
+    for (label, link, target_probe) in [
+        ("authority parent", "state", "recovery-authority"),
+        ("authority root", "state/recovery-authority", "authority.db"),
+    ] {
+        let global = TempDir::new().expect("global root");
+        let elsewhere = TempDir::new().expect("redirection target");
+        let link = global.path().join(link);
+        if let Some(parent) = link.parent() {
+            std::fs::create_dir_all(parent).expect("link parent");
+        }
+        symlink(elsewhere.path(), &link).expect("plant redirection symlink");
+
+        let error =
+            RecoveryAuthority::open(global.path()).expect_err("a redirected component must fail");
+        assert!(
+            error.to_string().contains("symlinked path"),
+            "`{label}` must be refused as a symlink: {error}",
+        );
+        assert!(
+            !elsewhere.path().join(target_probe).exists(),
+            "`{label}` redirected authority state into `{}`",
+            elsewhere.path().display(),
+        );
+        assert!(
+            link.symlink_metadata()
+                .expect("link metadata")
+                .file_type()
+                .is_symlink(),
+            "the planted `{label}` link must be left untouched, not written through",
+        );
+
+        // The deny appended to a sandbox profile derives from the same root, so
+        // it must refuse the redirected layout too rather than name a path the
+        // authority never uses.
+        let mut resolved = ResolvedFsProfile {
+            name: "implementer".to_string(),
+            read: vec!["/**".to_string()],
+            modify: Vec::new(),
+        };
+        let error = append_recovery_authority_denies(global.path(), &mut resolved)
+            .expect_err("a redirected root must not yield a deny rule");
+        assert!(error.to_string().contains("symlinked path"), "{error}");
+        assert!(resolved.modify.is_empty());
+    }
+}
+
+/// A symlinked database file keeps every directory on the way there looking
+/// correct while the certificate is read from, and written to, a file outside
+/// the protected root.
+#[cfg(unix)]
+#[test]
+fn a_symlinked_authority_database_is_refused() {
+    use std::os::unix::fs::symlink;
+
+    for name in ["authority.db", "authority.db-wal", "authority.db-shm"] {
+        let (global, _workspace, _accepted) = fixture();
+        let elsewhere = TempDir::new().expect("redirection target");
+        let planted = elsewhere.path().join("planted.db");
+        std::fs::write(&planted, b"planted").expect("planted file");
+
+        let file = global.path().join("state/recovery-authority").join(name);
+        std::fs::remove_file(&file).ok();
+        symlink(&planted, &file).expect("plant database symlink");
+
+        let error = RecoveryAuthority::open(global.path())
+            .expect_err("a symlinked database file must not be opened");
+        assert!(
+            error.to_string().contains("symlinked path"),
+            "`{name}` must be refused as a symlink: {error}",
+        );
+        assert_eq!(
+            std::fs::read(&planted).expect("planted contents"),
+            b"planted",
+            "`{name}` let the authority write outside the protected root",
+        );
+    }
+}
+
+/// The configured root is untrusted input, so a shape that would resolve
+/// against the process working directory — or climb out of itself — is refused
+/// before it can select where authority state lives.
+#[test]
+fn an_unanchored_global_root_is_refused() {
+    for (label, root) in [
+        ("relative", Path::new("relative/global").to_path_buf()),
+        ("traversing", Path::new("/tmp/../tmp/global").to_path_buf()),
+    ] {
+        let error = RecoveryAuthority::open(&root).expect_err("an unanchored root must fail");
+        assert!(
+            matches!(error, orbit_common::OrbitError::InvalidInput(_)),
+            "a `{label}` root must be refused as invalid input: {error}",
+        );
+    }
+
+    let base = TempDir::new().expect("base");
+    let error = RecoveryAuthority::open(&base.path().join("never-created"))
+        .expect_err("a missing root must fail");
+    assert!(
+        error
+            .to_string()
+            .contains("resolve recovery authority root"),
+        "{error}",
     );
 }

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -279,6 +279,16 @@ and unrenameable as a mountpoint. Removing the `orbit.db` grants was rejected as
 the fix: it would break admitted leaf writes without making the remaining
 evidence authentic.
 
+The trusted root is established before any filesystem effect. The configured
+global root must be absolute and traversal-free and must already exist; it is
+resolved once, without writing, and the canonical result anchors every later
+join. Aliasing in the configured root itself — a symlinked `$HOME`, a macOS
+`/var` prefix — is a supported operator layout, and anyone able to redirect that
+root already owns the run store the authority exists to outrank. Below the
+trusted root the tree is created one component at a time, so a symlink standing
+in for `state` or `recovery-authority` is refused instead of followed, and the
+database and its sidecars are refused when any of them is a link.
+
 Confinement here is by location, not by a secret. Bubblewrap mounts the host
 filesystem `--ro-bind / /` and enforces only write boundaries, so a key file
 would be readable by every leaf and a keyed MAC would add no authority.


### PR DESCRIPTION
## Task

[ORB-12014](https://orbit-cli.com/tasks/ORB-12014) — Validate recovery authority root before filesystem effects and close CodeQL alert 409

### Description

## Evidence
GitHub code-scanning alert https://github.com/constellation-works/orbit/security/code-scanning/409 (rust/path-injection) remains open as of 2026-09-10 05:10 UTC. The scan is on e3dcc364; source inspection of current remote agent-main 4dce658a07d16568f07243fe0d7b4607058aaa5b and local 9c02e47 confirms authority_root joins the configured global_root with fixed state/recovery-authority and calls create_dir_all before canonicalizing. The subsequent symlink check receives a canonical path, which has erased aliases in the original root. ORB-11977 introduced this authority boundary; no existing task covers alert 409.

## Required outcome
Establish trusted, validated root provenance before deriving/creating recovery authority paths. Inspect callers at checkpoint/verification and sandbox deny compilation. Prevent a symlinked or otherwise untrusted root/ancestor from redirecting authority data or weakening sandbox protection. Preserve supported canonical root behavior and crash/recovery semantics. If runtime construction already guarantees a canonical trusted root, enforce and test that invariant and use the existing CodeQL barrier mechanism only with justified behavioral evidence. Do not dismiss the alert, blanket suppress the rule, or reject supported roots without evaluating compatibility.
Add regression fixtures for a symlinked global_root itself and its ancestors, not only descendants below recovery-authority; include real Linux bwrap coverage at the security boundary. Use isolated temporary roots, never production authority data. Host CodeQL on the repair revision must be checked after merge; a source fix alone is not alert-resolution evidence.

### Acceptance Criteria

- Root validation happens before filesystem creation or authority reads/writes; alias/escape cases cannot create or consume authority state outside the intended trusted root.
- Regression tests cover symlinked global_root, symlinked ancestors/children, canonical valid roots, and normal checkpoint/verification flows, demonstrating the original gap and corrected behavior.
- Live Linux bwrap/security fixtures establish the repaired authority paths remain protected; no sandbox allowlist broadening or authority bypass is introduced.
- Focused recovery/sandbox tests, make ci-fast and make ci-lint pass. A post-merge hosted CodeQL scan on the repaired source is recorded and alert 409 closes or its remaining evidence is explicitly carried forward; no dismissal substitutes for repair.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Defect

`authority_root` in `crates/orbit-core/src/runtime/recovery_authority.rs` joined
the configured `global_root` with `state/recovery-authority`, called
`create_dir_all`, and only then canonicalized and symlink-checked. Canonicalize
erased the aliases the check was looking for, so a symlink planted at
`<global>/state` (or at `<global>/state/recovery-authority`) was followed during
creation and the resulting canonical path was then declared clean. A relative
root additionally resolved against the process working directory.

## Change

`crates/orbit-core/src/runtime/recovery_authority.rs`
- New `validated_authority_global_root`: requires the configured root to be
  absolute and traversal-free, requires it to already exist as a directory, and
  resolves it **without writing anything**. The canonical result is the trusted
  root every later join is anchored to. Aliasing in the configured root itself
  (symlinked `$HOME`, macOS `/var` prefix) stays supported and is resolved
  rather than refused; anyone able to redirect the global root already owns
  `<global>/orbit.db`, which the authority exists to outrank. This matches the
  existing house treatment in `validated_linux_provider_state_root`.
- New `create_authority_root_under`: builds `state/recovery-authority` one
  component at a time with `fs::create_dir` (never `create_dir_all`), so each
  component is created inside a parent already confirmed to be a real
  directory, and is re-inspected with `symlink_metadata` before becoming the
  next parent. A symlink or non-directory below the trusted root is refused
  with `OrbitError::PolicyDenied`.
- New `refuse_symlinked_authority_files`, called from `RecoveryAuthority::open`
  before `Connection::open`: refuses a symlinked `authority.db`, `-wal`, or
  `-shm`, closing the "every directory looks correct but the file points
  elsewhere" case.
- `restrict_permissions` now shares the `authority_file_names` helper.
- `#[derive(Debug)]` on `RecoveryAuthority` so tests can use `expect_err`.

`.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml`
- Registered `orbit_core::runtime::recovery_authority::validated_authority_global_root`
  as a `barrierModel` entry, the same mechanism used by the other `validated_*`
  path helpers. No rule suppression and no alert dismissal.

`docs/design/activity-job/2_design.md`
- Documented the validate-before-create ordering, the supported-alias rule for
  the configured root, and the per-component refusal below it.

`crates/orbit-core/src/adapter/engine_host/v2_host/tests/recovery_authority_sandbox.rs`
- Live bwrap probe extended with three redirection-precondition vectors:
  creating a plain entry in `<global>/state`, planting a symlink at
  `<global>/state/planted-link`, and planting one at `<global>/planted-link`.
  All must be denied, and the host asserts none of them exists afterwards. No
  grant was added or widened.

`crates/orbit-core/src/runtime/tests/recovery_authority.rs`
- `a_symlinked_global_root_resolves_to_one_trusted_authority`
- `a_symlinked_ancestor_of_the_global_root_resolves_to_the_same_authority`
- `a_symlink_below_the_trusted_root_is_refused_before_anything_is_created`
  (covers both `state` and `state/recovery-authority`, asserts nothing is
  created at the redirection target, asserts the planted link is untouched, and
  asserts `append_recovery_authority_denies` also refuses rather than emitting
  a rule for a path the authority never uses)
- `a_symlinked_authority_database_is_refused` (db and both sidecars)
- `an_unanchored_global_root_is_refused` (relative, traversing, missing)
- Fixed a stale doc pointer to `tests/recovery_authority_linux.rs`; the live
  fixture lives at
  `adapter/engine_host/v2_host/tests/recovery_authority_sandbox.rs`.

Isolated `tempfile::TempDir` roots throughout; no production authority data was
touched.

## Criteria

1. **Root validation before filesystem effects** — met. `authority_root` now
   calls `validated_authority_global_root` (no writes) before
   `create_authority_root_under`, and `RecoveryAuthority::open` refuses
   symlinked database files before opening the connection.
2. **Regression tests demonstrating the gap** — met and *demonstrated*. With
   the fix reverted in place, three new tests fail: the symlinked-`state`
   fixture showed the pre-fix code creating
   `/tmp/.tmptmJLfc/recovery-authority/authority.db` at the attacker-chosen
   target; the symlinked-db fixture reached `enable WAL on recovery authority:
   file is not a database`; the unanchored fixture wrote
   `crates/orbit-core/relative/global/state/recovery-authority/authority.db`
   under the process cwd. All 11 pass with the fix restored; the stray
   pre-fix artifacts were removed and `git status --short` is clean of them.
3. **Live Linux bwrap/security fixtures, no allowlist broadening** — partially
   verified on this host; see validation below. The `fs_profile` grant list is
   unchanged (diff touches only the probe script and its assertions).
4. **Gates** — `make ci-fast` and `make ci-lint` both exit 0. The post-merge
   hosted CodeQL check is carried forward (see Carried forward).

## Validation

| Command | Outcome |
| --- | --- |
| `cargo test -p orbit-core --lib runtime::recovery_authority` | passed — 11/11 |
| `cargo test -p orbit-core --lib recovery_authority` | passed — 14/14 (incl. both sandbox fixtures) |
| `cargo test -p orbit-core --lib sandbox` | passed — 46/46 |
| `cargo test -p orbit-core --lib rebase` | passed — 2/2 |
| `cargo test -p orbit-core --lib` | passed — 1325 passed, 0 failed, 2 ignored |
| `make ci-fast` | passed (exit 0) |
| `make ci-lint` | passed (exit 0) |
| pre-fix revert probe | 3 of the new tests failed as intended, then reverted |
| `git diff --check` / `git status --short` | clean; only the 5 intended files modified |

**Limit on the live bwrap fixture.** On this runner
`a_leaf_cannot_reach_the_recovery_authority_through_any_path_it_can_build`
reports `skipping live recovery authority sandbox test: Bubblewrap capability
probe failed: bwrap: No permissions to create new namespace`
(`/proc/sys/kernel/apparmor_restrict_unprivileged_userns` = 1; lifting it needs
root and is outside this task's authorization). The test's designed skip path
returns without asserting, so the three new probe vectors compiled and were
scheduled but were **not** exercised against a real sandbox here — they need a
CI host with unprivileged user namespaces. The plan-level counterparts did run
and pass on this host: `the_compiled_sandbox_mounts_the_authority_read_only`
(asserts the read-only bind and that no read-write bind covers the authority)
and `linux_leaf_keeps_run_store_grants_but_never_reaches_the_recovery_authority`
(asserts each authority path is attributably denied while every admitted leaf
write root stays granted). `make ci-fast` reports the same namespace skip for
`test-compiler-cache-namespaces`, so this is a host property, not a regression.

## Carried forward

Alert 409 cannot be closed from a working tree. After merge, a hosted CodeQL
scan on the repair revision must be checked and the alert confirmed closed. If
it stays open, the barrier entry's dataflow match needs inspection — the source
fix is real either way, and no dismissal was used.

## Risks

- The trusted root is resolved once and the tree is then built and re-inspected
  component by component. A same-UID attacker who can win the window between
  `create_dir` and `symlink_metadata` on a component is not excluded; closing
  that fully needs `openat`-with-`O_NOFOLLOW` dirfd walking and a new
  dependency, which this change does not introduce. The sandbox probe covers
  the precondition: a leaf has no write grant on `<global>` or `<global>/state`
  and so cannot plant the component in the first place.
- Requiring the configured global root to already exist is new. Every current
  caller (`RuntimeHost::checkpoint_rebase_recovery`,
  `verify_rebase_recovery`, `append_recovery_authority_deny` during sandbox
  resolution) runs against an initialized `<global>` holding `orbit.db`, and
  the full `orbit-core` lib suite passes, so no bootstrap path regressed.
- macOS was not exercised. The change is `cfg`-neutral, and resolving the
  configured root instead of refusing it is what keeps a `/var/folders` temp
  prefix working, but that is reasoned compatibility, not a run on macOS.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12014-6aa23cf5`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra