### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-common/src/fs/file_lock.rs

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -135,3 +135,9 @@ extensions:
           "path-injection",
           "manual",
         ]
+      - [
+          "orbit_common::fs::file_lock::validated_lock_holder_path",
+          "ReturnValue.Field[core::option::Option::Some(0)]",
+          "path-injection",
+          "manual",
+        ]

--- a/crates/orbit-common/src/fs/file_lock.rs
+++ b/crates/orbit-common/src/fs/file_lock.rs
@@ -161,9 +161,31 @@ pub(crate) fn acquire_shared_file_lock(
 /// Read advisory holder metadata. Missing, empty, torn, and legacy files are
 /// intentionally reported as no metadata because the OS lock is authoritative.
 pub fn read_file_lock_holder(lock_path: &Path) -> Option<FileLockHolderInfo> {
+    let validated = validated_lock_holder_path(lock_path)?;
     let mut raw = String::new();
-    File::open(lock_path).ok()?.read_to_string(&mut raw).ok()?;
+    File::open(validated).ok()?.read_to_string(&mut raw).ok()?;
     serde_json::from_str(&raw).ok()
+}
+
+/// Resolve `lock_path` through its canonical parent directory and require the
+/// final component to already exist as a regular, non-symlinked file.
+///
+/// `lock_path` reaches this function as a caller-selected value (a task lock,
+/// a store lock) with no upstream containment check, so canonicalizing the
+/// parent and rejecting a symlinked or non-regular final component keeps the
+/// read confined to the resolved parent directory instead of a planted
+/// symlink's target [ORB-11953]. `None` covers "nothing to read", matching
+/// this function's existing no-metadata-on-missing-file semantics.
+fn validated_lock_holder_path(lock_path: &Path) -> Option<PathBuf> {
+    let file_name = lock_path.file_name()?;
+    let parent = lock_path.parent()?;
+    let canonical_parent = parent.canonicalize().ok()?;
+    let candidate = canonical_parent.join(file_name);
+
+    match std::fs::symlink_metadata(&candidate) {
+        Ok(metadata) if metadata.is_file() => Some(candidate),
+        _ => None,
+    }
 }
 
 fn open_lock_file(lock_path: &Path, label: &str) -> io::Result<File> {

--- a/crates/orbit-common/src/fs/tests/io.rs
+++ b/crates/orbit-common/src/fs/tests/io.rs
@@ -4,7 +4,9 @@ use std::io;
 use tempfile::TempDir;
 
 use crate::OrbitError;
-use crate::fs::io::{remove_path_if_exists, sync_parent_dir, with_exclusive_file_lock};
+use crate::fs::io::{
+    read_file_lock_holder, remove_path_if_exists, sync_parent_dir, with_exclusive_file_lock,
+};
 
 #[test]
 fn sync_parent_dir_uses_a_preopened_directory_handle() {
@@ -117,6 +119,48 @@ fn private_append_rejects_a_final_symlink() {
         std::fs::read(&outside_file).expect("outside file remains"),
         b"unchanged"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn read_file_lock_holder_rejects_a_symlinked_lock_file() {
+    let root = tempfile::tempdir().expect("root tempdir");
+    let outside = tempfile::tempdir().expect("outside tempdir");
+    let outside_file = outside.path().join("holder.json");
+    std::fs::write(
+        &outside_file,
+        br#"{"pid":1,"acquired_at":"2026-01-01T00:00:00Z","label":"planted"}"#,
+    )
+    .expect("outside holder file");
+    let link = root.path().join(".task.yaml.lock");
+    std::os::unix::fs::symlink(&outside_file, &link).expect("symlink");
+
+    assert!(
+        read_file_lock_holder(&link).is_none(),
+        "a symlinked lock path must not be read as holder metadata"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn read_file_lock_holder_reads_through_a_symlinked_parent_route() {
+    let root = tempfile::tempdir().expect("root tempdir");
+    let real_dir = root.path().join("real");
+    std::fs::create_dir(&real_dir).expect("real directory");
+    let linked_dir = root.path().join("linked");
+    std::os::unix::fs::symlink(&real_dir, &linked_dir).expect("parent symlink");
+
+    let lock_path = real_dir.join(".task.yaml.lock");
+    std::fs::write(
+        &lock_path,
+        br#"{"pid":1,"acquired_at":"2026-01-01T00:00:00Z","label":"holder"}"#,
+    )
+    .expect("holder file");
+
+    let holder = read_file_lock_holder(&linked_dir.join(".task.yaml.lock"))
+        .expect("holder metadata through a symlinked parent");
+    assert_eq!(holder.pid, 1);
+    assert_eq!(holder.label, "holder");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Task

[ORB-11953](https://orbit-cli.com/tasks/ORB-11953) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-common/src/fs/file_lock.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#373`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.27.0`, guid `unknown`)
- Message: This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `3fced6f6a6bcfc1d6e85aa5e876f0acbc7c85ada`
- Location: `crates/orbit-common/src/fs/file_lock.rs` line 165
- Created: `2026-09-08T04:26:54Z`
- Updated: `2026-09-08T05:17:23Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/373

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-common/src/fs/file_lock.rs` line 165 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Remediated CodeQL rust/path-injection alert #373 at crates/orbit-common/src/fs/file_lock.rs:165 (`read_file_lock_holder`, a public API that opened a caller-supplied `lock_path` directly via `File::open`).

Fix: added `validated_lock_holder_path` (file_lock.rs), which canonicalizes `lock_path`'s parent directory and joins the file name back onto that canonical parent, then requires the resulting candidate to already exist as a regular (non-symlink) file via `symlink_metadata`. `read_file_lock_holder` now opens only that validated candidate; a missing parent, missing file, or symlinked final component all fall through to `None`, preserving the documented "missing/torn file = no metadata" contract. This follows the exact remediation pattern already established in this sweep for sibling alerts (orbit-common::fs::selector, orbit-store::auto_task, orbit-cmd::registry_runtime): canonicalize-then-verify before the filesystem call, no suppression.

Registered the new validator as a manual path-injection barrier in .github/codeql/extensions/orbit-rust-path-validation/path-validation.yml (`orbit_common::fs::file_lock::validated_lock_holder_path`, `ReturnValue.Field[core::option::Option::Some(0)]`) so CodeQL's data-flow model recognizes the sanitizer — consistent with the ~20 existing entries in that file for prior sweep tasks. The underlying alert is not suppressed or dismissed; the barrier only tells the analyzer that this specific validated path no longer carries untrusted taint.

Added two regression tests in crates/orbit-common/src/fs/tests/io.rs:
- `read_file_lock_holder_rejects_a_symlinked_lock_file`: a lock path that is a symlink to an outside file containing valid holder JSON must return `None` (proves the original vulnerability — reading through a planted symlink — is closed).
- `read_file_lock_holder_reads_through_a_symlinked_parent_route`: a lock path reached through a symlinked *parent* directory (a supported layout, e.g. checkout projections) still returns the holder metadata (proves behavior preservation for the legitimate case).

Acceptance criteria:
1. Rule remediated with a real code fix (canonicalize + symlink rejection), not suppressed/dismissed/excluded — done.
2. Intended behavior preserved (missing/torn/legacy files still report no metadata; symlinked-parent routes still work) while the unsafe direct-open-of-tainted-path construct is removed — done, verified by the two new tests plus the full existing suite.
3. Validation run — done (see below). Confirming the rule no longer reports at this location requires the hosted CodeQL rescan, which per task comments the orchestrator owns post-merge; this leaf cannot trigger GitHub Code Scanning directly.

Validation:
- `cargo test -p orbit-common` — passed, 250 unit tests + 1 integration test, including the 2 new regression tests.
- `make ci-fast` — passed (fmt-check + guardrail scripts).
- `make ci-lint` — passed (workspace-wide `cargo clippy --all-targets -- -D warnings`, zero warnings).
- `git diff --check` / `git status --short` — clean; only the 3 intended files changed (file_lock.rs, tests/io.rs, path-validation.yml).

No scope expansion beyond the two context_files already on the task plus the CodeQL barrier-model config, which is the established sibling pattern for every prior task in this sweep. Changes left uncommitted for the pipeline to commit/PR/merge.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11953-6aa2463a`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra