### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/runtime/mod.rs

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -4,6 +4,12 @@ extensions:
       extensible: barrierModel
     data:
       - [
+          "orbit_core::runtime::validated_config_path",
+          "ReturnValue.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]",
+          "path-injection",
+          "manual",
+        ]
+      - [
           "orbit_registry::host_identity::validated_host_toml_path",
           "ReturnValue.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]",
           "path-injection",

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -380,12 +380,14 @@ impl OrbitRuntime {
     /// Returns the effective config.toml path.
     /// Workspace config replaces global if present; otherwise global.
     pub fn config_path(&self) -> PathBuf {
-        let ws_config = self.shared_root().join("config.toml");
-        if ws_config.exists() && self.shared_root() != self.global_root() {
-            ws_config
-        } else {
-            self.global_root().join("config.toml")
+        let shared_root = self.shared_root();
+        let global_root = self.global_root();
+        if shared_root != global_root
+            && let Ok(Some(ws_config)) = validated_config_path(&shared_root)
+        {
+            return ws_config;
         }
+        global_root.join(CONFIG_TOML_FILE)
     }
 
     pub fn persistence_config_json(&self) -> Value {
@@ -687,6 +689,45 @@ impl OrbitRuntime {
         def: &orbit_types::policy::PolicyDef,
     ) -> Result<(), OrbitError> {
         self.stores().policies().upsert_policy_def(def)
+    }
+}
+
+const CONFIG_TOML_FILE: &str = "config.toml";
+
+/// Resolve an existing workspace `config.toml` through its canonical root.
+///
+/// The workspace root may be selected by an explicit runtime override
+/// (workspace discovery, `--root`, or an env var), but the file name is
+/// fixed. Canonicalizing the root and rejecting a symlinked result keeps the
+/// resolved path inside the selected root instead of following a planted
+/// symlink to an unintended location [ORB-11931].
+fn validated_config_path(root: &Path) -> Result<Option<PathBuf>, OrbitError> {
+    let canonical_root = match root.canonicalize() {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "failed to canonicalize config root '{}': {error}",
+                root.display()
+            )));
+        }
+    };
+    let candidate = canonical_root.join(CONFIG_TOML_FILE);
+
+    match std::fs::symlink_metadata(&candidate) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            Err(OrbitError::InvalidInput(format!(
+                "config path must be a regular {CONFIG_TOML_FILE} file inside '{}': {}",
+                root.display(),
+                candidate.display()
+            )))
+        }
+        Ok(_) => Ok(Some(candidate)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(OrbitError::Io(format!(
+            "failed to inspect config path '{}': {error}",
+            candidate.display()
+        ))),
     }
 }
 

--- a/crates/orbit-core/src/runtime/tests/runtime.rs
+++ b/crates/orbit-core/src/runtime/tests/runtime.rs
@@ -23,6 +23,50 @@ fn test_runtime() -> (tempfile::TempDir, OrbitRuntime, PathBuf, PathBuf) {
 }
 
 #[test]
+fn config_path_prefers_existing_workspace_config_over_global() {
+    let (_root, runtime, global_root, workspace_root) = test_runtime();
+    std::fs::write(global_root.join("config.toml"), "").expect("write global config");
+    std::fs::write(workspace_root.join("config.toml"), "").expect("write workspace config");
+
+    let expected = workspace_root
+        .canonicalize()
+        .expect("canonicalize workspace root")
+        .join("config.toml");
+    assert_eq!(runtime.config_path(), expected);
+}
+
+#[test]
+fn config_path_falls_back_to_global_when_workspace_config_is_absent() {
+    let (_root, runtime, global_root, _workspace_root) = test_runtime();
+
+    assert_eq!(runtime.config_path(), global_root.join("config.toml"));
+}
+
+/// [ORB-11931] A symlinked workspace `config.toml` must not be followed:
+/// resolving through it would let a planted symlink redirect config reads
+/// outside the selected workspace root, so the runtime falls back to the
+/// global config instead of the symlink target.
+#[test]
+#[cfg(unix)]
+fn config_path_falls_back_to_global_when_workspace_config_is_a_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let (_root, runtime, global_root, workspace_root) = test_runtime();
+    let outside_target = workspace_root
+        .parent()
+        .expect("workspace root has parent")
+        .join("outside-config.toml");
+    std::fs::write(&outside_target, "leaked = true\n").expect("write file outside workspace root");
+    symlink(&outside_target, workspace_root.join("config.toml"))
+        .expect("symlink workspace config.toml");
+
+    let resolved = runtime.config_path();
+
+    assert_eq!(resolved, global_root.join("config.toml"));
+    assert_ne!(resolved, outside_target);
+}
+
+#[test]
 fn orbit_root_env_pins_global_registry_root() {
     let home = tempdir().expect("home tempdir");
     let repo = tempdir().expect("repo tempdir");


### PR DESCRIPTION
## Task

[ORB-11931](https://orbit-cli.com/tasks/ORB-11931) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/runtime/mod.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#134`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `21f15ded65e31481021f434acb32160a5ea77761`
- Location: `crates/orbit-core/src/runtime/mod.rs` line 383
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:48:41Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/134

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-core/src/runtime/mod.rs` line 383 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Remediated CodeQL rust/path-injection alert #134 at crates/orbit-core/src/runtime/mod.rs:383 (`OrbitRuntime::config_path`).

Root cause: `config_path()` joined the runtime-resolved `shared_root()` (itself derived from operator-controlled workspace discovery / `--root` / env overrides) with the literal `config.toml` and then did a raw `.exists()` filesystem probe on that joined path — an unvalidated-path filesystem sink per the rule.

Fix: added a private `validated_config_path(root: &Path) -> Result<Option<PathBuf>, OrbitError>` helper (mirrors the established pattern in `orbit_registry::host_identity::validated_host_toml_path` and `orbit_store::driver::file::friction_store::validated_friction_root` from the two sibling path-injection tasks landed just before this one, ORB-12003/ORB-12004). It canonicalizes the candidate root, joins the fixed `config.toml` filename, and uses `symlink_metadata` to reject a symlinked or non-regular result instead of following it. `config_path()` now calls this helper for the workspace-config branch and falls back to the global config path (unchanged, unvalidated join — that branch was already infallible/existence-untested in the original code and is only ever read through `orbit_core::application::docs::config::read_config_contents`, which independently canonicalizes and validates before any read). Registered the new helper's `Ok(Some(_))` return as a `path-injection` barrier in `.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml`, matching the existing entries' shape exactly.

Behavior preserved: when the workspace `config.toml` exists as a regular file, `config_path()` still resolves to it (now via its canonical form) in preference to global; when absent, behavior is unchanged (falls back to global path, not existence-checked, exactly as before). New behavior: if a workspace `config.toml` were ever a symlink (or non-regular file), the runtime no longer resolves/exposes that path and instead falls back to the trusted global config — fail-safe rather than fail-open.

Regression coverage added in crates/orbit-core/src/runtime/tests/runtime.rs:
- config_path_prefers_existing_workspace_config_over_global (unchanged-behavior guard)
- config_path_falls_back_to_global_when_workspace_config_is_absent (unchanged-behavior guard)
- config_path_falls_back_to_global_when_workspace_config_is_a_symlink (#[cfg(unix)]; fails without the fix — proves the symlink is no longer followed/exposed)

Validation run (all passed):
- `cargo test -p orbit-core --lib runtime::tests::runtime` — 17/17 passed, including the 3 new tests.
- `make ci-fast` — fmt-check + guardrail scripts passed, no diff issues.
- `make ci-lint` — full workspace clippy (all targets, warnings denied) passed clean.
- `python3 scripts/test-codeql-extension-schema.py` — 7/7 passed (validates the new barrierModel entry's shape).
- `git diff --check` and `git status --short` reviewed; only the 3 intended files changed, no incidental artifacts.

Not run / out of scope for this leaf: an actual CodeQL rescan of the alert. No `codeql` CLI is available in this workspace; per task instructions the orchestrator owns hosted CodeQL rescan and alert-closure verification after merge. The finding was not suppressed, dismissed, or excluded — the underlying data flow was removed and independently regression-tested.

No scope changes beyond the two listed context_files plus the CodeQL extension yaml (needed to register the new sanitizer, following the exact precedent of the two sibling path-injection tasks ORB-12003/ORB-12004 merged just before this one).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11931-6aa240ca`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra