### PR TITLE
[code-review] Dashboard pagination shipped without updating the current design docs it contradicts

### DIFF
--- a/docs/design/remote-access/2_design.md
+++ b/docs/design/remote-access/2_design.md
@@ -1,8 +1,8 @@
 ---
 title: "Remote Access — Design"
 owner: codex
-last_updated: 2026-08-15
-last_validated: 2026-09-07
+last_updated: 2026-09-10
+last_validated: 2026-09-10
 status: Accepted
 feature: remote-access
 doc_role: design
@@ -54,9 +54,13 @@ Runtime construction happens outside state locks. Web calls orbit-cmd's Register
 
 Workspace-scoped API handlers use ?workspace=<id>, falling back to the pinned default. Unknown workspaces return not found; inactive workspaces return a client error. Omitting the selector with no default is also an error.
 
-GET /api/workspaces lists current entries. GET /api/tasks/all opens active workspaces, skips ones that cannot be opened, tags tasks with workspace metadata, sorts the union newest-first, and applies the standard task-list limit.
+GET /api/workspaces lists current entries. `GET /api/tasks` and `GET /api/tasks/all` share the same task-page query contract. Both accept `status`, `tag` (also `tags`), `type` (also `task_type`), `q` (also `search`), `limit`, and `cursor`. Status and tag values may be repeated or comma-separated; `q` is a case-insensitive task ID/title substring; and `limit` is a positive caller-supplied page size, defaulting to the server default only when omitted. Every predicate is applied before the page bound, so the page contains the newest matching tasks rather than the newest tasks filtered afterward.
 
-GET /api/tasks supports status, tag, type, and limit filters before truncation and returns an items/total/limit/truncated envelope. The aggregate endpoint remains an unfiltered bounded array.
+Both endpoints return `{ items, total, limit, truncated, offset, next_cursor }`. `total` is the count of all matches before the page bound and remains the pre-cursor total on later pages. `truncated` means `total > items.length` against that pre-cursor total; it can therefore remain `true` on a final cursor page. `next_cursor`, not `truncated`, tells a client whether to request another page. `offset` is zero for the first page and records the cursor's position thereafter.
+
+`GET /api/tasks` is scoped to the selected workspace. `GET /api/tasks/all` opens active workspaces, skips ones that cannot be opened, tags rows with workspace metadata, applies the same predicates independently in each workspace, and merges the candidate pages under one global `created_at DESC, id ASC` order. Its `total` is the sum of the untruncated per-workspace match counts, and its caller-supplied `limit` bounds the merged page.
+
+The cursor is opaque and bound to its endpoint scope and the active workspace set: a workspace cursor cannot be used for another workspace, and an aggregate cursor becomes invalid if its active workspace scope changes. It is also bound to the active status, tag, type, search, and limit values, so changing any of them requires a fresh request. The cursor continues the stable `created_at DESC, id ASC` order. Inserts newer than the first page do not disturb an existing continuation, but changes to a task's ordering or filter membership can move it across the boundary; clients that need a new live snapshot must restart without a cursor.
 
 ## 3. orbit web connect
 

--- a/docs/design/user-interface/2_design.md
+++ b/docs/design/user-interface/2_design.md
@@ -3,8 +3,8 @@ summary: "User Interface — Design"
 type: design
 title: "User Interface — Design"
 owner: gemini
-last_updated: 2026-08-16
-last_validated: 2026-08-17
+last_updated: 2026-09-10
+last_validated: 2026-09-10
 status: Draft
 feature: user-interface
 doc_role: design
@@ -73,7 +73,9 @@ In the aggregate ("All workspaces") view there is no ambient workspace to scope 
 
 ## 8. Task Count, Filters, and the Tasks/Log Layout
 
-The Tasks count states what it means instead of an ambiguous `N/50`: it names the shown count, the filtered-to-fetched relationship when they differ, and — using the `/api/tasks` paging envelope (`{ items, total, limit, truncated }`, ORB-10400) — the true total and the server's page limit when the result was truncated. The active status chips are sent to the server as an explicit `status=` filter rather than fetched wholesale and narrowed client-side, so `total`/`truncated` describe the filter actually in effect [ORB-10874].
+The Tasks count uses the `/api/tasks` or `/api/tasks/all` paging envelope (`{ items, total, limit, truncated, offset, next_cursor }`) to render the current page range and matching total rather than an ambiguous `N/50`. For example, a page with twenty items at offset zero of fifty-five matches reads `1–20 of 55`; the final fifteen-item page reads `41–55 of 55`. An empty page reads `0 of N`. If a client-side filter narrows the loaded page, the count prefixes that range with the number shown, such as `3 shown · page 1–20 of 55`. The count does not name a server page limit or describe a fetched-versus-filtered relationship. The active status chips are sent to the server as an explicit `status=` filter rather than fetched wholesale and narrowed client-side, so the envelope's `total` describes the filter actually in effect [ORB-10874].
+
+The Tasks pager has Previous and Next buttons. Previous follows the saved cursor history and is enabled after moving beyond the first page; Next follows `next_cursor` when the server supplies one and is disabled on the last page. Both controls are disabled while a page is loading. The adjacent polite live region reports `Loading task page…` or `Page failed: …`, and changing the status or search filters resets pagination to a new first-page request.
 
 The active status filter and search query are represented in the `#tasks` hash (mirroring the Audit tab's own hash-encoded filters) and restated as plain text next to the count, so the current view survives a reload or the browser's back/forward button and is legible without reading each chip's color. The selected workspace is likewise mirrored into the page's `?workspace=` query parameter on every change [ORB-10874].
 


### PR DESCRIPTION
## Task

[ORB-12024](https://orbit-cli.com/tasks/ORB-12024) — [code-review] Dashboard pagination shipped without updating the current design docs it contradicts

### Description

ORB-12012 (commit `3cc001d88`, PR #1840) added cursor pagination, a `q`/`search` filter, and filtered aggregate listing to `/api/tasks` and `/api/tasks/all`, and rewrote the dashboard's task count. It changed no file under `docs/`. Three statements in current (non-archived) design docs now describe behavior that no longer exists.

`CLAUDE.md` § Design Docs: "Change affected current docs in the same PR as the code. Stale descriptions of live behavior are a review blocker." Every other change in the same integration window did update its docs (ORB-12013 → `docs/runbooks/upgrades.md`; ORB-12014 → `docs/design/activity-job/2_design.md`; ORB-12000 → `docs/design/operation-mode/2_design.md`, `docs/design/routines/2_design.md`), so this is an isolated omission rather than an accepted convention.

## Evidence (verified against live code at `105d0e0b8`)

**1. `docs/design/remote-access/2_design.md:57`** — "GET /api/tasks/all … sorts the union newest-first, and **applies the standard task-list limit**."

The aggregate handler no longer applies a fixed limit. `crates/orbit-web/src/api/workspaces.rs:288` is `candidates.truncate(query.limit())`, where `query.limit()` is the caller-supplied `?limit=` parsed in `crates/orbit-web/src/api/pagination.rs:78-82` and `:196-204`, defaulting to `DEFAULT_TASK_LIST_LIMIT` only when absent. The pre-change line was `candidates.truncate(DEFAULT_TASK_LIST_LIMIT)`. The handler also now honors `?cursor=` (`crates/orbit-web/src/api/workspaces.rs:66-72`).

**2. `docs/design/remote-access/2_design.md:59`** — "GET /api/tasks supports status, tag, type, and limit filters before truncation and returns an items/total/limit/truncated envelope. **The aggregate endpoint remains an unfiltered bounded array.**"

Both halves are now wrong:

- `/api/tasks` additionally supports `q` (alias `search`) and `cursor`, and its envelope gained `offset` and `next_cursor` (`crates/orbit-web/src/api/tasks.rs:396-403`).
- The aggregate endpoint is no longer unfiltered: `list_all_tasks` parses the identical `TaskPageQuery` (`crates/orbit-web/src/api/workspaces.rs:63-72`) and applies `query.filter()` per workspace (`:277`), returning the same `{items,total,limit,truncated,offset,next_cursor}` envelope (`crates/orbit-web/src/api/workspaces.rs:326-334`). The `list_all_tasks` doc comment itself now states "Status/tag/type/search filters, limit, and cursor have the same semantics as `/api/tasks`" (`crates/orbit-web/src/api/workspaces.rs:60-62`), directly contradicting the design doc.
- Note for scope: the "bare array" clause was *already* stale before this window — ORB-11688 replaced the aggregate's bare array with an envelope, and this doc line was last touched on 2026-08-15 (`88070ffb7`). The "unfiltered" clause is what this window made wrong. Fix both while the line is being rewritten.

**3. `docs/design/user-interface/2_design.md:76`** — "The Tasks count … names the shown count, the filtered-to-fetched relationship when they differ, and — using the `/api/tasks` paging envelope (`{ items, total, limit, truncated }`, ORB-10400) — the true total and **the server's page limit when the result was truncated**."

`formatTaskCount` no longer renders a server limit or a "fetched" relationship. `crates/orbit-web/assets/dashboard/tasks.js:95-103` now renders `"<offset+1>–<offset+n> of <total>"`, falling back to `"<filtered> shown · page <range>"` when client-side filtering narrows the page. The strings "server limit" and "fetched" are gone from the formatter, and it no longer reads `meta.truncated` at all.

The regression is invisible to CI because the assertion that pinned the old wording was rewritten in the same commit: `crates/orbit-web/src/tests/dashboard_assets.rs:1188-1189` changed from `tasks.contains("shown") && tasks.contains("total") && tasks.contains("server limit")` to `tasks.contains("offset + 1") && tasks.contains("offset + fetchedCount")`.

## Failure scenario

An operator or agent reads `docs/design/remote-access/2_design.md:59` to integrate with the dashboard API, concludes `/api/tasks/all` accepts no filters and answers a bare bounded array, and writes a client that fetches the aggregate endpoint once and filters client-side — silently capping itself at one page while the server would have paged and filtered for it. Reading `docs/design/user-interface/2_design.md:76` to understand what the Tasks count means yields a description of a string the UI has not rendered since `3cc001d88`.

## Suggested direction

In one docs-only change:

- Rewrite `docs/design/remote-access/2_design.md:57-59` to state the shared contract: both endpoints accept `status`/`tag`/`type`/`q`/`limit`/`cursor`, apply every predicate before the page bound, and answer `{items, total, limit, truncated, offset, next_cursor}`; the aggregate merges per-workspace candidate pages under one global `created_at DESC, id ASC` order and its `total` sums untruncated per-workspace match counts.
- Rewrite `docs/design/user-interface/2_design.md:76` to describe the page-range count and the Previous/Next controls with their loading/error live region.
- Document the cursor's scope-and-filter binding and the restart-without-a-cursor rule, which currently exist only in the `list_tasks` rustdoc (`crates/orbit-web/src/api/tasks.rs:334-339`).
- While rewriting, state precisely what `truncated` now means: it is `total > items.len()` against the *pre-cursor* total (`crates/orbit-web/src/api/tasks.rs:398`), so it stays `true` on the final page even though `next_cursor` is `null`. `next_cursor`, not `truncated`, is the paging signal. No shipped consumer reads the task envelope's `truncated`, so this is a contract-clarity item rather than a behavior change to make.

### Acceptance Criteria

- `docs/design/remote-access/2_design.md` describes the actual `/api/tasks` and `/api/tasks/all` contract: the shared `status`/`tag`/`type`/`q`/`limit`/`cursor` parameters, predicates applied before the page bound, and the `{items, total, limit, truncated, offset, next_cursor}` envelope returned by both endpoints; no sentence still calls the aggregate endpoint unfiltered, a bare array, or fixed to a standard task-list limit.
- `docs/design/user-interface/2_design.md` describes the page-range Tasks count and the Previous/Next controls that `formatTaskCount` and `renderTaskPagination` actually render; it no longer claims the count names a server page limit or a fetched-vs-filtered relationship.
- The cursor's workspace/endpoint/filter binding and the restart-without-a-cursor rule for a live snapshot are documented in the design docs, not only in the `list_tasks` rustdoc.
- The documented meaning of `truncated` matches `total > items.len()` against the pre-cursor total, and names `next_cursor` as the signal a client follows to page.
- `make ci-fast` passes; no source behavior is changed by this task.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `docs/design/remote-access/2_design.md` with the shared `/api/tasks` and `/api/tasks/all` query parameters, predicate-before-limit behavior, common response envelope, aggregate merge/total semantics, cursor scope/filter binding, and live-snapshot restart rule.
- Updated `docs/design/user-interface/2_design.md` with the rendered page-range count, client-side narrowing wording, Previous/Next behavior, and loading/error live-region behavior.
- No source files changed; the worktree diff contains only the two declared design documents.

Acceptance criteria:
- Remote API contract: met. Both endpoints document `status`, `tag`, `type`, `q`, `limit`, and `cursor`, the six-field envelope, filtering before the page bound, and caller-supplied aggregate limits.
- UI count and controls: met. The docs describe examples such as `1–20 of 55`, `0 of N`, the `shown · page` fallback, and the actual Previous/Next loading/error behavior without server-limit or fetched-vs-filtered claims.
- Cursor binding/restart: met. Endpoint/workspace scope, active filters and limit, stable ordering, and restarting without a cursor for a new live snapshot are documented.
- `truncated` semantics: met. It is documented as `total > items.length` against the pre-cursor total, with `next_cursor` as the paging signal.
- CI and behavior scope: met. `make ci-fast` passed with exit code 0; no source behavior changed.

Validation:
- `make ci-fast`: passed (exit 0). The guardrail reported `test-compiler-cache-namespaces` skipped because this environment cannot create a bubblewrap mount namespace; the remaining fast checks passed.
- `git diff --check`: passed.
- `git status --short`: only `docs/design/remote-access/2_design.md` and `docs/design/user-interface/2_design.md` are modified.
- Stale-contract scan and final diff review: passed.

Assessment: The current design docs now match the live API and dashboard pagination behavior. No deviations or remaining task-scoped risks.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12024-6aa252cc`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra