### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-common/src/fs/selector.rs

### DIFF
--- a/crates/orbit-common/src/fs/selector.rs
+++ b/crates/orbit-common/src/fs/selector.rs
@@ -292,15 +292,18 @@ pub fn canonical_selector_in_workspace(
     match parsed {
         ParsedScope::Selector(selector) => {
             if let Some(anchor) = selector.anchor_path() {
-                let path = normalize_workspace_anchor(anchor, workspace)?;
+                let (path, _) = normalize_workspace_anchor(anchor, workspace)?;
                 Ok(selector.with_path(path).to_string())
             } else {
                 Ok(selector.to_string())
             }
         }
         ParsedScope::LegacyPath { path, is_dir_hint } => {
-            let path = normalize_workspace_anchor(path.as_str(), workspace)?;
-            let resolved = resolve_workspace_path(workspace, Path::new(&path));
+            // Use the already-validated, canonicalized anchor for the
+            // filesystem check instead of re-deriving a path from the
+            // caller-provided string: that avoids a second, unchecked
+            // filesystem access built from tainted input.
+            let (path, resolved) = normalize_workspace_anchor(path.as_str(), workspace)?;
             if is_dir_hint || resolved.is_dir() {
                 Ok(format!("dir:{path}"))
             } else {
@@ -477,7 +480,18 @@ fn normalize_selector_path(
     })
 }
 
-fn normalize_workspace_anchor(path: &str, workspace: &Path) -> Result<String, SelectorParseError> {
+/// Validate a selector anchor against a workspace root.
+///
+/// Returns both the workspace-relative anchor string and the canonicalized,
+/// containment-checked absolute path it resolved to. Callers that need to
+/// touch the filesystem (e.g. an `is_dir()` probe) must use the returned
+/// [`PathBuf`] rather than re-joining the relative string themselves, so the
+/// only path ever handed to a filesystem call is one that already passed the
+/// workspace-containment check below.
+fn normalize_workspace_anchor(
+    path: &str,
+    workspace: &Path,
+) -> Result<(String, PathBuf), SelectorParseError> {
     let normalized = normalize_path_text(path).map_err(|reason| SelectorParseError {
         input: path.to_string(),
         reason,
@@ -523,7 +537,7 @@ fn normalize_workspace_anchor(path: &str, workspace: &Path) -> Result<String, Se
             ),
         });
     }
-    contained
+    let relative = contained
         .strip_prefix(&workspace)
         .map(|path| path.to_string_lossy().replace('\\', "/"))
         .map_err(|_| SelectorParseError {
@@ -533,7 +547,8 @@ fn normalize_workspace_anchor(path: &str, workspace: &Path) -> Result<String, Se
                 resolved.display(),
                 workspace.display()
             ),
-        })
+        })?;
+    Ok((relative, contained))
 }
 
 fn canonicalize_existing_prefix(path: &Path) -> PathBuf {

--- a/crates/orbit-common/src/fs/tests/selector.rs
+++ b/crates/orbit-common/src/fs/tests/selector.rs
@@ -275,6 +275,27 @@ mod parse {
         ));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn legacy_path_dir_check_rejects_symlink_escaping_workspace() {
+        let workspace = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        std::fs::create_dir_all(outside.path().join("secret")).unwrap();
+        std::os::unix::fs::symlink(
+            outside.path().join("secret"),
+            workspace.path().join("linked"),
+        )
+        .unwrap();
+
+        // The legacy (no-prefix) path form is the one that probes the
+        // filesystem with `Path::is_dir()` to pick `dir:` vs `file:`. That
+        // probe must only ever run against the already containment-checked
+        // anchor, so a symlink escaping the workspace is rejected before any
+        // `is_dir()` call touches the outside target.
+        assert!(canonical_selector_in_workspace("linked", workspace.path()).is_err());
+        assert!(!exists_in_workspace("linked", workspace.path()));
+    }
+
     #[test]
     fn symbol_selector_preserves_opaque_qualified_name() {
         let selector: Selector = "symbol:src/lib.rs#<Foo as Runnable>::run#2:method"


### PR DESCRIPTION
## Task

[ORB-11934](https://orbit-cli.com/tasks/ORB-11934) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-common/src/fs/selector.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#142`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `21f15ded65e31481021f434acb32160a5ea77761`
- Location: `crates/orbit-common/src/fs/selector.rs` line 304
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:48:41Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/142

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-common/src/fs/selector.rs` line 304 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Rule remediated
`rust/path-injection` at `crates/orbit-common/src/fs/selector.rs:304` (CodeQL alert #142).

## Root cause
In `canonical_selector_in_workspace`'s legacy-path branch, `normalize_workspace_anchor` fully validated the caller-supplied anchor (canonicalized it, walked existing ancestors, and confirmed containment inside the canonicalized workspace root), but only returned the workspace-relative *string*. The caller then re-derived a second filesystem path from that string via `resolve_workspace_path(workspace, Path::new(&path))` and called `.is_dir()` on it. CodeQL's taint tracker could not follow the string-based validation performed several calls earlier and flagged the `.is_dir()` sink as operating on unsanitized, user-controlled input.

## Fix
`normalize_workspace_anchor` now returns `(String, PathBuf)`: the relative anchor string (unchanged, for selector formatting) plus the already-canonicalized, containment-checked `PathBuf` (`contained`) it validated internally. `canonical_selector_in_workspace` now calls `.is_dir()` directly on that returned, pre-validated `PathBuf` instead of reconstructing a path from tainted string data — removing the unsafe re-derivation CodeQL flagged, with no behavior change (same containment rules, same `dir:`/`file:` classification outcome). The `Selector` branch, which doesn't touch the filesystem, ignores the new `PathBuf` return value.

## Criteria mapping
1. Remediated at the exact flagged line/construct via a real code change (no `// codeql[...]` suppression, no query-filter exclusion). Confirmed no CodeQL config/suppression files exist in the repo (`.github/codeql/`, inline `codeql[...]` comments) — none were touched.
2. Behavior preserved: all pre-existing containment tests pass unchanged (symlink escape rejection, macOS `/var` alias handling, absolute/relative path rewriting, dir vs file classification). Added `legacy_path_dir_check_rejects_symlink_escaping_workspace` regression test exercising exactly the modified branch (a legacy no-prefix path through a symlink escaping the workspace) — confirms the `.is_dir()` probe never runs on an unvalidated path.
3. Validation run (see below); rule no longer applies to this construct since the sink now only ever receives the already-validated `PathBuf`, not a re-derived path from tainted input. Hosted CodeQL rescan/alert-closure verification is explicitly owned by the orchestrator post-merge per task comments, not this leaf.

## Validation
- `cargo check -p orbit-common` — passed
- `cargo check -p orbit-core` (downstream consumer of `canonical_selector_in_workspace`) — passed
- `cargo test -p orbit-common --lib` — 248 passed, 0 failed (incl. 23 `fs::selector` tests, 1 new)
- `make ci-fast` (fmt-check + guardrail scripts) — passed (ran `cargo fmt -p orbit-common` once to satisfy formatting, then reran clean)
- `make ci-lint` (workspace clippy, warnings denied) — passed
- `git diff --check` — no whitespace errors
- `git status --short` — only the two intended files changed (`crates/orbit-common/src/fs/selector.rs`, `crates/orbit-common/src/fs/tests/selector.rs`), both already in task `context_files`

## Scope
No context_files changes needed; both modified files were already listed.

## Remaining risk
None identified. Full `make ci` was intentionally not run locally per workspace policy (it's the PR merge gate). Hosted CodeQL alert-closure confirmation is an orchestrator-owned post-merge step per existing task comments.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11934-6aa242f4`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra