### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/auto_task/mod.rs

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -129,3 +129,9 @@ extensions:
           "path-injection",
           "manual",
         ]
+      - [
+          "orbit_store::driver::file::auto_task::validated_cursor_state_path",
+          "ReturnValue.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]",
+          "path-injection",
+          "manual",
+        ]

--- a/crates/orbit-store/src/driver/file/auto_task/mod.rs
+++ b/crates/orbit-store/src/driver/file/auto_task/mod.rs
@@ -45,14 +45,63 @@ pub fn cursor_lock_path(state_path: &Path) -> PathBuf {
 /// A missing file is empty state. An existing file that cannot be read or
 /// parsed is an error; callers must not treat that as a baseline or rewrite it.
 pub fn load_cursor_state(path: &Path) -> Result<AutoTaskCursorState, OrbitError> {
-    match fs::read_to_string(path) {
-        Ok(raw) => parse_state(&raw, path),
+    let validated = match validated_cursor_state_path(path)? {
+        Some(validated) => validated,
+        None => return Ok(AutoTaskCursorState::default()),
+    };
+
+    match fs::read_to_string(&validated) {
+        Ok(raw) => parse_state(&raw, &validated),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             Ok(AutoTaskCursorState::default())
         }
         Err(error) => Err(OrbitError::Io(format!(
             "unreadable auto-task cursor state {}: {error}; file left unchanged for investigation",
-            path.display()
+            validated.display()
+        ))),
+    }
+}
+
+/// Resolve `path` through its canonical parent dir, rejecting a symlinked
+/// target. `path` is built by [`cursor_state_path`] from a caller-selected
+/// state dir (workspace discovery, `--root`, or web dashboard workspace
+/// routing), so canonicalizing the parent and refusing to follow a symlinked
+/// result keeps the read inside the selected state dir instead of a planted
+/// symlink's target [ORB-11948]. `Ok(None)` means "no existing file", which
+/// callers treat as empty baseline state, matching prior behavior for a
+/// missing state dir or a missing data file.
+fn validated_cursor_state_path(path: &Path) -> Result<Option<PathBuf>, OrbitError> {
+    let Some(parent) = path.parent() else {
+        return Ok(Some(path.to_path_buf()));
+    };
+    let Some(file_name) = path.file_name() else {
+        return Ok(Some(path.to_path_buf()));
+    };
+
+    let canonical_parent = match parent.canonicalize() {
+        Ok(dir) => dir,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "failed to canonicalize auto-task state dir {}: {error}",
+                parent.display()
+            )));
+        }
+    };
+    let candidate = canonical_parent.join(file_name);
+
+    match fs::symlink_metadata(&candidate) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            Err(OrbitError::InvalidInput(format!(
+                "auto-task cursor state path must not be a symlink: {}",
+                candidate.display()
+            )))
+        }
+        Ok(_) => Ok(Some(candidate)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(OrbitError::Io(format!(
+            "failed to inspect auto-task cursor state path {}: {error}",
+            candidate.display()
         ))),
     }
 }

--- a/crates/orbit-store/src/driver/file/auto_task/tests/mod.rs
+++ b/crates/orbit-store/src/driver/file/auto_task/tests/mod.rs
@@ -114,6 +114,36 @@ fn empty_existing_file_is_malformed_not_a_baseline() {
     assert_eq!(fs::read_to_string(&path).expect("raw"), "");
 }
 
+/// [ORB-11948] A symlinked cursor-state file must not be followed: resolving
+/// through it would let a planted symlink redirect the read outside the
+/// selected state dir (e.g. toward an attacker-controlled path reached via a
+/// caller-selected workspace), so `load_cursor_state` rejects it outright
+/// instead of transparently reading the symlink target.
+#[cfg(unix)]
+#[test]
+fn load_cursor_state_rejects_a_symlinked_state_file() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempdir().expect("tempdir");
+    let path = cursor_state_path(root.path());
+    let outside_target = root
+        .path()
+        .parent()
+        .expect("state dir has parent")
+        .join("outside-auto-tasks.json");
+    fs::write(&outside_target, r#"{"definitions":{"leaked":{}}}"#)
+        .expect("write file outside state dir");
+    symlink(&outside_target, &path).expect("symlink cursor state file");
+
+    let error = load_cursor_state(&path).expect_err("symlinked state file");
+    assert!(
+        error.to_string().contains("must not be a symlink"),
+        "{error}"
+    );
+
+    fs::remove_file(&outside_target).expect("cleanup outside target");
+}
+
 #[test]
 fn concurrent_upserts_for_different_definitions_preserve_both_cursors() {
     let root = tempdir().expect("tempdir");


### PR DESCRIPTION
## Task

[ORB-11948](https://orbit-cli.com/tasks/ORB-11948) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-store/src/driver/file/auto_task/mod.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#366`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.27.0`, guid `unknown`)
- Message: This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `3fced6f6a6bcfc1d6e85aa5e876f0acbc7c85ada`
- Location: `crates/orbit-store/src/driver/file/auto_task/mod.rs` line 48
- Created: `2026-09-08T02:34:30Z`
- Updated: `2026-09-08T02:55:57Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/366

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-store/src/driver/file/auto_task/mod.rs` line 48 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Remediated CodeQL rust/path-injection alert #366 at crates/orbit-store/src/driver/file/auto_task/mod.rs:48 (`fs::read_to_string(path)` in `load_cursor_state`).

Root cause: `load_cursor_state` read the cursor-state file directly from a caller-supplied path built by `cursor_state_path(state_dir)`, where `state_dir` traces back to a caller-selected workspace (e.g. the `workspace` query param routed through `orbit-web`'s dashboard API in `crates/orbit-web/src/api/auto_tasks.rs`). CodeQL could not see that the workspace lookup is a whitelist match against registered entries, so it flagged the read as depending on a user-provided value.

Fix (matches the established pattern for this sweep, e.g. `orbit_core::runtime::validated_config_path` from ORB-11931): added a private `validated_cursor_state_path` helper in `crates/orbit-store/src/driver/file/auto_task/mod.rs` that canonicalizes the path's parent directory and rejects a symlinked target, returning `Ok(None)` for "no existing file" (preserving the existing missing-file-is-empty-state behavior) or `Ok(Some(validated_path))` for an existing regular file. `load_cursor_state` now reads through this validated path instead of the raw input, so a planted symlink at the cursor-state location can no longer redirect the read to an attacker-controlled file outside the selected state dir. No suppression, dismissal, or exclusion was used.

Registered the new function in `.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml` as a `path-injection` barrier (`orbit_store::driver::file::auto_task::validated_cursor_state_path`, `Ok(Some(_))` shape), consistent with the other ~20 entries in that model pack.

Behavior preserved: missing state dir, missing data file, malformed JSON, unreadable file, and concurrent/locked read-modify-write semantics are all unchanged and covered by existing tests, which still pass unmodified. Added one new regression test, `load_cursor_state_rejects_a_symlinked_state_file`, verifying a symlinked cursor-state file is rejected with an explicit "must not be a symlink" error rather than silently followed.

Acceptance criteria:
1. Remediated with a real code fix (new validation helper + CodeQL barrier registration), not a suppression/dismissal — done.
2. Intended behavior preserved while removing the unsafe direct-read data flow — done; all prior tests pass unchanged plus one new symlink-rejection test.
3. Ran repository's documented validation and security checks — done (see below). The hosted CodeQL rescan/alert-closure verification is explicitly owned by the orchestrator post-merge per task comments, not the implementation leaf.

Validation run (all passed):
- `cargo test -p orbit-store --lib driver::file::auto_task` — 9/9 passed (includes new symlink test).
- `cargo test -p orbit-store --lib` — 495 passed, 0 failed, 7 ignored.
- `make ci-fast` — passed (fmt-check reformatted the two touched Rust files to satisfy rustfmt; all guardrail scripts green, including dependency-direction guard).
- `make ci-lint` — passed (workspace-wide clippy, all targets, warnings denied; 0 warnings).
- `python3 scripts/check-codeql-extension-schema.py` — passed (validates the new barrier-model entry's YAML shape).
- `git diff --check` — clean (no whitespace errors).
- `git status --short` — only the 3 intended files touched: crates/orbit-store/src/driver/file/auto_task/mod.rs, crates/orbit-store/src/driver/file/auto_task/tests/mod.rs, .github/codeql/extensions/orbit-rust-path-validation/path-validation.yml.

Not run: actual hosted CodeQL rescan (no local CodeQL engine available in this environment; alert-closure verification is explicitly the orchestrator's responsibility post-merge per task comments).

Scope: touched only the three files above, all within the task's context_files boundary; no scope expansion needed.

Changes left uncommitted per workflow policy — pipeline owns commit/push/PR/merge.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11948-6aa24333`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra