### PR TITLE
Keep malformed task-pilot selectors from failing an entire partition

### DIFF
--- a/.orbit/resources/activities/task_pilot.yaml
+++ b/.orbit/resources/activities/task_pilot.yaml
@@ -41,6 +41,12 @@ spec:
         type: number
       crew:
         type: string
+      repair_attempt:
+        type: boolean
+      validation_errors:
+        type: array
+        items:
+          type: string
   # Agent-returned data is advisory until apply_task_pilot_results validates
   # the complete fan-in, so keep fields optional at this boundary (no
   # `required` list at any level) and let that validation step — not this
@@ -133,6 +139,12 @@ spec:
     task tools using the temporary checkout path.
 
     For every task:
+
+    If `repair_attempt` is true, this is the single targeted repair attempt for
+    an assessment rejected by deterministic apply. Reassess only the supplied
+    task IDs at the original `source_revision`, and correct every exact message
+    in `validation_errors`. Do not revisit successful siblings or resolve a new
+    source revision. The repaired output is validated through the same boundary.
 
     1. Call `orbit.task.show` and read its title, description, acceptance
        criteria, plan, tags, relations, status, and exact current

--- a/crates/orbit-core/assets/activities/apply_task_pilot_results.yaml
+++ b/crates/orbit-core/assets/activities/apply_task_pilot_results.yaml
@@ -5,11 +5,14 @@ metadata:
 spec:
   type: deterministic
   description: >
-    Partition-isolated, fail-closed task-pilot apply boundary. It validates each
-    partition's exact before snapshots, dispositions, canonical in-workspace
+    Task-isolated, fail-closed task-pilot apply boundary. It validates each
+    partition envelope, then each task's exact before snapshot, disposition, in-workspace
     file/dir/symbol selectors, and target existence against the prepared source
-    revision when one was pinned. Stale or malformed partitions are reported
-    without writes while independently valid partitions still apply. Every other task
+    revision when one was pinned. Harmless bare relative file and directory
+    targets are normalized from that pinned tree with the original and normalized
+    values retained. Stale or malformed tasks are reported without writes while
+    independently valid siblings still apply. Each accepted task mutation and
+    idempotency receipt commits atomically. Every other task
     field, lifecycle state, dispatch state, and recommendation remains unchanged
     unless a CI sweep supplies its exact filing record and explicit promotion
     authority. In that mode only a proposed, selector-backed task with no
@@ -35,12 +38,20 @@ spec:
         oneOf:
           - type: object
           - type: "null"
+      prior_applied_count:
+        type: number
+      carried_task_outcomes:
+        type: array
+        items:
+          type: object
   output_schema_json:
     type: object
     required:
       [status, error, mode, workspace_path, source, discovery,
        partition_decisions, partition_count, received_partition_count,
-       failed_partitions, skipped_stale_partitions, tasks, ci_sweep_admission]
+       failed_partitions, skipped_stale_partitions, task_outcomes, applied_count,
+       unresolved_count, repair_count, repair_partitions, repair_prepared,
+       non_repairable_outcomes, tasks, ci_sweep_admission]
     properties:
       status:
         type: string
@@ -73,6 +84,26 @@ spec:
         items:
           type: object
       skipped_stale_partitions:
+        type: array
+        items:
+          type: object
+      task_outcomes:
+        type: array
+        items:
+          type: object
+      applied_count:
+        type: number
+      unresolved_count:
+        type: number
+      repair_count:
+        type: number
+      repair_partitions:
+        type: array
+        items:
+          type: object
+      repair_prepared:
+        type: object
+      non_repairable_outcomes:
         type: array
         items:
           type: object

--- a/crates/orbit-core/assets/activities/task_pilot.yaml
+++ b/crates/orbit-core/assets/activities/task_pilot.yaml
@@ -41,6 +41,12 @@ spec:
         type: number
       crew:
         type: string
+      repair_attempt:
+        type: boolean
+      validation_errors:
+        type: array
+        items:
+          type: string
   # Agent-returned data is advisory until apply_task_pilot_results validates
   # the complete fan-in, so keep fields optional at this boundary (no
   # `required` list at any level) and let that validation step — not this
@@ -133,6 +139,12 @@ spec:
     task tools using the temporary checkout path.
 
     For every task:
+
+    If `repair_attempt` is true, this is the single targeted repair attempt for
+    an assessment rejected by deterministic apply. Reassess only the supplied
+    task IDs at the original `source_revision`, and correct every exact message
+    in `validation_errors`. Do not revisit successful siblings or resolve a new
+    source revision. The repaired output is validated through the same boundary.
 
     1. Call `orbit.task.show` and read its title, description, acceptance
        criteria, plan, tags, relations, status, and exact current

--- a/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
@@ -13,12 +13,14 @@
 # Prepare resolves an omitted base branch through the owning workspace's
 # `workflow.base_branch`; a non-empty run input remains an explicit override.
 # Any successful partition reaches apply even if another agent failed.
-# Apply isolates stale or malformed assessments by partition, applies
-# every independently valid partition, then a guard fails the total run when
-# any partition did not apply. Selector existence is validated against the
-# prepared source revision, not a later checkout. Apply normally changes only context_files. A CI sweep may pass its exact filing record plus
-# literal promotion authority; only then can apply promote a warning-free,
-# selector-backed proposed repair to backlog.
+# Apply rejects untrusted partition envelopes, then isolates stale or malformed
+# assessments by task and applies every independently valid sibling. The guard
+# fails the total run while any task remains unresolved. Bare relative file and
+# directory targets are normalized only from the pinned source tree. Selector
+# existence is validated against the prepared source revision, not a later
+# checkout. Apply normally changes only context_files. A CI sweep may pass its
+# exact filing record plus literal promotion authority; only then can apply
+# promote a warning-free, selector-backed proposed repair to backlog.
 #
 # Crew resolution
 # - The pilot step names the `system` crew directly, so this definition states
@@ -93,8 +95,51 @@ spec:
         promotion_authorized: "{{ input.promotion_authorized }}"
         ci_sweep_filing: "{{ input.ci_sweep_filing }}"
 
-    - id: require_apply_success
+    - id: repair_pilots
+      when: "{{ steps.apply.output.repair_count }} != 0"
+      fan_out:
+        items: "{{ steps.apply.output.repair_partitions }}"
+        max_workers: 5
+        worker:
+          id: repair_pilot
+          target: activity:task_pilot
+          default_input:
+            task_ids: "{{ item.task_ids }}"
+            partition_index: "{{ item.partition_index }}"
+            validation_errors: "{{ item.validation_errors }}"
+            repair_attempt: true
+            workspace_path: "{{ steps.prepare.output.workspace_path }}"
+            base_branch: "{{ steps.prepare.output.source.base_branch }}"
+            source_revision: "{{ steps.prepare.output.source.source_revision }}"
+            inspection_revision: "{{ steps.prepare.output.source.source_revision }}"
+            crew: system
+      fan_in:
+        join:
+          mode: any
+        collect: repair_results
+
+    - id: apply_repairs
+      when: "{{ steps.apply.output.repair_count }} != 0"
+      target: activity:apply_task_pilot_results
+      default_input:
+        prepared: "{{ steps.apply.output.repair_prepared }}"
+        results: "{{ steps.repair_results.output }}"
+        workspace_path: "{{ steps.prepare.output.workspace_path }}"
+        promotion_authorized: "{{ input.promotion_authorized }}"
+        ci_sweep_filing: "{{ input.ci_sweep_filing }}"
+        prior_applied_count: "{{ steps.apply.output.applied_count }}"
+        carried_task_outcomes: "{{ steps.apply.output.non_repairable_outcomes }}"
+
+    - id: require_initial_apply_success
+      when: "{{ steps.apply.output.repair_count }} == 0"
       target: activity:pipeline_success_guard
       default_input:
         context: task-pilot partition apply
         result: "{{ steps.apply.output }}"
+
+    - id: require_repair_apply_success
+      when: "{{ steps.apply.output.repair_count }} != 0"
+      target: activity:pipeline_success_guard
+      default_input:
+        context: task-pilot targeted repair apply
+        result: "{{ steps.apply_repairs.output }}"

--- a/crates/orbit-core/assets/skills/orbit/references/workflows.md
+++ b/crates/orbit-core/assets/skills/orbit/references/workflows.md
@@ -66,7 +66,7 @@ not a rewrite of failed history.
 | `task_local_pipeline` | Implement in a worktree and merge to the configured local base without a PR; optional push. |
 | `task_auto_pipeline` | Discover ready backlog tasks and ship them. |
 | `task_gate_pipeline` | Gated shipment with windowing and starvation handling. |
-| `task_pilot_pipeline` | Read-only agent preflight plus deterministic validated-selector apply; it defaults to no lifecycle promotion. An omitted optional `base_branch` binds as empty at the prepare activity boundary, then preparation resolves the owning workspace's `[workflow] base_branch`; pass a non-empty run input to inspect another branch. |
+| `task_pilot_pipeline` | Read-only agent preflight plus deterministic task-isolated apply. Apply normalizes only unambiguous bare file/directory targets from the pinned source, records the normalization, and commits valid siblings even when another assessment is invalid or stale; the overall run still fails while anything is unresolved. Replays use durable per-task operation receipts. It defaults to no lifecycle promotion. An omitted optional `base_branch` binds as empty at the prepare activity boundary, then preparation resolves the owning workspace's `[workflow] base_branch`; pass a non-empty run input to inspect another branch. |
 | `task_triage_pipeline` | Diagnose tasks blocked by failed runs. |
 | `epic_pipeline` | Ship an epic and its descendants against one worktree. |
 | `workspace_ship_pipeline` / `workspace_auto_pipeline` | Workspace-scoped wrappers that resolve mode and base branch, then invoke the pipelines above. |

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs
@@ -977,14 +977,32 @@ fn pipeline_wait_entry_failure(label: &str, entry: &Value) -> Option<String> {
         return None;
     }
 
-    let run_id = entry
-        .get("run_id")
-        .and_then(Value::as_str)
-        .unwrap_or("<unknown>");
     let error = entry
         .get("error")
         .and_then(Value::as_str)
         .filter(|value| !value.trim().is_empty());
+    if entry.get("partition_decisions").is_some() {
+        let applied = entry
+            .get("applied_count")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let unresolved = entry
+            .get("unresolved_count")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        return Some(match error {
+            Some(error) => format!(
+                "{label} task-pilot apply status {status}: {error} ({applied} applied, {unresolved} unresolved)"
+            ),
+            None => format!(
+                "{label} task-pilot apply status {status} ({applied} applied, {unresolved} unresolved)"
+            ),
+        });
+    }
+    let run_id = entry
+        .get("run_id")
+        .and_then(Value::as_str)
+        .unwrap_or("<unknown>");
     Some(match error {
         Some(error) => format!("{label} run {run_id} status {status}: {error}"),
         None => format!("{label} run {run_id} status {status}"),

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
@@ -27,6 +27,8 @@ mod source;
 mod validation_tools;
 
 pub(super) use apply::apply;
+#[cfg(test)]
+pub(super) use apply::inject_concurrent_edit_before_locked_apply;
 use source::{GitPathKind, SourceSnapshot, requested_base_branch, resolve_source_snapshot};
 use validation_tools::ImplementationLane;
 
@@ -418,6 +420,11 @@ fn task_snapshot(
     })
 }
 
+struct ValidatedSelectors {
+    values: Vec<String>,
+    normalizations: Vec<Value>,
+}
+
 fn validate_after_selectors(
     action: &str,
     task_id: &str,
@@ -426,7 +433,7 @@ fn validate_after_selectors(
     selectors: &[String],
     workspace_root: &Path,
     source: Option<&SourceSnapshot>,
-) -> Result<(), DispatchError> {
+) -> Result<ValidatedSelectors, DispatchError> {
     if selectors.is_empty() {
         if !matches!(disposition, "verified_no_diff" | "host_operational") {
             return Err(action_failed(
@@ -437,7 +444,10 @@ fn validate_after_selectors(
             ));
         }
         required_string(assessment, "evidence", action)?;
-        return Ok(());
+        return Ok(ValidatedSelectors {
+            values: Vec::new(),
+            normalizations: Vec::new(),
+        });
     }
     if disposition != "selectors" {
         return Err(action_failed(
@@ -449,24 +459,83 @@ fn validate_after_selectors(
     }
 
     let mut seen = BTreeSet::new();
+    let mut values = Vec::with_capacity(selectors.len());
+    let mut normalizations = Vec::new();
     for selector in selectors {
         let trimmed = selector.trim();
-        if !matches!(
+        let has_kind = matches!(
             trimmed.split_once(':').map(|(kind, _)| kind),
             Some("file" | "dir" | "symbol")
-        ) {
-            return Err(action_failed(
-                action,
-                format!("task {task_id} selector {selector:?} must use file:, dir:, or symbol:"),
-            ));
-        }
+        );
+        let candidate = if has_kind {
+            trimmed.to_string()
+        } else {
+            if trimmed.contains(':') {
+                return Err(action_failed(
+                    action,
+                    format!(
+                        "task {task_id} bare selector {selector:?} is ambiguous because it contains ':'"
+                    ),
+                ));
+            }
+            let source = source.ok_or_else(|| {
+                action_failed(
+                    action,
+                    format!(
+                        "task {task_id} selector {selector:?} must use file:, dir:, or symbol: when no pinned source is available"
+                    ),
+                )
+            })?;
+            let path_candidate =
+                canonical_selector(&format!("file:{trimmed}")).map_err(|error| {
+                    action_failed(
+                        action,
+                        format!("task {task_id} bare selector {selector:?} is invalid: {error}"),
+                    )
+                })?;
+            let anchor = anchor_path(&path_candidate).map_err(|error| {
+                action_failed(
+                    action,
+                    format!("task {task_id} bare selector {selector:?} is invalid: {error}"),
+                )
+            })?;
+            let kind = source.path_kind(action, workspace_root, &anchor)?;
+            let normalized = match kind {
+                GitPathKind::Blob => path_candidate,
+                GitPathKind::Tree => canonical_selector(&format!("dir:{trimmed}"))
+                    .map_err(|error| action_failed(action, error.to_string()))?,
+                GitPathKind::Missing => {
+                    return Err(action_failed(
+                        action,
+                        format!(
+                            "task {task_id} bare selector {selector:?} does not resolve at pinned source revision {}",
+                            source.source_revision
+                        ),
+                    ));
+                }
+                GitPathKind::Other => {
+                    return Err(action_failed(
+                        action,
+                        format!(
+                            "task {task_id} bare selector {selector:?} has an unsupported or ambiguous kind at pinned source revision {}",
+                            source.source_revision
+                        ),
+                    ));
+                }
+            };
+            normalizations.push(json!({
+                "original": selector,
+                "normalized": normalized,
+            }));
+            normalized
+        };
         // A dirty primary may replace an anchor with a symlink or a different
         // kind. Only syntax comes from this parser; pinned Git objects own
         // containment and target validation when source identity is present.
         let canonical = if source.is_some() {
-            canonical_selector(trimmed)
+            canonical_selector(&candidate)
         } else {
-            canonical_selector_in_workspace(trimmed, workspace_root)
+            canonical_selector_in_workspace(&candidate, workspace_root)
         }
         .map_err(|error| {
             action_failed(
@@ -474,7 +543,7 @@ fn validate_after_selectors(
                 format!("task {task_id} selector {selector:?} is invalid: {error}"),
             )
         })?;
-        if canonical != trimmed {
+        if has_kind && canonical != trimmed {
             return Err(action_failed(
                 action,
                 format!(
@@ -501,8 +570,12 @@ fn validate_after_selectors(
                 format!("task {task_id} repeats selector {selector:?}"),
             ));
         }
+        values.push(candidate);
     }
-    Ok(())
+    Ok(ValidatedSelectors {
+        values,
+        normalizations,
+    })
 }
 
 /// Whether a validated assessment leaves the task ready for the state
@@ -576,6 +649,56 @@ fn validate_recommendations(
                 format!("task {task_id} is missing {field} recommendation"),
             ));
         }
+    }
+    validate_optional_finding(
+        action,
+        task_id,
+        assessment,
+        "duplicate_of",
+        &["task_id", "evidence"],
+    )?;
+    validate_optional_finding(action, task_id, assessment, "already_landed", &["evidence"])?;
+    validate_optional_finding(
+        action,
+        task_id,
+        assessment,
+        "release_action_required",
+        &["action", "evidence"],
+    )?;
+    Ok(())
+}
+
+fn validate_optional_finding(
+    action: &str,
+    task_id: &str,
+    assessment: &Value,
+    field: &str,
+    required_fields: &[&str],
+) -> Result<(), DispatchError> {
+    let Some(value) = assessment.get(field) else {
+        return Ok(());
+    };
+    if value.is_null() {
+        return Ok(());
+    }
+    let object = value.as_object().ok_or_else(|| {
+        action_failed(
+            action,
+            format!("task {task_id} {field} must be an object or null"),
+        )
+    })?;
+    for required in required_fields {
+        object
+            .get(*required)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                action_failed(
+                    action,
+                    format!("task {task_id} {field}.{required} must be a non-empty string"),
+                )
+            })?;
     }
     Ok(())
 }

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs
@@ -1,15 +1,19 @@
-//! Partition-isolated validation and compare-and-set application for task pilots.
+//! Task-isolated validation, idempotent recovery, and atomic application for task pilots.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use orbit_common::OrbitError;
 use orbit_engine::DispatchError;
+use orbit_store::contracts::{AtomicTaskMutationOutcome, AtomicTaskMutationParams};
+use orbit_types::record::OrbitEvent;
 use orbit_types::task::{Task, TaskStatus};
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 
 use crate::OrbitRuntime;
 use crate::adapter::engine_host::v2_host::ci_failure_admission;
+#[cfg(test)]
 use crate::application::task::TaskUpdateParams;
 
 use super::source::SourceSnapshot;
@@ -37,7 +41,10 @@ struct ValidatedTask {
     assessment: Value,
     admission: Option<Value>,
     promote: bool,
+    operation_id: String,
 }
+
+const STORAGE_APPLY_ATTEMPTS: usize = 3;
 
 pub(in super::super) fn apply(
     runtime: &OrbitRuntime,
@@ -80,6 +87,20 @@ pub(in super::super) fn apply(
         .get("results")
         .and_then(Value::as_array)
         .ok_or_else(|| action_failed(action, "`results` must be an array"))?;
+    let prior_applied_count = input
+        .get("prior_applied_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let carried_task_outcomes = input
+        .get("carried_task_outcomes")
+        .map(|value| {
+            value
+                .as_array()
+                .cloned()
+                .ok_or_else(|| action_failed(action, "carried_task_outcomes must be an array"))
+        })
+        .transpose()?
+        .unwrap_or_default();
     let claim = crate::application::automation::members::claim(runtime, prepared_value)
         .map_err(|error| action_failed(action, error.to_string()))?;
     let source = SourceSnapshot::from_prepared(prepared_value, action)?;
@@ -293,27 +314,41 @@ pub(in super::super) fn apply(
             ));
             continue;
         }
+        let assessment_ids = assessments_by_id.keys().cloned().collect::<BTreeSet<_>>();
+        let expected_id_set = expected_ids.iter().cloned().collect::<BTreeSet<_>>();
+        if assessment_ids != expected_id_set {
+            partition_decisions.push(failed_partition(
+                expected_index,
+                &expected_ids,
+                format!(
+                    "partition {expected_index} task assessment identities do not match the prepared partition"
+                ),
+            ));
+            continue;
+        }
 
-        let mut validated = Vec::with_capacity(expected_ids.len());
-        let mut stale = Vec::new();
-        let mut validation_error = None;
+        let mut outcomes = Vec::with_capacity(expected_ids.len());
+        let mut applied_task_ids = Vec::new();
         for task_id in &expected_ids {
             let Some(assessment) = assessments_by_id.get(task_id) else {
-                validation_error =
-                    Some(format!("partition {expected_index} omitted task {task_id}"));
-                break;
+                outcomes.push(task_outcome(
+                    task_id,
+                    "invalid",
+                    Some(format!("partition {expected_index} omitted task {task_id}")),
+                ));
+                continue;
             };
             let snapshot = &prepared_before[task_id];
             let reported_before =
                 match required_string_array(assessment, "context_files_before", action) {
                     Ok(before) => before,
                     Err(error) => {
-                        validation_error = Some(error.to_string());
-                        break;
+                        outcomes.push(task_outcome(task_id, "invalid", Some(error.to_string())));
+                        continue;
                     }
                 };
             if reported_before != snapshot.context_files {
-                stale.push(stale_task(
+                outcomes.push(stale_task(
                     task_id,
                     "reported_context_snapshot_mismatch",
                     "agent context_files_before does not match this run's prepared snapshot",
@@ -323,37 +358,42 @@ pub(in super::super) fn apply(
             let disposition = match required_string(assessment, "disposition", action) {
                 Ok(value) => value,
                 Err(error) => {
-                    validation_error = Some(error.to_string());
-                    break;
+                    outcomes.push(task_outcome(task_id, "invalid", Some(error.to_string())));
+                    continue;
                 }
             };
-            let after = match required_string_array(assessment, "context_files_after", action) {
-                Ok(value) => value,
-                Err(error) => {
-                    validation_error = Some(error.to_string());
-                    break;
-                }
-            };
-            if let Err(error) = validate_after_selectors(
+            let proposed_after =
+                match required_string_array(assessment, "context_files_after", action) {
+                    Ok(value) => value,
+                    Err(error) => {
+                        outcomes.push(task_outcome(task_id, "invalid", Some(error.to_string())));
+                        continue;
+                    }
+                };
+            let selectors = match validate_after_selectors(
                 action,
                 task_id,
                 disposition,
                 assessment,
-                &after,
+                &proposed_after,
                 &workspace_root,
                 source.as_ref(),
             ) {
-                validation_error = Some(error.to_string());
-                break;
-            }
+                Ok(selectors) => selectors,
+                Err(error) => {
+                    outcomes.push(task_outcome(task_id, "invalid", Some(error.to_string())));
+                    continue;
+                }
+            };
+            let after = selectors.values;
             if let Err(error) = validate_recommendations(action, task_id, assessment) {
-                validation_error = Some(error.to_string());
-                break;
+                outcomes.push(task_outcome(task_id, "invalid", Some(error.to_string())));
+                continue;
             }
             let current = match runtime.get_task(task_id) {
                 Ok(task) => task,
                 Err(OrbitError::NotFound { .. }) => {
-                    stale.push(stale_task(
+                    outcomes.push(stale_task(
                         task_id,
                         "task_deleted",
                         "task no longer exists after preparation",
@@ -361,14 +401,14 @@ pub(in super::super) fn apply(
                     continue;
                 }
                 Err(error) => {
-                    validation_error = Some(format!("reload task {task_id}: {error}"));
-                    break;
+                    outcomes.push(task_outcome(
+                        task_id,
+                        "apply_failed",
+                        Some(format!("reload task {task_id}: {error}")),
+                    ));
+                    continue;
                 }
             };
-            if let Some(reason) = task_snapshot_drift(runtime, &current, snapshot) {
-                stale.push(stale_task(task_id, reason.0, reason.1));
-                continue;
-            }
             // The pilot never sees the deterministic feasibility findings, so
             // apply attaches them here: every downstream readiness and
             // admission rule then reads one assessment that carries both the
@@ -378,6 +418,11 @@ pub(in super::super) fn apply(
                 fields.insert(
                     VALIDATION_TOOL_WARNINGS.to_string(),
                     json!(snapshot.validation_tool_warnings),
+                );
+                fields.insert("context_files_after".to_string(), json!(after));
+                fields.insert(
+                    "selector_normalizations".to_string(),
+                    json!(selectors.normalizations),
                 );
             }
 
@@ -397,66 +442,113 @@ pub(in super::super) fn apply(
             {
                 Ok(admission) => admission,
                 Err(error) => {
-                    validation_error = Some(error.to_string());
-                    break;
+                    outcomes.push(task_outcome(task_id, "invalid", Some(error.to_string())));
+                    continue;
                 }
             };
             let promote = admission
                 .as_ref()
                 .is_some_and(|decision| decision["decision"] == "promote");
-            validated.push(ValidatedTask {
+            let operation_id = task_operation_id(prepared_value, task_id, &assessment);
+            let validated = ValidatedTask {
                 task_id: task_id.clone(),
                 after,
                 assessment,
                 admission,
                 promote,
-            });
-        }
-        if let Some(error) = validation_error {
-            partition_decisions.push(failed_partition(expected_index, &expected_ids, error));
-            continue;
-        }
-        if !stale.is_empty() {
-            partition_decisions.push(stale_partition(expected_index, &expected_ids, stale));
-            continue;
+                operation_id,
+            };
+
+            inject_concurrent_edit(runtime, task_id)
+                .map_err(|error| action_failed(action, error.to_string()))?;
+            match apply_task(runtime, snapshot, &validated, prepared_value) {
+                Ok(ApplyTaskOutcome::Applied(fingerprint)) => {
+                    if let Some(fingerprint) = fingerprint {
+                        resulting_fingerprints.insert(task_id.clone(), fingerprint);
+                    }
+                    applied_task_ids.push(task_id.clone());
+                    outcomes.push(task_outcome(task_id, "applied", None));
+                    record_applied_assessment(
+                        validated,
+                        snapshot,
+                        "applied",
+                        &mut task_results,
+                        &mut ci_sweep_admission,
+                    );
+                }
+                Ok(ApplyTaskOutcome::AlreadyApplied(fingerprint)) => {
+                    if let Some(fingerprint) = fingerprint {
+                        resulting_fingerprints.insert(task_id.clone(), fingerprint);
+                    }
+                    applied_task_ids.push(task_id.clone());
+                    outcomes.push(task_outcome(task_id, "already_applied", None));
+                    record_applied_assessment(
+                        validated,
+                        snapshot,
+                        "already_applied",
+                        &mut task_results,
+                        &mut ci_sweep_admission,
+                    );
+                }
+                Ok(ApplyTaskOutcome::Stale(reason, detail)) => {
+                    outcomes.push(stale_task(task_id, reason, detail));
+                }
+                Err(error) => outcomes.push(task_outcome(
+                    task_id,
+                    "apply_failed",
+                    Some(error.to_string()),
+                )),
+            }
         }
 
-        match apply_partition(runtime, &prepared_before, &validated, prepared_value) {
-            Ok(ApplyPartitionOutcome::Applied(fingerprints)) => {
-                resulting_fingerprints.extend(fingerprints);
-                let mut applied_task_ids = Vec::with_capacity(validated.len());
-                for mut task in validated {
-                    let changed = prepared_before[&task.task_id].context_files != task.after;
-                    if let Value::Object(fields) = &mut task.assessment {
-                        fields.insert("applied".to_string(), Value::Bool(changed || task.promote));
-                        if let Some(admission) = task.admission.clone() {
-                            fields.insert("ci_sweep_admission".to_string(), admission);
-                        }
-                    }
-                    if let Some(admission) = task.admission {
-                        ci_sweep_admission.push(admission);
-                    }
-                    applied_task_ids.push(task.task_id);
-                    task_results.push(task.assessment);
-                }
-                partition_decisions.push(json!({
-                    "partition_index": expected_index,
-                    "task_ids": expected_ids,
-                    "outcome": "applied",
-                    "applied_task_ids": applied_task_ids,
-                }));
-            }
-            Ok(ApplyPartitionOutcome::Stale(stale)) => {
-                partition_decisions.push(stale_partition(expected_index, &expected_ids, stale));
-            }
-            Err(error) => {
-                partition_decisions.push(failed_partition(
-                    expected_index,
-                    &expected_ids,
-                    error.to_string(),
-                ));
-            }
-        }
+        let unresolved = outcomes
+            .iter()
+            .filter(|outcome| {
+                !matches!(
+                    outcome["outcome"].as_str(),
+                    Some("applied" | "already_applied")
+                )
+            })
+            .count();
+        let outcome = if unresolved == 0 {
+            "applied"
+        } else if applied_task_ids.is_empty()
+            && outcomes.iter().all(|outcome| outcome["outcome"] == "stale")
+        {
+            "skipped_stale"
+        } else if applied_task_ids.is_empty() {
+            "failed"
+        } else {
+            "partial"
+        };
+        let error = outcomes.iter().find_map(|task| {
+            (!matches!(
+                task["outcome"].as_str(),
+                Some("applied" | "already_applied")
+            ))
+            .then(|| {
+                task.get("error")
+                    .and_then(Value::as_str)
+                    .or_else(|| task.get("detail").and_then(Value::as_str))
+                    .map(ToOwned::to_owned)
+            })
+            .flatten()
+        });
+        let stale_tasks = outcomes
+            .iter()
+            .filter(|task| task["outcome"] == "stale")
+            .cloned()
+            .collect::<Vec<_>>();
+        partition_decisions.push(json!({
+            "partition_index": expected_index,
+            "task_ids": expected_ids,
+            "outcome": outcome,
+            "applied_task_ids": applied_task_ids,
+            "task_outcomes": outcomes,
+            "unresolved_count": unresolved,
+            "error": error,
+            "stale_tasks": stale_tasks,
+        }));
     }
 
     if seen_task_ids.len() != prepared_before.len() {
@@ -471,57 +563,145 @@ pub(in super::super) fn apply(
             "task_ids": [],
             "outcome": "failed",
             "error": format!("unexpected extra partition result at position {position}"),
+            "unresolved_count": 1,
+            "applied_task_ids": [],
+            "task_outcomes": [],
         }));
     }
 
     let failed_partitions = partition_decisions
         .iter()
-        .filter(|decision| decision["outcome"] == "failed")
+        .filter(|decision| matches!(decision["outcome"].as_str(), Some("failed" | "partial")))
         .cloned()
         .collect::<Vec<_>>();
+    let own_task_outcomes = partition_decisions
+        .iter()
+        .filter_map(|decision| decision["task_outcomes"].as_array())
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>();
+    let mut task_outcomes = carried_task_outcomes.clone();
+    task_outcomes.extend(own_task_outcomes.iter().cloned());
     let skipped_stale_partitions = partition_decisions
         .iter()
         .filter(|decision| decision["outcome"] == "skipped_stale")
         .cloned()
         .collect::<Vec<_>>();
-    let applied_partitions = partition_decisions
-        .iter()
-        .filter(|decision| decision["outcome"] == "applied")
-        .count();
-    let succeeded = failed_partitions.is_empty() && skipped_stale_partitions.is_empty();
+    let applied_tasks = prior_applied_count as usize
+        + partition_decisions
+            .iter()
+            .filter_map(|decision| decision["applied_task_ids"].as_array())
+            .map(Vec::len)
+            .sum::<usize>();
+    let unresolved_tasks = carried_task_outcomes.len() as u64
+        + partition_decisions
+            .iter()
+            .filter_map(|decision| decision.get("unresolved_count").and_then(Value::as_u64))
+            .sum::<u64>();
+    let succeeded = failed_partitions.is_empty()
+        && skipped_stale_partitions.is_empty()
+        && carried_task_outcomes.is_empty();
     let status = if succeeded { "succeeded" } else { "failed" };
     let error = (!succeeded).then(|| {
-        let stale_tasks = skipped_stale_partitions
+        let first_unresolved = partition_decisions
             .iter()
-            .flat_map(|partition| partition["stale_tasks"].as_array())
-            .flatten()
-            .filter_map(|task| {
+            .find_map(|partition| {
+                let partition_index = partition["partition_index"].as_u64()?;
+                let task = partition["task_outcomes"]
+                    .as_array()?
+                    .iter()
+                    .find(|task| {
+                        !matches!(task["outcome"].as_str(), Some("applied" | "already_applied"))
+                    })?;
+                let classification = task
+                    .get("reason")
+                    .and_then(Value::as_str)
+                    .unwrap_or_else(|| task["outcome"].as_str().unwrap_or("unresolved"));
+                let detail = task
+                    .get("error")
+                    .and_then(Value::as_str)
+                    .or_else(|| task.get("detail").and_then(Value::as_str))
+                    .unwrap_or("unresolved task");
                 Some(format!(
-                    "{}: {}",
-                    task["task_id"].as_str()?,
-                    task["reason"].as_str()?
+                    "partition {partition_index}, task {}: {classification}: {detail}",
+                    task["task_id"].as_str().unwrap_or("<unknown>"),
                 ))
             })
-            .collect::<Vec<_>>();
-        let stale_details = if stale_tasks.is_empty() {
-            String::new()
-        } else {
-            format!(" ({})", stale_tasks.join(", "))
-        };
-        let applied_details = if applied_partitions == 0 {
-            String::new()
-        } else {
-            "; valid partitions were applied".to_string()
-        };
+            .or_else(|| {
+                carried_task_outcomes.first().map(|task| {
+                    format!(
+                        "carried task {}: {}",
+                        task["task_id"].as_str().unwrap_or("<unknown>"),
+                        task.get("error")
+                            .and_then(Value::as_str)
+                            .or_else(|| task.get("detail").and_then(Value::as_str))
+                            .unwrap_or("unresolved task")
+                    )
+                })
+            })
+            .unwrap_or_else(|| "partition envelope validation failed".to_string());
         format!(
-            "{} partition(s) failed, {} partition(s) were skipped as stale{}, and {} partition(s) applied{}",
-            failed_partitions.len(),
-            skipped_stale_partitions.len(),
-            stale_details,
-            applied_partitions,
-            applied_details
+            "task-pilot apply unresolved: {first_unresolved}; {applied_tasks} applied, {unresolved_tasks} unresolved"
         )
     });
+    let repair_task_ids = own_task_outcomes
+        .iter()
+        .filter(|outcome| outcome["outcome"] == "invalid")
+        .filter_map(|outcome| outcome["task_id"].as_str().map(ToOwned::to_owned))
+        .collect::<Vec<_>>();
+    let repair_partitions = repair_task_ids
+        .iter()
+        .enumerate()
+        .map(|(partition_index, task_id)| {
+            let errors = own_task_outcomes
+                .iter()
+                .filter(|outcome| outcome["task_id"].as_str() == Some(task_id))
+                .filter_map(|outcome| outcome["error"].as_str())
+                .collect::<Vec<_>>();
+            json!({
+                "partition_index": partition_index,
+                "task_ids": [task_id],
+                "validation_errors": errors,
+                "source_revision": source.as_ref().map(|source| source.source_revision.as_str()),
+            })
+        })
+        .collect::<Vec<_>>();
+    let repair_tasks = prepared_tasks
+        .iter()
+        .filter(|task| {
+            task["task_id"]
+                .as_str()
+                .is_some_and(|id| repair_task_ids.iter().any(|repair_id| repair_id == id))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let repair_claim = (repair_task_ids.len() == prepared_before.len())
+        .then(|| prepared.get("state_automation").cloned())
+        .flatten()
+        .unwrap_or(Value::Null);
+    let repair_prepared = json!({
+        "state_automation": repair_claim,
+        "mode": mode,
+        "workspace_path": workspace_root,
+        "source": prepared.get("source").cloned().unwrap_or(Value::Null),
+        "task_count": repair_task_ids.len(),
+        "task_ids": repair_task_ids,
+        "tasks": repair_tasks,
+        "partition_size": 1,
+        "partition_count": repair_partitions.len(),
+        "partitions": repair_partitions,
+        "excluded": [],
+    });
+    let non_repairable_outcomes = task_outcomes
+        .iter()
+        .filter(|outcome| {
+            !matches!(
+                outcome["outcome"].as_str(),
+                Some("invalid" | "applied" | "already_applied")
+            )
+        })
+        .cloned()
+        .collect::<Vec<_>>();
 
     let member_evidence = claim.filter(|_| succeeded).and_then(|claim| {
         let id = claim.member.task_ids.first()?;
@@ -555,96 +735,185 @@ pub(in super::super) fn apply(
         "received_partition_count": results.len(),
         "failed_partitions": failed_partitions,
         "skipped_stale_partitions": skipped_stale_partitions,
+        "task_outcomes": task_outcomes,
+        "applied_count": applied_tasks,
+        "unresolved_count": unresolved_tasks,
+        "repair_count": repair_task_ids.len(),
+        "repair_partitions": repair_partitions,
+        "repair_prepared": repair_prepared,
+        "non_repairable_outcomes": non_repairable_outcomes,
         "tasks": task_results,
         "ci_sweep_admission": ci_sweep_admission,
     }))
 }
 
-enum ApplyPartitionOutcome {
-    Applied(BTreeMap<String, String>),
-    Stale(Vec<Value>),
+enum ApplyTaskOutcome {
+    Applied(Option<String>),
+    AlreadyApplied(Option<String>),
+    Stale(&'static str, &'static str),
 }
 
-fn apply_partition(
+fn apply_task(
     runtime: &OrbitRuntime,
-    snapshots: &BTreeMap<String, PreparedTaskSnapshot>,
-    tasks: &[ValidatedTask],
+    snapshot: &PreparedTaskSnapshot,
+    task: &ValidatedTask,
     prepared: &Value,
-) -> Result<ApplyPartitionOutcome, OrbitError> {
-    let mut task_ids = tasks
-        .iter()
-        .map(|task| task.task_id.clone())
-        .collect::<Vec<_>>();
-    task_ids.sort();
-    let mut lock_ids = task_ids.clone();
-    for id in &task_ids {
-        lock_ids.extend(runtime.get_task(id)?.dependencies());
-    }
+) -> Result<ApplyTaskOutcome, OrbitError> {
+    let mut lock_ids = vec![task.task_id.clone()];
+    lock_ids.extend(runtime.get_task(&task.task_id)?.dependencies());
     lock_ids.sort();
     lock_ids.dedup();
     let mut outcome = None;
     let mut operation = || {
         crate::application::automation::members::claim(runtime, prepared)?;
-        let mut fingerprints = BTreeMap::new();
-        let mut stale = Vec::new();
-        for task_id in &task_ids {
-            match runtime.get_task(task_id) {
-                Ok(current) => {
-                    if let Some(reason) =
-                        task_snapshot_drift(runtime, &current, &snapshots[task_id])
-                    {
-                        stale.push(stale_task(task_id, reason.0, reason.1));
-                    }
-                }
-                Err(OrbitError::NotFound { .. }) => stale.push(stale_task(
-                    task_id,
+        let receipt = format!("operation_id={}", task.operation_id);
+        if runtime
+            .get_task_history(&task.task_id)?
+            .iter()
+            .any(|event| {
+                event.event == "task_pilot_applied"
+                    && event.note.as_deref() == Some(receipt.as_str())
+            })
+        {
+            outcome = Some(ApplyTaskOutcome::AlreadyApplied(resulting_fingerprint(
+                runtime,
+                &task.task_id,
+                snapshot,
+            )?));
+            return Ok(());
+        }
+        let current = match runtime.get_task(&task.task_id) {
+            Ok(current) => current,
+            Err(OrbitError::NotFound { .. }) => {
+                outcome = Some(ApplyTaskOutcome::Stale(
                     "task_deleted",
                     "task no longer exists at the write boundary",
-                )),
-                Err(error) => return Err(error),
+                ));
+                return Ok(());
             }
-        }
-        if !stale.is_empty() {
-            outcome = Some(ApplyPartitionOutcome::Stale(stale));
+            Err(error) => return Err(error),
+        };
+        if let Some(reason) = task_snapshot_drift(runtime, &current, snapshot) {
+            outcome = Some(ApplyTaskOutcome::Stale(reason.0, reason.1));
             return Ok(());
         }
 
-        for task in tasks.iter() {
-            let changed = snapshots[&task.task_id].context_files != task.after;
-            if changed || task.promote {
-                runtime.update_task(
+        let target_status = if task.promote {
+            TaskStatus::Backlog
+        } else {
+            snapshot.status
+        };
+        let mutation_params = AtomicTaskMutationParams {
+            actor: "task-pilot".to_string(),
+            operation_id: task.operation_id.clone(),
+            expected_context_files: snapshot.context_files.clone(),
+            expected_status: snapshot.status,
+            context_files: task.after.clone(),
+            status: target_status,
+            event_type: "task_pilot_applied".to_string(),
+            event_note: "task-pilot atomic application".to_string(),
+        };
+        let mutation = apply_atomic_with_retries(runtime, &task.task_id, &mutation_params)?;
+        match mutation {
+            AtomicTaskMutationOutcome::Applied => {
+                runtime.record_event(OrbitEvent::TaskUpdated {
+                    id: task.task_id.clone(),
+                })?;
+                outcome = Some(ApplyTaskOutcome::Applied(resulting_fingerprint(
+                    runtime,
                     &task.task_id,
-                    TaskUpdateParams {
-                        context_files: changed.then_some(task.after.clone()),
-                        status: task.promote.then_some(TaskStatus::Backlog),
-                        comment: task.promote.then(|| {
-                            "CI-sweep admission: task-pilot validated current relevance and selectors; promoted proposed repair to backlog."
-                                .to_string()
-                        }),
-                        ..TaskUpdateParams::default()
-                    },
-                )?;
+                    snapshot,
+                )?));
+            }
+            AtomicTaskMutationOutcome::AlreadyApplied => {
+                outcome = Some(ApplyTaskOutcome::AlreadyApplied(resulting_fingerprint(
+                    runtime,
+                    &task.task_id,
+                    snapshot,
+                )?));
+            }
+            AtomicTaskMutationOutcome::Stale => {
+                outcome = Some(ApplyTaskOutcome::Stale(
+                    "write_boundary_changed",
+                    "task changed between validation and the atomic write boundary",
+                ));
             }
         }
-        for task in tasks {
-            if let Some((_, revision)) = &snapshots[&task.task_id].material {
-                let current = runtime.get_task(&task.task_id)?;
-                fingerprints.insert(
-                    task.task_id.clone(),
-                    crate::application::automation::preparation::fingerprint(
-                        runtime, &current, revision,
-                    )
-                    .map_err(orbit_automation::automation_error_to_orbit)?,
-                );
-            }
-        }
-        outcome = Some(ApplyPartitionOutcome::Applied(fingerprints));
         Ok(())
     };
     with_task_locks(runtime, &lock_ids, 0, &mut operation)?;
-    outcome.ok_or_else(|| {
-        OrbitError::Execution("task-pilot partition operation did not run".to_string())
-    })
+    outcome.ok_or_else(|| OrbitError::Execution("task-pilot operation did not run".to_string()))
+}
+
+fn apply_atomic_with_retries(
+    runtime: &OrbitRuntime,
+    task_id: &str,
+    params: &AtomicTaskMutationParams,
+) -> Result<AtomicTaskMutationOutcome, OrbitError> {
+    let mut last_error = None;
+    for attempt in 0..STORAGE_APPLY_ATTEMPTS {
+        match runtime
+            .stores()
+            .tasks()
+            .apply_atomic_task_mutation(task_id, params)
+        {
+            Ok(outcome) => return Ok(outcome),
+            Err(error @ OrbitError::Io(_)) if attempt + 1 < STORAGE_APPLY_ATTEMPTS => {
+                last_error = Some(error);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| {
+        OrbitError::Execution("task-pilot storage retry loop did not run".to_string())
+    }))
+}
+
+fn resulting_fingerprint(
+    runtime: &OrbitRuntime,
+    task_id: &str,
+    snapshot: &PreparedTaskSnapshot,
+) -> Result<Option<String>, OrbitError> {
+    let Some((_, revision)) = &snapshot.material else {
+        return Ok(None);
+    };
+    let current = runtime.get_task(task_id)?;
+    crate::application::automation::preparation::fingerprint(runtime, &current, revision)
+        .map(Some)
+        .map_err(orbit_automation::automation_error_to_orbit)
+}
+
+fn task_operation_id(prepared: &Value, task_id: &str, assessment: &Value) -> String {
+    let identity = json!({
+        "task_id": task_id,
+        "source": prepared.get("source"),
+        "prepared_tasks": prepared.get("tasks"),
+        "assessment": assessment,
+    });
+    let encoded = serde_json::to_vec(&identity).unwrap_or_default();
+    format!("{:x}", Sha256::digest(encoded))
+}
+
+fn record_applied_assessment(
+    mut task: ValidatedTask,
+    snapshot: &PreparedTaskSnapshot,
+    outcome: &str,
+    task_results: &mut Vec<Value>,
+    ci_sweep_admission: &mut Vec<Value>,
+) {
+    let changed = snapshot.context_files != task.after;
+    if let Value::Object(fields) = &mut task.assessment {
+        fields.insert("applied".to_string(), Value::Bool(changed || task.promote));
+        fields.insert("outcome".to_string(), json!(outcome));
+        fields.insert("operation_id".to_string(), json!(task.operation_id));
+        if let Some(admission) = task.admission.clone() {
+            fields.insert("ci_sweep_admission".to_string(), admission);
+        }
+    }
+    if let Some(admission) = task.admission {
+        ci_sweep_admission.push(admission);
+    }
+    task_results.push(task.assessment);
 }
 
 fn with_task_locks(
@@ -697,24 +966,59 @@ fn task_snapshot_drift(
 }
 
 fn stale_task(task_id: &str, reason: &str, detail: &str) -> Value {
-    json!({ "task_id": task_id, "reason": reason, "detail": detail })
+    json!({
+        "task_id": task_id,
+        "outcome": "stale",
+        "reason": reason,
+        "detail": detail,
+    })
+}
+
+fn task_outcome(task_id: &str, outcome: &str, error: Option<String>) -> Value {
+    json!({ "task_id": task_id, "outcome": outcome, "error": error })
+}
+
+#[cfg(test)]
+thread_local! {
+    static INJECT_CONCURRENT_EDIT: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[cfg(test)]
+pub(in super::super) fn inject_concurrent_edit_before_locked_apply() {
+    INJECT_CONCURRENT_EDIT.set(true);
+}
+
+#[cfg(test)]
+fn inject_concurrent_edit(runtime: &OrbitRuntime, task_id: &str) -> Result<(), OrbitError> {
+    if INJECT_CONCURRENT_EDIT.replace(false) {
+        runtime.update_task(
+            task_id,
+            TaskUpdateParams {
+                tags: Some(vec!["concurrent-edit".to_string()]),
+                ..TaskUpdateParams::default()
+            },
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(not(test))]
+fn inject_concurrent_edit(_runtime: &OrbitRuntime, _task_id: &str) -> Result<(), OrbitError> {
+    Ok(())
 }
 
 fn failed_partition(partition_index: u64, task_ids: &[String], error: String) -> Value {
+    let task_outcomes = task_ids
+        .iter()
+        .map(|task_id| task_outcome(task_id, "invalid", Some(error.clone())))
+        .collect::<Vec<_>>();
     json!({
         "partition_index": partition_index,
         "task_ids": task_ids,
         "outcome": "failed",
         "error": error,
-    })
-}
-
-fn stale_partition(partition_index: u64, task_ids: &[String], stale: Vec<Value>) -> Value {
-    json!({
-        "partition_index": partition_index,
-        "task_ids": task_ids,
-        "outcome": "skipped_stale",
-        "stale_tasks": stale,
+        "task_outcomes": task_outcomes,
+        "unresolved_count": task_ids.len(),
         "applied_task_ids": [],
     })
 }

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/pipeline_actions.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/pipeline_actions.rs
@@ -53,6 +53,29 @@ fn pipeline_success_guard_rejects_failed_result() {
 }
 
 #[test]
+fn pipeline_success_guard_reports_task_pilot_apply_without_unknown_run() {
+    let error = pipeline_success_guard(
+        "pipeline_success_guard",
+        &json!({
+            "context": "task-pilot apply",
+            "result": {
+                "status": "failed",
+                "error": "partition 0, task ORB-11991: selector missing",
+                "partition_decisions": [],
+                "applied_count": 4,
+                "unresolved_count": 1,
+            }
+        }),
+    )
+    .expect_err("unresolved apply fails the guard");
+
+    let message = action_failure_message(error, "pipeline_success_guard");
+    assert!(message.contains("partition 0, task ORB-11991: selector missing"));
+    assert!(message.contains("4 applied, 1 unresolved"));
+    assert!(!message.contains("<unknown>"));
+}
+
+#[test]
 fn pipeline_success_guard_rejects_mixed_results() {
     let err = pipeline_success_guard(
         "pipeline_success_guard",

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs
@@ -3,7 +3,9 @@ use orbit_types::task::{Task, TaskPriority, TaskStatus, TaskType};
 use orbit_types::workflow::{JobRunState, PipelineState};
 use serde_json::{Value, json};
 
-use super::super::task_pilot::{apply, member_ready, prepare};
+use super::super::task_pilot::{
+    apply, inject_concurrent_edit_before_locked_apply, member_ready, prepare,
+};
 use crate::OrbitRuntime;
 use crate::adapter::engine_host::v2_host::test_support::{
     runtime_with_workspace_layout, write_workspace_file,
@@ -550,7 +552,7 @@ fn adr_conflicts_rejects_object_array_conflict_evidence_shape() {
 }
 
 #[test]
-fn invalid_selector_in_later_assessment_prevents_every_mutation() {
+fn invalid_selector_does_not_discard_valid_sibling_in_same_partition() {
     let (_root, runtime, repo_root) = runtime_with_workspace_layout();
     write_workspace_file(&repo_root, "src/alpha.rs");
     let alpha = seed_task(&runtime, "alpha", TaskStatus::Backlog, &[], &[]);
@@ -578,21 +580,103 @@ fn invalid_selector_in_later_assessment_prevents_every_mutation() {
     .expect("invalid partition is reported as durable output");
 
     assert_eq!(output["status"], "failed");
-    assert_eq!(output["partition_decisions"][0]["outcome"], "failed");
+    assert_eq!(output["partition_decisions"][0]["outcome"], "partial");
     assert!(
         output["partition_decisions"][0]["error"]
             .as_str()
             .unwrap()
             .contains("does not resolve")
     );
-    assert!(
-        runtime
-            .get_task(&alpha.id)
-            .unwrap()
-            .context_files
-            .is_empty()
+    assert_eq!(
+        runtime.get_task(&alpha.id).unwrap().context_files,
+        vec!["file:src/alpha.rs"]
     );
     assert!(runtime.get_task(&beta.id).unwrap().context_files.is_empty());
+
+    let repaired = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": output["repair_prepared"],
+            "results": [partition_result(
+                0,
+                std::slice::from_ref(&beta.id),
+                vec![selector_assessment(&beta, vec!["file:src/alpha.rs"])],
+            )],
+            "workspace_path": repo_root,
+            "prior_applied_count": output["applied_count"],
+            "carried_task_outcomes": output["non_repairable_outcomes"],
+        }),
+    )
+    .expect("targeted repair reuses the deterministic apply boundary");
+    assert_eq!(output["repair_count"], 1);
+    assert_eq!(
+        output["repair_partitions"][0]["validation_errors"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(repaired["status"], "succeeded");
+    assert_eq!(repaired["applied_count"], 2);
+    assert_eq!(
+        runtime.get_task(&beta.id).unwrap().context_files,
+        vec!["file:src/alpha.rs"]
+    );
+}
+
+#[test]
+fn replay_returns_already_applied_without_a_second_mutation() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "src/alpha.rs");
+    write_workspace_file(&repo_root, "src/beta.rs");
+    let task = seed_task(&runtime, "replay", TaskStatus::Backlog, &[], &[]);
+    let task_ids = vec![task.id.clone()];
+    let snapshot = prepared(&runtime, &repo_root, &task_ids);
+    let result = partition_result(
+        0,
+        &task_ids,
+        vec![selector_assessment(&task, vec!["file:src/alpha.rs"])],
+    );
+    let input = json!({
+        "prepared": snapshot,
+        "results": [result],
+        "workspace_path": repo_root,
+    });
+
+    let first = apply(&runtime, "apply_task_pilot_results", &input).expect("first apply");
+    let replay = apply(&runtime, "apply_task_pilot_results", &input).expect("replay apply");
+    let changed = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": input["prepared"],
+            "results": [partition_result(
+                0,
+                &task_ids,
+                vec![selector_assessment(&task, vec!["file:src/beta.rs"])],
+            )],
+            "workspace_path": repo_root,
+        }),
+    )
+    .expect("changed replay is a structured stale result");
+
+    assert_eq!(first["tasks"][0]["outcome"], "applied");
+    assert_eq!(replay["tasks"][0]["outcome"], "already_applied");
+    assert_eq!(changed["task_outcomes"][0]["outcome"], "stale");
+    assert_eq!(
+        runtime.get_task(&task.id).unwrap().context_files,
+        vec!["file:src/alpha.rs"]
+    );
+    assert_eq!(
+        runtime
+            .get_task_history(&task.id)
+            .unwrap()
+            .iter()
+            .filter(|event| event.event == "task_pilot_applied")
+            .count(),
+        1
+    );
 }
 
 #[test]
@@ -657,6 +741,53 @@ fn stale_partition_does_not_discard_independent_valid_partition() {
 }
 
 #[test]
+fn edit_between_validation_and_locked_write_is_stale_and_preserved() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "src/new.rs");
+    let raced = seed_task(&runtime, "raced", TaskStatus::Backlog, &[], &[]);
+    let sibling = seed_task(&runtime, "sibling", TaskStatus::Backlog, &[], &[]);
+    let task_ids = vec![raced.id.clone(), sibling.id.clone()];
+    let snapshot = prepared(&runtime, &repo_root, &task_ids);
+    inject_concurrent_edit_before_locked_apply();
+
+    let output = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": snapshot,
+            "results": [partition_result(
+                0,
+                &task_ids,
+                vec![
+                    selector_assessment(&raced, vec!["file:src/new.rs"]),
+                    selector_assessment(&sibling, vec!["file:src/new.rs"]),
+                ],
+            )],
+            "workspace_path": repo_root,
+        }),
+    )
+    .expect("concurrent edit is a structured task outcome");
+
+    assert_eq!(output["task_outcomes"][0]["outcome"], "stale");
+    assert_eq!(output["task_outcomes"][0]["reason"], "tags_changed");
+    assert_eq!(
+        runtime.get_task(&raced.id).unwrap().tags,
+        vec!["concurrent-edit"]
+    );
+    assert!(
+        runtime
+            .get_task(&raced.id)
+            .unwrap()
+            .context_files
+            .is_empty()
+    );
+    assert_eq!(
+        runtime.get_task(&sibling.id).unwrap().context_files,
+        vec!["file:src/new.rs"]
+    );
+}
+
+#[test]
 fn all_stale_partition_diagnostic_identifies_zero_apply() {
     let (_root, runtime, repo_root) = runtime_with_workspace_layout();
     write_workspace_file(&repo_root, "src/new.rs");
@@ -695,7 +826,7 @@ fn all_stale_partition_diagnostic_identifies_zero_apply() {
         output["skipped_stale_partitions"].as_array().unwrap().len(),
         1
     );
-    assert!(error.contains("1 partition(s) were skipped as stale"));
+    assert!(error.contains("1 unresolved"));
     assert!(error.contains("status_changed"));
     assert!(error.contains(&task.id));
     assert!(

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_source.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_source.rs
@@ -295,6 +295,104 @@ fn clean_stale_primary_is_preserved_and_apply_admits_newly_merged_file() {
 }
 
 #[test]
+fn bare_file_and_directory_selectors_normalize_at_the_pinned_revision() {
+    let fixture = remote_landing_fixture();
+    let prepared = prepare_landing(&fixture).expect("prepare pinned source");
+
+    let output = apply_selectors(
+        &fixture.runtime,
+        &prepared,
+        &fixture.task,
+        vec!["src/merged.rs", "src"],
+    );
+
+    assert_eq!(output["status"], "succeeded", "{output}");
+    assert_eq!(
+        output["tasks"][0]["context_files_after"],
+        json!(["file:src/merged.rs", "dir:src"])
+    );
+    assert_eq!(
+        output["tasks"][0]["selector_normalizations"],
+        json!([
+            {"original": "src/merged.rs", "normalized": "file:src/merged.rs"},
+            {"original": "src", "normalized": "dir:src"},
+        ])
+    );
+    assert_eq!(
+        fixture
+            .runtime
+            .get_task(&fixture.task.id)
+            .unwrap()
+            .context_files,
+        vec!["file:src/merged.rs", "dir:src"]
+    );
+}
+
+#[test]
+fn five_task_partition_keeps_valid_siblings_when_bare_target_is_missing() {
+    let fixture = remote_landing_fixture();
+    let mut tasks = vec![fixture.task.clone()];
+    for index in 1..5 {
+        tasks.push(seed_task(&fixture.runtime, &format!("sibling-{index}")));
+    }
+    let task_ids = tasks.iter().map(|task| task.id.clone()).collect::<Vec<_>>();
+    let prepared = prepare(
+        &fixture.runtime,
+        "prepare_task_pilot",
+        &json!({
+            "task_ids": task_ids,
+            "workspace_path": fixture.repo,
+            "base_branch": LANDING,
+        }),
+    )
+    .expect("prepare five-task partition");
+    let assessments = tasks
+        .iter()
+        .enumerate()
+        .map(|(index, task)| {
+            selector_assessment(
+                task,
+                if index == 0 {
+                    vec![".orbit/resources/activities/task_pilot.yaml"]
+                } else {
+                    vec!["file:src/merged.rs"]
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let output = apply(
+        &fixture.runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": prepared,
+            "results": [{
+                "partition_index": 0,
+                "task_ids": task_ids,
+                "tasks": assessments,
+            }],
+            "workspace_path": fixture.repo,
+        }),
+    )
+    .expect("mixed partition returns structured outcomes");
+
+    assert_eq!(output["status"], "failed");
+    assert_eq!(output["partition_decisions"][0]["outcome"], "partial");
+    assert_eq!(output["applied_count"], 4);
+    assert_eq!(output["unresolved_count"], 1);
+    assert_eq!(
+        output["partition_decisions"][0]["task_outcomes"][0]["outcome"],
+        "invalid"
+    );
+    for task in tasks.iter().skip(1) {
+        assert_eq!(
+            fixture.runtime.get_task(&task.id).unwrap().context_files,
+            vec!["file:src/merged.rs"]
+        );
+    }
+}
+
+#[test]
 fn dirty_primary_preserves_head_index_tracked_and_untracked_bytes() {
     let fixture = remote_landing_fixture();
     fs::write(fixture.repo.join("src/existing.rs"), "staged edit\n").unwrap();

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -464,7 +464,7 @@ fn task_pilot_pipeline_resolves_system_crew_and_bounded_partial_join_partitions(
         defaults.get("crew").is_none(),
         "a job-input crew would be dead: the system-crew marker overwrites it before resolution"
     );
-    assert_eq!(asset.spec.steps.len(), 4);
+    assert_eq!(asset.spec.steps.len(), 7);
 
     let JobV2StepBody::TargetRef(prepare) = &asset.spec.steps[0].body else {
         panic!("task pilot preparation must be deterministic activity reference");
@@ -533,8 +533,19 @@ fn task_pilot_pipeline_resolves_system_crew_and_bounded_partial_join_partitions(
          system-crew injection, which only runs for agent-loop targets"
     );
 
-    let JobV2StepBody::TargetRef(require_success) = &asset.spec.steps[3].body else {
-        panic!("task pilot must guard the durable partition apply result");
+    let JobV2StepBody::FanOut {
+        fan_out: repair,
+        fan_in: repair_join,
+    } = &asset.spec.steps[3].body
+    else {
+        panic!("task pilot repair must be a bounded fan-out");
+    };
+    assert_eq!(repair.items, "{{ steps.apply.output.repair_partitions }}");
+    assert_eq!(repair.max_workers, 5);
+    assert_eq!(repair_join.collect.as_deref(), Some("repair_results"));
+
+    let JobV2StepBody::TargetRef(require_success) = &asset.spec.steps[5].body else {
+        panic!("task pilot must guard the durable initial apply result");
     };
     assert_eq!(require_success.target, "activity:pipeline_success_guard");
     assert_eq!(

--- a/crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs
+++ b/crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs
@@ -3,18 +3,23 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Arc, Mutex};
 
-use orbit_engine::JobOutcome;
+use orbit_engine::{DispatchError, JobOutcome, ResolvedCliExecutor, RuntimeHost};
+use orbit_tools::{FsAuditLogger, ToolContext};
+use orbit_types::task::{TaskPriority, TaskStatus, TaskType};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use super::exec::{seed_default_catalogs, try_execute_named_job};
 use crate::OrbitRuntime;
+use crate::application::task::TaskAddParams;
 
 struct TaskPilotJobFixture {
     _root: TempDir,
     runtime: OrbitRuntime,
     repo_root: PathBuf,
+    global_root: PathBuf,
     stale_sha: String,
     current_sha: String,
     dirty_status: String,
@@ -107,6 +112,7 @@ fn task_pilot_job_fixture(config_branch: &str, remote_branch: &str) -> TaskPilot
         _root: root,
         runtime,
         repo_root,
+        global_root,
         stale_sha,
         current_sha,
         dirty_status,
@@ -208,4 +214,152 @@ fn shipped_task_pilot_job_rejects_an_unavailable_explicit_branch() {
         git(&fixture.repo_root, &["status", "--short"]),
         fixture.dirty_status
     );
+}
+
+struct ScriptedPilotHost<'a> {
+    runtime: &'a OrbitRuntime,
+    calls: Mutex<Vec<bool>>,
+}
+
+impl RuntimeHost for ScriptedPilotHost<'_> {
+    fn run_deterministic(
+        &self,
+        action: &str,
+        config: &Value,
+        input: &Value,
+        tool_context: ToolContext,
+    ) -> Result<Value, DispatchError> {
+        if action != "scripted_task_pilot" {
+            return <OrbitRuntime as RuntimeHost>::run_deterministic(
+                self.runtime,
+                action,
+                config,
+                input,
+                tool_context,
+            );
+        }
+        let repair = input["repair_attempt"].as_bool().unwrap_or(false);
+        self.calls.lock().expect("calls").push(repair);
+        let task_ids = input["task_ids"].as_array().expect("task ids");
+        let tasks = task_ids
+            .iter()
+            .enumerate()
+            .map(|(index, task_id)| {
+                let selector = if !repair && index == 0 {
+                    ".orbit/resources/activities/task_pilot.yaml"
+                } else {
+                    "file:src/remote.rs"
+                };
+                json!({
+                    "task_id": task_id,
+                    "context_files_before": [],
+                    "context_files_after": [selector],
+                    "disposition": "selectors",
+                    "recommended_crew": "system",
+                    "recommended_complexity": "medium",
+                    "blocked_by": [],
+                    "duplicate_of": null,
+                    "already_landed": null,
+                    "release_action_required": null,
+                    "adr_conflicts": [],
+                    "utility_warnings": [],
+                    "surface_warnings": [],
+                })
+            })
+            .collect::<Vec<_>>();
+        Ok(json!({
+            "partition_index": input["partition_index"],
+            "task_ids": task_ids,
+            "tasks": tasks,
+            "summary": "scripted pilot",
+        }))
+    }
+
+    fn resolve_cli_executor(&self, provider: &str) -> Result<ResolvedCliExecutor, DispatchError> {
+        <OrbitRuntime as RuntimeHost>::resolve_cli_executor(self.runtime, provider)
+    }
+
+    fn tool_context_for_activity(
+        &self,
+        run_id: Option<&str>,
+        fs_profile: Option<&str>,
+        fs_audit: Option<Arc<dyn FsAuditLogger>>,
+        proc_allowed_programs: Option<&[String]>,
+    ) -> ToolContext {
+        <OrbitRuntime as RuntimeHost>::tool_context_for_activity(
+            self.runtime,
+            run_id,
+            fs_profile,
+            fs_audit,
+            proc_allowed_programs,
+        )
+    }
+}
+
+#[test]
+fn shipped_pipeline_repairs_only_invalid_task_and_preserves_partial_progress() {
+    let fixture = task_pilot_job_fixture("agent-main", "agent-main");
+    fs::write(
+        fixture
+            .global_root
+            .join("resources/activities/task_pilot.yaml"),
+        r#"schemaVersion: 2
+kind: Activity
+metadata:
+  name: task_pilot
+spec:
+  type: deterministic
+  description: Scripted task-pilot fixture.
+  input_schema_json: {type: object}
+  output_schema_json: {type: object}
+  action: scripted_task_pilot
+  config: {}
+"#,
+    )
+    .expect("write scripted pilot activity");
+    let task_ids = (0..2)
+        .map(|index| {
+            fixture
+                .runtime
+                .add_task(TaskAddParams {
+                    title: format!("pipeline repair {index}"),
+                    description: "pipeline repair fixture".to_string(),
+                    acceptance_criteria: vec!["repair completes".to_string()],
+                    plan: "run pilot".to_string(),
+                    workspace_path: Some(".".to_string()),
+                    priority: TaskPriority::Medium,
+                    task_type: Some(TaskType::Bug),
+                    status: Some(TaskStatus::Backlog),
+                    ..Default::default()
+                })
+                .expect("seed task")
+                .id
+        })
+        .collect::<Vec<_>>();
+    let host = ScriptedPilotHost {
+        runtime: &fixture.runtime,
+        calls: Mutex::new(Vec::new()),
+    };
+
+    let outcome = try_execute_named_job(
+        &fixture.runtime,
+        &fixture.repo_root,
+        &host,
+        "task_pilot_pipeline",
+        json!({"task_ids": task_ids, "base_branch": "agent-main"}),
+        "jrun-task-pilot-repair",
+    )
+    .expect("execute task-pilot repair workflow");
+
+    assert!(outcome.success, "{outcome:?}");
+    assert_eq!(outcome.pipeline["apply"]["applied_count"], 1);
+    assert_eq!(outcome.pipeline["apply"]["repair_count"], 1);
+    assert_eq!(outcome.pipeline["apply_repairs"]["applied_count"], 2);
+    assert_eq!(host.calls.lock().unwrap().as_slice(), &[false, true]);
+    for task_id in task_ids {
+        assert_eq!(
+            fixture.runtime.get_task(&task_id).unwrap().context_files,
+            vec!["file:src/remote.rs"]
+        );
+    }
 }

--- a/crates/orbit-store/src/contracts/params.rs
+++ b/crates/orbit-store/src/contracts/params.rs
@@ -100,6 +100,27 @@ pub struct TaskHistoryUpdateParams {
     pub expected_status: Option<Vec<TaskStatus>>,
 }
 
+/// One task-bundle mutation whose freshness guard, durable receipt, history
+/// event, and envelope changes share the envelope publish commit point.
+#[derive(Debug, Clone)]
+pub struct AtomicTaskMutationParams {
+    pub actor: String,
+    pub operation_id: String,
+    pub expected_context_files: Vec<String>,
+    pub expected_status: TaskStatus,
+    pub context_files: Vec<String>,
+    pub status: TaskStatus,
+    pub event_type: String,
+    pub event_note: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AtomicTaskMutationOutcome {
+    Applied,
+    AlreadyApplied,
+    Stale,
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct TaskArtifactUpdateParams {
     pub actor: String,

--- a/crates/orbit-store/src/contracts/traits.rs
+++ b/crates/orbit-store/src/contracts/traits.rs
@@ -120,6 +120,19 @@ pub trait TaskStoreBackend: Send + Sync {
         op()
     }
 
+    /// Atomically apply a freshness-guarded task mutation and its durable
+    /// idempotency receipt. Backends that cannot provide one commit point must
+    /// reject the operation rather than emulate it with partial writes.
+    fn apply_atomic_task_mutation(
+        &self,
+        _id: &str,
+        _params: &AtomicTaskMutationParams,
+    ) -> Result<AtomicTaskMutationOutcome, OrbitError> {
+        Err(OrbitError::Store(
+            "atomic task mutation is not supported by this backend".to_string(),
+        ))
+    }
+
     /// Status counts per complexity bucket from the generated task index.
     /// Default is empty; the v2 store answers from SQLite without bundle reads.
     fn task_completion_by_complexity(&self) -> Result<Vec<TaskCompletionByComplexity>, OrbitError> {

--- a/crates/orbit-store/src/repository/file_backends.rs
+++ b/crates/orbit-store/src/repository/file_backends.rs
@@ -9,9 +9,10 @@ use orbit_types::task::{
 use orbit_types::workflow::ExecutorDef;
 
 use crate::contracts::{
-    ExecutorDefStoreBackend, PolicyDefStoreBackend, TaskArtifactStoreBackend,
-    TaskArtifactUpdateParams, TaskCreateParams, TaskDocumentStoreBackend, TaskDocumentUpdateParams,
-    TaskHistoryStoreBackend, TaskHistoryUpdateParams, TaskStoreBackend,
+    AtomicTaskMutationOutcome, AtomicTaskMutationParams, ExecutorDefStoreBackend,
+    PolicyDefStoreBackend, TaskArtifactStoreBackend, TaskArtifactUpdateParams, TaskCreateParams,
+    TaskDocumentStoreBackend, TaskDocumentUpdateParams, TaskHistoryStoreBackend,
+    TaskHistoryUpdateParams, TaskStoreBackend,
 };
 use crate::driver::file::executor_def_store::ExecutorDefFileStore;
 use crate::driver::file::policy_def_store::PolicyDefFileStore;
@@ -107,6 +108,14 @@ impl TaskStoreBackend for TaskV2Store {
         op: &mut dyn FnMut() -> Result<(), OrbitError>,
     ) -> Result<(), OrbitError> {
         self.with_task_lock(id, op)
+    }
+
+    fn apply_atomic_task_mutation(
+        &self,
+        id: &str,
+        params: &AtomicTaskMutationParams,
+    ) -> Result<AtomicTaskMutationOutcome, OrbitError> {
+        self.apply_atomic_task_mutation(id, params)
     }
 
     fn task_completion_by_complexity(

--- a/crates/orbit-store/src/repository/task/v2/tests/mod.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/mod.rs
@@ -6,7 +6,8 @@ use tempfile::TempDir;
 
 use super::*;
 use crate::contracts::{
-    TaskArtifactUpdateParams, TaskCreateParams, TaskDocumentUpdateParams, TaskHistoryUpdateParams,
+    AtomicTaskMutationOutcome, AtomicTaskMutationParams, TaskArtifactUpdateParams,
+    TaskCreateParams, TaskDocumentUpdateParams, TaskHistoryUpdateParams,
 };
 use crate::driver::sqlite::task_registry::{
     BindWorkspaceParams, TaskRegistryStore, task_registry_path,

--- a/crates/orbit-store/src/repository/task/v2/tests/update.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/update.rs
@@ -626,3 +626,86 @@ fn document_update_aborts_description_when_envelope_stage_fails() {
     assert_eq!(task.description, "Detailed task description");
     assert_eq!(task.status, TaskStatus::Backlog);
 }
+
+#[test]
+fn atomic_task_mutation_commits_receipt_event_and_envelope_together() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    store
+        .create_task(create_params("Atomic", TaskStatus::Backlog))
+        .expect("create task");
+    let params = AtomicTaskMutationParams {
+        actor: "task-pilot".to_string(),
+        operation_id: "operation-one".to_string(),
+        expected_context_files: vec!["docs/design/task-artifacts/1_overview.md".to_string()],
+        expected_status: TaskStatus::Backlog,
+        context_files: vec!["file:src/lib.rs".to_string()],
+        status: TaskStatus::Backlog,
+        event_type: "task_pilot_applied".to_string(),
+        event_note: "task-pilot atomic application".to_string(),
+    };
+
+    assert_eq!(
+        store
+            .apply_atomic_task_mutation("ORB-00000", &params)
+            .expect("apply mutation"),
+        AtomicTaskMutationOutcome::Applied
+    );
+    assert_eq!(
+        store
+            .apply_atomic_task_mutation("ORB-00000", &params)
+            .expect("replay mutation"),
+        AtomicTaskMutationOutcome::AlreadyApplied
+    );
+    let task = store.get_task("ORB-00000").unwrap().unwrap();
+    assert_eq!(task.context_files, vec!["file:src/lib.rs"]);
+    let history = store.get_task_history("ORB-00000").unwrap().unwrap();
+    assert_eq!(
+        history
+            .iter()
+            .filter(|event| event.event == "task_pilot_applied")
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn atomic_task_mutation_rolls_back_receipt_when_envelope_publish_fails() {
+    use crate::driver::file::task_bundle::{BundleWriteFault, inject_bundle_write_faults};
+
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    store
+        .create_task(create_params("Atomic fault", TaskStatus::Backlog))
+        .expect("create task");
+    let history_before = store.get_task_history("ORB-00000").unwrap().unwrap();
+    inject_bundle_write_faults(&[BundleWriteFault::AfterEnvelopeStage]);
+
+    store
+        .apply_atomic_task_mutation(
+            "ORB-00000",
+            &AtomicTaskMutationParams {
+                actor: "task-pilot".to_string(),
+                operation_id: "operation-fault".to_string(),
+                expected_context_files: vec![
+                    "docs/design/task-artifacts/1_overview.md".to_string(),
+                ],
+                expected_status: TaskStatus::Backlog,
+                context_files: vec!["file:src/lib.rs".to_string()],
+                status: TaskStatus::Backlog,
+                event_type: "task_pilot_applied".to_string(),
+                event_note: "task-pilot atomic application".to_string(),
+            },
+        )
+        .expect_err("injected publish failure");
+
+    let task = store.get_task("ORB-00000").unwrap().unwrap();
+    assert_eq!(
+        task.context_files,
+        vec!["docs/design/task-artifacts/1_overview.md"]
+    );
+    assert_eq!(
+        store.get_task_history("ORB-00000").unwrap().unwrap(),
+        history_before
+    );
+}

--- a/crates/orbit-store/src/repository/task/v2/updates.rs
+++ b/crates/orbit-store/src/repository/task/v2/updates.rs
@@ -1,7 +1,65 @@
 use super::*;
+use crate::contracts::{AtomicTaskMutationOutcome, AtomicTaskMutationParams};
 use crate::driver::file::task_bundle::{BundleWriteFault, PendingWriteGuard, fail_if_injected};
 
 impl TaskV2Store {
+    pub(crate) fn apply_atomic_task_mutation(
+        &self,
+        id: &str,
+        fields: &AtomicTaskMutationParams,
+    ) -> Result<AtomicTaskMutationOutcome, OrbitError> {
+        orbit_types::task::validate_orb_task_id(id)?;
+        if fields.actor.trim().is_empty()
+            || fields.operation_id.trim().is_empty()
+            || fields.event_type.trim().is_empty()
+        {
+            return Err(OrbitError::InvalidInput(
+                "atomic task mutation actor, operation id, and event type must not be empty"
+                    .to_string(),
+            ));
+        }
+
+        self.with_task_lock(id, || {
+            let mut bundle = self.read_existing_bundle(id)?;
+            let receipt = format!("operation_id={}", fields.operation_id);
+            if bundle.events.iter().any(|event| {
+                event.event_type == fields.event_type
+                    && event.note.as_deref() == Some(receipt.as_str())
+            }) {
+                return Ok(AtomicTaskMutationOutcome::AlreadyApplied);
+            }
+            if bundle.envelope.context_files != fields.expected_context_files
+                || bundle.envelope.status != fields.expected_status
+            {
+                return Ok(AtomicTaskMutationOutcome::Stale);
+            }
+
+            let mut pending = PendingWriteGuard::begin(&self.bundle_store.bundle_path(id)?)?;
+            let now = Utc::now();
+            let status_changed = fields.status != bundle.envelope.status;
+            let event = TaskEventRowV2 {
+                schema_version: TASK_ARTIFACT_SCHEMA_VERSION,
+                event_id: next_event_id(&bundle.events),
+                at: now,
+                by: fields.actor.clone(),
+                event_type: fields.event_type.clone(),
+                note: Some(receipt),
+                from_status: status_changed.then_some(bundle.envelope.status),
+                to_status: status_changed.then_some(fields.status),
+            };
+            self.bundle_store.append_event(id, &event)?;
+            fail_if_injected(BundleWriteFault::AfterJsonlAppend)?;
+
+            bundle.envelope.context_files = fields.context_files.clone();
+            bundle.envelope.status = fields.status;
+            bundle.envelope.updated_at = now;
+            self.bundle_store.rewrite_envelope(id, &bundle.envelope)?;
+            pending.finish();
+            self.replace_index_best_effort(&bundle.envelope, &fields.event_note);
+            Ok(AtomicTaskMutationOutcome::Applied)
+        })
+    }
+
     pub(crate) fn update_task_document(
         &self,
         id: &str,

--- a/docs/design/operation-mode/2_design.md
+++ b/docs/design/operation-mode/2_design.md
@@ -66,11 +66,19 @@ has no lifecycle or repository-write authority. It reports scope, dependency,
 duplicate, already-landed, utility, and current-contract findings as data.
 
 [Apply](../../../crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs)
-validates selectors at the pinned source, isolates invalid/stale partitions, and
-rechecks task state under write locks. Its `task_snapshot_drift` compares context,
-status, title, and tags; it is not a full description/criteria/plan freshness
-check. Ordinary apply changes selectors, leaving orchestration recommendations
-advisory. There is no reusable general promotion-readiness certificate today.
+validates selectors at the pinned source, deterministically normalizes unambiguous
+bare file/directory targets, rejects untrusted partition identities, isolates
+invalid/stale tasks, and rechecks task state under write locks. Each accepted
+task mutation carries a stable operation identity; the task envelope and durable
+receipt event share one bundle commit point, so replay reports `already_applied`
+without another mutation. Invalid assessments alone enter one targeted repair
+fan-out carrying their exact validation errors and the original pinned revision;
+stale and storage-failed tasks require fresh preparation, and successful siblings
+are not sent back to a model. The prepared material fingerprint covers task
+meaning and dependency evidence, while `task_snapshot_drift` also names direct
+context, status, title, and tag changes in its structured stale outcomes.
+Ordinary apply changes selectors, leaving orchestration recommendations advisory.
+There is no reusable general promotion-readiness certificate today.
 
 The [CI-failure admission seam](../../../crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_admission.rs)
 is a **shipped narrow exception**: explicit `promotion_authorized`, matching

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -169,8 +169,11 @@ and `overlap: forbid`. The pipeline runs every GitHub query on the host, files e
 current, non-stale failure cluster as a proposed bug task carrying that evidence inline,
 dedupes against still-open owners by failure key, and pilots each candidate through the
 existing task-pilot job. The all-join lets independently valid pilots apply even when a
-sibling is stale or fails; a following `pipeline_success_guard` then fails the parent from
-the collected child statuses. The guard is skipped only for a filer-reported zero-candidate
+sibling is stale or fails. Within a returned partition, deterministic apply also commits
+valid tasks independently, then sends only invalid assessments through one targeted repair
+attempt at the original pinned revision; stale tasks require fresh preparation. A following
+`pipeline_success_guard` fails the parent while any task remains unresolved. The guard is
+skipped only for a filer-reported zero-candidate
 result, so empty clean/deduped sweeps remain no-ops without hiding failed work.
 
 A release-head failure remains current even when the same workflow is green on the

--- a/plugin/skills/orbit/references/workflows.md
+++ b/plugin/skills/orbit/references/workflows.md
@@ -66,7 +66,7 @@ not a rewrite of failed history.
 | `task_local_pipeline` | Implement in a worktree and merge to the configured local base without a PR; optional push. |
 | `task_auto_pipeline` | Discover ready backlog tasks and ship them. |
 | `task_gate_pipeline` | Gated shipment with windowing and starvation handling. |
-| `task_pilot_pipeline` | Read-only agent preflight plus deterministic validated-selector apply; it defaults to no lifecycle promotion. An omitted optional `base_branch` binds as empty at the prepare activity boundary, then preparation resolves the owning workspace's `[workflow] base_branch`; pass a non-empty run input to inspect another branch. |
+| `task_pilot_pipeline` | Read-only agent preflight plus deterministic task-isolated apply. Apply normalizes only unambiguous bare file/directory targets from the pinned source, records the normalization, and commits valid siblings even when another assessment is invalid or stale; the overall run still fails while anything is unresolved. Replays use durable per-task operation receipts. It defaults to no lifecycle promotion. An omitted optional `base_branch` binds as empty at the prepare activity boundary, then preparation resolves the owning workspace's `[workflow] base_branch`; pass a non-empty run input to inspect another branch. |
 | `task_triage_pipeline` | Diagnose tasks blocked by failed runs. |
 | `epic_pipeline` | Ship an epic and its descendants against one worktree. |
 | `workspace_ship_pipeline` / `workspace_auto_pipeline` | Workspace-scoped wrappers that resolve mode and base branch, then invoke the pipelines above. |


### PR DESCRIPTION
## Task

[ORB-12000](https://orbit-cli.com/tasks/ORB-12000) — Keep malformed task-pilot selectors from failing an entire partition

### Description

## Problem
Run `jrun-20260910-0412` of `task_pilot_pipeline` failed in deterministic apply after the pilot agent completed successfully. Partition 0 covered ORB-11991 through ORB-11995. ORB-11991 mixed canonical selectors with the bare repository-relative path `.orbit/resources/activities/task_pilot.yaml` in `context_files_after`. Selector validation rejected it, and none of the five assessments applied.

The parent `pipeline_success_guard` surfaced `result run <unknown> status failed`, hiding the concrete task, partition, and selector retained in the run bundle. No recovery was attempted.

## Why It Matters
One formatting mistake can discard a batch of valid preparation work. Retrying the whole batch wastes completed work and, once partial application is allowed, risks duplicate audit mutations or overwriting concurrent edits unless recovery is explicit.

## Required Behavior
Keep batched agent execution, but make each task the unit of validation, atomic application, and recovery.

- Normalize harmless selector formatting deterministically at the authoritative validation boundary. A bare relative modification target may become `file:` or `dir:` only when its existence, kind, and containment are unambiguous at the pinned source revision. Record the original and normalized values. Reject traversal, out-of-root or escaping symlink targets, missing targets, and ambiguous values. Never discard invalid selectors and apply the remaining scope.
- Validate every field of each assessment before mutation. Return structured task outcomes such as `applied`, `already_applied`, `invalid`, `stale`, and `apply_failed`. Invalid or stale tasks must not discard valid siblings. Reject untrustworthy partition envelopes, such as mismatched partition identity or ambiguous task attribution, before applying their contents.
- Give each application a stable identity tied to the preparation, task, pinned revision, and validated result. Persist the application receipt atomically with the task change and normal audit mutation. Replaying a committed operation must return its recorded outcome without a second mutation. Recheck the prepared material fingerprint at the write boundary; concurrent edits must produce a stale outcome rather than be overwritten.
- Recover only unresolved tasks. Deterministic normalization needs no model call. Allow at most one targeted repair attempt for an invalid assessment, supplying the exact validation errors and original pinned source. Revalidate the repaired result through the same boundary. Stale tasks require fresh preparation; transient storage failures use bounded retries through the idempotent apply path. Successful siblings remain committed throughout.
- Report partial progress accurately. The pipeline remains unsuccessful while tasks are unresolved, but its terminal diagnostic includes task and partition identities, the offending selector when relevant, error classification, and applied/unresolved counts. An apply result must not be misrepresented as a child run with an unknown run ID.

## Evidence
- Run: `jrun-20260910-0412`, failed 2026-09-10 after 458,944 ms.
- Source revision: `923bd085af7569d133a93bb11fdbbefa7cc8e0fa`.
- Partition tasks: ORB-11991, ORB-11992, ORB-11993, ORB-11994, ORB-11995.
- First actionable error: `deterministic action apply_task_pilot_results failed: task ORB-11991 selector ".orbit/resources/activities/task_pilot.yaml" must use file:, dir:, or symbol:`.
- Provider process exited 0 with a valid success envelope; the malformed value was inside `context_files_after`.

## Constraints / Notes
Preserve pinned-source validation, canonical selectors, modification-scope boundaries, existing promotion authority, and automation claim checks. Do not convert background-reading paths into modification scope or widen scope during normalization/replay. Task locks alone do not provide rollback: task state, application receipt, and mutation audit must have an explicit atomic persistence guarantee. Reuse existing domain/store mechanisms where possible rather than introducing a general retry framework.

Confirm the implementation against current `agent-main` before planning; the source inspected during proposal was behind its remote tracking branch. Update affected activity/job output contracts, consumers, and current documentation together. This task prepares a validated candidate; it does not authorize merge or release.

### Acceptance Criteria

- A deterministic regression reproduces the five-task shape from jrun-20260910-0412 with the bare `.orbit/resources/activities/task_pilot.yaml` selector. Valid siblings apply even if that task is rejected; a separate fixture where the bare target exists unambiguously at the pinned revision proves safe normalization succeeds.
- Boundary tests prove bare file/directory modification targets are normalized using the pinned source, with original and normalized values recorded. Traversal, escaping symlinks, out-of-root, missing, ambiguous, and wrong-kind selectors remain rejected. No invalid selector is silently dropped, and no normalization broadens modification scope.
- Every assessment is fully validated before mutation. A malformed or stale assessment yields a structured task-level outcome without changing that task or discarding independently valid siblings. Invalid partition identity, duplicate/ambiguous task attribution, and unexpected task IDs cannot cause unauthorized task application.
- Each task's state change, application receipt, and normal mutation audit commit atomically. Fault injection at the persistence boundary demonstrates either all commit or none commit; an invalid or failed task never has partial selector/status changes.
- Crash-recovery tests interrupt after one task commits but before aggregate output is returned, then replay the same preparation/results. The committed task returns already_applied, remaining valid tasks complete, and task history/audit mutation counts show exactly one application per operation. A changed payload cannot be mistaken for the prior operation.
- A deterministic concurrency test changes task material after preparation, including a change between initial validation and the locked write boundary. Apply reports stale, preserves the concurrent edit, and still applies valid siblings. Replaying an earlier committed operation cannot overwrite a later edit.
- Recovery tests prove deterministic normalization uses no additional model call; invalid assessments receive at most one targeted repair attempt with exact errors and the original pinned revision; repaired output is revalidated; stale tasks require fresh preparation; transient storage retries are bounded and idempotent. Successful tasks are excluded from repair work, and exhausted recovery remains visible.
- The terminal pipeline diagnostic names the failing partition, task ID, offending selector when applicable, and concrete validation/apply error, with applied and unresolved counts. It does not emit `result run <unknown>` for an apply result when the relevant evidence is available. Unresolved tasks keep the overall result unsuccessful while preserving successful work.
- An end-to-end task_pilot_pipeline test exercises mixed valid/invalid output, targeted repair, partial progress, and replay through the actual workflow boundary. Existing promotion authorization and automation claim/fingerprint guarantees remain covered; affected output contracts and consumers handle the new task outcomes.
- Focused task-pilot/apply, persistence/recovery, and pipeline tests pass using deterministic fixtures and temporary repositories rather than live runtime state. `make ci-fast` and `make ci-lint` pass, and affected current documentation is updated.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added pinned-revision normalization for unambiguous bare file and directory selectors, retaining original and normalized values and rejecting unsafe, missing, ambiguous, escaping, or wrong-kind targets without widening scope.
- Reworked apply around structured per-task outcomes so valid siblings commit despite invalid or stale peers, while partition identity and assessment attribution remain fail-closed.
- Added stable per-task operation identities and a store-level atomic mutation contract that commits selector/status changes with one durable receipt event at the task-bundle envelope commit point; replay returns already_applied and changed payloads remain stale.
- Added bounded idempotent storage retry handling and a single targeted repair workflow that receives exact validation errors at the original pinned revision, excludes successful and stale tasks, and reuses the same validator/apply boundary.
- Improved terminal diagnostics with partition, task, validation detail, and applied/unresolved counts; deterministic apply results no longer appear as run <unknown>. Updated activity/job contracts, mirrored assets, workflow references, and current design docs.

Criteria evidence:
1. The five-task regression uses the exact .orbit/resources/activities/task_pilot.yaml bare selector and proves four valid siblings apply; a pinned-source fixture proves bare file and directory normalization succeeds.
2. Selector boundary coverage exercises pinned file/directory normalization and existing traversal, symlink, containment, missing, and kind validation; normalization records selector_normalizations and duplicate checking runs after normalization.
3. Apply validates trustworthy partition identity and the complete task assessment before that task mutation, reports invalid/stale/apply_failed outcomes, and preserves valid siblings.
4. AtomicTaskMutationParams and TaskV2Store apply_atomic_task_mutation share one pending-write/envelope commit point for receipt event and envelope state; fault injection proves rollback.
5. Stable operation receipts make replay already_applied with one history mutation; changed payload coverage proves it cannot reuse the prior receipt.
6. A deterministic injected edit immediately before locked apply reports stale, preserves the edit, and applies the sibling.
7. The shipped job runs one repair fan-out only for invalid tasks with exact errors and the original revision; stale tasks are carried unresolved, successful tasks are excluded, and storage retries are bounded to three through the idempotent mutation.
8. The apply and guard tests prove diagnostics include partition/task/error and applied/unresolved totals without <unknown>.
9. The real task_pilot_pipeline boundary test exercises mixed invalid/valid output, targeted repair, preserved partial progress, and final success; catalog and existing automation tests remain green.
10. Focused Core, Store, pipeline, catalog, formatting, guardrail, and workspace Clippy checks passed; current docs and generated mirrors are synchronized.

Validation:
- cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::task_pilot -- --nocapture: passed, 42 tests.
- cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::pipeline_actions::pipeline_success_guard -- --nocapture: passed, 6 tests.
- cargo test -p orbit-core --lib application::job::tests::task_pilot_pipeline -- --nocapture: passed, 4 tests.
- cargo test -p orbit-store --lib atomic_task_mutation -- --nocapture: passed, 2 tests.
- cargo fmt --all -- --check: passed.
- make ci-fast: passed. Its compiler-cache namespace probe reported the documented environment skip because unprivileged user namespaces are unavailable; the guardrail command itself passed.
- make ci-lint: passed.
- git diff --check: passed.

Assessment: The implementation keeps the existing pinned-source and promotion/claim authorities, makes the task the validation and durability unit, and adds only one concrete atomic store seam and one bounded recovery pass.
Deviations from original plan: none.
Remaining risks: none identified within the validated Linux and temporary-repository coverage.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12000-6aa23cea`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra