### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-cmd/src/registry_runtime.rs

### DIFF
--- a/crates/orbit-cmd/src/registry_runtime.rs
+++ b/crates/orbit-cmd/src/registry_runtime.rs
@@ -14,7 +14,9 @@ use orbit_types::workspace::{
 };
 use serde_json::Value;
 
-use orbit_registry::{HOST_TOML_FILE, load_host_identity, workspace_registry};
+use orbit_registry::{
+    HostIdentityState, inspect_host_identity, load_host_identity, workspace_registry,
+};
 
 use crate::workspace_catalog::attach as attach_workspace_catalog;
 
@@ -582,10 +584,14 @@ fn unsupported_cli_workspace(selector: &str) -> OrbitError {
 /// Custom/legacy roots without host.toml retain the historical ORB default;
 /// once an identity exists, malformed or conflicting state fails closed.
 pub(crate) fn sync_task_prefix(global_root: &Path) -> Result<(), OrbitError> {
-    if !global_root.join(HOST_TOML_FILE).is_file() {
-        return Ok(());
-    }
-    let identity = load_host_identity(global_root)?;
+    let identity = match inspect_host_identity(global_root)? {
+        HostIdentityState::Present(identity) => identity,
+        HostIdentityState::Absent => return Ok(()),
+        // Keep legacy files on the established migration-required path while
+        // using Registry's validated classifier for every host.toml access.
+        HostIdentityState::Legacy { .. } => load_host_identity(global_root)?,
+    };
+
     let registry = TaskRegistryStore::open(&task_registry_path(global_root))?;
     registry.set_task_prefix(&identity.task_prefix)
 }

--- a/crates/orbit-cmd/src/tests/registry_runtime.rs
+++ b/crates/orbit-cmd/src/tests/registry_runtime.rs
@@ -14,7 +14,7 @@ use orbit_registry::workspace_registry::{registry_path_for, save_registry_to};
 
 use crate::registry_runtime::{
     RegisteredRuntimeFactory, resolved_workspace_binding, select_workspace_for_cwd_and_roots,
-    workspace_runtime_binding,
+    sync_task_prefix, workspace_runtime_binding,
 };
 
 fn workspace(id: &str, ship_mode: &str) -> Workspace {
@@ -213,6 +213,43 @@ fn registered_checkout_task_creation_uses_host_task_prefix() {
         )
         .expect("task creation");
     assert_eq!(task["id"], "DE-00000");
+}
+
+#[test]
+fn sync_task_prefix_rejects_legacy_host_identity() {
+    let root = tempfile::tempdir().expect("root");
+    std::fs::write(root.path().join("host.toml"), "host_id = \"legacy\"\n")
+        .expect("legacy host identity");
+
+    let error =
+        sync_task_prefix(root.path()).expect_err("legacy host identity must require migration");
+
+    assert!(
+        matches!(error, OrbitError::InvalidInput(message) if message.contains("legacy pre-migration"))
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn sync_task_prefix_rejects_a_symlinked_host_identity() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().expect("root");
+    let outside = tempfile::tempdir().expect("outside");
+    let outside_identity = outside.path().join("host.toml");
+    std::fs::write(
+        &outside_identity,
+        "schema_version = 2\nmachine_id = \"hm_outside\"\nhost_id = \"outside\"\ntask_prefix = \"DE\"\n",
+    )
+    .expect("outside host identity");
+    symlink(&outside_identity, root.path().join("host.toml")).expect("host identity symlink");
+
+    let error =
+        sync_task_prefix(root.path()).expect_err("symlinked host identity must fail closed");
+
+    assert!(
+        matches!(error, OrbitError::InvalidInput(message) if message.contains("regular host.toml"))
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11932](https://orbit-cli.com/tasks/ORB-11932) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-cmd/src/registry_runtime.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#140`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `21f15ded65e31481021f434acb32160a5ea77761`
- Location: `crates/orbit-cmd/src/registry_runtime.rs` line 585
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:48:41Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/140

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-cmd/src/registry_runtime.rs` line 585 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced the direct host.toml path probe in sync_task_prefix with orbit_registry::inspect_host_identity, which validates the canonical root and rejects symlinked or non-regular host identity files before access.
- Preserved behavior: absent host identity keeps the historical default; a current identity sets its prefix; legacy identity still returns the established migration-required error.
- Added command-boundary regressions for legacy host identity and an escaping host.toml symlink.

Criteria evidence:
1. The direct path join formerly at line 585 is removed. This is a code fix using Registry validation, with no CodeQL suppression, dismissal, exclusion, or extension-model edit.
2. Focused runtime tests verify current-prefix behavior remains covered, legacy files remain migration-required, and symlinked host identities fail closed.
3. Validation passed: cargo test -p orbit-cmd --lib registry_runtime (19 passed); make ci-fast (including CodeQL extension schema tests); make ci-lint; make audit with CARGO_DENY_DB_PATH in a writable temporary directory (advisories, bans, licenses, and sources passed); git diff --check. The CodeQL CLI and database are unavailable locally, so a hosted CodeQL rescan is still required to observe alert 140 closure; the latest task comment assigns that post-merge confirmation to the orchestrator. Static inspection confirms the originally reported direct path sink no longer exists.

Assessment: small, behavior-preserving trust-boundary repair with focused regression coverage.
Remaining risk: hosted CodeQL analysis has not yet run. A temporary writable advisory database remains outside the checkout because cleanup was denied by the execution environment; no repository artifact was created.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11932-6aa24126`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra