### PR TITLE
Document controlled child environments for mutable Orbit fixture reproductions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,13 @@ Project instructions for agents working on Orbit (loaded as both `AGENTS.md` and
 
 `make ci-fast` (fmt-check + guardrail scripts; no compile) and `make ci-lint` (the same workspace-wide, all-target clippy pass as CI, with warnings denied) must both pass before a task moves to `review`. Each task therefore pays for one workspace clippy compile; cold runs can take several minutes, while warm runs reuse Cargo's incremental cache. The full `make ci` is the canonical merge gate via [`.github/workflows/ci.yml`](.github/workflows/ci.yml) on every PR — don't run it per task locally.
 
+## Mutable Fixture Operations
+
+- Keep authorized operator/production CLI actions separate from test fixtures and ad-hoc reproductions. Normal user commands may use the configured Orbit state; a fixture that can create, update, archive, or run Orbit tasks, runs, workspaces, or registry entries must use a controlled child process.
+- Give the child absolute disposable paths for its `HOME`/`USERPROFILE` and checkout or data roots. Before setting deliberate fixture values, apply the existing [`orbit_common::test_env::clear_inherited_authority`](crates/orbit-common/src/test_env.rs) helper to the `assert_cmd::Command` or `std::process::Command`; do not recreate its environment-variable list locally.
+- After controlled setup and before the first task/run mutation, verify routing with a read-only command such as `orbit workspace show --format json`, asserting the expected `checkout.repo_root` and `checkout.orbit_dir`. If initialization is the behavior under test, keep initialization itself on the disposable paths and verify routing before any subsequent mutation.
+- Do not run bare mutable fixture commands from a shell inside a managed worker. Exporting `HOME` alone is insufficient: the inherited managed-run marker plus `ORBIT_REGISTRY_ROOT`/`ORBIT_WORKSPACE` can carry durable authority and outrank home-directory discovery. These rules guide fixtures only; they do not add restrictions to legitimate operator or production CLI use.
+
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,79 @@ cargo test --workspace
 Use targeted tests while iterating, then run the full workspace suite before
 landing an internal change.
 
+## Safe Mutable CLI Fixtures
+
+Test fixtures and manual reproductions that mutate Orbit task, run, workspace,
+or registry state must be isolated from the process that launches them. This is
+separate from authorized operator or production CLI work, which should retain
+normal Orbit routing and state.
+
+Use absolute disposable paths and spawn the CLI as a child. The shared helper
+clears the managed-run routing, identity, and grant variables before the
+fixture sets its own `HOME` and `USERPROFILE`:
+
+```rust
+use std::fs;
+use std::path::Path;
+
+use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
+
+fn fixture_orbit(work: &Path, home: &Path) -> Command {
+    let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
+    command
+        .current_dir(work)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+}
+```
+
+The pattern above is already used by
+[`crates/orbit-cli/tests/tool_list.rs`](crates/orbit-cli/tests/tool_list.rs).
+For a complete disposable fixture, create absolute temporary paths, initialize
+the fixture workspace through that helper, then perform a read-only routing
+check before adding tasks or starting runs:
+
+```rust
+let temp = tempfile::tempdir().expect("fixture tempdir");
+let home = temp.path().join("home");
+let work = temp.path().join("work");
+fs::create_dir_all(&home).expect("fixture home");
+fs::create_dir_all(&work).expect("fixture work");
+
+fixture_orbit(&work, &home)
+    .args(["workspace", "init", "--name", "fixture"])
+    .assert()
+    .success();
+
+let report = fixture_orbit(&work, &home)
+    .args(["workspace", "show", "--format", "json"])
+    .output()
+    .expect("workspace routing check");
+assert!(report.status.success());
+let report: serde_json::Value = serde_json::from_slice(&report.stdout).expect("routing JSON");
+assert_eq!(report["registered"], true);
+assert_eq!(report["checkout"]["repo_root"], work.to_string_lossy().to_string());
+assert_eq!(
+    report["checkout"]["orbit_dir"],
+    work.join(".orbit").to_string_lossy().to_string()
+);
+```
+
+`workspace show` exposes the resolved checkout paths, so this check catches a
+fixture routed to an ambient workspace before the fixture performs its useful
+mutation. A shell `export HOME=/tmp/...` is not an isolation boundary: a
+managed child can inherit `ORBIT_MANAGED_RUN_CONTEXT` and the
+`ORBIT_REGISTRY_ROOT`/`ORBIT_WORKSPACE` pair, which carries durable authority
+and takes precedence over home discovery. Never use bare mutable fixture CLI
+commands against ambient authority in a managed worker. See
+[`crates/orbit-cli/tests/ambient_authority_isolation.rs`](crates/orbit-cli/tests/ambient_authority_isolation.rs)
+for the regression coverage.
+
 ## Toolchain (MSRV)
 
 Orbit's minimum supported Rust version is declared as `rust-version` in the


### PR DESCRIPTION
## Task

[ORB-12020](https://orbit-cli.com/tasks/ORB-12020) — Document controlled child environments for mutable Orbit fixture reproductions

### Description

During ORB11998 manual reproduction, provider Bash ignored export HOME=/tmp/gc-direct/home. Bare fixture init/task-add/archive/run commands consequently created live archived ORB12017 and completed gc_fixture_pipeline jrun-20260910-0542 at05:42. No managed configuration changed. Existing test_env::clear_inherited_authority and explicit Command/assert_cmd child HOME+USERPROFILE are correct; pending11998 integration test already uses them. Earlier ORB11300/11243 fixed inherited-authority fixtures, but current repo agent/developer guidance does not prevent this ad-hoc shell reproduction mistake.

Add concise repository agent/developer guidance requiring any fixture that mutates Orbit task/run/workspace state to use an explicitly controlled child process with cleared inherited Orbit authority and absolute disposable state paths, with resolved routing checked before mutation. Document existing helper and a small usable example in CONTRIBUTING.md. Explain that provider Bash HOME exports are not proof of isolation; prohibit bare mutable fixture CLI reproduction against ambient authority in managed workers. Preserve legitimate operator/production CLI actions and existing test semantics. Do not introduce product CLI restrictions, new global policy, or rewrite all tests. This is guidance only; no need for mirror-implementation tests.

### Acceptance Criteria

- Owning agent guidance and CONTRIBUTING.md clearly distinguish authorized live operations from test fixtures and require controlled child env + existing clear_inherited_authority helper for mutable fixtures.
- Document an accurate minimal existing test-helper/Command pattern with disposable paths and a routing verification step; explain why a shell HOME export alone is insufficient and preserve normal user CLI behavior.
- Validate referenced helper names/paths and example against current source; run applicable docs/fast checks. Do not mutate live Orbit state while validating the example.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated canonical CLAUDE.md with fixture-vs-live-operation guidance requiring controlled child processes, absolute disposable roots, clear_inherited_authority, routing checks, and explicit preservation of normal operator/production CLI behavior.
- Added CONTRIBUTING.md guidance with the existing assert_cmd helper pattern and a disposable workspace init plus workspace show --format json verification example.
- Preserved AGENTS.md as the existing symlink to CLAUDE.md; no source or runtime state was changed.

Assessment: The guidance is scoped to mutable fixture and managed-worker reproduction work, names current helper/source paths, and matches the existing routing contract.

Acceptance criteria:
- Owning guidance and CONTRIBUTING.md distinguish authorized live operations from mutable fixtures and require the existing helper: passed; both documents state the boundary and reference orbit_common::test_env::clear_inherited_authority.
- Minimal controlled Command example, disposable paths, routing verification, HOME limitation, and normal CLI behavior: passed; CONTRIBUTING.md includes the helper, tempfile paths, workspace init, and read-only workspace show JSON assertions.
- Current-source validation and safe checks: passed; helper/path rg checks and the exact documented CLI sequence succeeded in an env-cleared temporary HOME/work directory without touching live Orbit state.

Validation:
- make ci-fast: passed. The suite reported one bounded bubblewrap mount-namespace probe as skipped because this runner lacks permission for non-privileged namespaces; the command exited 0.
- make ci-lint: passed; workspace all-target clippy with -D warnings completed successfully.
- ./scripts/build-budget.py -- cargo build -p orbit-cli --bin orbit: passed.
- Disposable CLI smoke using env -i, temporary HOME/USERPROFILE, workspace init, and workspace show --format json: passed.
- Source reference checks for test_env.rs, tool_list.rs, ambient_authority_isolation.rs, clear_inherited_authority, and workspace_show_json: passed.
- git diff --check: passed.
- GIT_OPTIONAL_LOCKS=0 git status --short: passed; only CLAUDE.md and CONTRIBUTING.md are modified.
- Initial smoke attempt: failed because the ad-hoc harness omitted the child's working directory; it was corrected and rerun successfully, with no live-state changes.
- Full make ci and full workspace tests: not run; not required for this documentation-only change and the repository guidance says the full CI gate runs on PRs.

Remaining risks or deviations: The disposable smoke validates Linux CLI routing and the documented argument form; it does not exercise provider-specific shell behavior or non-Linux environments. No friction record was filed because the corrected harness mistake did not recur or exceed the checkpoint threshold.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12020-6aa254bb`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra