### PR TITLE
[code-review] A pre-boundary rebase-recovery checkpoint hard-fails every resume instead of redoing the rebase as documented

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/freshness.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/freshness.rs
@@ -190,8 +190,27 @@ fn rebase_pr_branch_inner<H: RuntimeHost + ?Sized>(
             }
             ("skipped_current", false, current_sha)
         } else if sync_required {
-            validate_recovered_rewrite(host, input, context, &current_sha)?;
-            ("reused_recovery", true, current_sha)
+            if validate_recovered_rewrite(host, input, context, &current_sha)? {
+                ("reused_recovery", true, current_sha)
+            } else {
+                // No host-certified evidence justifies inheriting this changed
+                // HEAD (a pre-authority-boundary checkpoint, a forged one, or
+                // none at all — the certificate check cannot tell them apart,
+                // and none of them is trusted). Discard it and redo the rebase
+                // from the durable pre-rewrite checkpoint instead: a clean
+                // redo produces a freshly self-verified HEAD, and a redo that
+                // hits conflicts falls into the ordinary supported
+                // conflict-recovery path, which certifies fresh evidence on
+                // completion.
+                discard_unauthenticated_rewrite(&context.workspace_path, head_sha_before)?;
+                perform_rebase_onto_base(
+                    &context.workspace_path,
+                    head,
+                    head_sha_before,
+                    base_ref,
+                    base_sha,
+                )?
+            }
         } else {
             return Err(OrbitError::Execution(format!(
                 "git_rebase: branch HEAD changed from prepared checkpoint '{head_sha_before}' to '{current_sha}' without a recorded rewrite decision"
@@ -204,45 +223,13 @@ fn rebase_pr_branch_inner<H: RuntimeHost + ?Sized>(
                     .to_string(),
             ));
         }
-        let rebase_outcome = git_run(&context.workspace_path, &["rebase", base_sha])?;
-        if rebase_outcome.timed_out {
-            return recover_started_rebase_timeout(
-                &context.workspace_path,
-                head,
-                head_sha_before,
-                base_sha,
-                &rebase_outcome,
-            );
-        }
-        if !rebase_outcome.success {
-            let conflicting_paths = unmerged_paths(&context.workspace_path)?;
-            if conflicting_paths.is_empty() {
-                return Err(git_failure_error(
-                    &context.workspace_path,
-                    &["rebase", base_sha],
-                    &rebase_outcome.stderr,
-                ));
-            }
-            return Err(rebase_conflict_error(
-                &context.workspace_path,
-                head_sha_before,
-                base_sha,
-                conflicting_paths,
-                &format!("rebase of '{head}' onto checkpoint '{base_sha}' stopped with conflicts"),
-            )?);
-        }
-        let after =
-            branch_freshness_against_ref(&context.workspace_path, head, base_ref, base_sha)?;
-        if after.commits_behind != 0 {
-            return Err(OrbitError::Execution(
-                "git_rebase: branch remains behind the recorded base after rebase".to_string(),
-            ));
-        }
-        (
-            "performed",
-            true,
-            commit_sha(&context.workspace_path, head)?,
-        )
+        perform_rebase_onto_base(
+            &context.workspace_path,
+            head,
+            head_sha_before,
+            base_ref,
+            base_sha,
+        )?
     };
 
     Ok(json!({
@@ -257,6 +244,69 @@ fn rebase_pr_branch_inner<H: RuntimeHost + ?Sized>(
         "remote_sha_before": input_string_field(input, "remote_sha"),
         "rewritten": rewritten,
     }))
+}
+
+/// Run the deterministic rebase itself, from `head_sha_before` (which the
+/// caller must already have made the worktree's actual HEAD) onto `base_sha`.
+/// A clean result is self-verifying and needs no stored evidence; a conflict
+/// routes into the existing supported conflict-recovery path via
+/// [`rebase_conflict_error`].
+fn perform_rebase_onto_base(
+    workspace_path: &Path,
+    head: &str,
+    head_sha_before: &str,
+    base_ref: &str,
+    base_sha: &str,
+) -> Result<(&'static str, bool, String), OrbitError> {
+    let rebase_outcome = git_run(workspace_path, &["rebase", base_sha])?;
+    if rebase_outcome.timed_out {
+        return recover_started_rebase_timeout(
+            workspace_path,
+            head,
+            head_sha_before,
+            base_sha,
+            &rebase_outcome,
+        );
+    }
+    if !rebase_outcome.success {
+        let conflicting_paths = unmerged_paths(workspace_path)?;
+        if conflicting_paths.is_empty() {
+            return Err(git_failure_error(
+                workspace_path,
+                &["rebase", base_sha],
+                &rebase_outcome.stderr,
+            ));
+        }
+        return Err(rebase_conflict_error(
+            workspace_path,
+            head_sha_before,
+            base_sha,
+            conflicting_paths,
+            &format!("rebase of '{head}' onto checkpoint '{base_sha}' stopped with conflicts"),
+        )?);
+    }
+    let after = branch_freshness_against_ref(workspace_path, head, base_ref, base_sha)?;
+    if after.commits_behind != 0 {
+        return Err(OrbitError::Execution(
+            "git_rebase: branch remains behind the recorded base after rebase".to_string(),
+        ));
+    }
+    Ok(("performed", true, commit_sha(workspace_path, head)?))
+}
+
+/// Discard a changed HEAD that could not be authenticated as a certified
+/// recovery, restoring the worktree to the last durable pre-rewrite
+/// checkpoint so the ordinary rebase path can redo the work from there.
+fn discard_unauthenticated_rewrite(
+    workspace_path: &Path,
+    head_sha_before: &str,
+) -> Result<(), OrbitError> {
+    git_success(workspace_path, &["reset", "--hard", head_sha_before]).map_err(|error| {
+        OrbitError::Execution(format!(
+            "git_rebase: failed to discard an unauthenticated rewritten HEAD before redoing the \
+             rebase from checkpoint '{head_sha_before}': {error}"
+        ))
+    })
 }
 
 fn refuse_or_recover_existing_rebase(
@@ -287,13 +337,13 @@ fn refuse_or_recover_existing_rebase(
     )))
 }
 
-fn recover_started_rebase_timeout(
+fn recover_started_rebase_timeout<T>(
     workspace_path: &Path,
     head: &str,
     head_sha_before: &str,
     base_sha: &str,
     outcome: &super::git::GitOutcome,
-) -> Result<Value, OrbitError> {
+) -> Result<T, OrbitError> {
     let timeout = git_timeout_error(
         workspace_path,
         &["rebase", base_sha],
@@ -388,23 +438,42 @@ fn read_rebase_state(workspace_path: &Path, name: &str) -> Result<Option<String>
     Ok(None)
 }
 
+/// Whether `current_sha` is backed by an exact, host-certified recovery
+/// checkpoint for the prepared rewrite.
+///
+/// - `Ok(true)`: a certified checkpoint matches and its provenance agrees
+///   with this attempt; the caller may reuse `current_sha`.
+/// - `Ok(false)`: a checkpoint matching this exact HEAD exists but carries no
+///   certificate (a pre-authority-boundary checkpoint and a forged one look
+///   identical here). The caller must not inherit `current_sha`; discarding
+///   it and redoing the rebase is safe precisely because a real redo either
+///   reproduces an equivalent, freshly self-verified result or hits the same
+///   conflicts a forged shortcut was trying to skip.
+/// - `Err`: either nothing at all backs this changed HEAD (the ordinary
+///   "unexplained rewrite" refusal, unchanged from before this existed), or a
+///   certified checkpoint was found whose recorded provenance does not match
+///   this attempt. Both stay hard refusals with no redo.
 fn validate_recovered_rewrite<H: RuntimeHost + ?Sized>(
     host: &H,
     input: &Value,
     context: &HandoffContext,
     current_sha: &str,
-) -> Result<(), OrbitError> {
+) -> Result<bool, OrbitError> {
     let run_id = input
         .get("run_id")
         .and_then(Value::as_str)
         .unwrap_or(&context.batch_id);
-    let Some(checkpoint) =
-        recovered_head_checkpoint(host, run_id, &context.workspace_path, current_sha)?
-    else {
-        return Err(OrbitError::Execution(
-            "git_rebase: changed HEAD has no exact host-validated recovery checkpoint".to_string(),
-        ));
-    };
+    let checkpoint =
+        match recovery_checkpoint_lookup(host, run_id, &context.workspace_path, current_sha)? {
+            RecoveryCheckpointLookup::Certified(checkpoint) => checkpoint,
+            RecoveryCheckpointLookup::Uncertified => return Ok(false),
+            RecoveryCheckpointLookup::Absent => {
+                return Err(OrbitError::Execution(
+                    "git_rebase: changed HEAD has no exact host-validated recovery checkpoint"
+                        .to_string(),
+                ));
+            }
+        };
     let task_ids = context
         .tasks
         .iter()
@@ -422,7 +491,7 @@ fn validate_recovered_rewrite<H: RuntimeHost + ?Sized>(
                 .to_string(),
         ));
     }
-    Ok(())
+    Ok(true)
 }
 
 fn unmerged_paths(repo_root: &Path) -> Result<Vec<String>, OrbitError> {
@@ -563,24 +632,39 @@ fn parse_divergence_count(
     })
 }
 
+/// Outcome of scanning a run's `rebase_recovery_checkpoints` for `head_sha`.
+enum RecoveryCheckpointLookup {
+    /// A candidate matched by shape and carries the host's certificate; every
+    /// remaining integrity check (source consistency, ancestry, retry
+    /// lineage) also passed.
+    Certified(Value),
+    /// A candidate matched by shape (head/workspace/step/rewritten) but
+    /// carries no host certificate — a pre-authority-boundary checkpoint and
+    /// a forged one look identical here, and neither is authority. Distinct
+    /// from [`Self::Absent`] so a caller that can safely redo the underlying
+    /// work (see `rebase_pr_branch_inner`) knows a redo is warranted, while a
+    /// caller with no such fallback keeps refusing outright.
+    Uncertified,
+    /// Nothing in the run's checkpoints matches this HEAD at all.
+    Absent,
+}
+
 /// Read only host-written provenance, authenticating the original durable run
 /// when a resume carries a copy. Advisory activity outputs never authorize HEAD.
 ///
 /// The run store these entries come from is writable by managed leaves, so a
 /// matching entry is a candidate, not authority. Every candidate must also
 /// carry the host's certificate from [`RuntimeHost::verify_rebase_recovery`].
-/// A checkpoint written before that boundary existed has no certificate and is
-/// refused here; the run redoes the rebase rather than inheriting an
-/// unauthenticated HEAD.
-pub(super) fn recovered_head_checkpoint<H: RuntimeHost + ?Sized>(
+fn recovery_checkpoint_lookup<H: RuntimeHost + ?Sized>(
     host: &H,
     run_id: &str,
     workspace: &Path,
     head_sha: &str,
-) -> Result<Option<Value>, OrbitError> {
+) -> Result<RecoveryCheckpointLookup, OrbitError> {
     let Some(state) = host.read_run_state(run_id)? else {
-        return Ok(None);
+        return Ok(RecoveryCheckpointLookup::Absent);
     };
+    let mut saw_uncertified_match = false;
     for (step_id, checkpoint) in &state.rebase_recovery_checkpoints {
         if !matches!(step_id.as_str(), "sync_base" | "complete_pr")
             || checkpoint.get("head_sha").and_then(Value::as_str) != Some(head_sha)
@@ -592,10 +676,12 @@ pub(super) fn recovered_head_checkpoint<H: RuntimeHost + ?Sized>(
         }
         let source_run_id = required_input_string(checkpoint, "run_id")?;
         if !host.verify_rebase_recovery(source_run_id, step_id, checkpoint)? {
-            return Err(OrbitError::Execution(format!(
-                "recovered rebase for step `{step_id}` of run {source_run_id} carries no host \
-                 recovery certificate; rerun the rebase instead of trusting run-store evidence"
-            )));
+            // No certificate: this candidate is not usable evidence, whether
+            // because it predates the authority boundary or was never the
+            // host's own record. Note it and keep scanning rather than
+            // trusting it.
+            saw_uncertified_match = true;
+            continue;
         }
         if source_run_id != run_id {
             let source = host.read_run_state(source_run_id)?.ok_or_else(|| {
@@ -634,7 +720,31 @@ pub(super) fn recovered_head_checkpoint<H: RuntimeHost + ?Sized>(
                 "recovered candidate does not descend from its pinned base".to_string(),
             ));
         }
-        return Ok(Some(checkpoint.clone()));
+        return Ok(RecoveryCheckpointLookup::Certified(checkpoint.clone()));
     }
-    Ok(None)
+    Ok(if saw_uncertified_match {
+        RecoveryCheckpointLookup::Uncertified
+    } else {
+        RecoveryCheckpointLookup::Absent
+    })
+}
+
+/// The certified recovery checkpoint for `head_sha`, or `None` if there is
+/// none — whether because nothing matches at all or because the only match
+/// carries no host certificate. Both are equally untrusted for a caller that
+/// has no redo fallback of its own (see `resume.rs`'s identity checks); only
+/// [`validate_recovered_rewrite`] needs the finer distinction, via
+/// [`recovery_checkpoint_lookup`] directly.
+pub(super) fn recovered_head_checkpoint<H: RuntimeHost + ?Sized>(
+    host: &H,
+    run_id: &str,
+    workspace: &Path,
+    head_sha: &str,
+) -> Result<Option<Value>, OrbitError> {
+    Ok(
+        match recovery_checkpoint_lookup(host, run_id, workspace, head_sha)? {
+            RecoveryCheckpointLookup::Certified(checkpoint) => Some(checkpoint),
+            RecoveryCheckpointLookup::Uncertified | RecoveryCheckpointLookup::Absent => None,
+        },
+    )
 }

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_preservation.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_preservation.rs
@@ -163,12 +163,13 @@ fn resumed_recovery_requires_the_exact_immutable_source_checkpoint() {
     host.write_state(resumed.clone());
 
     // The row exists in the run store the leaf can write, but nothing has
-    // certified it yet. That is the pre-boundary shape, and it is refused.
-    let error =
-        recovered_head_checkpoint(&host, SECOND_RESUME_RUN_ID, &workspace.repo, &head).unwrap_err();
-    assert!(
-        error.to_string().contains("no host recovery certificate"),
-        "{error}"
+    // certified it yet. That is the pre-boundary shape (ORB-12015): it is not
+    // authority, so it is treated as no usable checkpoint — not trusted, but
+    // also not a hard refusal — which is what lets a resume redo the rebase
+    // instead of getting stuck.
+    assert_eq!(
+        recovered_head_checkpoint(&host, SECOND_RESUME_RUN_ID, &workspace.repo, &head).unwrap(),
+        None
     );
 
     host.inner
@@ -187,11 +188,11 @@ fn resumed_recovery_requires_the_exact_immutable_source_checkpoint() {
         .get_mut("sync_base")
         .unwrap()["head_sha_before"] = json!("substituted-origin");
     host.write_state(resumed.clone());
-    let error =
-        recovered_head_checkpoint(&host, SECOND_RESUME_RUN_ID, &workspace.repo, &head).unwrap_err();
-    assert!(
-        error.to_string().contains("no host recovery certificate"),
-        "{error}"
+    // The substituted payload has no certificate of its own either, so it is
+    // just as unusable as the pre-boundary case above.
+    assert_eq!(
+        recovered_head_checkpoint(&host, SECOND_RESUME_RUN_ID, &workspace.repo, &head).unwrap(),
+        None
     );
 
     // Certifying the substituted payload isolates the second gate, which is

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
@@ -102,6 +102,16 @@ impl PrOpenTestHost {
             .insert((run_id.to_string(), step_id.to_string()), output.clone());
     }
 
+    /// Write run-store state directly, the way a managed leaf can, without
+    /// certifying it. Used to reproduce a pre-authority-boundary (or forged)
+    /// rebase recovery checkpoint that carries no host certificate.
+    pub fn write_run_state(&self, state: orbit_types::workflow::PipelineState) {
+        self.run_states
+            .lock()
+            .expect("run states lock")
+            .insert(state.run_id.clone(), state);
+    }
+
     pub fn review_landings(&self) -> Vec<ReviewLandingRequest> {
         self.review_landings
             .lock()

--- a/crates/orbit-engine/src/executor/automation/vcs/tests/freshness.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/tests/freshness.rs
@@ -236,6 +236,205 @@ fn pre_existing_rebase_without_conflicts_is_refused_and_left_intact() {
     );
 }
 
+/// Build the run-store checkpoint shape a `sync_base` rebase recovery writes,
+/// matching `prepared` and the worktree's actual `rewritten_head`. The
+/// `workspace_path` must be canonicalized the same way
+/// `load_handoff_context` canonicalizes it, or the checkpoint will never be
+/// treated as a candidate at all.
+fn uncertified_recovery_checkpoint(
+    task_id: &str,
+    repo: &std::path::Path,
+    prepared: &serde_json::Value,
+    rewritten_head: &str,
+) -> serde_json::Value {
+    json!({
+        "run_id": "batch-1",
+        "step_id": "sync_base",
+        "task_ids": [task_id],
+        "workspace_path": repo.canonicalize().expect("canonicalize workspace"),
+        "head": prepared["head"],
+        "head_sha_before": prepared["head_sha"],
+        "original_base_sha": prepared["base_sha"],
+        "base_ref": prepared["base_ref"],
+        "base_sha": prepared["base_sha"],
+        "remote_sha_before": prepared["remote_sha"],
+        "head_sha": rewritten_head,
+        "rewritten": true,
+    })
+}
+
+fn write_sync_base_checkpoint(host: &PrOpenTestHost, checkpoint: serde_json::Value) {
+    let mut state = orbit_types::workflow::PipelineState::new(
+        "batch-1".to_string(),
+        "task_pr_pipeline".to_string(),
+        json!({}),
+    );
+    state
+        .rebase_recovery_checkpoints
+        .insert("sync_base".to_string(), checkpoint);
+    host.write_run_state(state);
+}
+
+// ORB-12015: a `sync_base` rebase recovery checkpoint written before the
+// authority boundary (ORB-11977) existed carries no host certificate.
+// `verify_rebase_recovery` returns `false` for it exactly as it would for a
+// forged one, so it must never be inherited as a trusted HEAD — but the run
+// must still be able to make forward progress instead of hard-failing every
+// resume forever, per the doc comment on `recovered_head_checkpoint`.
+#[test]
+fn uncertified_pre_boundary_checkpoint_redoes_the_rebase_instead_of_failing_resume() {
+    let workspace = pr_workspace();
+    advance_base(&workspace.repo);
+    let task_id = "ORB-12015-UNCERTIFIED-REDO";
+    let host = PrOpenTestHost::new(
+        vec![batch_task(
+            task_id,
+            "Uncertified redo",
+            "Outcome: success\nChanges:\n- Candidate remains mergeable.",
+        )],
+        workspace.repo.clone(),
+    );
+    let common = json!({
+        "workspace_path": workspace.repo,
+        "job_run_id": "batch-1",
+        "completed_task_ids": [task_id],
+        "base": "agent-main",
+        "base_sync": "local",
+    });
+    let prepared = prepare_pr_handoff(&host, &common).expect("prepare");
+    assert_eq!(prepared["sync_required"], json!(true));
+
+    // Simulate a rebase that already completed (e.g. by an older binary,
+    // before the authority boundary existed): the branch already sits
+    // cleanly on top of the base, but its HEAD no longer matches the
+    // prepared pre-rewrite checkpoint.
+    git(&workspace.repo, &["rebase", "agent-main"]);
+    let rewritten_head = git(&workspace.repo, &["rev-parse", "HEAD"]);
+    assert_ne!(rewritten_head, prepared["head_sha"].as_str().unwrap());
+
+    // The row exists in the run store a leaf can write, but nothing ever
+    // certified it. That is the pre-boundary shape this task fixes; no
+    // manual runtime-store edit is used to unstick it.
+    write_sync_base_checkpoint(
+        &host,
+        uncertified_recovery_checkpoint(task_id, &workspace.repo, &prepared, &rewritten_head),
+    );
+
+    let result = rebase_pr_branch(&host, &rebase_input(&common, &prepared))
+        .expect("resume must make forward progress through a supported path");
+    assert_eq!(result["decision"], json!("performed"));
+    assert_eq!(result["rewritten"], json!(true));
+    assert!(workspace.repo.join("BASE_ADVANCE.md").exists());
+
+    // Repeating the resume must not loop on the same stale, uncertified
+    // entry: the branch is now genuinely fresh, so the next attempt takes
+    // the ordinary already-fresh path rather than revisiting recovery.
+    let reprepared = prepare_pr_handoff(&host, &common).expect("re-prepare after redo");
+    assert_eq!(reprepared["decision"], json!("already_fresh"));
+    let retried =
+        rebase_pr_branch(&host, &rebase_input(&common, &reprepared)).expect("retry after redo");
+    assert_eq!(retried["decision"], json!("skipped_current"));
+}
+
+// The redo is only automatic when it is safe: when the discarded rewrite
+// actually required conflict resolution, the redo hits the same conflicts
+// and falls into the existing supported conflict-recovery path (the same
+// typed error a first-time conflicted rebase produces) rather than silently
+// dropping work or hard-failing with no path forward.
+#[test]
+fn uncertified_recovery_redo_that_conflicts_uses_the_existing_conflict_recovery_path() {
+    let workspace = rebase_conflict_pr_workspace();
+    let task_id = "ORB-12015-UNCERTIFIED-CONFLICT";
+    let host = PrOpenTestHost::new(
+        vec![batch_task(
+            task_id,
+            "Uncertified redo with conflict",
+            "Outcome: success\nChanges:\n- Candidate is complete.",
+        )],
+        workspace.repo.clone(),
+    );
+    let common = json!({
+        "workspace_path": workspace.repo,
+        "job_run_id": "batch-1",
+        "completed_task_ids": [task_id],
+        "base": "agent-main",
+        "base_sync": "local",
+    });
+    let prepared = prepare_pr_handoff(&host, &common).expect("prepare");
+    assert_eq!(prepared["sync_required"], json!(true));
+
+    // Force the "already rewritten, but uncertified" shape onto a branch
+    // whose real rebase conflicts, without actually running the conflicting
+    // rebase: fast-forward-merge base into the branch so it looks fresh,
+    // then record an (uncertified) recovery checkpoint for that HEAD.
+    git(&workspace.repo, &["merge", "-X", "ours", "agent-main"]);
+    let rewritten_head = git(&workspace.repo, &["rev-parse", "HEAD"]);
+    assert_ne!(rewritten_head, prepared["head_sha"].as_str().unwrap());
+    write_sync_base_checkpoint(
+        &host,
+        uncertified_recovery_checkpoint(task_id, &workspace.repo, &prepared, &rewritten_head),
+    );
+
+    let error = rebase_pr_branch(&host, &rebase_input(&common, &prepared))
+        .expect_err("redo of a conflicting rebase must not silently succeed or hard-fail");
+    assert!(
+        matches!(error, OrbitError::RecoverableVcsConflict(_)),
+        "unsafe automatic redo must route to the supported conflict-recovery path, got {error}"
+    );
+    assert!(
+        rebase_in_progress(&workspace.repo),
+        "conflicted redo must not be aborted; conflict recovery remains retryable"
+    );
+}
+
+// A checkpoint that *is* certified but whose recorded provenance does not
+// match this attempt (a different base, task set, or pre-rewrite HEAD) stays
+// a hard refusal: the redo path only ever engages when there is no usable
+// certified evidence at all, never to paper over a genuine mismatch.
+#[test]
+fn certified_but_mismatched_recovery_checkpoint_remains_refused() {
+    let workspace = pr_workspace();
+    advance_base(&workspace.repo);
+    let task_id = "ORB-12015-MISMATCHED-CERT";
+    let host = PrOpenTestHost::new(
+        vec![batch_task(
+            task_id,
+            "Mismatched certificate",
+            "Outcome: success\nChanges:\n- Candidate remains mergeable.",
+        )],
+        workspace.repo.clone(),
+    );
+    let common = json!({
+        "workspace_path": workspace.repo,
+        "job_run_id": "batch-1",
+        "completed_task_ids": [task_id],
+        "base": "agent-main",
+        "base_sync": "local",
+    });
+    let prepared = prepare_pr_handoff(&host, &common).expect("prepare");
+    git(&workspace.repo, &["rebase", "agent-main"]);
+    let rewritten_head = git(&workspace.repo, &["rev-parse", "HEAD"]);
+
+    let mut checkpoint =
+        uncertified_recovery_checkpoint(task_id, &workspace.repo, &prepared, &rewritten_head);
+    checkpoint["task_ids"] = json!(["ORB-SOME-OTHER-TASK"]);
+    write_sync_base_checkpoint(&host, checkpoint.clone());
+    host.certify_recovery("batch-1", "sync_base", &checkpoint);
+
+    let error = rebase_pr_branch(&host, &rebase_input(&common, &prepared))
+        .expect_err("a certified but mismatched checkpoint must stay refused");
+    assert!(
+        !matches!(error, OrbitError::RecoverableVcsConflict(_)),
+        "a provenance mismatch is not a merge conflict: {error}"
+    );
+    assert!(
+        error
+            .to_string()
+            .contains("does not match the prepared rewrite checkpoint"),
+        "{error}"
+    );
+}
+
 #[test]
 fn conflicting_rebase_still_uses_conflict_recovery_not_timeout_abort() {
     let workspace = rebase_conflict_pr_workspace();


### PR DESCRIPTION
## Task

[ORB-12015](https://orbit-cli.com/tasks/ORB-12015) — [code-review] A pre-boundary rebase-recovery checkpoint hard-fails every resume instead of redoing the rebase as documented

### Description

ORB-11977 (commit `6f785c0a9`) made `recovered_head_checkpoint` require a host certificate for every candidate checkpoint. Its doc comment states the fallback is a rebase redo, but the code returns an error that every call site propagates, so a run holding a checkpoint written before the authority boundary existed fails its resume and has no path back to a good state.

## Evidence (live code at `dbe1d4038578ecf1bfbda955715342b7d84463c6`)

- `crates/orbit-engine/src/executor/automation/vcs/freshness.rs:568-573` — the doc comment promises self-healing:
  ```
  /// A checkpoint written before that boundary existed has no certificate and is
  /// refused here; the run redoes the rebase rather than inheriting an
  /// unauthenticated HEAD.
  ```
- `crates/orbit-engine/src/executor/automation/vcs/freshness.rs:592-597` — what actually happens is a hard error, not a redo:
  ```rust
  if !host.verify_rebase_recovery(source_run_id, step_id, checkpoint)? {
      return Err(OrbitError::Execution(format!(
          "recovered rebase for step `{step_id}` of run {source_run_id} carries no host \
           recovery certificate; rerun the rebase instead of trusting run-store evidence"
      )));
  }
  ```
- All three production call sites propagate that error with `?`; none maps it to "no usable checkpoint" or triggers a rebase:
  - `crates/orbit-engine/src/executor/automation/vcs/freshness.rs:402` (`validate_recovered_rewrite`)
  - `crates/orbit-engine/src/executor/automation/vcs/resume.rs:351`
  - `crates/orbit-engine/src/executor/automation/vcs/resume.rs:482`
- The change's own test fixes the error as the contract for exactly this input: `crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_preservation.rs:167-173` asserts `unwrap_err()` containing `no host recovery certificate`, under the comment "That is the pre-boundary shape, and it is refused."
- Nothing clears the stale entry. `PipelineState::rebase_recovery_checkpoints` is persisted per run (`crates/orbit-types/src/workflow/run_state.rs:134-142`) and `RecoveryAuthority` only ever inserts (`crates/orbit-core/src/runtime/recovery_authority.rs:119-135`), so a retry re-reads the same uncertified row and fails the same way.

## Failure scenario

A run recorded a `sync_base` rebase recovery checkpoint before `6f785c0a9` was deployed, and that checkpoint still matches the current HEAD, workspace path, step ID, and `rewritten: true`. After the upgrade the run is resumed:

1. `recovered_head_checkpoint` matches the entry, calls `verify_rebase_recovery`, and gets `false` because no certificate was ever issued for it.
2. It returns `Err(... carries no host recovery certificate ...)`.
3. The caller propagates the error, so the resume fails rather than redoing the rebase.
4. Retrying finds the identical uncertified entry and fails identically — the run is stuck until an operator edits the run store by hand.

The fail-closed posture is correct and should be preserved; the defect is that the documented recovery path does not exist, so the upgrade window has no automatic remedy.

## Scope note

Only `OrbitRuntime` implements `RuntimeHost` in production (`crates/orbit-core/src/adapter/engine_host/runtime_host.rs:38`) and it does override `verify_rebase_recovery` (`:649`), so the `Ok(false)` default at `crates/orbit-engine/src/context/hosts.rs:638-645` is not itself a production exposure.

## Suggested direction

Either make the behavior match the comment — treat an uncertified candidate as "no usable checkpoint" (skip it, the way the preceding field mismatches already `continue`) so the step re-runs the rebase and certifies fresh evidence — or keep the hard refusal and correct the comment plus document the operator remedy for a stuck pre-boundary run. If the refusal is kept, decide explicitly whether a run whose checkpoint cannot be certified should have that entry pruned so a retry can make progress.

### Acceptance Criteria

- A deterministic regression reproduces a pre-boundary uncertified checkpoint matching the run/step/current HEAD and proves recovery can make forward progress through a supported path without accepting unauthenticated recovery evidence.
- The chosen automatic redo or explicit operator recovery path preserves all host-certificate, workspace/source/step and rewritten-head integrity checks; forged, stale and mismatched checkpoints remain refused.
- Repeated resume after recovery does not loop on the same stale entry, and interrupted recovery remains retryable. No manual runtime-store edit or bypass of the authority boundary is required.
- Diagnostics and current comments/documentation accurately describe the safe recovery action and its limits, with a concrete command/operation when operator intervention is necessary.
- Focused freshness/resume preservation/security tests, make ci-fast and make ci-lint pass, with coverage demonstrating the original blocked-resume behavior.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Root cause: `recovered_head_checkpoint` (crates/orbit-engine/src/executor/automation/vcs/freshness.rs) hard-errored whenever a matching `rebase_recovery_checkpoints` entry failed `RuntimeHost::verify_rebase_recovery` -- true both for a pre-authority-boundary checkpoint (ORB-11977) and a forged one, since the certificate check cannot distinguish them. All three call sites propagated that `Err` via `?`, so a resume holding such a checkpoint failed permanently with no path back, contradicting the doc comment's promised "rebase redo" fallback.

Fix (safe automatic redo, not a bypass):
- Split the internal lookup into `recovery_checkpoint_lookup` returning a 3-way `RecoveryCheckpointLookup { Certified(Value), Uncertified, Absent }`, so callers can tell "no evidence at all" (unchanged hard refusal -- this is the pre-existing, still-tested "explicit host certification" operator path via `RuntimeHost::checkpoint_rebase_recovery`) apart from "a shape-matching but uncertified candidate" (new: safe to redo).
- `recovered_head_checkpoint` (used by `resume.rs`'s two identity-check call sites, which have no redo fallback) now collapses both Uncertified and Absent to `None` -- fixing the same error-propagation bug there without changing their behavior otherwise.
- `validate_recovered_rewrite` (used by `rebase_pr_branch_inner`) now returns `Ok(false)` for Uncertified (instead of `Err`), and the rebase step responds by discarding the untrusted rewritten HEAD (`git reset --hard head_sha_before`, an already-durable, previously-verified checkpoint) and redoing the deterministic `git rebase base_sha` via a new extracted `perform_rebase_onto_base` helper (shared with the ordinary non-recovery rebase path). A clean redo self-verifies via git and needs no stored evidence; a redo that hits conflicts falls into the existing, already-tested `RecoverableVcsConflict` conflict-recovery path, which certifies fresh evidence on completion -- so an unsafe automatic redo naturally becomes the supported explicit recovery path instead of a dead end. `Absent` still returns the original `Err` message unchanged, preserving the existing, already-tested "manual continuation lacks host provenance" refusal for cases where nothing was ever recorded.
- Updated the doc comments on `recovered_head_checkpoint`/`validate_recovered_rewrite`/the new lookup enum to describe this accurately.

Acceptance criteria:
1. Deterministic regression reproducing a pre-boundary uncertified checkpoint and proving forward progress: `uncertified_pre_boundary_checkpoint_redoes_the_rebase_instead_of_failing_resume` (tests/freshness.rs) -- writes an uncertified `sync_base` checkpoint matching run/step/current HEAD via the run store (no certificate), then asserts `rebase_pr_branch` succeeds with decision "performed" rather than erroring.
2. Redo preserves all integrity checks; forged/stale/mismatched stay refused: `uncertified_recovery_redo_that_conflicts_uses_the_existing_conflict_recovery_path` proves an unsafe redo surfaces as `RecoverableVcsConflict`, not silent success; `certified_but_mismatched_recovery_checkpoint_remains_refused` proves a certified-but-provenance-mismatched checkpoint still hard-fails with "does not match the prepared rewrite checkpoint". Existing `resumed_recovery_requires_the_exact_immutable_source_checkpoint` (resume_preservation.rs) updated to assert `Ok(None)` for the uncertified case (was `unwrap_err`), and still asserts the "differs from its source checkpoint" hard refusal is unchanged.
3. No loop on stale entry / interrupted recovery retryable: the first new test also asserts a subsequent prepare+rebase cycle takes the ordinary "already_fresh"/"skipped_current" path rather than revisiting the stale entry; the conflict test asserts `rebase_in_progress` remains true afterward (conflict recovery stays retryable, matching the existing tested conflict-recovery contract).
4. Diagnostics/comments accurate: doc comments rewritten to describe the actual Certified/Uncertified/Absent behavior and the redo-vs-refuse split; the pre-existing operator remedy (`RuntimeHost::checkpoint_rebase_recovery`, exercised by `recovered_rebase_continues_remaining_handoff_phases_without_replay` in handoff.rs) remains the documented explicit path when nothing at all is recorded.
5. No manual runtime-store edit or authority bypass: the fix never grants trust to run-store data; every path either uses the existing host-certified authority or independently re-derives state via real git operations.

Validation:
- `cargo test -p orbit-engine --lib executor::automation::vcs` -- passed, 254/254 (includes 3 new tests plus the updated pre-existing tests, e.g. `recovered_rebase_continues_remaining_handoff_phases_without_replay` in handoff.rs, which continues to pass unchanged).
- `cargo test -p orbit-engine --lib` (full crate, `--test-threads=1`) -- passed, 672/672. Note: with default parallel test execution, an unrelated pre-existing test in `executor::automation::vcs::commit::tests::already_landed` intermittently fails due to a shared-tmp-path race in the `with_fake_git` test harness (a different test fails each run, passes standalone and under `--test-threads=1`); not touched by this change.
- `make ci-fast` -- passed.
- `make ci-lint` (workspace-wide clippy, all targets, `-D warnings`) -- passed.
- `git diff --check` / `git status --short` -- clean, only the 4 intended files changed, no whitespace issues.

Files changed: crates/orbit-engine/src/executor/automation/vcs/freshness.rs (fix), crates/orbit-engine/src/executor/automation/vcs/tests/freshness.rs (new regression tests), crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_preservation.rs (updated pre-existing test contract), crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs (added `PrOpenTestHost::write_run_state` test helper to write an uncertified checkpoint directly, mirroring `ResumeFailureHost::write_state`).

Left uncommitted per workflow policy (pipeline owns commit/PR).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12015-6aa248c6`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra