### PR TITLE
[code-review] `orbit run readiness` skips the drain's `max_tasks` candidate pool, so it can report `ready` for a task the drain never examines

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
@@ -317,6 +317,65 @@ fn readiness_matches_dispatch_and_does_not_mutate_the_snapshot() {
 }
 
 #[test]
+fn readiness_uses_the_classifier_candidate_pool() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "crates/shared/src/lib.rs");
+    write_workspace_file(&repo_root, "crates/outside/src/lib.rs");
+
+    let mut task_ids = (0..50)
+        .map(|index| {
+            seed_list_backlog_task(
+                &runtime,
+                &format!("Conflicting candidate {index}"),
+                TaskStatus::Backlog,
+                TaskPriority::Medium,
+                TaskType::Chore,
+                None,
+                vec!["crates/shared/src/lib.rs"],
+            )
+            .id
+        })
+        .collect::<Vec<_>>();
+    let outside_pool = seed_list_backlog_task(
+        &runtime,
+        "Conflict-free task outside the candidate pool",
+        TaskStatus::Backlog,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        None,
+        vec!["crates/outside/src/lib.rs"],
+    );
+    task_ids.push(outside_pool.id.clone());
+
+    let classified = classify_with(&runtime, json!({ "max_active_leaf_runs": 4 }));
+    let readiness = runtime
+        .workspace_auto_readiness(&task_ids, Some(4), 51, &[])
+        .expect("explain readiness");
+    let readiness_admitted = readiness["tasks"]
+        .as_array()
+        .expect("readiness tasks")
+        .iter()
+        .filter(|task| task["eligible"] == true)
+        .map(|task| task["task_id"].clone())
+        .collect::<Vec<_>>();
+
+    let classified_admitted = classified["loose_task_ids"]
+        .as_array()
+        .expect("classified task ids");
+    assert_eq!(&readiness_admitted, classified_admitted);
+    assert_eq!(readiness["capacity"]["candidate_pool_size"], 50);
+    assert_eq!(readiness["capacity"]["candidate_pool_truncated"], true);
+    assert_eq!(
+        readiness_task(&readiness, &outside_pool.id)["reason"],
+        "outside_candidate_pool"
+    );
+    assert_eq!(
+        readiness_task(&readiness, &outside_pool.id)["eligible"],
+        false
+    );
+}
+
+#[test]
 fn epic_descendants_are_dependency_then_dispatch_ordered_and_terminal_tasks_are_skipped() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
     let epic = runtime

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
@@ -426,9 +426,11 @@ pub fn explain_workspace_auto_readiness(
         })
         .map(|task| task.id.clone())
         .collect::<Vec<_>>();
-    // [ORB-11973] The identical routine the classifier runs, over the identical
-    // ordered pool, so readiness explains the wave the drain would actually
-    // admit rather than a second guess at it.
+    // [ORB-11973] Use the classifier's identical ordered prefix and admission
+    // routine, so readiness explains the wave the drain would actually admit
+    // rather than a second guess at it.
+    let candidate_pool_size = usize::try_from(DEFAULT_CANDIDATE_POOL).unwrap_or(usize::MAX);
+    let examined = &pending[..pending.len().min(candidate_pool_size)];
     let workspace_root = runtime.paths().repo_root.as_path();
     let claimed = claimed_by_task.keys().cloned().collect::<BTreeSet<_>>();
     let holders = AdmissionHolders::new(
@@ -438,12 +440,14 @@ pub fn explain_workspace_auto_readiness(
         workspace_root,
     );
     let selection = select_admissions(
-        &pending,
+        examined,
         &snapshot.task_lookup,
         workspace_root,
         &holders,
         free_slots,
     );
+    let candidate_pool_truncated =
+        pending.len() > examined.len() && selection.selected.len() < free_slots;
     let admitted = selection.selected.iter().cloned().collect::<BTreeSet<_>>();
     let occupancy = read_leaf_occupancy(
         runtime,
@@ -598,6 +602,11 @@ pub fn explain_workspace_auto_readiness(
             } else if admitted.contains(&task.id) {
                 object.insert("eligible".to_string(), Value::Bool(true));
                 object.insert("reason".to_string(), Value::String("ready".to_string()));
+            } else if !examined.contains(&task.id) {
+                object.insert(
+                    "reason".to_string(),
+                    Value::String("outside_candidate_pool".to_string()),
+                );
             } else if let Some(deferred) = selection.deferred_for(&task.id) {
                 // [ORB-11973] A slot was free and this task did not take it,
                 // which is a different problem from having no slot at all.
@@ -626,6 +635,8 @@ pub fn explain_workspace_auto_readiness(
             // indistinguishable from a busy one by the counts above alone.
             "occupancy": occupancy_json(&occupancy, free_slots),
             "deferred_conflicts": selection.deferred_json(),
+            "candidate_pool_size": examined.len(),
+            "candidate_pool_truncated": candidate_pool_truncated,
             "limit_source": limit_source,
             "drain_run_id": active_drain.as_ref().map(|drain| &drain.run_id),
             "worker_limit": active_drain.as_ref().and_then(|drain| drain.limit.clone()),


### PR DESCRIPTION
## Task

[ORB-11993](https://orbit-cli.com/tasks/ORB-11993) — [code-review] `orbit run readiness` skips the drain's `max_tasks` candidate pool, so it can report `ready` for a task the drain never examines

### Description

ORB-11973 (commit `9a0b4d11b`) made the auto-drain classifier and the read-only readiness diagnostic share `select_admissions` so they "cannot disagree about which task takes a slot". They still disagree, because only the classifier bounds the candidate pool.

## Evidence

- `crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs:184-199` — the classifier truncates the ordered backlog before selecting:
  ```rust
  let max_tasks = candidate_pool_limit(action, input)?;
  let examined = &pending[..pending.len().min(max_tasks)];
  let selection = select_admissions(examined, ...);
  ```
  `candidate_pool_limit` (`:826-829`) defaults to `DEFAULT_CANDIDATE_POOL = 50`.
- `crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs:418-446` — `explain_workspace_auto_readiness` builds the same `pending` list and passes it to `select_admissions` **whole**, with no `max_tasks` truncation. The comment immediately above the call (`:428-430`) claims "The identical routine the classifier runs, over the identical ordered pool", which is not what the code does.
- `crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs:598-600` — readiness marks anything in `selection.selected` as `eligible: true, reason: "ready"`.

## Failure scenario

A workspace has 60 dependency-ready backlog leaves. The first 50 in priority/age order all overlap one another's lock footprints, so `select_admissions` fills only 1 of 4 free slots from that prefix. Candidate #55 is conflict-free.

- The classifier examines only `pending[..50]`, admits 1 task, and reports `candidate_pool_truncated: true`.
- Readiness examines all 60, admits #55 as well, and reports it `eligible: true` / `reason: "ready"`.

An operator watching `orbit run readiness` sees a task that is "ready", waits for the next drain iteration, and it never starts — the exact confusion between contention and saturation that ORB-11973 set out to remove. Readiness also omits the classifier's `candidate_pool_size` / `candidate_pool_truncated` fields (`crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs:251-257` vs the readiness `capacity` block at `:619-628`), so the payload carries no evidence that a bound was even applied.

The divergence needs more pending leaves than `max_tasks` and enough mutual conflict to leave the wave short, so it is a diagnostic-accuracy defect rather than a scheduling one — the drain's own behavior is correct.

## Suggested direction

Apply the same `candidate_pool_limit` truncation in `explain_workspace_auto_readiness` (readiness has no activity `input`, so the default must be shared rather than re-derived), report `candidate_pool_size` and `candidate_pool_truncated` in the readiness `capacity` block, and give tasks beyond the pool their own reason instead of `ready`.

### Acceptance Criteria

- With more dependency-ready backlog leaves than the candidate-pool bound, `explain_workspace_auto_readiness` and `classify_workspace_auto_tasks` name the same admitted task set, covered by a test that fails without the fix.
- A backlog leaf outside the examined candidate pool is not reported as `eligible` / `ready` by readiness.
- The readiness `capacity` block reports the candidate-pool size and whether it truncated the wave, and the `select_admissions` call-site comment matches the code.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Bounded readiness admission selection to the shared default candidate-pool prefix used by auto-drain.
- Added readiness capacity fields for examined pool size and short-wave truncation, and report leaves beyond that prefix as `outside_candidate_pool` rather than ready.
- Added a 51-leaf conflict-prefix regression proving readiness and the classifier name the same admitted task set while the 51st leaf remains ineligible.

Criteria evidence:
1. The regression compares readiness eligible IDs against `classify_workspace_auto_tasks` for a 50-task conflicting prefix plus one conflict-free tail candidate.
2. The tail candidate is asserted `eligible: false` with reason `outside_candidate_pool`.
3. The regression asserts `capacity.candidate_pool_size == 50` and `candidate_pool_truncated == true`; the selection comment now states it uses the classifier's identical ordered prefix.

Validation:
- `cargo fmt --check` — passed.
- `cargo test -p orbit-core readiness_uses_the_classifier_candidate_pool` — passed (1 test).
- `cargo test -p orbit-core workspace_auto --lib` — passed (41 tests).
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- `git diff --check` — passed.

Assessment: focused two-file change; no remaining known risks beyond normal snapshot staleness documented by readiness. Changes are intentionally uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11993-6aa250bb`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*

Orchestrated-By: astra