### PR TITLE
Make worker log creation and permissions safe across path replacement and close surviving CodeQL flows

### DIFF
--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -1,11 +1,20 @@
 use std::ffi::{OsStr, OsString};
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Component, Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
+
+#[cfg(not(unix))]
+use std::fs::OpenOptions;
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd};
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 
 use chrono::Utc;
 use orbit_common::fs::io::atomic_write_text;
@@ -2007,6 +2016,7 @@ fn pipeline_worker_file_name(run_id: &str, suffix: &str) -> Result<String, Orbit
 /// worker. A missing parent is rebuilt from that canonical ancestor so the
 /// caller can create intermediate directories. The final component itself
 /// must not be a symlink or a non-directory; traversal syntax fails closed.
+#[cfg(not(unix))]
 fn validated_pipeline_worker_log_directory(path: &Path) -> Result<PathBuf, OrbitError> {
     let validated_path = validate_pipeline_worker_log_directory_input(path)?;
     let parent = validated_path.parent().ok_or_else(|| {
@@ -2056,6 +2066,247 @@ fn validated_pipeline_worker_log_directory(path: &Path) -> Result<PathBuf, Orbit
     Ok(canonical_path)
 }
 
+#[cfg(unix)]
+struct PipelineWorkerLogDirectory {
+    path: PathBuf,
+    directory: File,
+}
+
+/// Open the validated authority and create the log directory beneath its fd.
+///
+/// The trusted authority is the inode of the nearest existing ancestor after
+/// resolving aliases which already existed when setup began. That preserves
+/// supported aliases such as a symlinked `/tmp`, home, or project root. The
+/// inode is checked while opening it, then every missing suffix component is
+/// created and opened relative to the held descriptor with symlink following
+/// disabled. Renames after that point cannot redirect creation, open, or chmod
+/// to another filesystem object.
+#[cfg(unix)]
+fn prepare_pipeline_worker_log_directory(
+    path: &Path,
+) -> Result<PipelineWorkerLogDirectory, OrbitError> {
+    let validated_path = validate_pipeline_worker_log_directory_input(path)?;
+    let parent = validated_path.parent().ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "pipeline worker log directory has no parent: {}",
+            path.display()
+        ))
+    })?;
+    let final_name = validated_path.file_name().ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "pipeline worker log directory has no final component: {}",
+            path.display()
+        ))
+    })?;
+    let (authority_path, missing, expected_authority) =
+        canonical_pipeline_worker_log_parent_components(parent)?;
+
+    #[cfg(all(test, unix))]
+    pipeline_worker_log_test_hook::run(
+        pipeline_worker_log_test_hook::Phase::AuthorityValidated,
+        &authority_path,
+    );
+
+    let mut directory = open_pipeline_worker_directory(None, &authority_path)?;
+    let opened_authority = directory.metadata().map_err(|error| {
+        OrbitError::Io(format!(
+            "inspect opened pipeline worker log authority '{}': {error}",
+            authority_path.display()
+        ))
+    })?;
+    if expected_authority.dev() != opened_authority.dev()
+        || expected_authority.ino() != opened_authority.ino()
+    {
+        return Err(OrbitError::InvalidInput(format!(
+            "pipeline worker log authority changed while it was opened: {}",
+            authority_path.display()
+        )));
+    }
+
+    let mut resolved_path = authority_path;
+    for component in missing
+        .iter()
+        .map(OsString::as_os_str)
+        .chain(std::iter::once(final_name))
+    {
+        resolved_path.push(component);
+        create_pipeline_worker_directory_at(&directory, component, &resolved_path)?;
+        directory = open_pipeline_worker_directory(Some(&directory), Path::new(component))?;
+    }
+
+    Ok(PipelineWorkerLogDirectory {
+        path: resolved_path,
+        directory,
+    })
+}
+
+#[cfg(unix)]
+fn canonical_pipeline_worker_log_parent_components(
+    parent: &Path,
+) -> Result<(PathBuf, Vec<OsString>, std::fs::Metadata), OrbitError> {
+    let mut existing = parent.to_path_buf();
+    let mut missing = Vec::<OsString>::new();
+    loop {
+        match std::fs::metadata(&existing) {
+            Ok(metadata) => {
+                let canonical = existing.canonicalize().map_err(|error| {
+                    OrbitError::Io(format!(
+                        "resolve pipeline worker log authority '{}': {error}",
+                        existing.display()
+                    ))
+                })?;
+                missing.reverse();
+                return Ok((canonical, missing, metadata));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let Some(name) = existing.file_name() else {
+                    return Err(OrbitError::InvalidInput(format!(
+                        "pipeline worker log directory has no parent: {}",
+                        parent.display()
+                    )));
+                };
+                missing.push(name.to_os_string());
+                if !existing.pop() {
+                    return Err(OrbitError::InvalidInput(format!(
+                        "pipeline worker log directory has no parent: {}",
+                        parent.display()
+                    )));
+                }
+            }
+            Err(error) => {
+                return Err(OrbitError::Io(format!(
+                    "inspect pipeline worker log directory '{}': {error}",
+                    existing.display()
+                )));
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+fn pipeline_worker_component_c_string(component: &OsStr) -> Result<std::ffi::CString, OrbitError> {
+    std::ffi::CString::new(component.as_bytes()).map_err(|_| {
+        OrbitError::InvalidInput(format!(
+            "pipeline worker log path contains an invalid null byte: {}",
+            component.to_string_lossy()
+        ))
+    })
+}
+
+#[cfg(unix)]
+fn open_pipeline_worker_directory(parent: Option<&File>, path: &Path) -> Result<File, OrbitError> {
+    let path_c = pipeline_worker_component_c_string(path.as_os_str())?;
+    let flags = libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW;
+    let fd = match parent {
+        Some(parent) => unsafe { libc::openat(parent.as_raw_fd(), path_c.as_ptr(), flags) },
+        None => unsafe { libc::open(path_c.as_ptr(), flags) },
+    };
+    if fd < 0 {
+        let error = std::io::Error::last_os_error();
+        if matches!(error.raw_os_error(), Some(code) if code == libc::ELOOP || code == libc::ENOTDIR)
+        {
+            return Err(OrbitError::InvalidInput(format!(
+                "pipeline worker log directory must not be a symlink or non-directory: {}",
+                path.display()
+            )));
+        }
+        return Err(OrbitError::Io(format!(
+            "open pipeline worker log directory '{}': {error}",
+            path.display(),
+        )));
+    }
+
+    Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+#[cfg(unix)]
+fn create_pipeline_worker_directory_at(
+    parent: &File,
+    component: &OsStr,
+    display_path: &Path,
+) -> Result<(), OrbitError> {
+    let component_c = pipeline_worker_component_c_string(component)?;
+    let result = unsafe { libc::mkdirat(parent.as_raw_fd(), component_c.as_ptr(), 0o700) };
+    if result < 0 {
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::AlreadyExists {
+            return Err(OrbitError::Io(format!(
+                "create pipeline worker log directory '{}': {error}",
+                display_path.display()
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn open_pipeline_worker_log_at(
+    directory: &File,
+    file_name: &OsStr,
+    display_path: &Path,
+) -> Result<File, OrbitError> {
+    let file_name_c = pipeline_worker_component_c_string(file_name)?;
+    let flags = libc::O_CREAT | libc::O_APPEND | libc::O_RDWR | libc::O_CLOEXEC | libc::O_NOFOLLOW;
+    let fd = unsafe { libc::openat(directory.as_raw_fd(), file_name_c.as_ptr(), flags, 0o600) };
+    if fd < 0 {
+        return Err(OrbitError::Io(format!(
+            "open pipeline worker log '{}': {}",
+            display_path.display(),
+            std::io::Error::last_os_error()
+        )));
+    }
+
+    Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+#[cfg(all(test, unix))]
+pub(crate) mod pipeline_worker_log_test_hook {
+    use std::cell::RefCell;
+    use std::path::Path;
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    pub(crate) enum Phase {
+        AuthorityValidated,
+        DirectoryReady,
+        BeforeLogOpen,
+    }
+
+    type Hook = Box<dyn FnOnce(&Path)>;
+
+    thread_local! {
+        static HOOK: RefCell<Option<(Phase, Hook)>> = RefCell::new(None);
+    }
+
+    pub(crate) fn install<F>(phase: Phase, hook: F)
+    where
+        F: FnOnce(&Path) + 'static,
+    {
+        HOOK.with(|slot| *slot.borrow_mut() = Some((phase, Box::new(hook))));
+    }
+
+    pub(crate) fn clear() {
+        HOOK.with(|slot| *slot.borrow_mut() = None);
+    }
+
+    pub(super) fn run(phase: Phase, path: &Path) {
+        let hook = HOOK.with(|slot| {
+            let mut slot = slot.borrow_mut();
+            if slot
+                .as_ref()
+                .is_some_and(|(expected, _)| *expected == phase)
+            {
+                slot.take().map(|(_, hook)| hook)
+            } else {
+                None
+            }
+        });
+        if let Some(hook) = hook {
+            hook(path);
+        }
+    }
+}
+
 /// Perform path-shape checks before the value reaches filesystem APIs.
 ///
 /// The returned value is the only path accepted by the filesystem-resolution
@@ -2084,6 +2335,7 @@ fn validate_pipeline_worker_log_directory_input(path: &Path) -> Result<PathBuf, 
 /// Canonicalize the nearest existing ancestor of `parent` and rejoin any
 /// missing suffix. Unrelated ancestor symlinks are resolved; a dangling
 /// symlink fails closed when canonicalization reaches that component.
+#[cfg(not(unix))]
 fn canonical_pipeline_worker_log_parent(parent: &Path) -> Result<PathBuf, OrbitError> {
     let mut existing = parent.to_path_buf();
     let mut missing = Vec::<OsString>::new();
@@ -2125,31 +2377,67 @@ pub(crate) fn configure_pipeline_worker_stdio(
     logs_dir: &Path,
     run_id: &str,
 ) -> Result<PipelineWorkerLog, OrbitError> {
-    let mut logs_dir = validated_pipeline_worker_log_directory(logs_dir)?;
-    std::fs::create_dir_all(&logs_dir).map_err(|error| {
-        OrbitError::Io(format!(
-            "create pipeline worker log directory '{}': {error}",
-            logs_dir.display()
-        ))
-    })?;
-    logs_dir = validated_pipeline_worker_log_directory(&logs_dir)?;
+    #[cfg(unix)]
+    let PipelineWorkerLogDirectory {
+        path: logs_dir,
+        directory,
+    } = prepare_pipeline_worker_log_directory(logs_dir)?;
+
+    #[cfg(not(unix))]
+    let logs_dir = {
+        let logs_dir = validated_pipeline_worker_log_directory(logs_dir)?;
+        std::fs::create_dir_all(&logs_dir).map_err(|error| {
+            OrbitError::Io(format!(
+                "create pipeline worker log directory '{}': {error}",
+                logs_dir.display()
+            ))
+        })?;
+        validated_pipeline_worker_log_directory(&logs_dir)?
+    };
     let log_path = pipeline_worker_log_path(&logs_dir, run_id)?;
 
+    #[cfg(all(test, unix))]
+    pipeline_worker_log_test_hook::run(
+        pipeline_worker_log_test_hook::Phase::DirectoryReady,
+        &logs_dir,
+    );
+
+    #[cfg(unix)]
+    restrict_pipeline_worker_log_directory(&directory, &logs_dir)?;
+    #[cfg(not(unix))]
     restrict_pipeline_worker_log_directory(&logs_dir)?;
 
-    let mut options = OpenOptions::new();
-    options.create(true).append(true).read(true);
+    #[cfg(all(test, unix))]
+    pipeline_worker_log_test_hook::run(
+        pipeline_worker_log_test_hook::Phase::BeforeLogOpen,
+        &log_path,
+    );
+
     #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
+    let mut log = open_pipeline_worker_log_at(
+        &directory,
+        log_path.file_name().ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "pipeline worker log has no final component: {}",
+                log_path.display()
+            ))
+        })?,
+        &log_path,
+    )?;
+    #[cfg(not(unix))]
+    let mut options = OpenOptions::new();
+    #[cfg(not(unix))]
+    options.create(true).append(true).read(true);
+    #[cfg(not(unix))]
     let mut log = options.open(&log_path).map_err(|error| {
         OrbitError::Io(format!(
             "open pipeline worker log '{}': {error}",
             log_path.display()
         ))
     })?;
+    #[cfg(unix)]
+    restrict_pipeline_worker_log_file(&log, &log_path)?;
+    #[cfg(not(unix))]
     restrict_pipeline_worker_log_file(&log_path)?;
     if let Some(profile) = pipeline_worker_profile_file(
         &logs_dir,
@@ -2227,15 +2515,16 @@ fn read_pipeline_worker_log_tail(file: &mut File) -> Option<String> {
 }
 
 #[cfg(unix)]
-fn restrict_pipeline_worker_log_directory(path: &Path) -> Result<(), OrbitError> {
-    use std::os::unix::fs::PermissionsExt;
-
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)).map_err(|error| {
-        OrbitError::Io(format!(
+fn restrict_pipeline_worker_log_directory(directory: &File, path: &Path) -> Result<(), OrbitError> {
+    if unsafe { libc::fchmod(directory.as_raw_fd(), 0o700) } < 0 {
+        let error = std::io::Error::last_os_error();
+        Err(OrbitError::Io(format!(
             "restrict pipeline worker log directory '{}': {error}",
             path.display()
-        ))
-    })
+        )))
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(not(unix))]
@@ -2244,15 +2533,16 @@ fn restrict_pipeline_worker_log_directory(_path: &Path) -> Result<(), OrbitError
 }
 
 #[cfg(unix)]
-fn restrict_pipeline_worker_log_file(path: &Path) -> Result<(), OrbitError> {
-    use std::os::unix::fs::PermissionsExt;
-
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|error| {
-        OrbitError::Io(format!(
+fn restrict_pipeline_worker_log_file(file: &File, path: &Path) -> Result<(), OrbitError> {
+    if unsafe { libc::fchmod(file.as_raw_fd(), 0o600) } < 0 {
+        let error = std::io::Error::last_os_error();
+        Err(OrbitError::Io(format!(
             "restrict pipeline worker log '{}': {error}",
             path.display()
-        ))
-    })
+        )))
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(not(unix))]

--- a/crates/orbit-core/src/application/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/application/tests/job_pipeline.rs
@@ -15,6 +15,8 @@ use tempfile::TempDir;
 
 use crate::OrbitRuntime;
 use crate::application::job::JobRunListParams;
+#[cfg(unix)]
+use crate::application::job::pipeline::pipeline_worker_log_test_hook::{self, Phase};
 use crate::application::job::pipeline::{
     ROUTINE_DISPATCH_ORBIT_DIR_FIELD, configure_pipeline_worker_command,
     configure_pipeline_worker_stdio, pipeline_worker_log_path, pipeline_worker_profile_file,
@@ -81,6 +83,27 @@ impl WorkerOverride {
 impl Drop for WorkerOverride {
     fn drop(&mut self) {
         worker_command_override::clear();
+    }
+}
+
+#[cfg(unix)]
+struct WorkerLogHook;
+
+#[cfg(unix)]
+impl WorkerLogHook {
+    fn install<F>(phase: Phase, hook: F) -> Self
+    where
+        F: FnOnce(&Path) + 'static,
+    {
+        pipeline_worker_log_test_hook::install(phase, hook);
+        Self
+    }
+}
+
+#[cfg(unix)]
+impl Drop for WorkerLogHook {
+    fn drop(&mut self) {
+        pipeline_worker_log_test_hook::clear();
     }
 }
 
@@ -252,6 +275,131 @@ fn configure_pipeline_worker_stdio_rejects_symlinked_log_directory() {
     assert!(
         !outside.join("jrun-child.worker.log").exists(),
         "worker setup must not follow a log-directory symlink"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn configure_pipeline_worker_stdio_binds_missing_suffix_to_validated_authority() {
+    let root = TempDir::new().expect("tempdir");
+    let authority = root.path().join("authority");
+    let held_authority = root.path().join("held-authority");
+    let outside = root.path().join("outside");
+    std::fs::create_dir(&authority).expect("create authority");
+    std::fs::create_dir(&outside).expect("create outside directory");
+
+    let authority_for_hook = authority.clone();
+    let outside_for_hook = outside.clone();
+    let _hook = WorkerLogHook::install(Phase::AuthorityValidated, move |_| {
+        std::fs::rename(&authority_for_hook, &held_authority).expect("move validated authority");
+        std::os::unix::fs::symlink(&outside_for_hook, &authority_for_hook)
+            .expect("replace authority with symlink");
+    });
+    let logs_dir = authority.join("missing").join("logs");
+    let mut command = Command::new("true");
+
+    let _error = match configure_pipeline_worker_stdio(&mut command, &logs_dir, "jrun-child") {
+        Ok(_) => panic!("replaced authority must fail closed"),
+        Err(error) => error,
+    };
+
+    assert!(
+        !outside.join("missing").exists(),
+        "missing suffix must not be created beneath replacement authority"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn configure_pipeline_worker_stdio_keeps_directory_effects_on_opened_inode() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = TempDir::new().expect("tempdir");
+    let logs_dir = root.path().join("logs");
+    let held_logs = root.path().join("held-logs");
+    let outside = root.path().join("outside");
+    std::fs::create_dir(&outside).expect("create outside directory");
+    std::fs::set_permissions(&outside, std::fs::Permissions::from_mode(0o755))
+        .expect("set outside permissions");
+
+    let logs_for_hook = logs_dir.clone();
+    let held_for_hook = held_logs.clone();
+    let outside_for_hook = outside.clone();
+    let _hook = WorkerLogHook::install(Phase::DirectoryReady, move |_| {
+        std::fs::rename(&logs_for_hook, &held_for_hook).expect("move opened log directory");
+        std::os::unix::fs::symlink(&outside_for_hook, &logs_for_hook)
+            .expect("redirect log-directory path");
+    });
+    let mut command = Command::new("true");
+
+    configure_pipeline_worker_stdio(&mut command, &logs_dir, "jrun-child")
+        .expect("opened directory descriptor remains authoritative");
+
+    let held_log = held_logs.join("jrun-child.worker.log");
+    assert!(held_log.is_file());
+    assert_eq!(
+        std::fs::metadata(&held_logs)
+            .expect("held directory metadata")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o700
+    );
+    assert_eq!(
+        std::fs::metadata(&held_log)
+            .expect("held log metadata")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+    assert!(!outside.join("jrun-child.worker.log").exists());
+    assert_eq!(
+        std::fs::metadata(&outside)
+            .expect("outside metadata")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o755,
+        "replacement target permissions must remain unchanged"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn configure_pipeline_worker_stdio_rejects_final_file_symlink_without_effects() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = TempDir::new().expect("tempdir");
+    let logs_dir = root.path().join("logs");
+    let outside_file = root.path().join("outside.log");
+    std::fs::create_dir(&logs_dir).expect("create logs directory");
+    std::fs::write(&outside_file, "untouched\n").expect("write outside fixture");
+    std::fs::set_permissions(&outside_file, std::fs::Permissions::from_mode(0o644))
+        .expect("set outside permissions");
+
+    let outside_for_hook = outside_file.clone();
+    let _hook = WorkerLogHook::install(Phase::BeforeLogOpen, move |log_path| {
+        std::os::unix::fs::symlink(&outside_for_hook, log_path).expect("redirect final log path");
+    });
+    let mut command = Command::new("true");
+
+    assert!(
+        configure_pipeline_worker_stdio(&mut command, &logs_dir, "jrun-child").is_err(),
+        "a final-file symlink must fail closed"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&outside_file).expect("read outside fixture"),
+        "untouched\n"
+    );
+    assert_eq!(
+        std::fs::metadata(&outside_file)
+            .expect("outside metadata")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o644,
+        "outside file permissions must remain unchanged"
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-12018](https://orbit-cli.com/tasks/ORB-12018) — Make worker log creation and permissions safe across path replacement and close surviving CodeQL flows

### Description

Completed hosted CodeQL34441275295 at76e2839ee1762179f450f93259ef6c808b783ef1 still reports pipeline.rs alerts408(create_dir_all line2079),393(log open2097),121(directory permissions2183),122(file permissions2200). ORB-12002 commit237afb6 and earlier remediations are ancestors of this scan. Current validated_pipeline_worker_log_directory canonicalizes nearest existing ancestor then appends a missing suffix; creation occurs before a second validation, leaving a replacement/symlink race across the create/open/chmod boundary. Inspect current source and use a race-resistant filesystem primitive/descriptor-anchored approach where needed, preserving supported trusted root aliases and normal missing directory creation. Do not simply add another barrier around unsafe effects. Existing ORB-11998 changes routing in the same module; depend on it to avoid competing edits. Hybrid search found only completed predecessor repairs ORB11971/11990/11899/12002 and no open covering mandate.

Orchestrator owns hosted scan closure verification; no dismissal or broad rule suppression. Preserve log naming, owner-only permissions, worker spawn and diagnostic capture. Use isolated roots only.

### Acceptance Criteria

- Directory creation, log opening and permission updates remain bound to validated intended authority across symlink/path replacement; validate before filesystem effects and avoid time-of-check/time-of-use escape. Document the actual trust boundary and supported root aliases.
- Deterministic adversarial tests cover missing suffix replacement, directory and final-file symlink redirection, and assert no external target creation/write/chmod. Demonstrate newly identified defects against old code; ordinary existing/missing log roots and supported ancestor aliases still work.
- Focused worker/log tests plus make ci-fast and make ci-lint pass. Exercise actual worker spawning/log capture with isolated runtime fixtures; do not weaken sandbox grants or lose stderr diagnostics.
- No alert dismissal, query suppression or broad unverified sanitizer modeling. Orchestrator verifies hosted Rust CodeQL on merged revision closes408/393/121/122; any surviving flow remains a repair obligation.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced Unix worker-log directory creation, file opening, and permission changes with descriptor-anchored mkdirat/openat/fchmod operations using O_NOFOLLOW and inode verification across initial authority opening.
- Documented the trust boundary: the nearest existing ancestor inode is authoritative, while pre-existing /tmp, home, and project-root aliases remain supported.
- Added deterministic mutation hooks and adversarial tests for nearest-authority/missing-suffix replacement, final-directory replacement, and final-file symlink replacement, with assertions that outside targets are neither created, written, nor chmodded. Existing/missing roots and ancestor aliases remain covered.
Criteria:
1. Filesystem effects are now relative to held directory descriptors after syntax validation and authority inode comparison; chmod targets opened descriptors.
2. All three adversarial cases pass on the repaired code. An isolated extract of starting HEAD 18a08c190688bc5c6be12876ed057a0177bb8307 with identical phase mutations failed all three safety assertions, demonstrating external directory creation/log opening, log writes, and chmod exposure in the old path-based flow.
3. Focused job-pipeline tests passed, including real shell worker spawning, stdout/stderr durable capture, startup diagnostics, routine-worker ownership, and isolated TempDir runtimes. Owner-only 0700/0600 modes are asserted after directory replacement.
4. No CodeQL dismissal, query suppression, or sanitizer model was added. Hosted Rust CodeQL closure for alerts 408/393/121/122 remains orchestrator-owned after merge.
Validation:
- passed: cargo test -p orbit-core application::tests::job_pipeline -- --nocapture (34 passed)
- passed: make ci-fast (exit 0; its mount-namespace capability subcheck reported the existing environment skip, while the command passed)
- passed: make ci-lint
- passed: git diff --check
- passed: git status --short accounted for only the two task-scoped modified files
- regression evidence: env CARGO_TARGET_DIR=/tmp/orb-12018-baseline-target CARGO_INCREMENTAL=0 RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo test -p orbit-core application::tests::job_pipeline::baseline_ -- --nocapture against extracted starting HEAD failed 3/3 newly added safety assertions as expected
Assessment: Descriptor-relative ownership makes the validated inode, rather than a mutable pathname, the authority for every security-sensitive log effect while preserving ordinary behavior and diagnostics.
Design weaknesses / risks:
- Severity: follow-up verification. Hosted CodeQL was not run locally and must be checked by the orchestrator on the merged revision.
- Severity: low. Runtime adversarial coverage was exercised on Linux; the same Unix APIs compile for macOS, but macOS race behavior was not directly exercised in this environment.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12018-6aa24f10`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra