### PR TITLE
[qa-sweep] Keep paginated task rows visible in the narrow dashboard layout

### DIFF
--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -4049,6 +4049,15 @@
         main.tasks-layout {
           grid-template-columns: 1fr !important;
         }
+        /* The stacked dock makes the task layout taller than the remaining
+           shell. Let the pane scroll instead of constraining its first grid
+           row to zero height, which leaves the task-body clipped below its
+           column header. */
+        .main-col > .tab-pane[data-tab="tasks"] { overflow-y: auto; }
+        .main-col > .tab-pane[data-tab="tasks"] > main.tasks-layout {
+          height: auto;
+          min-height: 100%;
+        }
         .col-log { min-height: 320px; }
       }
       .col-log {

--- a/crates/orbit-web/src/tests/dashboard_loading_browser.mjs
+++ b/crates/orbit-web/src/tests/dashboard_loading_browser.mjs
@@ -9,6 +9,43 @@ const evidence = path.resolve(process.argv[3]);
 fs.mkdirSync(evidence, { recursive: true });
 const assets = fileURLToPath(new URL('../../assets/dashboard/', import.meta.url));
 const scenarios = fileURLToPath(new URL('./dashboard_loading.mjs', import.meta.url));
+
+async function assertVisibleTaskRow(page, viewport, pageName) {
+  const visible = await page.evaluate(() => {
+    const row = document.querySelector('#tasks-body .row[data-key^="task-"]:not(.header)');
+    const body = document.getElementById('tasks-body');
+    if (!row || !body) return { visible: false, reason: 'task row or body missing' };
+
+    const rowRect = row.getBoundingClientRect();
+    const bodyRect = body.getBoundingClientRect();
+    const viewportRect = { top: 0, right: window.innerWidth, bottom: window.innerHeight, left: 0 };
+    const intersection = (rect, bounds) => ({
+      left: Math.max(rect.left, bounds.left),
+      top: Math.max(rect.top, bounds.top),
+      right: Math.min(rect.right, bounds.right),
+      bottom: Math.min(rect.bottom, bounds.bottom),
+    });
+    const area = (rect) => Math.max(0, rect.right - rect.left) * Math.max(0, rect.bottom - rect.top);
+    const bodyIntersection = intersection(rowRect, bodyRect);
+    const viewportIntersection = intersection(rowRect, viewportRect);
+    const visibleIntersection = intersection(bodyIntersection, viewportIntersection);
+    const paintPoint = {
+      x: (visibleIntersection.left + visibleIntersection.right) / 2,
+      y: (visibleIntersection.top + visibleIntersection.bottom) / 2,
+    };
+    const topmost = area(visibleIntersection) > 0 ? document.elementFromPoint(paintPoint.x, paintPoint.y) : null;
+
+    return {
+      visible: area(bodyIntersection) > 0 && area(viewportIntersection) > 0 && row.contains(topmost),
+      row: rowRect.toJSON(),
+      body: bodyRect.toJSON(),
+      viewport: viewportRect,
+      paintTarget: topmost?.className || topmost?.id || null,
+    };
+  });
+  if (!visible.visible) throw new Error(`First task row is clipped on ${pageName} at ${viewport.width}px: ${JSON.stringify(visible)}`);
+}
+
 const server = http.createServer((req, res) => {
   const name = new URL(req.url, 'http://fixture').pathname;
   const file = name === '/test.mjs' ? scenarios : path.join(assets, name === '/' ? 'index.html' : path.basename(name));
@@ -40,17 +77,40 @@ try {
   await page.waitForFunction(() => document.getElementById('tasks-count').textContent === '1–20 of 55');
   for (const viewport of [{ name: 'desktop', width: 1280 }, { name: 'mobile', width: 390 }]) {
     await page.setViewportSize({ width: viewport.width, height: 900 });
+    await page.evaluate(() => {
+      window.scrollTo(0, 0);
+      document.getElementById('tasks-body').scrollTop = 0;
+    });
     const pager = page.locator('.task-pagination');
     if (!(await pager.isVisible())) throw new Error(`Task pagination invisible at ${viewport.width}px`);
     if (!(await page.locator('#tasks-next').isEnabled())) throw new Error('First task page must enable Next');
     if (await page.locator('#tasks-previous').isEnabled()) throw new Error('First task page must disable Previous');
+    await assertVisibleTaskRow(page, viewport, 'page 1');
     await page.screenshot({ path: path.join(evidence, `task-pagination-${viewport.name}.png`), fullPage: true });
   }
+  await page.evaluate(() => { document.getElementById('tasks-body').scrollTop = 120; });
   await page.locator('#tasks-next').click();
   await page.waitForFunction(() => document.getElementById('tasks-count').textContent === '21–40 of 55');
-  await page.evaluate(() => window.scrollTo(0, 0));
+  if (await page.locator('#tasks-body').evaluate((body) => body.scrollTop !== 0)) throw new Error('Task page navigation must reset the task-body scroll position');
   if (!(await page.locator('#tasks-previous').isEnabled())) throw new Error('Second task page must enable Previous');
-  await page.screenshot({ path: path.join(evidence, 'task-pagination-mobile-page-2.png'), fullPage: true });
+  for (const viewport of [{ name: 'desktop', width: 1280 }, { name: 'mobile', width: 390 }]) {
+    await page.setViewportSize({ width: viewport.width, height: 900 });
+    await page.evaluate(() => {
+      window.scrollTo(0, 0);
+      document.getElementById('tasks-body').scrollTop = 0;
+    });
+    await assertVisibleTaskRow(page, viewport, 'page 2');
+    await page.screenshot({ path: path.join(evidence, `task-pagination-${viewport.name}-page-2.png`), fullPage: true });
+  }
+  await page.locator('#task-filter .chip[data-status="done"]').click();
+  await page.waitForFunction(() => document.getElementById('task-filter-summary').textContent.includes('done'));
+  await page.locator('#task-filter .chip[data-role="all"]').click();
+  const firstTask = page.locator('#tasks-body .row[data-key^="task-"]:not(.header)').first();
+  await firstTask.click();
+  const detail = page.locator('#tasks-body .row-detail').first();
+  await detail.waitFor({ state: 'visible' });
+  const pageOverflowsHorizontally = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth);
+  if (pageOverflowsHorizontally) throw new Error('Task filters or expanded details introduced horizontal page clipping');
   await page.evaluate(() => globalThis.showDiagnosticsEvidence());
   // Hold a real visible panel in refresh, then inspect its rendered accessible
   // feedback and retry affordance at desktop and narrow widths.
@@ -76,7 +136,7 @@ try {
   });
   await page.waitForFunction(() => document.getElementById('meta-text').textContent.includes('offline'));
   if (!(await page.locator('#conn-status').getAttribute('class')).includes('red')) throw new Error('Stopped server must show red connection status');
-  fs.writeFileSync(path.join(evidence, 'result.json'), JSON.stringify({ passed: true, scenarios: 'Task pagination page 1/page 2 and accessible Previous/Next at 1280px and 390px; Tasks, Recent runs, Errors, Operations: cold, stale refresh, scope changes, reordered responses, empty success, network error; Metrics HTTP failure isolation and network offline/recovery' }, null, 2));
+  fs.writeFileSync(path.join(evidence, 'result.json'), JSON.stringify({ passed: true, scenarios: 'Task pagination page 1/page 2 with visible, unoccluded first rows and accessible Previous/Next at 1280px and 390px; Tasks, Recent runs, Errors, Operations: cold, stale refresh, scope changes, reordered responses, empty success, network error; Metrics HTTP failure isolation and network offline/recovery' }, null, 2));
   console.log('Chromium dashboard lifecycle and accessible visible feedback passed.');
 } finally {
   await browser?.close();


### PR DESCRIPTION
## Task

[ORB-12022](https://orbit-cli.com/tasks/ORB-12022) — [qa-sweep] Keep paginated task rows visible in the narrow dashboard layout

### Description

Visual inspection of retained ORB12012 artifacts task-pagination-mobile.png and ta[REDACTED_SECRET].png at390px shows ranges1–20of55 and21–40of55, pager controls and Updated., but task panel ends after its column header with no task rows. Desktop artifact has rows. Merged revision3cc001d8852d4eabd0ad7928779a9e7dc8360471 uses shipped assets; dashboard_loading.mjs supplies20 PAGE-1-* rows and asserts task page1 in tasks-body before screenshot. Thus this is a responsive layout visibility gap, not simply an empty fixture. Inspect actual computed layout to confirm cause; likely flex/min-height/overflow in tasks-layout/col-tasks/tasks-panel body. Existing browser runner only checks count/buttons and screenshots, so it misses clipped rows. Search found done12012 and older10975 expanded-detail clipping, no open current coveringtask. Keep cursor/backend semantics unchanged unless reproduction proves directly necessary.

### Acceptance Criteria

- Using real Chromium and shipped dashboard assets at390px, page1 and page2 each display task rows alongside correct range and Previous/Next state, with usable scrolling to subsequent rows and preserved layout at1280px.
- Add a meaningful browser regression that fails against the current merged mobile layout: assert first task-row bounding rectangle has nonzero visible intersection with tasks-body and viewport after page navigation at reset scroll position. Check actual row visibility, not only DOM existence/count/button state.
- Capture and attach corrected desktop/mobile page1/page2 screenshots and browser result evidence to this task. Confirm filters, page reset, refresh and expanded task details remain usable without horizontal clipping.
- Run focused browser/asset validation and required make ci-fast/make ci-lint. Keep the repair confined to responsive layout and directly relevant rendering tests; document any demonstrated necessary scope expansion.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- On viewports at or below 760px, the Tasks pane now scrolls and its stacked task/log grid uses an automatic height with a minimum shell height. This prevents the dock from painting over task-body rows while retaining the desktop constrained layout.
- The Chromium regression resets document and task-body scroll on pages 1 and 2, checks the first data row has nonzero intersection with both task body and viewport, and verifies the row is the topmost painted element at that intersection. It captures desktop/mobile screenshots for both pages and records the visibility coverage in result evidence.

Criteria evidence:
1. Real Chromium passed at 1280px and 390px for page ranges 1–20/55 and 21–40/55, enabled/disabled Previous/Next states, reset task-body scrolling, and visible page rows. Corrected desktop/mobile page-1/page-2 screenshots are attached.
2. The browser assertion selects a real task data row, computes body/viewport rectangle intersections after reset scroll, and rejects rows occluded by another element. The same assertion failed against a clean HEAD asset extract at 390px before the CSS repair (exit 1; row paint target null).
3. The focused browser scenario confirms status filters, pagination scroll reset, expanded task details, refresh feedback/retry, diagnostics transition, offline recovery, and no horizontal page overflow at the narrow viewport. Attached result evidence reports visible/unoccluded row coverage.
4. Scope remained limited to dashboard CSS and its existing browser rendering test; no backend or cursor semantics changed.

Validation:
- Passed: focused Chromium dashboard test with shipped assets and temporary real Chromium: node crates/orbit-web/src/tests/dashboard_loading_browser.mjs <playwright-index> <evidence-dir>.
- Passed: node --check crates/orbit-web/src/tests/dashboard_loading_browser.mjs.
- Passed: make ci-fast.
- Passed: make ci-lint.
- Passed: git diff --check.

Assessment: The narrow layout preserves the desktop sizing model and gives the stacked page a single owner for vertical overflow. No remaining task-scoped risks found.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12022-6aa2482c`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra