### PR TITLE
[qa-sweep] `orbit update` renders the `invalid input:` error prefix inside its user-facing remediation sentence

### DIFF
--- a/crates/orbit-cli/tests/update.rs
+++ b/crates/orbit-cli/tests/update.rs
@@ -325,6 +325,34 @@ fn check_reports_the_available_release_and_exits_three() {
             .contains("make install"),
         "{report}"
     );
+    assert!(
+        !report["remediation"]
+            .as_str()
+            .expect("remediation")
+            .contains("invalid input: "),
+        "{report}"
+    );
+}
+
+#[test]
+fn check_renders_a_prefix_free_remediation_sentence() {
+    let home = tempdir().expect("home");
+    let mirror = mirror_publishing("9.9.9");
+    let output = orbit(home.path(), home.path(), mirror.path())
+        .args(["update", "--check"])
+        .output()
+        .expect("run update --check");
+
+    assert_eq!(output.status.code(), Some(3), "{output:?}");
+    let text = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        text.contains("An update is available, but cannot update '")
+            && text.contains(
+                "in place: this is a local build inside a checkout; update the checkout and rebuild (`git pull && make install`)."
+            ),
+        "{text}"
+    );
+    assert!(!text.contains("invalid input: "), "{text}");
 }
 
 #[test]

--- a/crates/orbit-cmd/src/update/channel.rs
+++ b/crates/orbit-cmd/src/update/channel.rs
@@ -116,14 +116,11 @@ impl InstallChannel {
         }
     }
 
-    /// Refuse an in-place replacement, naming the command that does work.
+    /// Describe why an in-place replacement is unsupported, naming the command
+    /// that does work.
     ///
     /// Returns `None` for [`Self::Managed`], which is updatable.
-    pub fn unsupported_reason(
-        &self,
-        executable: &Path,
-        target_version: &str,
-    ) -> Option<OrbitError> {
+    pub fn unsupported_reason(&self, executable: &Path, target_version: &str) -> Option<String> {
         let remediation = match self {
             Self::Managed { .. } => return None,
             Self::Npm => format!(
@@ -152,10 +149,10 @@ impl InstallChannel {
                  or set {INSTALL_DIR_ENV} to the directory it owns"
             ),
         };
-        Some(OrbitError::InvalidInput(format!(
+        Some(format!(
             "cannot update '{}' in place: {remediation}",
             executable.display()
-        )))
+        ))
     }
 }
 

--- a/crates/orbit-cmd/src/update/mod.rs
+++ b/crates/orbit-cmd/src/update/mod.rs
@@ -212,8 +212,7 @@ pub fn run_update(
     let asset = channel::release_archive_name(&environment.target_triple);
     let remediation = environment
         .install_channel
-        .unsupported_reason(&environment.executable, &target.to_string())
-        .map(|error| error.to_string());
+        .unsupported_reason(&environment.executable, &target.to_string());
     let mut report = UpdateReport {
         install_channel: environment.install_channel.as_str(),
         updatable: remediation.is_none(),
@@ -250,11 +249,11 @@ pub fn run_update(
     }
 
     // Everything past this point can write, so the channel guard comes first.
-    if let Some(error) = environment
+    if let Some(remediation) = environment
         .install_channel
         .unsupported_reason(&environment.executable, &target.to_string())
     {
-        return Err(error);
+        return Err(OrbitError::InvalidInput(remediation));
     }
 
     let install_dir = environment.executable.parent().ok_or_else(|| {

--- a/crates/orbit-cmd/src/update/tests/channel.rs
+++ b/crates/orbit-cmd/src/update/tests/channel.rs
@@ -64,6 +64,7 @@ fn package_manager_installs_are_classified_and_get_their_own_command() {
         let message = error.to_string();
         assert!(message.contains(remediation), "{path}: {message}");
         assert!(message.contains(path), "{path}: {message}");
+        assert!(!message.contains("invalid input: "), "{path}: {message}");
     }
 }
 


### PR DESCRIPTION
## Task

[ORB-12037](https://orbit-cli.com/tasks/ORB-12037) — [qa-sweep] `orbit update` renders the `invalid input:` error prefix inside its user-facing remediation sentence

### Description

## Problem

`orbit update` / `orbit update --check` render the install-channel remediation into prose that leaks Orbit's internal error-kind prefix:

```
An update is available, but invalid input: cannot update '~/.orbit/bin/orbit' in place: Orbit does not recognize the installer that owns this path; install through the managed installer with `curl -sSf https://raw.githubusercontent.com/constellation-works/orbit/main/install.sh | sh`, or set ORBIT_INSTALL_DIR to the directory it owns.
```

`invalid input: ` is `OrbitError::InvalidInput`'s `Display` prefix (`crates/orbit-common/src/error.rs:189` — `#[error("invalid input: {0}")]`), not prose anyone intended a user to read mid-sentence.

## Root cause

`InstallChannel::unsupported_reason` (`crates/orbit-cmd/src/update/channel.rs:122-159`) builds a well-worded, per-channel remediation string, then wraps **every** channel's text in `OrbitError::InvalidInput(format!("cannot update '{}' in place: {remediation}", ...))`.

`run_update` (`crates/orbit-cmd/src/update/mod.rs:213-216`) turns that error straight into the report field:

```rust
let remediation = environment
    .install_channel
    .unsupported_reason(&environment.executable, &target.to_string())
    .map(|error| error.to_string());
```

`crates/orbit-cli/src/command/update.rs:110` then interpolates the stringified error into a sentence:

```rust
let _ = writeln!(text, "An update is available, but {remediation}.");
```

So a value that is only ever *displayed* is carried as an error type, and its type prefix becomes user-visible copy. The same string is also emitted verbatim in the `--json` `remediation` field.

## Scope

This affects **every** non-managed install channel, because the wrap is unconditional — Homebrew, npm, cargo, local build, and unknown. The Homebrew path is the one explicitly named in the current upgrade guidance, e.g.:

> An update is available, but invalid input: cannot update '/opt/homebrew/bin/orbit' in place: Homebrew owns this installation; run `brew update && brew upgrade constellation-works/tap/orbit`.

## Reproduction

Verified against installed `~/.orbit/bin/orbit` 0.20.0 (built from `agent-main` @ `18a08c190688bc5c6be12876ed057a0177bb8307`), on this Linux host whose install is channel `unknown`:

```
$ orbit update --check --version 0.19.0 --allow-downgrade
orbit 0.20.0 → 0.19.0
  install:  ~/.orbit/bin/orbit (unknown)
  platform: x86_64-unknown-linux-gnu
  releases: https://github.com/constellation-works/orbit/releases

An update is available, but invalid input: cannot update '~/.orbit/bin/orbit' in place: ...
(exit 3)
```

The `already_current` branch does not print the remediation, so the leak only shows when an update is actually available — i.e. exactly when a user is being asked to act on it.

## Suggested direction

Carry the remediation as a plain `String` (it is presentation text, not a failure), and construct the `OrbitError` only where an error genuinely needs to be returned. That keeps the per-channel wording in `unsupported_reason` intact while removing the type prefix from the rendered sentence and from the JSON field.

## Provenance

Found during the ORB-12009 QA sweep of the newly installed binary, under the `update`/Homebrew-guidance scope. Not covered by ORB-12013 (which corrected the formula naming and legacy-tap migration text, not this rendering path).

### Acceptance Criteria

- `orbit update` and `orbit update --check` render the remediation without any `invalid input: ` (or other error-kind) prefix, for every non-managed install channel.
- The `--json` `remediation` field carries the same prefix-free text.
- Per-channel remediation wording (managed/npm/Homebrew canonical/Homebrew legacy/cargo/local build/unknown) is otherwise unchanged, and the pre-download channel refusal still returns a genuine error with a non-zero exit.
- A test asserts the rendered `An update is available, but ...` sentence for at least one non-managed channel and would fail against the current prefixed output.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Changed InstallChannel::unsupported_reason to return presentation text as Option<String>, so update reports and --json remediation carry the existing channel wording without OrbitError's error-kind prefix.
- Kept the non-check channel guard as a genuine OrbitError::InvalidInput, preserving pre-download refusal and non-zero CLI behavior.
- Added coverage for prefix-free remediation across channel cases, JSON output, and the rendered `An update is available, but ...` sentence.

Acceptance criteria:
- Prefix-free `orbit update --check` prose is covered by `check_renders_a_prefix_free_remediation_sentence`; the same report path is used by update.
- JSON remediation is asserted prefix-free in `check_reports_the_available_release_and_exits_three`.
- Existing per-channel wording tests remain green for managed/npm/Homebrew canonical/Homebrew legacy/cargo/local-build/unknown; pre-download refusal tests remain green.
- The CLI sentence assertion fails against the former `invalid input: ` output.

Validation:
- `cargo fmt --all -- --check`: passed.
- `cargo test -p orbit-cmd update --lib`: passed (55 update-related tests; one expected ignored test).
- `cargo test -p orbit-cli --test update`: passed (8 tests).
- `make ci-fast`: passed; the repository's namespace capability subcheck reported its documented environment skip.
- `make ci-lint`: passed.
- `git diff --check`: passed.
- `GIT_OPTIONAL_LOCKS=0 git status --short`: only the four task-scoped files are modified.

Assessment: Small, boundary-owned change with unchanged channel copy and error behavior for actual writes. No known remaining risks or deviations.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12037-6aa25441`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra