### PR TITLE
[code-review] A symlinked `.orbit/frictions` root hard-fails every friction command

### DIFF
--- a/crates/orbit-store/src/driver/file/friction_store/mod.rs
+++ b/crates/orbit-store/src/driver/file/friction_store/mod.rs
@@ -12,7 +12,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use orbit_common::OrbitError;
@@ -359,10 +359,16 @@ fn split_frontmatter(raw: &str) -> Option<(&str, &str)> {
 
 /// Resolve the legacy corpus root before enumerating records.
 ///
-/// The root is selected by the workspace configuration, but it is still a
-/// path boundary for the importer. Rejecting a symlinked root and returning
-/// its canonical directory prevents a configured path from redirecting the
-/// import outside the selected legacy tree.
+/// A workspace-local legacy tree is Orbit's own configuration, not
+/// attacker-controlled input, and an ordinary layout may reach it through a
+/// symlinked ancestor (a symlinked `$HOME`, a relocated data dir, macOS's
+/// `/var` -> `/private/var`) or a symlinked root itself. Canonicalizing and
+/// accepting any directory the root resolves to — rather than rejecting a
+/// path that resolves through a symlink — matches the policy already applied
+/// to `canonical_pipeline_worker_log_parent` and
+/// `validated_linux_provider_state_root`. Containment against a corpus entry
+/// that escapes this root is enforced separately, by `friction_record_paths`
+/// refusing to follow any symlinked month or record entry during the walk.
 pub(crate) fn validated_friction_root(frictions_root: &Path) -> Result<PathBuf, OrbitError> {
     let canonical_root = fs::canonicalize(frictions_root).map_err(|error| {
         OrbitError::Io(format!(
@@ -371,52 +377,14 @@ pub(crate) fn validated_friction_root(frictions_root: &Path) -> Result<PathBuf, 
         ))
     })?;
 
-    // Compare the resolved path with a purely lexical absolute path. This
-    // rejects symlinked roots without sending the unvalidated path through a
-    // second filesystem operation.
-    let absolute_root = if frictions_root.is_absolute() {
-        frictions_root.to_path_buf()
-    } else {
-        let current_dir = std::env::current_dir()
-            .map_err(|error| OrbitError::Io(format!("resolve current directory: {error}")))?;
-        let canonical_current_dir = fs::canonicalize(&current_dir).map_err(|error| {
-            OrbitError::Io(format!(
-                "canonicalize current directory {}: {error}",
-                current_dir.display()
-            ))
-        })?;
-        canonical_current_dir.join(frictions_root)
-    };
-    let normalized_root = normalize_path_components(&absolute_root);
-    if canonical_root != normalized_root {
-        return Err(OrbitError::InvalidInput(format!(
-            "friction corpus root must be a regular directory and must not resolve through a symlink: {}",
-            frictions_root.display()
-        )));
-    }
-
     if !canonical_root.is_dir() {
         return Err(OrbitError::InvalidInput(format!(
-            "canonical friction corpus root must be a directory: {}",
+            "friction corpus root must be a directory: {}",
             canonical_root.display()
         )));
     }
 
     Ok(canonical_root)
-}
-
-fn normalize_path_components(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            other => normalized.push(other.as_os_str()),
-        }
-    }
-    normalized
 }
 
 pub(crate) fn friction_record_paths(frictions_root: &Path) -> Result<Vec<PathBuf>, OrbitError> {
@@ -426,6 +394,10 @@ pub(crate) fn friction_record_paths(frictions_root: &Path) -> Result<Vec<PathBuf
         .map_err(|error| OrbitError::Io(format!("read {}: {error}", frictions_root.display())))?
     {
         let month_entry = month_entry.map_err(|error| OrbitError::Io(error.to_string()))?;
+        // `DirEntry::file_type` reports the entry itself (it does not follow a
+        // symlink), so a month or record entry that is a symlink is neither
+        // `is_dir()` nor `is_file()` here and is skipped below — including one
+        // that resolves outside `frictions_root`.
         let month_type = month_entry
             .file_type()
             .map_err(|error| OrbitError::Io(error.to_string()))?;

--- a/crates/orbit-store/src/driver/file/friction_store/tests/friction_store.rs
+++ b/crates/orbit-store/src/driver/file/friction_store/tests/friction_store.rs
@@ -181,31 +181,38 @@ fn the_record_walk_lists_month_records_in_order() {
     fs::write(root.join("2026-05/F001.md"), "first\n").unwrap();
 
     let paths = friction_record_paths(root).expect("walk");
+    let canonical_root = fs::canonicalize(root).expect("canonical root");
 
     assert_eq!(
         paths,
         vec![
-            root.join("2026-05/F001.md"),
-            root.join("2026-05/F002.md"),
-            root.join("2026-06/F001.md"),
+            canonical_root.join("2026-05/F001.md"),
+            canonical_root.join("2026-05/F002.md"),
+            canonical_root.join("2026-06/F001.md"),
         ]
     );
 }
 
+/// A legacy tree reached through a symlinked root (a symlinked `$HOME`, a
+/// relocated data dir, macOS's `/var` -> `/private/var`) is workspace-local
+/// configuration, not attacker-controlled input; the walk must resolve it
+/// rather than fail workspace-wide friction access closed.
 #[cfg(unix)]
 #[test]
-fn the_record_walk_rejects_a_symlinked_root() {
+fn the_record_walk_follows_a_symlinked_root() {
     use std::os::unix::fs::symlink;
 
     let temp = tempfile::tempdir().expect("tempdir");
     let real_root = temp.path().join("real");
     let linked_root = temp.path().join("linked");
-    fs::create_dir(&real_root).expect("real root");
+    fs::create_dir_all(real_root.join("2026-05")).expect("real root");
+    fs::write(real_root.join("2026-05/F001.md"), "record\n").expect("record");
     symlink(&real_root, &linked_root).expect("root symlink");
 
-    let error = friction_record_paths(&linked_root).expect_err("symlinked root must fail");
+    let paths = friction_record_paths(&linked_root).expect("symlinked root must resolve");
+    let canonical_root = fs::canonicalize(&real_root).expect("canonical real root");
 
-    assert!(error.to_string().contains("regular directory"));
+    assert_eq!(paths, vec![canonical_root.join("2026-05/F001.md")]);
 }
 
 #[cfg(unix)]
@@ -228,6 +235,32 @@ fn the_record_walk_ignores_symlinked_months_and_records() {
     .expect("record symlink");
 
     let paths = friction_record_paths(&root).expect("walk");
+    let canonical_root = fs::canonicalize(&root).expect("canonical root");
 
-    assert_eq!(paths, vec![root.join("2026-05/F001.md")]);
+    assert_eq!(paths, vec![canonical_root.join("2026-05/F001.md")]);
+}
+
+/// A symlinked root must resolve (`the_record_walk_follows_a_symlinked_root`)
+/// without weakening containment: a month entry inside that root which is
+/// itself a symlink escaping the resolved corpus must still be refused.
+#[cfg(unix)]
+#[test]
+fn a_symlinked_root_still_refuses_an_escaping_record_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let real_root = temp.path().join("real");
+    let linked_root = temp.path().join("linked");
+    let outside = temp.path().join("outside");
+    fs::create_dir_all(real_root.join("2026-05")).expect("month dir");
+    fs::create_dir_all(outside.join("2026-06")).expect("outside month dir");
+    fs::write(real_root.join("2026-05/F001.md"), "inside\n").expect("inside record");
+    fs::write(outside.join("2026-06/F002.md"), "outside\n").expect("outside record");
+    symlink(outside.join("2026-06"), real_root.join("2026-06")).expect("month symlink");
+    symlink(&real_root, &linked_root).expect("root symlink");
+
+    let paths = friction_record_paths(&linked_root).expect("symlinked root must resolve");
+    let canonical_root = fs::canonicalize(&real_root).expect("canonical real root");
+
+    assert_eq!(paths, vec![canonical_root.join("2026-05/F001.md")]);
 }

--- a/crates/orbit-store/src/repository/friction/tests/import.rs
+++ b/crates/orbit-store/src/repository/friction/tests/import.rs
@@ -5,7 +5,7 @@ use std::fs;
 use orbit_types::record::FrictionStatus;
 
 use super::super::{FrictionListFilter, FrictionUpdateParams};
-use super::support::{at, friction_store, legacy_record, store};
+use super::support::{add_params, at, friction_store, legacy_record, store};
 use crate::workflow::friction::export_workspace_frictions;
 
 #[test]
@@ -24,6 +24,42 @@ fn a_fresh_database_with_no_legacy_tree_imports_nothing() {
             .expect("list")
             .is_empty()
     );
+}
+
+/// A workspace whose legacy friction tree is reached through a symlinked
+/// root is workspace-local configuration Orbit created, not attacker input;
+/// it must not lose friction access (ORB-11992).
+#[cfg(unix)]
+#[test]
+fn a_symlinked_legacy_root_constructs_and_serves_the_friction_store() {
+    use orbit_common::test_fixtures::TEST_CODEX_MODEL;
+    use std::os::unix::fs::symlink;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let real_source = temp.path().join("real_ws_one");
+    let linked_source = temp.path().join("ws_one");
+    legacy_record(&real_source, "F2026-05-001", "codex", FrictionStatus::Open);
+    symlink(&real_source, &linked_source).expect("legacy root symlink");
+
+    let frictions =
+        crate::compose::workspace_friction_store(store(temp.path()), "ws_one", &linked_source)
+            .expect("friction store must open behind a symlinked legacy root");
+
+    assert_eq!(
+        frictions
+            .list(&FrictionListFilter::default())
+            .expect("list")
+            .len(),
+        1,
+        "the imported legacy record must be listed"
+    );
+    assert!(
+        frictions.show("F2026-05-001").expect("show").is_some(),
+        "the imported legacy record must be readable"
+    );
+    frictions
+        .add(add_params(TEST_CODEX_MODEL, at(6, 0), &["tooling"]))
+        .expect("add must still work behind a symlinked legacy root");
 }
 
 /// Every field the legacy envelope carried has to survive: record identity,

--- a/crates/orbit-store/src/workflow/friction.rs
+++ b/crates/orbit-store/src/workflow/friction.rs
@@ -21,7 +21,9 @@ use orbit_common::OrbitError;
 use rusqlite::{Connection, TransactionBehavior};
 
 use crate::Store;
-use crate::driver::file::friction_store::{friction_record_paths, read_record_at, write_record_at};
+use crate::driver::file::friction_store::{
+    friction_record_paths, read_record_at, validated_friction_root, write_record_at,
+};
 
 use crate::contracts::{FrictionListFilter, StoredFrictionRecord};
 use crate::repository::friction::queries::upsert_record;
@@ -126,10 +128,15 @@ fn run_import(
     source_root: &Path,
     source_key: &str,
 ) -> Result<FrictionImportReport, OrbitError> {
-    let paths = if source_root.is_dir() {
-        friction_record_paths(source_root)?
-    } else {
-        Vec::new()
+    // `validated_friction_root` follows symlinks the same way `Path::is_dir`
+    // does, so a missing or non-directory source is "nothing to import" here
+    // exactly as it is for the caller that reports `report.discovered == 0`
+    // — not a hard error. A resolved root is kept so every record location
+    // below is checked against the same canonical path the walk used.
+    let canonical_root = validated_friction_root(source_root).ok();
+    let paths = match &canonical_root {
+        Some(root) => friction_record_paths(root)?,
+        None => Vec::new(),
     };
 
     let mut seen: BTreeSet<String> = BTreeSet::new();
@@ -137,39 +144,43 @@ fn run_import(
     let mut skipped_existing = 0u64;
 
     // Streamed one record at a time: the whole corpus is never resident, only
-    // the ID set used to detect a collision inside this source tree.
-    for path in &paths {
-        let stored = read_record_at(path)?;
-        let record = stored.record;
-        let (month, seq) = split_friction_id(&record.id).ok_or_else(|| {
-            OrbitError::Store(format!(
-                "friction record '{}' declares malformed id '{}'",
-                path.display(),
-                record.id
-            ))
-        })?;
-        verify_record_location(path, source_root, &month, seq, &record.id)?;
-        if !seen.insert(record.id.clone()) {
-            return Err(OrbitError::Store(format!(
-                "friction id '{}' is claimed twice in source tree '{}' (at '{}')",
-                record.id,
-                source_root.display(),
-                path.display()
-            )));
+    // the ID set used to detect a collision inside this source tree. `paths`
+    // is only non-empty when `canonical_root` resolved, so the two stay in
+    // lockstep without an unreachable-error branch.
+    if let Some(corpus_root) = canonical_root.as_deref() {
+        for path in &paths {
+            let stored = read_record_at(path)?;
+            let record = stored.record;
+            let (month, seq) = split_friction_id(&record.id).ok_or_else(|| {
+                OrbitError::Store(format!(
+                    "friction record '{}' declares malformed id '{}'",
+                    path.display(),
+                    record.id
+                ))
+            })?;
+            verify_record_location(path, corpus_root, &month, seq, &record.id)?;
+            if !seen.insert(record.id.clone()) {
+                return Err(OrbitError::Store(format!(
+                    "friction id '{}' is claimed twice in source tree '{}' (at '{}')",
+                    record.id,
+                    source_root.display(),
+                    path.display()
+                )));
+            }
+            if record_exists(conn, workspace_id, &record.id)? {
+                skipped_existing += 1;
+                continue;
+            }
+            upsert_record(
+                conn,
+                workspace_id,
+                &record,
+                &month,
+                seq,
+                Some(&path.to_string_lossy()),
+            )?;
+            imported += 1;
         }
-        if record_exists(conn, workspace_id, &record.id)? {
-            skipped_existing += 1;
-            continue;
-        }
-        upsert_record(
-            conn,
-            workspace_id,
-            &record,
-            &month,
-            seq,
-            Some(&path.to_string_lossy()),
-        )?;
-        imported += 1;
     }
 
     let discovered = paths.len() as u64;
@@ -235,14 +246,18 @@ fn record_exists(
 /// The legacy layout addressed a record by its ID, so a record filed under a
 /// path its ID does not resolve to was unreachable through `friction show`.
 /// Importing it silently would change which record an ID refers to.
+///
+/// `corpus_root` must be the same canonical root `friction_record_paths`
+/// walked to produce `path`; comparing against the caller's raw, possibly
+/// symlinked `source_root` would report every record as misfiled.
 fn verify_record_location(
     path: &Path,
-    source_root: &Path,
+    corpus_root: &Path,
     month: &str,
     seq: u32,
     id: &str,
 ) -> Result<(), OrbitError> {
-    let expected = source_root.join(month).join(format!("F{seq:03}.md"));
+    let expected = corpus_root.join(month).join(format!("F{seq:03}.md"));
     if path != expected {
         return Err(OrbitError::Store(format!(
             "friction record '{}' declares id '{id}', which addresses '{}'",


### PR DESCRIPTION
## Task

[ORB-11992](https://orbit-cli.com/tasks/ORB-11992) — [code-review] A symlinked `.orbit/frictions` root hard-fails every friction command

### Description

ORB-11903 (commit `00f35560b`) added `validated_friction_root` to `friction_record_paths`. It rejects a friction corpus root that is itself a symlink, but the caller chain treats that rejection as a fatal store-construction error, so a workspace whose legacy friction tree is a symlinked directory loses all friction access.

## Evidence

- `crates/orbit-store/src/driver/file/friction_store/mod.rs:366-393` — `validated_friction_root` calls `fs::symlink_metadata` and returns `OrbitError::InvalidInput("friction corpus root must be a regular directory: ...")` when the root is a symlink.
- `crates/orbit-store/src/driver/file/friction_store/mod.rs:396-397` — `friction_record_paths` now runs that validator before enumerating.
- `crates/orbit-store/src/workflow/friction.rs:129-130` — `run_import` guards with `source_root.is_dir()`, which *follows* symlinks, so a symlinked root passes the guard and then fails inside the validator. The guard and the validator disagree about what a directory is.
- `crates/orbit-store/src/compose/mod.rs:85-96` — `workspace_friction_store` only downgrades the import error to a warning when `is_readonly_or_access_failure()` matches. `crates/orbit-common/src/error.rs:463-472` shows that predicate matches only read-only/permission text, so `InvalidInput` propagates and store construction returns `Err`.
- `crates/orbit-core/src/runtime/friction.rs:14-21` — `store_for` builds that store from `runtime.data_root().join("frictions")` on every friction operation, so the failure is not confined to the one-time import.

## Reproduction (verified against live code)

A temporary probe test added to `crates/orbit-store/src/repository/friction/tests/import.rs` (since reverted; worktree clean) built a legacy corpus at `real_ws`, symlinked `ws_one -> real_ws`, and called `crate::compose::workspace_friction_store(store(temp.path()), "ws_one", &linked)`:

```
PROBE ERROR: invalid input: friction corpus root must be a regular directory: /tmp/.tmpqk7ulI/ws_one
```

The call returns `Err`, not a warning, so `orbit friction list/add/show` in that workspace fail rather than degrade.

## Why this is a defect rather than intended hardening

The legacy tree is workspace-local configuration created by Orbit itself, not attacker-controlled input, and the same class of over-strict symlink rejection has already been repaired twice in this area (ORB-11971 for pipeline worker logs, ORB-11972 for docs roots). Containment is what the check is for; a symlinked root can be canonicalized and then bounded, exactly as `canonical_pipeline_worker_log_parent` does in `crates/orbit-core/src/application/job/pipeline.rs:2024-2062`.

## Suggested direction

Canonicalize the root and enforce containment on the enumerated records instead of rejecting a symlinked root outright, or — if rejection is the deliberate policy — make it a skip with a warning at `crates/orbit-store/src/compose/mod.rs:85` so a symlinked legacy tree cannot take the whole friction surface down.

### Acceptance Criteria

- A workspace whose legacy friction root is a symlink to a directory can construct its friction store and run `friction list`, `add`, and `show` without error.
- Record enumeration still refuses to follow a symlink that escapes the resolved corpus root, covered by a test that fails without the fix.
- `run_import`'s `is_dir()` guard and the root validator agree on which roots are acceptable.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed the over-strict `validated_friction_root` check (widened by ORB-12003/`a77647c6e`) that rejected any friction corpus root reached through a symlinked ancestor, not just a symlinked root itself.

Changes:
- `crates/orbit-store/src/driver/file/friction_store/mod.rs`: `validated_friction_root` now only canonicalizes the root and checks it is a directory (matching `Path::is_dir`'s follow-symlinks semantics), dropping the lexical-vs-canonical comparison that rejected any ancestor symlink. Doc comment updated to explain that containment against an escaping symlink is enforced by the enumeration walk (`friction_record_paths`'s existing `DirEntry::file_type()` checks, which never follow a symlinked month/record entry), not by rejecting the root. Removed the now-unused `normalize_path_components` helper and `Component` import.
- `crates/orbit-store/src/workflow/friction.rs`: `run_import` now resolves the corpus root once via `validated_friction_root` (treating resolution failure as "nothing to import," same as the prior `source_root.is_dir()` guard) and reuses that single canonical root for both the enumeration walk and `verify_record_location`'s expected-path check. Previously `verify_record_location` compared canonicalized enumerated paths against a path built from the raw, non-canonical `source_root`, which would spuriously report every record as "misfiled" once a symlinked root was accepted. Restructured to avoid an `expect()`/unreachable-error branch (clippy `expect_used` is denied workspace-wide): the whole per-record loop is now scoped under `if let Some(corpus_root) = canonical_root.as_deref()`, and `paths` stays empty exactly when the root didn't resolve.
- `crates/orbit-store/src/driver/file/friction_store/tests/friction_store.rs`: replaced `the_record_walk_rejects_a_symlinked_root` (asserted the old, now-wrong, rejection) with `the_record_walk_follows_a_symlinked_root` (asserts a symlinked root resolves and enumerates). Added `a_symlinked_root_still_refuses_an_escaping_record_symlink`, which combines a symlinked root with an interior symlink escaping to an outside directory — this fails against the pre-fix code (root rejection fires before containment is ever exercised) and passes after, directly covering AC2's escape-refusal requirement in the presence of a symlinked root. Also fixed `the_record_walk_lists_month_records_in_order` and `the_record_walk_ignores_symlinked_months_and_records` to compare against `fs::canonicalize(root)`-joined paths instead of the raw (non-canonical) root, per the code-review comment noting these fail under a symlinked `TMPDIR` (macOS `/var` -> `/private/var`).
- `crates/orbit-store/src/repository/friction/tests/import.rs`: added `a_symlinked_legacy_root_constructs_and_serves_the_friction_store`, exercising AC1 end-to-end through `compose::workspace_friction_store` with a symlinked legacy root containing a real record: asserts `list`, `show`, and `add` all succeed.

Acceptance criteria:
1. "A workspace whose legacy friction root is a symlink to a directory can construct its friction store and run friction list, add, and show without error." — Covered by new test `a_symlinked_legacy_root_constructs_and_serves_the_friction_store` (repository/friction/tests/import.rs), which passes.
2. "Record enumeration still refuses to follow a symlink that escapes the resolved corpus root, covered by a test that fails without the fix." — Covered by new test `a_symlinked_root_still_refuses_an_escaping_record_symlink` (driver/file/friction_store/tests/friction_store.rs); verified this test fails against the pre-fix `validated_friction_root` (which rejects the symlinked root outright, per the diff in `a77647c6e`) and passes after the fix. Pre-existing `the_record_walk_ignores_symlinked_months_and_records` (interior-only case, no root symlink) continues to pass unchanged, since containment there relies on `DirEntry::file_type()` never following a symlinked entry — untouched by this change.
3. "run_import's is_dir() guard and the root validator agree on which roots are acceptable." — `run_import` now calls `validated_friction_root` directly instead of a separate `source_root.is_dir()` guard, so there is exactly one acceptance decision. This also fixed a latent correctness bug: `verify_record_location` was comparing canonicalized enumerated paths against a non-canonical `source_root`, which would have falsely failed every import through a symlinked root as "declares id X, which addresses Y" (visible once AC1 stopped rejecting the root outright).

Validation:
- `cargo test -p orbit-store --lib` — 500 passed, 0 failed, 7 ignored. Ran twice (before and after the clippy-driven restructure), both green.
- `cargo test -p orbit-store --lib friction` — 43 passed, 0 failed, 1 ignored (unrelated pre-existing benchmark).
- `make ci-fast` — passed (fmt-check + guardrail scripts).
- `make ci-lint` — passed (workspace-wide `cargo clippy --all-targets -- -D warnings`); caught and required removing an initial `expect()` I had used to bridge `canonical_root`/`paths` — replaced with a structural fix.
- `cargo fmt -p orbit-store` — applied.
- `git status --short` / `git diff --check` — only the four context_files are modified; no unrelated changes, no whitespace errors.

No new context_files were needed; the change stayed within the four files already listed on the task. No blockers. No friction filed — the sibling precedent (`canonical_pipeline_worker_log_parent`, ORB-11984's `validated_linux_provider_state_root`) was already surfaced in the task's own code-review comment, so this wasn't a fresh 10-minute-plus discovery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11992-6aa248a6`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra