### PR TITLE
Resolve reopened sandbox root-to-filesystem CodeQL flows without weakening path guards

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -88,6 +88,12 @@ extensions:
           "manual",
         ]
       - [
+          "orbit_core::adapter::engine_host::v2_host::sandbox::validated_linux_runtime_descendant",
+          "ReturnValue.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]",
+          "path-injection",
+          "manual",
+        ]
+      - [
           "orbit_common::storage::sqlite::validated_sqlite_path",
           "ReturnValue.Field[core::result::Result::Ok(0)]",
           "path-injection",

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
@@ -314,81 +314,203 @@ fn append_linux_runtime_write_roots(
     let global = validated_linux_runtime_root(&runtime.paths().global_dir)?;
     let workspace = validated_linux_runtime_root(&runtime.paths().orbit_dir)?;
 
-    for directory in [
-        global.join("state/logs"),
-        global.join("state/audit"),
-        global.join("tasks"),
-    ] {
-        ensure_owned_directory(&directory)?;
-        append_unique_modify_root(resolved, directory.display().to_string());
+    for relative in ["state/logs", "state/audit", "tasks"] {
+        append_runtime_directory_grant(&global, relative, resolved)?;
     }
-    for file in [
-        global.join("orbit.db"),
-        global.join("orbit.db-wal"),
-        global.join("orbit.db-shm"),
-    ] {
-        if file.exists() {
-            append_unique_modify_root(resolved, file.display().to_string());
-        }
+    for relative in ["orbit.db", "orbit.db-wal", "orbit.db-shm"] {
+        append_runtime_sidecar_grant(&global, relative, resolved)?;
     }
 
     if !grants_workspace_modify {
         return Ok(());
     }
 
-    for directory in [
-        workspace.join("tasks"),
-        workspace.join("frictions"),
-        workspace.join("state/audit"),
-        workspace.join("state/logs"),
-        workspace.join("state/job-runs"),
+    for relative in [
+        "tasks",
+        "frictions",
+        "state/audit",
+        "state/logs",
+        "state/job-runs",
     ] {
-        ensure_owned_directory(&directory)?;
-        append_unique_modify_root(resolved, directory.display().to_string());
+        append_runtime_directory_grant(&workspace, relative, resolved)?;
     }
-    for file in [
-        workspace.join("state/semantic.db"),
-        workspace.join("state/semantic.db-wal"),
-        workspace.join("state/semantic.db-shm"),
+    for relative in [
+        "state/semantic.db",
+        "state/semantic.db-wal",
+        "state/semantic.db-shm",
     ] {
-        if file.exists() {
-            append_unique_modify_root(resolved, file.display().to_string());
-        }
+        append_runtime_sidecar_grant(&workspace, relative, resolved)?;
     }
 
     // Language-neutral host cache for toolchain artifacts shared across
     // worktrees (compiler caches, etc.). Implementer-only so read-only
     // profiles stay non-writers. Not a workspace `.orbit` path and not a
     // shared Cargo target directory. [ORB-11259]
-    let host_cache = global.join("cache");
-    ensure_owned_directory(&host_cache)?;
-    append_unique_modify_root(resolved, host_cache.display().to_string());
+    append_runtime_directory_grant(&global, "cache", resolved)?;
 
     Ok(())
+}
+
+/// Grant one runtime store directory, creating it when it is missing.
+///
+/// A descendant that resolves outside its runtime root is skipped instead of
+/// created: the grant only exists so nested Orbit processes can initialize
+/// their own stores, so dropping it costs a convenience, while a hard failure
+/// would break dispatch on every host that legitimately relocates a store
+/// behind a symlink [ORB-11992].
+// pub(super) widened for the sibling tests/ layout.
+#[cfg(target_os = "linux")]
+pub(super) fn append_runtime_directory_grant(
+    root: &Path,
+    relative: &str,
+    resolved: &mut ResolvedFsProfile,
+) -> Result<(), DispatchError> {
+    let Some(directory) = validated_linux_runtime_descendant(root, relative)? else {
+        tracing::warn!(
+            runtime_root = %root.display(),
+            store = relative,
+            "skipping sandbox grant for a runtime store that resolves outside its runtime root"
+        );
+        return Ok(());
+    };
+
+    std::fs::create_dir_all(&directory).map_err(|error| {
+        DispatchError::CliInvocationPermanent(format!(
+            "create Linux sandbox runtime store `{}`: {error}",
+            directory.display()
+        ))
+    })?;
+    append_unique_modify_root(resolved, directory.display().to_string());
+    Ok(())
+}
+
+/// Grant one SQLite sidecar of a runtime store, when it is already present.
+///
+/// Sidecars are never created here — SQLite writes them next to a database it
+/// opens — so an absent one simply yields no grant. Only a regular file inside
+/// the runtime root is granted: a sidecar that is a dangling or escaping
+/// symlink would otherwise hand the sandbox a writable bind on whatever the
+/// link names.
+// pub(super) widened for the sibling tests/ layout.
+#[cfg(target_os = "linux")]
+pub(super) fn append_runtime_sidecar_grant(
+    root: &Path,
+    relative: &str,
+    resolved: &mut ResolvedFsProfile,
+) -> Result<(), DispatchError> {
+    let Some(file) = validated_linux_runtime_descendant(root, relative)? else {
+        tracing::warn!(
+            runtime_root = %root.display(),
+            sidecar = relative,
+            "skipping sandbox grant for a database sidecar that resolves outside its runtime root"
+        );
+        return Ok(());
+    };
+
+    match std::fs::symlink_metadata(&file) {
+        Ok(metadata) if metadata.is_file() => {
+            append_unique_modify_root(resolved, file.display().to_string());
+            Ok(())
+        }
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(DispatchError::CliInvocationPermanent(format!(
+            "inspect Linux sandbox runtime sidecar `{}`: {error}",
+            file.display()
+        ))),
+    }
+}
+
+/// Resolve a store Orbit owns beneath an already-validated runtime root.
+///
+/// The root is canonical, but nothing below it is. An intermediate or leaf
+/// symlink under the root — or a `..` in `relative` — would move both the
+/// directory creation in [`append_runtime_directory_grant`] and the writable
+/// grant derived from it outside the root, so the path is resolved as far as it
+/// already exists *before* any caller creates anything, and the result must
+/// still live under the root.
+///
+/// `None` means the descendant escapes the root; the caller drops that grant
+/// rather than following it.
+#[cfg(target_os = "linux")]
+pub(super) fn validated_linux_runtime_descendant(
+    root: &Path,
+    relative: &str,
+) -> Result<Option<PathBuf>, DispatchError> {
+    let Some(resolved) = resolved_existing_ancestor(&root.join(relative))? else {
+        return Ok(None);
+    };
+    Ok(resolved.starts_with(root).then_some(resolved))
+}
+
+/// Split a path into the deepest ancestor that already exists and the
+/// components that do not, canonicalize that ancestor, and rejoin them.
+///
+/// Canonicalizing resolves every symlink on the existing part, which is what
+/// makes the result usable as a containment decision: whatever the caller does
+/// next happens at the real location, not at the name it was given. `Ok(None)`
+/// means the walk ran out of ancestors; callers phrase their own rejection.
+#[cfg(target_os = "linux")]
+fn resolved_existing_ancestor(path: &Path) -> Result<Option<PathBuf>, DispatchError> {
+    let mut existing = path.to_path_buf();
+    let mut missing = Vec::<OsString>::new();
+
+    let canonical_existing = loop {
+        match existing.canonicalize() {
+            Ok(canonical) => break canonical,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let Some(name) = existing.file_name() else {
+                    return Ok(None);
+                };
+                missing.push(name.to_os_string());
+                if !existing.pop() {
+                    return Ok(None);
+                }
+            }
+            Err(error) => {
+                return Err(DispatchError::CliInvocationPermanent(format!(
+                    "inspect Linux sandbox path ancestor `{}`: {error}",
+                    existing.display()
+                )));
+            }
+        }
+    };
+
+    let mut resolved = canonical_existing;
+    for component in missing.iter().rev() {
+        resolved.push(component);
+    }
+    Ok(Some(resolved))
 }
 
 /// Validate runtime roots before constructing any sandbox path beneath them.
 ///
 /// These roots can be selected through the managed-run registry locator or an
-/// explicit root override. They must already exist as directories when a
-/// runtime is resolving its executor sandbox; accepting a missing or redirected
-/// root here would let the later joins and directory creation follow an
-/// attacker-controlled filesystem path.
+/// explicit root override. Unlike a provider state root, a runtime root is
+/// never created here: it must already exist as a directory when a runtime is
+/// resolving its executor sandbox, so the root is canonicalized first and the
+/// directory check is made against the resolved location rather than the name
+/// that was supplied. A root reached through a symlinked ancestor stays
+/// supported and resolves to its real directory [ORB-11984].
+///
+/// The returned root bounds nothing on its own; every path built beneath it
+/// goes through [`validated_linux_runtime_descendant`].
 #[cfg(target_os = "linux")]
 pub(super) fn validated_linux_runtime_root(path: &Path) -> Result<PathBuf, DispatchError> {
     let validated = validated_linux_provider_state_root(path, None)?;
-    if !validated.is_dir() {
+    let canonical = validated.canonicalize().map_err(|error| {
+        DispatchError::CliInvocationPermanent(format!(
+            "canonicalize Linux sandbox runtime root `{}`: {error}",
+            path.display()
+        ))
+    })?;
+    if !canonical.is_dir() {
         return Err(DispatchError::CliInvocationPermanent(format!(
             "Linux sandbox runtime root `{}` must be an existing directory",
             path.display()
         )));
     }
-    validated.canonicalize().map_err(|error| {
-        DispatchError::CliInvocationPermanent(format!(
-            "canonicalize Linux sandbox runtime root `{}`: {error}",
-            path.display()
-        ))
-    })
+    Ok(canonical)
 }
 
 #[cfg(target_os = "linux")]
@@ -512,41 +634,15 @@ pub(super) fn validated_linux_provider_state_root(
     }
     reject_overbroad_linux_provider_state_root(path, path, home)?;
 
-    // Walk up to the deepest path that already exists. `exists` follows
-    // symlinks, so a provider directory that is itself a symlink to an existing
-    // directory counts as existing and canonicalizes to its real destination.
-    let mut existing = path.to_path_buf();
-    let mut missing = Vec::<OsString>::new();
-    let canonical_existing = loop {
-        match existing.canonicalize() {
-            Ok(canonical) => break canonical,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                let Some(name) = existing.file_name() else {
-                    return Err(DispatchError::CliInvocationPermanent(format!(
-                        "Linux provider state root `{}` has no existing ancestor",
-                        path.display()
-                    )));
-                };
-                missing.push(name.to_os_string());
-                if !existing.pop() {
-                    return Err(DispatchError::CliInvocationPermanent(format!(
-                        "Linux provider state root `{}` has no existing ancestor",
-                        path.display()
-                    )));
-                }
-            }
-            Err(error) => {
-                return Err(DispatchError::CliInvocationPermanent(format!(
-                    "inspect Linux provider state root ancestor `{}`: {error}",
-                    existing.display()
-                )));
-            }
-        }
+    // Resolve the deepest part of the path that already exists, so a provider
+    // directory that is itself a symlink to an existing directory validates
+    // against its real destination.
+    let Some(validated) = resolved_existing_ancestor(path)? else {
+        return Err(DispatchError::CliInvocationPermanent(format!(
+            "Linux provider state root `{}` has no existing ancestor",
+            path.display()
+        )));
     };
-    let mut validated = canonical_existing;
-    for component in missing.iter().rev() {
-        validated.push(component);
-    }
 
     reject_overbroad_linux_provider_state_root(&validated, path, home)?;
 
@@ -603,8 +699,9 @@ fn linux_pi_state_roots(provider: &str, home: Option<&Path>) -> Vec<PathBuf> {
 /// `/login` credentials, settings, saved project trust decisions, installed
 /// packages, and sessions under `$PI_CODING_AGENT_DIR` when set, otherwise
 /// `$HOME/.pi`. No other provider receives this grant — every entry in the
-/// caller's list is *created* by `ensure_owned_directory`, so an unconditional
-/// entry would mkdir a `~/.pi` on hosts that never installed Pi. [ORB-11296]
+/// caller's list is *created* by `ensure_linux_provider_directory`, so an
+/// unconditional entry would mkdir a `~/.pi` on hosts that never installed Pi.
+/// [ORB-11296]
 #[cfg(target_os = "linux")]
 pub(super) fn linux_pi_state_roots_with(
     provider: &str,
@@ -656,9 +753,9 @@ pub(super) struct OpencodeStateEnv {
 /// config, and state directories at startup, before it reads Orbit's envelope.
 /// The data root holds `auth.json` from `opencode auth login`, the session and
 /// message stores, and logs. No other provider receives this grant — every
-/// entry in the caller's list is *created* by `ensure_owned_directory`, so an
-/// unconditional entry would mkdir an `~/.local/share/opencode` on hosts that
-/// never installed OpenCode. [ORB-11295]
+/// entry in the caller's list is *created* by `ensure_linux_provider_directory`,
+/// so an unconditional entry would mkdir an `~/.local/share/opencode` on hosts
+/// that never installed OpenCode. [ORB-11295]
 #[cfg(target_os = "linux")]
 pub(super) fn linux_opencode_state_roots_with(
     provider: &str,
@@ -745,16 +842,6 @@ pub(super) fn linux_copilot_state_roots_with(
         }
     }
     roots
-}
-
-#[cfg(target_os = "linux")]
-fn ensure_owned_directory(path: &Path) -> Result<(), DispatchError> {
-    std::fs::create_dir_all(path).map_err(|error| {
-        DispatchError::CliInvocationPermanent(format!(
-            "create Linux sandbox runtime root `{}`: {error}",
-            path.display()
-        ))
-    })
 }
 
 /// Re-allow the active job-run worktree under `<workspace>/.orbit/state/worktrees/`

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
@@ -871,8 +871,8 @@ fn resolve_executor_sandbox_rejects_bare_worktrees_root_cwd() {
 }
 
 // [ORB-10946] The Linux half of the Copilot state-root gate. Every entry this
-// returns is created by `ensure_owned_directory`, so an ungated entry would
-// mkdir a `~/.copilot` on hosts that never installed the CLI.
+// returns is created by `ensure_linux_provider_directory`, so an ungated entry
+// would mkdir a `~/.copilot` on hosts that never installed the CLI.
 #[cfg(target_os = "linux")]
 mod copilot_state_roots {
     use std::path::{Path, PathBuf};
@@ -1317,5 +1317,266 @@ fn linux_resolution_appends_git_protection_after_provider_grants() {
         linux_bwrap_write_grant_diagnostic(&sandbox.fs_profile, &git_dir.join("HEAD"))
             .unwrap()
             .is_some()
+    );
+}
+
+/// Runtime stores are reached by joining constant segments onto an already
+/// canonical runtime root, so validating the root says nothing about them.
+/// These cover that descendant boundary and the two grants built on it.
+#[cfg(target_os = "linux")]
+mod runtime_store_grants {
+    use std::os::unix::fs::symlink;
+    use std::path::Path;
+
+    use orbit_types::policy::ResolvedFsProfile;
+
+    use crate::adapter::engine_host::v2_host::sandbox::{
+        append_runtime_directory_grant, append_runtime_sidecar_grant,
+        validated_linux_runtime_descendant,
+    };
+
+    fn canonical_root(root: &Path) -> std::path::PathBuf {
+        root.canonicalize().expect("canonical runtime root")
+    }
+
+    fn empty_profile() -> ResolvedFsProfile {
+        ResolvedFsProfile {
+            name: "test".to_string(),
+            read: Vec::new(),
+            modify: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn accepts_a_store_that_stays_under_its_root() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let root = canonical_root(root.path());
+        std::fs::create_dir_all(root.join("state/logs")).expect("create store");
+
+        let resolved = validated_linux_runtime_descendant(&root, "state/logs")
+            .expect("validate store")
+            .expect("a store inside the root is grantable");
+
+        assert_eq!(resolved, root.join("state/logs"));
+    }
+
+    #[test]
+    fn accepts_a_store_that_has_not_been_created_yet_without_creating_it() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let root = canonical_root(root.path());
+
+        let resolved = validated_linux_runtime_descendant(&root, "state/logs")
+            .expect("validate store")
+            .expect("a store that has never been created is still grantable");
+
+        assert_eq!(resolved, root.join("state/logs"));
+        assert!(
+            !root.join("state").exists(),
+            "validation alone must not create the store"
+        );
+    }
+
+    /// Relocating a store behind a symlink is an ordinary host configuration,
+    /// so an alias that still lands inside the root keeps its grant — reported
+    /// at the real location rather than at the link name. [ORB-11984]
+    #[test]
+    fn resolves_an_alias_that_still_lands_inside_the_root() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let root = canonical_root(root.path());
+        std::fs::create_dir_all(root.join("real-tasks")).expect("create real store");
+        symlink(root.join("real-tasks"), root.join("tasks")).expect("alias the store");
+
+        let resolved = validated_linux_runtime_descendant(&root, "tasks")
+            .expect("validate store")
+            .expect("an in-root alias stays grantable");
+
+        assert_eq!(resolved, root.join("real-tasks"));
+    }
+
+    #[test]
+    fn rejects_a_store_redirected_outside_the_root() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let outside = tempfile::tempdir().expect("redirect target");
+        let root = canonical_root(root.path());
+        symlink(outside.path(), root.join("state")).expect("redirect the state store");
+
+        assert_eq!(
+            validated_linux_runtime_descendant(&root, "state/logs").expect("validate store"),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_a_store_that_traverses_or_escapes_the_root() {
+        let parent = tempfile::tempdir().expect("runtime parent");
+        let root = parent.path().join("root");
+        std::fs::create_dir_all(&root).expect("create runtime root");
+        let root = canonical_root(&root);
+
+        for relative in ["../sibling", "state/../../sibling", "/etc"] {
+            assert_eq!(
+                validated_linux_runtime_descendant(&root, relative).expect("validate store"),
+                None,
+                "`{relative}` must not resolve to a grant"
+            );
+        }
+    }
+
+    #[test]
+    fn directory_grant_creates_and_grants_a_store_inside_the_root() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let root = canonical_root(root.path());
+        let mut profile = empty_profile();
+
+        append_runtime_directory_grant(&root, "state/logs", &mut profile).expect("grant store");
+
+        assert!(
+            root.join("state/logs").is_dir(),
+            "the store must be created"
+        );
+        assert_eq!(
+            profile.modify,
+            vec![root.join("state/logs").display().to_string()]
+        );
+    }
+
+    /// A store whose parent is redirected out of the runtime root must not be
+    /// created at the redirect target and must not become a writable grant:
+    /// either one would hand a sandboxed leaf a host path the profile never
+    /// authorized.
+    #[test]
+    fn directory_grant_neither_creates_nor_grants_a_redirected_store() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let outside = tempfile::tempdir().expect("redirect target");
+        let root = canonical_root(root.path());
+        let outside = canonical_root(outside.path());
+        symlink(&outside, root.join("state")).expect("redirect the state store");
+        let mut profile = empty_profile();
+
+        append_runtime_directory_grant(&root, "state/logs", &mut profile)
+            .expect("a redirected store is skipped, not a dispatch failure");
+
+        assert!(profile.modify.is_empty(), "grants: {:?}", profile.modify);
+        assert!(
+            !outside.join("logs").exists(),
+            "the redirect target must be left untouched"
+        );
+    }
+
+    #[test]
+    fn sidecar_grant_covers_an_existing_regular_file_and_skips_a_missing_one() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let root = canonical_root(root.path());
+        std::fs::write(root.join("orbit.db-wal"), b"").expect("create sidecar");
+        let mut profile = empty_profile();
+
+        append_runtime_sidecar_grant(&root, "orbit.db-wal", &mut profile).expect("grant sidecar");
+        append_runtime_sidecar_grant(&root, "orbit.db-shm", &mut profile).expect("skip sidecar");
+
+        assert_eq!(
+            profile.modify,
+            vec![root.join("orbit.db-wal").display().to_string()]
+        );
+    }
+
+    /// SQLite writes its sidecars next to the database it opens, so a sidecar
+    /// that is a symlink is never Orbit's own file. Granting one would bind the
+    /// link's target into the sandbox as writable.
+    #[test]
+    fn sidecar_grant_skips_a_sidecar_symlinked_outside_the_root() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let outside = tempfile::tempdir().expect("redirect target");
+        let root = canonical_root(root.path());
+        let target = canonical_root(outside.path()).join("credentials");
+        std::fs::write(&target, b"secret").expect("create redirect target");
+        symlink(&target, root.join("orbit.db-wal")).expect("redirect the sidecar");
+        let mut profile = empty_profile();
+
+        append_runtime_sidecar_grant(&root, "orbit.db-wal", &mut profile)
+            .expect("a redirected sidecar is skipped, not a dispatch failure");
+
+        assert!(profile.modify.is_empty(), "grants: {:?}", profile.modify);
+    }
+
+    #[test]
+    fn sidecar_grant_skips_a_dangling_sidecar_symlink() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let root = canonical_root(root.path());
+        symlink(root.join("never-created"), root.join("orbit.db-wal")).expect("dangling sidecar");
+        let mut profile = empty_profile();
+
+        append_runtime_sidecar_grant(&root, "orbit.db-wal", &mut profile)
+            .expect("a dangling sidecar is skipped, not a dispatch failure");
+
+        assert!(profile.modify.is_empty(), "grants: {:?}", profile.modify);
+    }
+}
+
+/// A redirected runtime store must stay out of the profile that reaches
+/// Bubblewrap, not just out of the helper that builds it.
+#[cfg(target_os = "linux")]
+#[test]
+fn resolved_linux_sandbox_drops_a_redirected_global_runtime_store() {
+    use std::os::unix::fs::symlink;
+
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    let outside = tempfile::tempdir().expect("redirect target");
+    let outside = outside.path().canonicalize().expect("canonical target");
+    let redirected = runtime.paths().global_dir.join("cache");
+    symlink(&outside, &redirected).expect("redirect the host cache store");
+
+    seed_executor(
+        &runtime,
+        "claude",
+        Some(orbit_types::workflow::ExecutorSandboxKind::LinuxBwrap),
+    );
+    let sandbox = runtime
+        .resolve_executor_sandbox("claude", None, Some(&repo_root))
+        .expect("resolve sandbox")
+        .expect("descriptor");
+
+    // Bubblewrap resolves the paths it binds, so naming the link is the same
+    // grant as naming its target. Neither may appear.
+    let denied = [
+        outside.display().to_string(),
+        redirected.display().to_string(),
+    ];
+    assert!(
+        sandbox.fs_profile.modify.iter().all(|rule| denied
+            .iter()
+            .all(|prefix| !rule.trim_start_matches('!').starts_with(prefix))),
+        "a redirected runtime store must not widen the sandbox: {:?}",
+        sandbox.fs_profile.modify
+    );
+}
+
+/// Sandbox preparation appends runtime write roots before the recovery
+/// authority deny that rejects a symlinked `<global>/state`. The later
+/// rejection is not a substitute for validating the store first: without it,
+/// preparation has already created directories at the redirect target by the
+/// time dispatch fails.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_failed_linux_resolution_still_writes_nothing_at_a_redirect_target() {
+    use std::os::unix::fs::symlink;
+
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    let outside = tempfile::tempdir().expect("redirect target");
+    let outside = outside.path().canonicalize().expect("canonical target");
+    symlink(&outside, runtime.paths().global_dir.join("state"))
+        .expect("redirect the global state store");
+
+    seed_executor(
+        &runtime,
+        "claude",
+        Some(orbit_types::workflow::ExecutorSandboxKind::LinuxBwrap),
+    );
+    runtime
+        .resolve_executor_sandbox("claude", None, Some(&repo_root))
+        .expect_err("a symlinked global state root must not resolve a sandbox");
+
+    assert!(
+        !outside.join("logs").exists() && !outside.join("audit").exists(),
+        "sandbox preparation must not create runtime stores at a redirect target"
     );
 }


### PR DESCRIPTION
## Task

[ORB-12016](https://orbit-cli.com/tasks/ORB-12016) — Resolve reopened sandbox root-to-filesystem CodeQL flows without weakening path guards

### Description

Hosted CodeQL run 34440336681 on dbe1d4038578ecf1bfbda955715342b7d84463c6 reports rust/path-injection alerts #107, #127, #128, and new #410 in crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs. Prior fixed commit dddecc4 is an ancestor of this scan: these are reopened descendant findings, not simply missing an earlier fix. #127 targets line330 global orbit.db sidecar exists; #128 line354 workspace semantic.db sidecar exists; #410 line380 validated_linux_runtime_root is_dir; #107 line752 ensure_owned_directory create_dir_all. Inspect actual current dataflows and root trust boundaries as one repair. Prior ORB-11927, ORB-11898, ORB-11984, ORB-12005 cover earlier versions; hybrid search found no open covering repair. ORB-12014 repaired recovery_authority.rs separately and must remain intact.

Verify security behavior before adjusting any narrow CodeQL barrier. Preserve legitimate initialized global/workspace roots, aliases supported by current contracts, and denied malicious descendants; do not replace actual guards with suppression or discard functionality to quiet a scanner. The orchestrator will verify hosted alerts on merged revision; leaf must report local proof and any unexecuted live sandbox checks honestly. All alert links are https://github.com/constellation-works/orbit/security/code-scanning/<number>.

### Acceptance Criteria

- Trace and address all four reported validator-to-sink flows against current agent-main. Every affected filesystem operation must be justified by explicit validated authority before its side effects; document source proof when a narrowly scoped model correction is appropriate.
- Adversarial tests cover relative/traversal paths, missing supported roots, symlinked descendants/sidecars, supported canonical roots and trusted aliases, with no attacker-target writes or widened sandbox grants. Include old-code failure evidence for newly identified behavior defects.
- Run relevant sandbox and root-validation tests, make ci-fast and make ci-lint. Distinguish actual live bwrap execution from skipped namespace fixtures and provide an operator/CI handoff for unexecuted required cases.
- Do not dismiss alerts, suppress rules, weaken path checks, or register broad unverified barriers. Orchestrator must confirm alerts107/127/128/410 fixed in hosted Rust CodeQL on the merged repair revision and route any surviving flows into repair.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Outcome

Repaired the four reported validator-to-sink flows in `v2_host/sandbox.rs` by making every
filesystem effect on a runtime store carry its own validated authority, and established with
hard evidence that alerts #107/#127/#128/#410 **cannot close on the hosted scan** until the
repository CodeQL model pack is actually loaded (see "Blocker" below and friction F2026-09-115).

## What was wrong (traced against agent-main @ 18a08c190)

`append_linux_runtime_write_roots` validated the two runtime *roots*
(`validated_linux_runtime_root`) and then treated every path built beneath them as trusted:

- `ensure_owned_directory` (old L752) ran `create_dir_all` on a bare `&Path` with no validation
  of its own. `global.join("state/logs")` etc. were never re-checked, so a symlinked `state/`
  under a runtime root redirected both the mkdir and the resulting writable bwrap grant.
- The sidecar probes (old L330 / L354) were `file.exists()`, which follows symlinks. A
  `orbit.db-wal` or `semantic.db-wal` that was a symlink resolved to its target and the target
  became a writable sandbox grant.
- `validated_linux_runtime_root` (old L380) ran `is_dir()` on the composed
  "canonical-ancestor + not-yet-existing suffix" candidate and canonicalized afterwards.

## Change

- New `validated_linux_runtime_descendant(root, relative)`: resolves the deepest existing part
  of the path *before* anything is created and requires the result to stay under the canonical
  root. Traversal (`../`) and absolute `relative` are subsumed by the same containment check.
- New `append_runtime_directory_grant` / `append_runtime_sidecar_grant` own the two effects.
  A directory is created only after containment holds; a sidecar is granted only when it is a
  regular file inside the root (dangling and escaping symlinks are skipped, never followed).
- `validated_linux_runtime_root` now canonicalizes first and checks `is_dir()` on the resolved
  path. Symlinked roots stay supported (ORB-11984).
- Extracted `resolved_existing_ancestor`, shared with `validated_linux_provider_state_root`,
  which previously carried its own copy of the same ancestor walk.
- Deleted `ensure_owned_directory` and fixed three stale comments that named it.
- Registered one narrow barrier entry for `validated_linux_runtime_descendant` in
  `path-validation.yml`, matching the file's existing validator convention.

## Acceptance criteria

1. **All four flows addressed.** Yes. Each sink now consumes the output of an explicit
   containment validator: L752 -> `append_runtime_directory_grant`, L330/L354 ->
   `append_runtime_sidecar_grant`, L380 -> canonicalize-then-`is_dir`. No guard was weakened;
   the CodeQL model gained exactly one entry, for a function that performs real validation.
2. **Adversarial tests.** New module `runtime_store_grants` (9 tests) plus 2 end-to-end tests
   cover: in-root store, not-yet-created store (and that validation creates nothing), in-root
   symlink alias (still granted, at its real location), descendant redirected outside the root,
   `../` / `state/../../` / absolute `/etc`, create+grant happy path, redirected store neither
   created nor granted, existing vs. missing sidecar, sidecar symlinked outside the root,
   dangling sidecar symlink, and full `resolve_executor_sandbox` runs asserting no grant names a
   redirect target or its link and no directory is created at the target.
   **Old-code failure evidence** (grant helpers reverted to `create_dir_all(root.join(..))` /
   `path.exists()`, tests unchanged): 4 fail ->
   `directory_grant_neither_creates_nor_grants_a_redirected_store`
   (`grants: ["/tmp/.tmpsFcUVJ/state/logs"]`),
   `sidecar_grant_skips_a_sidecar_symlinked_outside_the_root`
   (`grants: ["/tmp/.tmpUifQbA/orbit.db-wal"]`),
   `a_failed_linux_resolution_still_writes_nothing_at_a_redirect_target`
   (preparation had already created `logs`/`audit` at the target before the recovery-authority
   deny rejected dispatch), and
   `resolved_linux_sandbox_drops_a_redirected_global_runtime_store`
   (`/tmp/.../home/.orbit/cache` granted while symlinked out of the root).
3. **Validation.** See table below.
4. **No dismissals or weakening.** No alert dismissed, no rule suppressed, no path check
   relaxed. The one model addition is narrow. Orchestrator confirmation on the hosted scan is
   still required and is currently blocked — see below.

## Validation run

| Command | Outcome |
| --- | --- |
| `cargo test -p orbit-core --lib sandbox` | passed (58 tests) |
| `cargo test -p orbit-core --lib` | passed (1349 passed, 2 ignored) |
| `cargo test -p orbit-exec` | passed (81 + 18 + 20 + 3; 1 ignored) |
| `cargo test -p orbit-engine` | passed (672 + 6 + 1 + 1) |
| `make ci-fast` | passed (exit 0) |
| `make ci-lint` | passed (exit 0) |
| `cargo fmt` / `git diff --check` | clean |

**Live bwrap: NOT executed.** This host has unprivileged user namespaces disabled
(`bwrap: No permissions to create new namespace`; bubblewrap 0.9.0 is installed). Every
`probe_bwrap()`-gated test self-skipped with that message, and
`orbit-exec --test linux_sandbox -- --ignored`
(`kernel_git_metadata_integrity_through_original_and_build_aliases`) fails with
`live boundary unvalidated`. What ran locally is argv compilation, grant preparation, and the
resolved `ResolvedFsProfile` contents — not kernel enforcement of that profile.
**Operator/CI handoff:** the `Linux Sandbox & Policy Enforcement` job in `.github/workflows/ci.yml`
(`cargo test -p orbit-exec -p orbit-policy -p orbit-tools`) runs these on ubuntu-latest where the
probe succeeds; the orbit-core sandbox tests run in the main `ci` nextest pass. Both must be green
on the PR before this is considered live-verified. None of the new tests need bwrap.

## Blocker on criterion 4 (orchestrator action required)

The four alerts will **not** close from this change alone. The repository's CodeQL model pack is
never loaded by the hosted scan, so every `barrierModel` entry — including the two that already
name `validated_linux_provider_state_root` and `validated_linux_runtime_root` — is inert.

Evidence: SARIF for analysis 1752884819 (rust, 13075f2c6) lists tool extensions
`generated/extension-pack`, `codeql/rust-queries`, `codeql/rust-all`, `codeql/threat-models`
only; run 34444672936 job `Analyze (rust)` records only `codeql/rust-queries`; and the reported
code flows pass straight through both modeled functions
(`sandbox.rs:494 [Ok]` -> `379 validated_linux_provider_state_root(...) [Ok]`
-> `314 validated_linux_runtime_root(...)`). Cause: `codeql.yml` uses advanced setup and
`codeql-config.yml` has no `packs:` key; repository-local extension packs are auto-detected only
under default setup.

Expect the alerts to reappear at the new line numbers. Wiring the pack (publish to GHCR + `packs:`,
or `--additional-packs`/`--extension-packs` on the analyze step) is a CI-configuration change
outside this task's declared scope and unverifiable in this worktree — no `codeql` CLI here — so
it was deliberately not attempted. Filed as friction **F2026-09-115** with the full evidence and
fix direction; recommend a dedicated task, gated on a scan whose SARIF `tool.extensions` actually
lists the pack.

## Deviations and risks

- **Behavior narrowing (deliberate).** A runtime store relocated by symlink *outside* its runtime
  root now loses its convenience grant, with a `tracing::warn!`, instead of silently granting the
  target. Dispatch is not failed — hard-failing would reproduce the ORB-11992 regression shape.
  An in-root alias keeps its grant, reported at the real location. Concrete effect: on a host that
  symlinks `.orbit/frictions` outside `.orbit`, a nested sandboxed `orbit friction add` loses its
  write grant. This is the intended trade for "no widened sandbox grants".
- **File size.** `sandbox.rs` is now ~957 lines and `tests/sandbox.rs` ~1583, both past the
  ~800-line design warning. Splitting by responsibility is broad restructuring and was not done
  inside a security repair; flagging it as a follow-up signal.
- Scope stayed within the declared `context_files`; no selector was added.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12016-6aa24f0f`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra