### PR TITLE
[code-scanning-sweep] Fix rust/uncontrolled-allocation-size in crates/orbit-web/src/log_format.rs

### DIFF
--- a/crates/orbit-web/src/log_format.rs
+++ b/crates/orbit-web/src/log_format.rs
@@ -186,7 +186,9 @@ pub(crate) fn read_recent_matching_events_from<R: Read + Seek>(
         return Ok(Vec::new());
     }
 
-    let mut newest_first = Vec::with_capacity(limit);
+    // `limit` ultimately originates at the request boundary. Grow this vector
+    // only as matching records are found rather than preallocating from it.
+    let mut newest_first = Vec::new();
     let mut carry = Vec::new();
     let mut buf = Vec::new();
 

--- a/crates/orbit-web/src/tests/log_format.rs
+++ b/crates/orbit-web/src/tests/log_format.rs
@@ -221,6 +221,19 @@ fn reverse_scan_zero_limit_returns_empty_without_reading() {
 }
 
 #[test]
+fn reverse_scan_does_not_preallocate_from_requested_limit() {
+    let raw = join_lines(
+        &[event_line("2026-04-27T01:00:01Z", "orbit.keep", "only")],
+        true,
+    );
+
+    let events = scan(&raw, &Filters::default(), usize::MAX, 16);
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["fields"]["message"], "only");
+}
+
+#[test]
 fn missing_log_file_returns_empty() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("missing.jsonl");


### PR DESCRIPTION
## Task

[ORB-11950](https://orbit-cli.com/tasks/ORB-11950) — [code-scanning-sweep] Fix rust/uncontrolled-allocation-size in crates/orbit-web/src/log_format.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#368`
- Rule: `rust/uncontrolled-allocation-size` (rust/uncontrolled-allocation-size)
- Security severity: `high`
- Tool: `CodeQL` (version `2.27.0`, guid `unknown`)
- Message: This allocation size is derived from a user-provided value and could allocate arbitrary amounts of memory. This allocation size is derived from a user-provided value and could allocate arbitrary amounts of memory.
- Ref: `refs/heads/agent-main`
- Commit: `3fced6f6a6bcfc1d6e85aa5e876f0acbc7c85ada`
- Location: `crates/orbit-web/src/log_format.rs` line 189
- Created: `2026-09-08T02:48:50Z`
- Updated: `2026-09-08T02:55:57Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/368

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/uncontrolled-allocation-size` at `crates/orbit-web/src/log_format.rs` line 189 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced `Vec::with_capacity(limit)` in the reverse JSONL scan with incremental growth, so the request-derived result limit is no longer used as an upfront allocation size.
- Added a regression test that scans a one-record log with `usize::MAX` as the requested limit and verifies normal output without preallocation.

Criteria:
1. The CodeQL sink at `log_format.rs:189` was removed with a behavior-preserving code fix; no suppression, dismissal, or exclusion was added.
2. Backward scan ordering and filtering remain unchanged; the focused test suite passes, including the oversized-limit regression.
3. Validation passed: `cargo fmt --all -- --check`; `cargo test -p orbit-web log_format` (13 passed); `make ci-fast`; `make ci-lint`; `CARGO_DENY_DB_PATH=/tmp/orb-11950-deny.0prg3Y make audit`; and `git diff --check`.

Security validation: local `codeql` was not installed, so an on-host CodeQL rerun was unavailable. Source inspection confirms the flagged `Vec::with_capacity(limit)` sink and its `uncontrolled-allocation-size` pattern are absent. Per the task refinement, hosted CodeQL rescan and alert closure are owned by the orchestrator after merge. The initial plain `make audit` was blocked by the read-only default advisory database; it passed when rerun with the documented writable `CARGO_DENY_DB_PATH` override.

Assessment: two task-scoped source files are modified; no unrelated changes or residual generated artifacts are present.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11950-6aa24468`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra