### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/bootstrap/global_defaults.rs

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -10,6 +10,12 @@ extensions:
           "manual",
         ]
       - [
+          "orbit_core::bootstrap::global_defaults::validated_stamp_path",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]
+      - [
           "orbit_core::runtime::validated_config_path",
           "ReturnValue.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]",
           "path-injection",

--- a/crates/orbit-core/src/bootstrap/global_defaults.rs
+++ b/crates/orbit-core/src/bootstrap/global_defaults.rs
@@ -47,7 +47,10 @@ struct GlobalDefaultsStamp {
 /// binary embeds. An absent, unreadable, or unrecognized stamp reads as stale,
 /// so an unusable stamp costs one reconciliation rather than correctness.
 pub(crate) fn global_defaults_are_current(global_root: &Path) -> bool {
-    let Ok(raw) = fs::read_to_string(stamp_path(global_root)) else {
+    let Ok(path) = validated_stamp_path(global_root) else {
+        return false;
+    };
+    let Ok(raw) = fs::read_to_string(path) else {
         return false;
     };
     let Ok(stamp) = serde_json::from_str::<GlobalDefaultsStamp>(&raw) else {
@@ -70,7 +73,7 @@ pub(crate) fn record_global_defaults_reconciled(global_root: &Path) -> Result<()
         .map_err(|error| OrbitError::Store(format!("serialize global defaults stamp: {error}")))?;
     encoded.push('\n');
 
-    let path = stamp_path(global_root);
+    let path = validated_stamp_path(global_root)?;
     atomic_write_text(&path, &encoded).map_err(|error| {
         OrbitError::Io(format!(
             "write global defaults stamp '{}': {error}",
@@ -83,10 +86,64 @@ pub(crate) fn record_global_defaults_reconciled(global_root: &Path) -> Result<()
 /// describes, and never in `state/`, which the layout reserves for workspace
 /// runtime state. Exposed so fixtures can model a root left by another release
 /// without duplicating the path.
+#[cfg(test)]
 pub(crate) fn stamp_path(global_root: &Path) -> PathBuf {
     global_root
         .join("resources")
         .join(".orbit-global-defaults.json")
+}
+
+/// Resolve the defaults stamp beneath the canonical global root.
+///
+/// The root can come from an explicit runtime override, but both the resources
+/// directory and stamp filename are fixed. Resolving existing components and
+/// requiring their expected locations prevents a symlink from redirecting a
+/// stamp read or write outside the selected root.
+fn validated_stamp_path(global_root: &Path) -> Result<PathBuf, OrbitError> {
+    let canonical_root = fs::canonicalize(global_root).map_err(|error| {
+        OrbitError::Io(format!(
+            "resolve global defaults root {}: {error}",
+            global_root.display()
+        ))
+    })?;
+    let expected_parent = canonical_root.join("resources");
+    let expected_path = expected_parent.join(".orbit-global-defaults.json");
+
+    let canonical_parent = match fs::canonicalize(&expected_parent) {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(expected_path),
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "resolve global defaults directory {}: {error}",
+                expected_parent.display()
+            )));
+        }
+    };
+    if canonical_parent != expected_parent || !canonical_parent.is_dir() {
+        return Err(OrbitError::InvalidInput(format!(
+            "global defaults directory must be a regular directory directly under {}",
+            canonical_root.display()
+        )));
+    }
+
+    let canonical_path = match fs::canonicalize(&expected_path) {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(expected_path),
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "resolve global defaults stamp {}: {error}",
+                expected_path.display()
+            )));
+        }
+    };
+    if canonical_path != expected_path || !canonical_path.is_file() {
+        return Err(OrbitError::InvalidInput(format!(
+            "global defaults stamp must be a regular file directly under {}",
+            expected_parent.display()
+        )));
+    }
+
+    Ok(canonical_path)
 }
 
 /// Identity of the defaults a global-scope bootstrap installs into one root.

--- a/crates/orbit-core/src/bootstrap/tests/global_defaults.rs
+++ b/crates/orbit-core/src/bootstrap/tests/global_defaults.rs
@@ -7,7 +7,9 @@ use std::path::{Path, PathBuf};
 use tempfile::{TempDir, tempdir};
 
 use crate::OrbitRuntime;
-use crate::bootstrap::global_defaults::{global_defaults_are_current, stamp_path};
+use crate::bootstrap::global_defaults::{
+    global_defaults_are_current, record_global_defaults_reconciled, stamp_path,
+};
 use crate::bootstrap::init::ensure_orbit_root_initialized;
 use crate::runtime::OrbitRuntimeRoots;
 
@@ -80,6 +82,30 @@ fn first_open_seeds_global_defaults_and_stamps_the_root() {
     assert!(
         global_defaults_are_current(&roots.global),
         "a completed first open must stamp the root"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn stamp_rejects_a_symlinked_resources_directory() {
+    use std::os::unix::fs::symlink;
+
+    let roots = roots();
+    let outside = roots._temp.path().join("outside-resources");
+    fs::create_dir_all(&roots.global).expect("create global root");
+    fs::create_dir_all(&outside).expect("create outside resources directory");
+    symlink(&outside, roots.global.join("resources")).expect("link resources outside root");
+
+    assert!(
+        !global_defaults_are_current(&roots.global),
+        "a symlinked resources directory must not be read as a stamp location"
+    );
+
+    let error = record_global_defaults_reconciled(&roots.global)
+        .expect_err("a symlinked resources directory must not receive a stamp");
+    assert!(
+        matches!(error, orbit_common::OrbitError::InvalidInput(_)),
+        "the unsafe stamp location must be rejected"
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-11952](https://orbit-cli.com/tasks/ORB-11952) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-core/src/bootstrap/global_defaults.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#372`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.27.0`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `3fced6f6a6bcfc1d6e85aa5e876f0acbc7c85ada`
- Location: `crates/orbit-core/src/bootstrap/global_defaults.rs` line 50
- Created: `2026-09-08T03:45:50Z`
- Updated: `2026-09-08T05:17:23Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/372

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-core/src/bootstrap/global_defaults.rs` line 50 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Repaired the rebase conflict in .github/codeql/extensions/orbit-rust-path-validation/path-validation.yml by preserving the target-base docs configuration barrier and the candidate validated_stamp_path barrier.
- Kept the candidate implementation and regression tests unchanged; no unrelated paths were modified.

Validation:
- cargo test -p orbit-core global_defaults: passed (6 tests).
- cargo fmt --all -- --check: passed.
- make ci-fast: passed.
- make ci-lint: passed.
- YAML parse with Python PyYAML: passed.
- git diff --check: passed.
- Local CodeQL CLI was not available; hosted rescan remains pipeline-owned.

Recovery state:
- Run jrun-20260910-0555-5 remains running for host-owned continuation.
- Candidate HEAD 84dabb1bcab6313d6627911dfda617cc1dab5611 and target base 5d592fee5e5904598800ae90d4d4074a55aff3c5 matched the supplied evidence.
- The supplied conflict remains intentionally unstaged for the executor to stage and continue the existing rebase.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11952-6aa2463a`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra