### PR TITLE
Fix scheduled worktree GC losing its workspace context

### DIFF
--- a/crates/orbit-cli/tests/worktree_gc_routing.rs
+++ b/crates/orbit-cli/tests/worktree_gc_routing.rs
@@ -1,0 +1,453 @@
+#![allow(missing_docs)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+//! [ORB-11998] Regression coverage for scheduled worktree GC losing its
+//! workspace context.
+//!
+//! Two independent bugs combined to produce the incident's
+//! `success, dry_run:false, bytes_reclaimed:0, reports:[]` signature:
+//!
+//! 1. **Workspace routing.** The routine sweep correctly identifies which
+//!    registered workspace owns a due routine and submits its job against
+//!    that workspace's own runtime — but the *detached worker subprocess*
+//!    that actually executes the job re-resolves its own workspace from
+//!    scratch (cwd walk-up), and an `ORBIT_ROOT` value inherited from the
+//!    sweep process's own environment outranks that cwd. A stale/ambient
+//!    `ORBIT_ROOT` therefore silently redirects every routine-dispatched
+//!    worker to one fixed (and usually irrelevant) root, regardless of which
+//!    workspace's routine fired.
+//! 2. **A field-name collision**, independent of (1) and sufficient on its
+//!    own to reproduce the empty-report symptom: the engine's step
+//!    dispatcher auto-injects `run_id` (the *dispatching* run's own id) into
+//!    every step input that doesn't already declare one
+//!    (`activity_job::dispatcher::inject_run_id`). The `worktree_gc`
+//!    activity's own input schema also named its "restrict to one historical
+//!    run" scoping field `run_id`, so every real job/routine-dispatched run
+//!    got that scope silently clobbered with its own id — a run that never
+//!    has a worktree of its own — and reaped nothing, every time, regardless
+//!    of workspace correctness. Renamed to `target_run_id`.
+//!
+//! This test builds two independently registered workspaces sharing one
+//! global root, each with a real, eligible, terminal-task worktree, then
+//! fires workspace B's `worktree_gc_pipeline` routine through `orbit sweep`
+//! while `ORBIT_ROOT` in the sweep process's own environment points at a
+//! third, unrelated (but validly initialized) root — exactly reproducing the
+//! incident's ambient-environment shape. It asserts B's eligible worktree is
+//! actually reclaimed and A's is left untouched, proving the dispatch
+//! reaches worktree collection with an explicit, correct workspace identity
+//! rather than falling back to cwd-losing environment state or another
+//! registered workspace.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command as StdCommand;
+use std::time::{Duration, Instant};
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
+use serde_json::Value;
+use tempfile::tempdir;
+
+struct Workspace {
+    repo: PathBuf,
+    orbit_dir: PathBuf,
+}
+
+#[test]
+fn routine_dispatch_ignores_ambient_orbit_root_and_reaps_only_the_owning_workspaces_worktree() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let repo_a = temp.path().join("workspace-a");
+    let repo_b = temp.path().join("workspace-b");
+    let decoy_root = temp.path().join("decoy-root");
+    fs::create_dir_all(&home).expect("create isolated home");
+    fs::create_dir_all(&repo_a).expect("create repo a");
+    fs::create_dir_all(&repo_b).expect("create repo b");
+    init_git_repo(&repo_a);
+    init_git_repo(&repo_b);
+
+    // Host identity lives in the default global root ($HOME/.orbit) — no
+    // --root/ORBIT_ROOT override, matching the real split-root production
+    // layout the incident happened in.
+    run_success(
+        &repo_a,
+        &home,
+        &[
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "gc-routing-host",
+            "--task-prefix",
+            "WG",
+        ],
+    );
+    let workspace_a = register_workspace(&repo_a, &home, "workspace-a");
+    let workspace_b = register_workspace(&repo_b, &home, "workspace-b");
+
+    // A third, independently initialized (but otherwise irrelevant) pinned
+    // root: self-consistent enough that a worker mistakenly pinned to it
+    // opens successfully — it just owns none of this test's workspaces or
+    // job runs. This is what an ambient ORBIT_ROOT looks like in practice: a
+    // valid root, just not the one the firing routine belongs to.
+    run_success(
+        &repo_a,
+        &home,
+        &[
+            "--root",
+            &decoy_root.to_string_lossy(),
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "decoy-host",
+            "--task-prefix",
+            "DC",
+        ],
+    );
+
+    let (worktree_a, _task_a) = seed_eligible_worktree(&workspace_a, &home, "A");
+    let (worktree_b, task_b) = seed_eligible_worktree(&workspace_b, &home, "B");
+    assert!(worktree_a.exists(), "workspace A fixture worktree missing");
+    assert!(worktree_b.exists(), "workspace B fixture worktree missing");
+
+    // The routine's own job asset defaults to a 24h `older_than_hours`
+    // floor; drop it so a freshly finished fixture run is eligible without
+    // needing to fabricate a backdated run record.
+    zero_worktree_gc_age_floor(&home);
+    enable_worktree_gc_routine(&workspace_b);
+
+    // Fire the sweep from workspace A's checkout — the "non-current"
+    // workspace relative to B, whose routine is the one that must dispatch.
+    //
+    // `--root` pins sweep's *own* discovery to the real registry (it takes
+    // precedence over `ORBIT_ROOT`, so sweep still correctly finds and fires
+    // workspace B's routine) — but the detached worker sweep spawns for that
+    // routine receives no `--root` of its own (its parent runtime is not
+    // pinned: global root != workspace B's `.orbit`), so it falls through to
+    // whatever `ORBIT_ROOT` it inherited. This is exactly how the incident
+    // reproduced in practice: an operator/service passes `--root` (or relies
+    // on `$HOME`) for the sweep invocation itself while an unrelated,
+    // ambient `ORBIT_ROOT` sits in the same process environment.
+    let global_root = home.join(".orbit");
+    let fire_sweep = || -> Value {
+        let mut sweep = command(&repo_a, &home);
+        sweep.env("ORBIT_ROOT", &decoy_root);
+        let output = sweep
+            .args([
+                "sweep",
+                "--root",
+                global_root.to_str().expect("global root is utf-8"),
+                "--format",
+                "json",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        serde_json::from_slice(&output).unwrap_or_else(|error| {
+            panic!(
+                "parse sweep JSON: {error}\nstdout:\n{}",
+                String::from_utf8_lossy(&output)
+            )
+        })
+    };
+
+    // The routine has never been observed before, so this first pass only
+    // records a baseline cursor (avoiding a catch-up burst of fires) rather
+    // than dispatching. Cross into the next whole minute — `* * * * *`'s
+    // finest granularity — before sweeping again, which is when the cursor
+    // makes it due.
+    let baseline = fire_sweep();
+    assert!(
+        routine_report(&baseline, "worktree-gc-workspace-b").is_some(),
+        "sweep never evaluated workspace B's worktree_gc routine: {baseline}"
+    );
+
+    sleep_past_next_minute_boundary();
+
+    let fired = fire_sweep();
+    let report = routine_report(&fired, "worktree-gc-workspace-b").unwrap_or_else(|| {
+        panic!(
+            "sweep never evaluated workspace B's worktree_gc routine on the second pass: {fired}"
+        )
+    });
+    assert!(
+        matches!(
+            report["action"].as_str(),
+            Some("fired") | Some("retry_fired")
+        ),
+        "workspace B's worktree_gc routine did not dispatch on its due pass: {report}"
+    );
+
+    let gc_run_id = report["run_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("fired report carried no run_id: {report}"))
+        .to_string();
+
+    wait_until(Duration::from_secs(20), || !worktree_b.exists());
+
+    assert!(
+        !worktree_b.exists(),
+        "workspace B's eligible worktree was not reclaimed by its own routine dispatch \
+         (ambient ORBIT_ROOT silently redirected the worker to a different workspace)"
+    );
+    assert!(
+        worktree_a.exists(),
+        "workspace A's worktree was removed by workspace B's routine dispatch — \
+         cross-workspace deletion"
+    );
+
+    // Confirm the reclamation is attributed correctly, not just that the
+    // directory happened to disappear: the dispatched run's own workspace
+    // identity must match workspace B, and its activity output must name
+    // exactly the reclaimed worktree with a real `bytes_reclaimed` total.
+    let run_show = run_json(
+        &workspace_b.repo,
+        &home,
+        &["run", "show", &gc_run_id, "--json"],
+    );
+    assert_eq!(run_show["run"]["state"], "success");
+    assert_eq!(
+        run_show["pipeline_state"]["initial_input"]["__routine_dispatch_orbit_dir"],
+        workspace_b.orbit_dir.to_string_lossy().as_ref(),
+    );
+    let reap = &run_show["pipeline_state"]["pipeline"]["reap"];
+    assert!(reap["bytes_reclaimed"].as_u64().unwrap_or(0) > 0, "{reap}");
+    let reports = reap["reports"].as_array().expect("reap reports array");
+    assert!(
+        reports.iter().any(|report| {
+            report["action"] == "removed"
+                && report["task_id"] == task_b.as_str()
+                && report["path"].as_str()
+                    == Some(worktree_b.to_str().expect("worktree path is utf-8"))
+        }),
+        "reap output did not attribute the removal to workspace B's fixture worktree: {reap}"
+    );
+}
+
+fn register_workspace(repo: &Path, home: &Path, name: &str) -> Workspace {
+    // `workspace init` has no `--json` flag; read its `orbit_dir:` summary line.
+    let output = command(repo, home)
+        .args(["workspace", "init", "--name", name])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8_lossy(&output);
+    let orbit_dir = text
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("orbit_dir:"))
+        .unwrap_or_else(|| panic!("workspace init reported no orbit_dir line:\n{text}"))
+        .trim();
+    Workspace {
+        repo: repo.to_path_buf(),
+        orbit_dir: PathBuf::from(orbit_dir),
+    }
+}
+
+/// Create a task settled to `archived` (one of the three GC-eligible terminal
+/// statuses), a job run naming it via the legacy singular `task_id` input
+/// field, and a real, clean git worktree at the exact path GC resolves for
+/// that run — the same shape `setup_worktree` produces for a live task.
+fn seed_eligible_worktree(workspace: &Workspace, home: &Path, label: &str) -> (PathBuf, String) {
+    let task = run_json(
+        &workspace.repo,
+        home,
+        &[
+            "task",
+            "add",
+            "--title",
+            &format!("GC fixture task {label}"),
+            "--complexity",
+            "low",
+            "--json",
+        ],
+    );
+    let task_id = task["id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("task add reported no id: {task}"))
+        .to_string();
+    run_success(&workspace.repo, home, &["task", "archive", &task_id]);
+
+    let fixture_job = workspace.repo.join(format!("gc-fixture-{label}.yaml"));
+    fs::write(
+        &fixture_job,
+        r#"schemaVersion: 2
+kind: Job
+metadata:
+  name: gc_fixture_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  steps:
+    - id: nap
+      default_input:
+        seconds: 0
+      spec:
+        type: deterministic
+        action: sleep
+        config: {}
+"#,
+    )
+    .expect("write fixture job asset");
+    let run = run_json(
+        &workspace.repo,
+        home,
+        &[
+            "run",
+            "job",
+            fixture_job.to_str().expect("fixture job path is utf-8"),
+            "--input",
+            &format!("task_id={task_id}"),
+            "--wait",
+            "--json",
+        ],
+    );
+    assert_eq!(
+        run["state"], "succeeded",
+        "fixture job run did not settle: {run}"
+    );
+    let run_id = run["run_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("run job reported no run_id: {run}"))
+        .to_string();
+
+    let worktree = workspace
+        .repo
+        .join(".orbit/state/worktrees")
+        .join(format!("orbit-{run_id}"));
+    let branch = format!("orbit/gc-fixture-{label}");
+    run_git(
+        &workspace.repo,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            &branch,
+            worktree.to_str().expect("worktree path is utf-8"),
+            "HEAD",
+        ],
+    );
+    fs::write(worktree.join("fixture.txt"), label).expect("write worktree fixture file");
+    run_git(&worktree, &["add", "fixture.txt"]);
+    run_git(&worktree, &["commit", "-m", "gc fixture content"]);
+
+    (worktree, task_id)
+}
+
+fn zero_worktree_gc_age_floor(home: &Path) {
+    let path = home.join(".orbit/resources/jobs/worktree_gc_pipeline.yaml");
+    let content = fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    let updated = content.replace("older_than_hours: 24", "older_than_hours: 0");
+    assert_ne!(
+        content,
+        updated,
+        "expected an `older_than_hours: 24` default in {}",
+        path.display()
+    );
+    fs::write(&path, updated).unwrap_or_else(|error| panic!("write {}: {error}", path.display()));
+}
+
+fn enable_worktree_gc_routine(workspace: &Workspace) {
+    let path = workspace.orbit_dir.join("routines/worktree_gc.yaml");
+    let content = fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    let updated = content
+        .replace("enabled: false", "enabled: true")
+        .replace("cron: \"35 * * * *\"", "cron: \"* * * * *\"");
+    fs::write(&path, updated).unwrap_or_else(|error| panic!("write {}: {error}", path.display()));
+
+    let config_path = workspace.orbit_dir.join("config.toml");
+    let mut config = fs::read_to_string(&config_path).unwrap_or_default();
+    config.push_str("\n[routines]\nrole = \"source\"\n");
+    fs::write(&config_path, config).expect("enable routine source role");
+}
+
+fn routine_report<'a>(sweep_report: &'a Value, routine_name: &str) -> Option<&'a Value> {
+    sweep_report["reports"]
+        .as_array()?
+        .iter()
+        .find(|report| report["routine"].as_str() == Some(routine_name))
+}
+
+fn sleep_past_next_minute_boundary() {
+    use chrono::{Timelike, Utc};
+    let now = Utc::now();
+    let remaining = 60 - now.second();
+    std::thread::sleep(Duration::from_secs(u64::from(remaining) + 2));
+}
+
+fn wait_until(timeout: Duration, mut condition: impl FnMut() -> bool) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if condition() {
+            return;
+        }
+        if Instant::now() >= deadline {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+}
+
+fn run_success(cwd: &Path, home: &Path, args: &[&str]) {
+    command(cwd, home).args(args).assert().success();
+}
+
+fn run_json(cwd: &Path, home: &Path, args: &[&str]) -> Value {
+    let output = command(cwd, home)
+        .args(args)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    serde_json::from_slice(&output).unwrap_or_else(|error| {
+        panic!(
+            "parse JSON from `orbit {}`: {error}\nstdout:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output)
+        )
+    })
+}
+
+fn command(cwd: &Path, home: &Path) -> assert_cmd::Command {
+    let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("USERPROFILE", home);
+    command
+}
+
+fn init_git_repo(repo: &Path) {
+    run_git(repo, &["init", "--quiet"]);
+    run_git(repo, &["config", "user.name", "Orbit Test"]);
+    run_git(repo, &["config", "user.email", "orbit-test@example.com"]);
+    run_git(repo, &["config", "commit.gpgsign", "false"]);
+    fs::write(repo.join("README.md"), "# worktree gc routing test\n").expect("write readme");
+    run_git(repo, &["add", "README.md"]);
+    run_git(repo, &["commit", "--quiet", "-m", "initial"]);
+}
+
+fn run_git(cwd: &Path, args: &[&str]) -> String {
+    let output = StdCommand::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {} failed in {}:\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        cwd.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}

--- a/crates/orbit-core/assets/activities/worktree_gc.yaml
+++ b/crates/orbit-core/assets/activities/worktree_gc.yaml
@@ -14,7 +14,13 @@ spec:
       older_than_hours:
         type: integer
         minimum: 0
-      run_id:
+      # Named `target_run_id`, not `run_id`: the engine's step dispatcher
+      # auto-injects `run_id` (the *dispatching* run's own id) into every step
+      # input that doesn't already declare one. A field literally named
+      # `run_id` here would always be clobbered with this activity's own run
+      # id on every real job/routine dispatch, scoping collection to a run
+      # that never has a worktree of its own and silently reaping nothing.
+      target_run_id:
         type: string
   output_schema_json:
     type: object

--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -63,6 +63,13 @@ const AGENT_INVOKE_IDEMPOTENCY_SCAN_LIMIT: usize = 200;
 /// enough to spot a duplicate dispatch without walking the whole history.
 const SHIP_IN_FLIGHT_SCAN_LIMIT: usize = 200;
 
+/// [ORB-11998] Run-input field carrying the owning workspace's `.orbit`
+/// directory, as set by routine dispatch (`RuntimeDispatch::submit`). The
+/// executing worker verifies its own resolved workspace against this value
+/// before running any step, so a workspace-routing failure surfaces as a
+/// visibly failed run instead of a silent no-op success.
+pub(crate) const ROUTINE_DISPATCH_ORBIT_DIR_FIELD: &str = "__routine_dispatch_orbit_dir";
+
 /// The refusal for a submission that supplied the reserved trusted-host
 /// admission key it is not entitled to write [ORB-11354].
 ///
@@ -1041,6 +1048,11 @@ impl OrbitRuntime {
                 )));
             }
 
+            if let Err(error) = self.verify_routine_dispatch_workspace(&run) {
+                let _ = self.cancel_job_run(&run.run_id);
+                return Err(error);
+            }
+
             self.reconcile_stale_job_runs(Some(&run.job_id))?;
             let active_runs = self
                 .stores()
@@ -1053,6 +1065,37 @@ impl OrbitRuntime {
 
             return self.execute_pipeline_run_now(&run, &yaml_path);
         }
+    }
+
+    /// [ORB-11998] A routine-dispatched run declares the `.orbit` directory of
+    /// the workspace that owns it (see [`ROUTINE_DISPATCH_ORBIT_DIR_FIELD`]).
+    /// Confirm this worker actually opened that same workspace before it runs
+    /// any step. A mismatch — an ambient `ORBIT_ROOT`, an unregistered cwd, or
+    /// any other workspace-routing failure — must fail the run visibly rather
+    /// than silently execute (or vacuously succeed) against the wrong scope.
+    /// A run with no declared field is not routine-dispatched and is
+    /// unaffected.
+    fn verify_routine_dispatch_workspace(&self, run: &JobRun) -> Result<(), OrbitError> {
+        let Some(declared) = run
+            .input
+            .as_ref()
+            .and_then(|input| input.get(ROUTINE_DISPATCH_ORBIT_DIR_FIELD))
+            .and_then(Value::as_str)
+        else {
+            return Ok(());
+        };
+        let declared_dir = Path::new(declared);
+        let actual_dir = &self.paths().orbit_dir;
+        if declared_dir == actual_dir.as_path() {
+            return Ok(());
+        }
+        Err(OrbitError::WorkspaceError(format!(
+            "run '{}' was dispatched for workspace '{}' but this worker resolved workspace '{}'; \
+             refusing to execute against a mismatched workspace context",
+            run.run_id,
+            declared_dir.display(),
+            actual_dir.display(),
+        )))
     }
 
     /// Reopen the shared SQLite store before the worker claims a run.
@@ -1876,11 +1919,18 @@ pub(crate) fn configure_pipeline_worker_command(
     run_id: &str,
     root_override: Option<&Path>,
 ) {
+    // [ORB-11998] `resolve_roots` prefers an `ORBIT_ROOT` env value over cwd
+    // walk-up, so an inherited value — from the sweep clock's own service
+    // environment, an operator's shell, or any other ambient source — would
+    // silently redirect this worker to a different registered workspace than
+    // the one `current_dir` below pins it to. Every worker gets an explicit
+    // workspace identity, either via `--root` (pinned parent) or cwd (default
+    // split-root layout), so `ORBIT_ROOT` must never be left to compete with
+    // either.
+    command.env_remove("ORBIT_ROOT");
     if let Some(root) = root_override {
-        // `--root` pins both stores. Clear inherited `ORBIT_ROOT` so the child
-        // cannot reopen `$HOME/.orbit` via the env-only workspace selector
-        // while the parent persisted the run under the pinned root.
-        command.arg("--root").arg(root).env_remove("ORBIT_ROOT");
+        // `--root` pins both stores.
+        command.arg("--root").arg(root);
     }
     command
         .arg("job")

--- a/crates/orbit-core/src/application/routines/sweep.rs
+++ b/crates/orbit-core/src/application/routines/sweep.rs
@@ -70,8 +70,15 @@ impl RoutineDispatch for RuntimeDispatch<'_> {
                 source_orbit_dir.display()
             ))
         })?;
+        // [ORB-11998] Carry the owning workspace's `.orbit` directory into the
+        // run explicitly, so the detached worker that ends up executing it can
+        // verify its own resolved workspace matches this one — instead of the
+        // run silently trusting whatever the worker's cwd/env resolved to.
+        let mut input = json!({});
+        input[crate::application::job::pipeline::ROUTINE_DISPATCH_ORBIT_DIR_FIELD] =
+            json!(source_orbit_dir.to_string_lossy());
         runtime
-            .submit_pipeline_run(job_name, json!({}), None, Some(actor))
+            .submit_pipeline_run(job_name, input, None, Some(actor))
             .map(|invoke| invoke.run_id)
     }
 

--- a/crates/orbit-core/src/application/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/application/tests/job_pipeline.rs
@@ -16,10 +16,10 @@ use tempfile::TempDir;
 use crate::OrbitRuntime;
 use crate::application::job::JobRunListParams;
 use crate::application::job::pipeline::{
-    configure_pipeline_worker_command, configure_pipeline_worker_stdio, pipeline_worker_log_path,
-    pipeline_worker_profile_file, pipeline_worker_root_override,
-    resolve_pipeline_worker_executable, run_definition_snapshot_path, worker_command_override,
-    worker_observer_read_counter,
+    ROUTINE_DISPATCH_ORBIT_DIR_FIELD, configure_pipeline_worker_command,
+    configure_pipeline_worker_stdio, pipeline_worker_log_path, pipeline_worker_profile_file,
+    pipeline_worker_root_override, resolve_pipeline_worker_executable,
+    run_definition_snapshot_path, worker_command_override, worker_observer_read_counter,
 };
 use crate::application::task::TaskAddParams;
 use crate::application::workflow::{CompletionPolicy, ShipMode};
@@ -112,6 +112,15 @@ fn pipeline_worker_command_discovers_registered_workspace_from_cwd() {
         "an unpinned parent must not pass --root; that pins both roots and disconnects the worker from the global store"
     );
     assert_eq!(command.get_current_dir(), Some(workspace));
+    assert!(
+        command
+            .get_envs()
+            .any(|(key, value)| key == OsStr::new("ORBIT_ROOT") && value.is_none()),
+        "ORB-11998: an inherited ORBIT_ROOT must not be left to outrank the cwd this \
+         worker was explicitly pinned to — resolve_roots prefers the env var over cwd \
+         walk-up, so a leftover value would silently redirect the worker to a different \
+         registered workspace"
+    );
 }
 
 #[test]
@@ -988,6 +997,90 @@ fn newer_schema_fails_before_worker_claims_or_executes() {
     assert_eq!(stored.state, JobRunState::Pending);
     assert_eq!(stored.pid, None);
     assert!(stored.steps.is_empty());
+}
+
+/// Seed a trivial always-enabled job (a single `sleep` step) so a run can
+/// reach step execution without depending on catalog defaults.
+fn seed_sleep_job(runtime: &OrbitRuntime, job_name: &str) {
+    let jobs_dir = runtime.paths().global_dir.join("resources/jobs");
+    std::fs::create_dir_all(&jobs_dir).expect("create jobs dir");
+    std::fs::write(
+        jobs_dir.join(format!("{job_name}.yaml")),
+        format!(
+            r#"schemaVersion: 2
+kind: Job
+metadata:
+  name: {job_name}
+spec:
+  state: enabled
+  kind: workflow
+  steps:
+    - id: nap
+      default_input:
+        seconds: 0
+      spec:
+        type: deterministic
+        action: sleep
+        config: {{}}
+"#
+        ),
+    )
+    .expect("seed sleep job definition");
+}
+
+/// [ORB-11998] A routine-dispatched run declares the `.orbit` directory of its
+/// owning workspace. If the worker that claims it resolved a different
+/// workspace — the exact failure mode behind the original incident, where an
+/// inherited `ORBIT_ROOT` silently redirected the worker — the run must fail
+/// visibly instead of vacuously succeeding against the wrong (or empty) scope.
+#[test]
+fn routine_dispatch_workspace_mismatch_fails_the_run_before_it_executes() {
+    let (_root, runtime) = test_runtime();
+    seed_sleep_job(&runtime, "task_gate_pipeline");
+    let mismatched_dir = "/completely/unrelated/workspace/.orbit";
+    let input = serde_json::json!({ ROUTINE_DISPATCH_ORBIT_DIR_FIELD: mismatched_dir });
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("task_gate_pipeline", 1, Utc::now(), Some(input), None)
+        .expect("insert routine-dispatched run declaring a mismatched workspace");
+
+    let error = runtime
+        .execute_pipeline_run_worker(&run.run_id)
+        .expect_err("a mismatched declared workspace must fail the run");
+    let message = error.to_string();
+    assert!(message.contains(mismatched_dir), "{message}");
+    assert!(message.contains("mismatched workspace"), "{message}");
+
+    let terminal = runtime.show_job_run(&run.run_id).expect("show run");
+    assert_eq!(
+        terminal.state,
+        JobRunState::Cancelled,
+        "a workspace-routing failure must be a visible terminal outcome, not success"
+    );
+}
+
+/// The companion positive case: a routine-dispatched run whose declared
+/// workspace matches the executing worker's own resolved workspace must run
+/// its steps normally, proving the new check is not a blanket refusal.
+#[test]
+fn routine_dispatch_workspace_match_lets_the_run_execute() {
+    let (_root, runtime) = test_runtime();
+    seed_sleep_job(&runtime, "task_gate_pipeline");
+    let matching_dir = runtime.paths().orbit_dir.to_string_lossy().into_owned();
+    let input = serde_json::json!({ ROUTINE_DISPATCH_ORBIT_DIR_FIELD: matching_dir });
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("task_gate_pipeline", 1, Utc::now(), Some(input), None)
+        .expect("insert routine-dispatched run declaring the correct workspace");
+
+    runtime
+        .execute_pipeline_run_worker(&run.run_id)
+        .expect("a matching declared workspace must not be refused");
+
+    let terminal = runtime.show_job_run(&run.run_id).expect("show run");
+    assert_eq!(terminal.state, JobRunState::Success);
 }
 
 #[test]

--- a/crates/orbit-engine/src/executor/automation/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/mod.rs
@@ -108,8 +108,15 @@ pub(crate) fn execute_engine_action<
                 host,
                 &vcs::WorktreeGcOptions {
                     delete: true,
+                    // [ORB-11998] Read the activity's own `target_run_id`
+                    // field, not the engine-injected `run_id` (every step's
+                    // own dispatching run id — see `inject_run_id` in
+                    // `activity_job::dispatcher`). Reading `run_id` here
+                    // would scope every real job/routine dispatch to itself,
+                    // a run with no worktree of its own, and silently reap
+                    // nothing on every invocation.
                     run_id: input
-                        .get("run_id")
+                        .get("target_run_id")
                         .and_then(Value::as_str)
                         .map(ToOwned::to_owned),
                     older_than,


### PR DESCRIPTION
## Task

[ORB-11998](https://orbit-cli.com/tasks/ORB-11998) — Fix scheduled worktree GC losing its workspace context

### Description

## Problem

The scheduled `worktree_gc_pipeline` can finish successfully without inspecting or reclaiming eligible worktrees in the routine's owning workspace.

Observed on `dk-server-1` on 2026-09-10:

- `worktree-gc-orbit-graph` was enabled, unpaused, and last reported `succeeded` at 03:35 UTC.
- Its run `jrun-20260910-0336` completed with `dry_run: false`, `bytes_reclaimed: 0`, and an empty `reports` array.
- Immediately afterward, running `orbit gc worktrees --older-than-hours 24` from the registered `orbit-graph` checkout found 25,154,087,948 bytes of eligible settled worktrees.
- The same scheduled pipeline shape in the constellation workspace also returned success with no reports.
- Manual GC subsequently reclaimed the accumulated worktrees, so the stale directories are no longer a durable reproduction fixture.

This suggests the routine/job/activity path is dropping or resolving the wrong workspace context. The CLI collector itself sees the correct candidates when invoked from the owning checkout.

## Why It Matters

Rust build output inside Orbit-managed worktrees caused disk use to climb to 211 GB. A manual GC during this investigation dropped usage by roughly 45 GB, while additional old candidates existed in other workspaces. Reporting scheduled GC as successful while silently scanning the wrong or empty scope defeats the disk-safety mechanism.

## Constraints / Notes

- Preserve the collector's safety gates: never reap live runs, unfinished task states, dirty rescue candidates, or unrecognized worktrees.
- Use isolated temporary registered workspaces and deterministic fixtures in tests; do not depend on live `.orbit/state` data.
- A workspace-routing failure must be visible as a failed/diagnostic outcome, not a successful zero-candidate run.
- The fix should cover routines dispatched across multiple registered workspaces, not only the process's current checkout.

### Acceptance Criteria

- An integration test creates at least two registered workspaces, dispatches `worktree_gc_pipeline` for the non-current workspace, and proves the activity inventories and removes an eligible terminal-task worktree from that owning workspace.
- The scheduled routine → job → deterministic activity path carries an explicit authoritative workspace identity through to worktree collection; it does not fall back to process cwd or another registered workspace.
- A missing, invalid, or mismatched workspace context produces a visible failed/diagnostic run rather than `state: success` with `dry_run:false`, zero bytes, and an empty report.
- Regression coverage proves live runs, unfinished task states, dirty rescue candidates, and unrecognized worktrees remain protected after the routing fix.
- A real dry-run/manual verification against two isolated workspace fixtures shows reports and reclaimed-byte totals are attributed to the correct workspace with no cross-workspace deletion.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Root cause: two independent bugs, both required to fix the reported symptom

1. **Workspace-routing leak.** `configure_pipeline_worker_command` (crates/orbit-core/src/application/job/pipeline.rs) only cleared an inherited `ORBIT_ROOT` env var in the "pinned root" branch (`--root` forwarded). In the default split-root layout — the actual production layout ($HOME/.orbit global + per-checkout `.orbit`) — `ORBIT_ROOT` was left in the detached pipeline-worker subprocess's environment. `resolve_roots` (runtime/resolve.rs) prefers `ORBIT_ROOT` over cwd walk-up, so an ambient value anywhere in the dispatching process's environment silently redirects every routine-dispatched worker to a different (and usually irrelevant) registered workspace, regardless of the `current_dir` the parent explicitly set. Confirmed via a real two-registered-workspace `orbit sweep` invocation with `--root` (pinning sweep's own discovery to the real registry) plus an ambient `ORBIT_ROOT` pointing at an unrelated, independently-initialized root — before the fix this silently redirects the worker; the fix restores correct routing.
2. **Field-name collision — the direct, sufficient cause of the exact "success/dry_run:false/bytes_reclaimed:0/reports:[]" signature.** The `worktree_gc` activity's own "restrict collection to one historical run" input field was named `run_id`. The engine's step dispatcher (`activity_job::dispatcher::inject_run_id`, called by every ordinary job/routine step dispatch) auto-inserts `run_id = <the dispatching run's own id>` into any step input that doesn't already declare one. Every real job- or routine-dispatched `worktree_gc_pipeline` run therefore had its own id silently injected as if it were an explicit single-run filter, scoping `collect_worktrees` to a run that never has a worktree of its own — reaping nothing, every time, **independent of workspace-routing correctness**. The dedicated `orbit gc worktrees` CLI path was unaffected (it builds `WorktreeGcOptions` directly in Rust, bypassing the JSON activity-input contract entirely), which is why manual CLI GC always "worked" while the scheduled/job path never did. Reproduced this in isolation: even after fix (1), the routing-correct e2e run still returned an empty report until this field was renamed.

## Fix

- `pipeline.rs`: `configure_pipeline_worker_command` now unconditionally `env_remove("ORBIT_ROOT")` before spawning any detached worker (not only when `--root` is forwarded).
- `pipeline.rs` / `sweep.rs`: routine dispatch (`RuntimeDispatch::submit`) now carries the owning workspace's `.orbit` directory explicitly in run input (`__routine_dispatch_orbit_dir`); the executing worker (`execute_pipeline_run_worker` → new `verify_routine_dispatch_workspace`) verifies its own resolved workspace against this declared value before running any step, cancelling the run with a descriptive `WorkspaceError` on mismatch instead of silently executing (or vacuously succeeding) against the wrong scope.
- `crates/orbit-core/assets/activities/worktree_gc.yaml` + `crates/orbit-engine/src/executor/automation/mod.rs`: renamed the activity's single-run scoping field from `run_id` to `target_run_id`, eliminating the collision with the engine's `run_id` convention. `WorktreeGcReport.run_id` (an unrelated output-attribution field) and the CLI's Rust-native `--run` flag were left untouched — confirmed unaffected.

## Acceptance criteria → evidence

1. **Integration test, ≥2 registered workspaces, real dispatch/removal** — `crates/orbit-cli/tests/worktree_gc_routing.rs` (new). Registers two workspaces under one shared root plus a third independent root as an ORBIT_ROOT decoy; seeds a real, eligible, terminal-task (archived) worktree in each via the real CLI; fires workspace B's routine through two real `orbit sweep` passes (crossing the cron baseline-then-due boundary); asserts workspace B's worktree is actually removed with correct `task_id`/`path`/`bytes_reclaimed` attribution in the run's own output, and workspace A's untouched. This lives in orbit-cli (not orbit-core) because the real detached-worker subprocess path is `#[cfg(not(test))]` — an orbit-core test only ever exercises the `worker_command_override` stub, never the real spawn the bug lived in; only a black-box `assert_cmd` run of the actual compiled binary reaches it.
2. **Explicit authoritative workspace identity, no fallback** — `ROUTINE_DISPATCH_ORBIT_DIR_FIELD` + `verify_routine_dispatch_workspace`, exercised by the e2e test (asserts the run's `initial_input.__routine_dispatch_orbit_dir` matches workspace B) and by the ORBIT_ROOT-clearing fix itself.
3. **Mismatch fails visibly, not silent empty success** — new unit tests in `job_pipeline.rs`: `routine_dispatch_workspace_mismatch_fails_the_run_before_it_executes` (declared vs. resolved workspace differ → `Err(WorkspaceError)`, run terminalizes `Cancelled`, not `Success`) and `routine_dispatch_workspace_match_lets_the_run_execute` (matching declaration proceeds normally — the check isn't a blanket refusal).
4. **Existing safety gates unaffected** — full `orbit-engine` suite (669 tests, including every `vcs::worktree::tests::gc` case: dirty rescue, non-terminal run, blocked/review task status, unrecognized/unregistered directories, ambiguous run paths, etc.) passes unchanged.
5. **Correct-workspace attribution, no cross-workspace deletion, dry-run/manual verification** — the same e2e test's final assertions (workspace A's worktree survives; workspace B's run output names exactly the reclaimed path/task with `bytes_reclaimed > 0`).

## Validation (commands run, this checkout)

- `cargo test -p orbit-engine --lib` — 669 passed, 0 failed, 3 ignored.
- `cargo test -p orbit-core --lib` — 1322 passed, 0 failed, 2 ignored (includes new `job_pipeline.rs` tests and the repository-agnostic embedded-asset guardrail, which caught and required removing a task-ID reference from the shipped activity YAML comment).
- `cargo test -p orbit-cmd --lib` — 118 passed, 0 failed.
- `cargo test -p orbit-cli --test worktree_gc_routing -- --nocapture` — 1 passed (real `orbit sweep`/detached-worker e2e, ~40s).
- `make ci-fast` — passed (fmt-check + guardrail scripts, including `sync-activity-assets`).
- `make ci-lint` — passed (workspace-wide `cargo clippy --all-targets -D warnings`).
- `git diff --check` — clean. `git status --short` — only the intended 5 modified files + 1 new test file.
- Did not run the full `make ci` (not required per workspace policy; it's the merge gate, not a per-task local check).

## Scope note

Of the task's pre-identified context files, `crates/orbit-core/src/application/routines/tests/sweep.rs`, `crates/orbit-core/src/adapter/engine_host/v2_host/tests/dispatch.rs`, and `crates/orbit-cmd/src/tests/registry_routines.rs` were read and confirmed to already exercise (and pass unchanged against) the surfaces they cover; no new coverage was added there because the actual defects and their regression tests concentrate in `pipeline.rs`'s worker-spawn path, `automation/mod.rs`'s action handler, and the new black-box e2e test — the three files that needed to change. Added `crates/orbit-cli/tests/worktree_gc_routing.rs` to context_files (see task comment) since it was required to satisfy AC#1/#5 through the real subprocess path.

## Disclosure: incidental live-state artifacts from manual investigation

While root-causing this outside the eventual isolated test harness, a Bash-tool env-isolation mistake (details in friction F2026-09-113) caused two real, harmless artifacts in this project's own live Orbit state: task `ORB-12017` (created and immediately archived, empty/labeled as a fixture) and job runs `jrun-20260910-0542` / `jrun-20260910-0542-4`. No destructive action occurred (the GC run found nothing to match; a separate manual `orbit gc worktrees` check was read-only, `--confirm` was never passed). Per prior task comment guidance, these are preserved as audit evidence rather than removed (no CLI task-delete surface exists, and `.orbit/` must not be hand-edited).

## Remaining risk / not done

- No `make ci` (full suite) run locally — deferred to the merge gate per workspace policy.
- The friction record recommends a follow-up (separate task) for narrower fixture-isolation guidance to prevent this specific manual-repro mistake from recurring; not created here since it's out of this task's scope.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11998-6aa23aff`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra