### PR TITLE
[code-scanning-sweep] Fix rust/uncontrolled-allocation-size in crates/orbit-web/src/api/runs.rs

### DIFF
--- a/crates/orbit-web/src/api/runs.rs
+++ b/crates/orbit-web/src/api/runs.rs
@@ -22,6 +22,10 @@ use super::{
 const RUN_EVENTS_DEFAULT_LIMIT: usize = 100;
 /// Hard cap on rows scanned from a single run's persisted v2 audit events.
 pub(super) const RUN_EVENTS_MAX_SCAN_LINES: usize = 50_000;
+/// Capacity hint for the returned events page. A fixed constant rather than
+/// the caller-supplied `limit` so the allocation size never derives from
+/// request input, regardless of how large a `limit` a caller requests.
+const RUN_EVENTS_PAGE_CAPACITY_HINT: usize = 64;
 /// Maximum bytes included in stdout/stderr previews returned by run-log APIs.
 const RUN_LOG_PREVIEW_MAX_BYTES: usize = 8192;
 /// Maximum lines included in stdout/stderr previews returned by run-log APIs.
@@ -474,7 +478,7 @@ pub(super) async fn list_run_events(
             limit: Some(RUN_EVENTS_MAX_SCAN_LINES + 1),
             ..Default::default()
         })?;
-        let mut page: Vec<Value> = Vec::with_capacity(limit.min(64));
+        let mut page: Vec<Value> = Vec::with_capacity(RUN_EVENTS_PAGE_CAPACITY_HINT);
         let mut matched: usize = 0;
         let mut lines_scanned: usize = 0;
         let mut budget_exceeded = false;


### PR DESCRIPTION
## Task

[ORB-11951](https://orbit-cli.com/tasks/ORB-11951) — [code-scanning-sweep] Fix rust/uncontrolled-allocation-size in crates/orbit-web/src/api/runs.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#371`
- Rule: `rust/uncontrolled-allocation-size` (rust/uncontrolled-allocation-size)
- Security severity: `high`
- Tool: `CodeQL` (version `2.27.0`, guid `unknown`)
- Message: This allocation size is derived from a user-provided value and could allocate arbitrary amounts of memory.
- Ref: `refs/heads/agent-main`
- Commit: `3fced6f6a6bcfc1d6e85aa5e876f0acbc7c85ada`
- Location: `crates/orbit-web/src/api/runs.rs` line 477
- Created: `2026-09-08T03:05:49Z`
- Updated: `2026-09-08T03:16:32Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/371

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/uncontrolled-allocation-size` at `crates/orbit-web/src/api/runs.rs` line 477 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Remediated CodeQL rust/uncontrolled-allocation-size at crates/orbit-web/src/api/runs.rs (alert #371).

Root cause: `list_run_events` allocated `Vec::with_capacity(limit.min(64))` where `limit` is `bounded_limit(q.limit, RUN_EVENTS_DEFAULT_LIMIT)` — already clamped to <=200 (HISTORY_MAX_LIMIT) and further `.min(64)`'d at the call site, so the allocation was never actually unbounded. CodeQL's taint tracker still reported the finding because the `with_capacity` argument's data flow visibly originated from the query-string `limit` parameter, even though it passed through a clamp.

Fix: removed the data flow entirely rather than adding another clamp. Introduced `RUN_EVENTS_PAGE_CAPACITY_HINT: usize = 64` (compile-time constant) and changed the call to `Vec::with_capacity(RUN_EVENTS_PAGE_CAPACITY_HINT)`. The capacity argument no longer references `limit` or any request-derived value at all — it's purely a preallocation hint; `Vec` still grows dynamically via `push` if the page needs more than 64 slots (loop still bounds items pushed by `page.len() >= limit`, and `limit` itself remains capped at 200), so observable behavior (pagination, limits, budget-exceeded responses) is unchanged.

Acceptance criteria:
1. Real code fix (new named constant replacing the request-derived expression) at the exact flagged line; no suppression/dismissal/exclusion used. Done.
2. Behavior preserved: `limit` still governs how many events are returned/scanned; only the *capacity hint* source changed. Verified via existing test suite (all pass, including list_run_events_streams_small_page_from_oversized_fixture, list_run_events_kind_filter_still_works_with_streaming, list_run_events_returns_payload_too_large_when_scan_budget_exceeded).
3. Hosted CodeQL rescan/alert-closure is owned by the orchestrator post-merge per task comment (no local CodeQL CLI available in this workspace to rescan directly). Local static verification: the flagged allocation call site no longer contains any expression derived from `q.limit`/`limit`, which is what the rule's taint-flow sink required — grep-confirmed only one `with_capacity` call in the function, using the new named constant.

Validation run (all from repo root):
- `cargo build -p orbit-web` — passed.
- `cargo test -p orbit-web --lib api::tests::runs::` — 31/31 passed.
- `cargo fmt --check -p orbit-web` — passed, no diff.
- `make ci-fast` — passed (one pre-existing sandbox-only skip: test-compiler-cache-namespaces, unrelated, reports "cannot create a mount namespace" under bwrap, not caused by this change).
- `make ci-lint` — passed, workspace clippy clean, no warnings.
- `git diff --check` / `git status --short` — clean; only crates/orbit-web/src/api/runs.rs modified (context_files already listed it; tests file inspected but needed no changes since existing coverage already exercises the changed code path).

No blockers. Left uncommitted per pipeline ownership of commit/PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11951-6aa244a6`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra