### PR TITLE
Validate host identity root before internal metadata probe and close surviving CodeQL406

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -22,7 +22,7 @@ extensions:
           "manual",
         ]
       - [
-          "orbit_registry::host_identity::validated_host_toml_path",
+          "orbit_registry::host_identity::validated_existing_global_root",
           "ReturnValue.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]",
           "path-injection",
           "manual",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2336,6 +2336,7 @@ version = "0.20.0"
 dependencies = [
  "chrono",
  "hostname",
+ "libc",
  "orbit-common",
  "orbit-types",
  "serde",

--- a/crates/orbit-registry/Cargo.toml
+++ b/crates/orbit-registry/Cargo.toml
@@ -20,5 +20,8 @@ serde.workspace = true
 serde_json.workspace = true
 toml.workspace = true
 
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/orbit-registry/src/host_identity.rs
+++ b/crates/orbit-registry/src/host_identity.rs
@@ -12,6 +12,8 @@
 //! no silent fallback to the OS hostname. Routine `hosts:` pinning,
 //! the sweep, and status all resolve through [`HostIdentity::host_id`].
 
+use std::fs::{File, OpenOptions};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -168,13 +170,13 @@ fn host_toml_path(global_root: &Path) -> PathBuf {
     global_root.join(HOST_TOML_FILE)
 }
 
-/// Resolve the existing host identity through the canonical global root.
+/// Resolve an existing global root to the directory selected by the caller.
 ///
-/// The root may be selected by an explicit runtime override, but the identity
-/// filename is fixed. Canonicalizing the root and checking the final component
-/// without following it keeps the resulting path inside that selected root and
-/// rejects a symlink or non-regular file before it is read.
-fn validated_host_toml_path(global_root: &Path) -> Result<Option<PathBuf>, OrbitError> {
+/// Runtime overrides and configured aliases are supported: an existing symlinked
+/// root resolves to its canonical target. Returning the validated directory
+/// before deriving the fixed identity filename keeps path validation ahead of
+/// every metadata and open sink for `host.toml`.
+fn validated_existing_global_root(global_root: &Path) -> Result<Option<PathBuf>, OrbitError> {
     let canonical_root = match global_root.canonicalize() {
         Ok(path) => path,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -185,24 +187,86 @@ fn validated_host_toml_path(global_root: &Path) -> Result<Option<PathBuf>, Orbit
             )));
         }
     };
-    let canonical_path = canonical_root.join(HOST_TOML_FILE);
 
-    match std::fs::symlink_metadata(&canonical_path) {
+    Ok(Some(canonical_root))
+}
+
+/// Open the fixed identity file beneath the validated root without following a
+/// swapped final symlink.
+///
+/// Unix uses `O_NOFOLLOW`; Windows opens the reparse point itself. The descriptor
+/// is checked for a regular file before any bytes are read. Platforms without
+/// either primitive still perform both pathname and descriptor type checks, but
+/// cannot close a final-component check/open race. Canonicalization also permits
+/// trusted root aliases, so this leaf protection does not claim to prevent a
+/// privileged concurrent rename or replacement of a mutable ancestor directory.
+fn open_existing_host_toml_with_hook<F>(
+    global_root: &Path,
+    before_open: F,
+) -> Result<Option<(PathBuf, File)>, OrbitError>
+where
+    F: FnOnce(&Path) -> Result<(), OrbitError>,
+{
+    let Some(canonical_root) = validated_existing_global_root(global_root)? else {
+        return Ok(None);
+    };
+    let path = canonical_root.join(HOST_TOML_FILE);
+
+    match std::fs::symlink_metadata(&path) {
         Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
             Err(OrbitError::InvalidInput(format!(
                 "host identity path must be a regular {HOST_TOML_FILE} file inside '{}': {}",
                 global_root.display(),
-                canonical_path.display()
+                path.display()
             )))
         }
-        Ok(_) => Ok(Some(canonical_path)),
+        Ok(_) => {
+            before_open(&path)?;
+
+            let mut options = OpenOptions::new();
+            options.read(true);
+            apply_no_follow_final_component(&mut options);
+            let file = options.open(&path).map_err(|error| {
+                OrbitError::Io(format!("failed to open '{}': {error}", path.display()))
+            })?;
+            let metadata = file.metadata().map_err(|error| {
+                OrbitError::Io(format!("failed to inspect '{}': {error}", path.display()))
+            })?;
+            if !metadata.is_file() {
+                return Err(OrbitError::InvalidInput(format!(
+                    "host identity path must open as a regular {HOST_TOML_FILE} file inside '{}': {}",
+                    global_root.display(),
+                    path.display()
+                )));
+            }
+
+            Ok(Some((path, file)))
+        }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(error) => Err(OrbitError::Io(format!(
             "failed to inspect host identity '{}': {error}",
-            canonical_path.display()
+            path.display()
         ))),
     }
 }
+
+#[cfg(unix)]
+fn apply_no_follow_final_component(options: &mut OpenOptions) {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    options.custom_flags(libc::O_NOFOLLOW);
+}
+
+#[cfg(windows)]
+fn apply_no_follow_final_component(options: &mut OpenOptions) {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+}
+
+#[cfg(not(any(unix, windows)))]
+fn apply_no_follow_final_component(_options: &mut OpenOptions) {}
 
 fn non_blank(value: &Option<String>) -> Option<String> {
     value
@@ -217,10 +281,33 @@ fn non_blank(value: &Option<String>) -> Option<String> {
 /// for malformed, incomplete, blank, or future-schema files (fail closed —
 /// never rewrites the file).
 pub fn inspect_host_identity(global_root: &Path) -> Result<HostIdentityState, OrbitError> {
-    let Some(path) = validated_host_toml_path(global_root)? else {
+    inspect_host_identity_with_hook(global_root, |_| Ok(()))
+}
+
+#[cfg(test)]
+pub(crate) fn inspect_host_identity_after_check<F>(
+    global_root: &Path,
+    before_open: F,
+) -> Result<HostIdentityState, OrbitError>
+where
+    F: FnOnce(&Path) -> Result<(), OrbitError>,
+{
+    inspect_host_identity_with_hook(global_root, before_open)
+}
+
+fn inspect_host_identity_with_hook<F>(
+    global_root: &Path,
+    before_open: F,
+) -> Result<HostIdentityState, OrbitError>
+where
+    F: FnOnce(&Path) -> Result<(), OrbitError>,
+{
+    let Some((path, mut file)) = open_existing_host_toml_with_hook(global_root, before_open)?
+    else {
         return Ok(HostIdentityState::Absent);
     };
-    let raw_text = std::fs::read_to_string(&path)
+    let mut raw_text = String::new();
+    file.read_to_string(&mut raw_text)
         .map_err(|error| OrbitError::Io(format!("failed to read '{}': {error}", path.display())))?;
     let parsed: RawHostToml = toml::from_str(&raw_text).map_err(|error| {
         OrbitError::InvalidInput(format!(

--- a/crates/orbit-registry/src/tests/host_identity.rs
+++ b/crates/orbit-registry/src/tests/host_identity.rs
@@ -8,8 +8,8 @@ use crate::HOST_IDENTITY_SCHEMA_VERSION;
 
 use crate::host_identity::{
     HostIdentityOutcome, HostIdentityState, NewHostIdentity, ensure_host_identity,
-    inspect_host_identity, load_host_identity, rename_current_host_identity,
-    rename_current_host_identity_with_writer,
+    inspect_host_identity, inspect_host_identity_after_check, load_host_identity,
+    rename_current_host_identity, rename_current_host_identity_with_writer,
 };
 
 #[test]
@@ -196,6 +196,41 @@ fn absent_file_loads_as_actionable_error_not_hostname() {
 }
 
 #[test]
+fn nonexistent_global_root_is_absent_without_creating_it() {
+    let parent = tempfile::tempdir().expect("tempdir");
+    let missing = parent.path().join("missing-root");
+
+    assert!(matches!(
+        inspect_host_identity(&missing).expect("inspect missing root"),
+        HostIdentityState::Absent
+    ));
+    assert!(
+        !missing.exists(),
+        "inspection must not create the global root"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn host_identity_accepts_a_trusted_symlinked_global_root_alias() {
+    let real_root = tempfile::tempdir().expect("create real root");
+    std::fs::write(
+        real_root.path().join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_alias\"\nhost_id = \"aliased\"\ntask_prefix = \"DE\"\n",
+    )
+    .expect("write identity");
+    let alias_parent = tempfile::tempdir().expect("create alias parent");
+    let alias = alias_parent.path().join("global-root-alias");
+    symlink(real_root.path(), &alias).expect("create trusted root alias");
+
+    let state = inspect_host_identity(&alias).expect("read through configured alias");
+    assert!(matches!(
+        state,
+        HostIdentityState::Present(identity) if identity.host_id == "aliased"
+    ));
+}
+
+#[test]
 fn legacy_file_loads_as_error_until_migrated() {
     let dir = tempfile::tempdir().expect("tempdir");
     std::fs::write(dir.path().join("host.toml"), "host_id = \"dk-server-1\"\n").expect("write");
@@ -225,6 +260,55 @@ fn host_identity_rejects_a_host_toml_symlink_outside_its_root() {
     assert!(
         error.contains("regular host.toml file"),
         "unexpected: {error}"
+    );
+}
+
+#[test]
+fn host_identity_rejects_a_non_regular_host_toml() {
+    let root = tempfile::tempdir().expect("create root tempdir");
+    std::fs::create_dir(root.path().join("host.toml")).expect("create host.toml directory");
+
+    let error = inspect_host_identity(root.path())
+        .expect_err("host identity must reject a non-regular final component")
+        .to_string();
+    assert!(
+        error.contains("regular host.toml file"),
+        "unexpected: {error}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn host_identity_rejects_a_final_symlink_swapped_after_the_path_check() {
+    let root = tempfile::tempdir().expect("create root tempdir");
+    let checked_body = "schema_version = 2\nmachine_id = \"hm_checked\"\nhost_id = \"checked\"\ntask_prefix = \"DE\"\n";
+    std::fs::write(root.path().join("host.toml"), checked_body).expect("write checked identity");
+    let outside = tempfile::tempdir().expect("create outside tempdir");
+    let outside_path = outside.path().join("outside.toml");
+    let outside_body = "schema_version = 2\nmachine_id = \"hm_outside\"\nhost_id = \"outside\"\ntask_prefix = \"DE\"\n";
+    std::fs::write(&outside_path, outside_body).expect("write outside identity");
+    let preserved_path = root.path().join("checked-host.toml");
+
+    inspect_host_identity_after_check(root.path(), |checked_path| {
+        std::fs::rename(checked_path, &preserved_path).map_err(|error| {
+            orbit_common::OrbitError::Io(format!("failed to preserve checked file: {error}"))
+        })?;
+        symlink(&outside_path, checked_path).map_err(|error| {
+            orbit_common::OrbitError::Io(format!("failed to install swapped symlink: {error}"))
+        })?;
+        Ok(())
+    })
+    .expect_err("descriptor open must reject the swapped final symlink");
+
+    assert_eq!(
+        std::fs::read_to_string(&preserved_path).expect("read preserved checked identity"),
+        checked_body,
+        "inspection must not rewrite the originally checked file"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&outside_path).expect("read outside identity"),
+        outside_body,
+        "inspection must not read through or write the outside target"
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-12019](https://orbit-cli.com/tasks/ORB-12019) — Validate host identity root before internal metadata probe and close surviving CodeQL406

### Description

Hosted CodeQL34441275295 on76e2839ee1762179f450f93259ef6c808b783ef1 still reports alert406 rust/path-injection at crates/orbit-registry/src/host_identity.rs:190 symlink_metadata(&canonical_path). Prior ORB-12004 fix4dce658 is an ancestor of this scan. validated_host_toml_path canonicalizes global_root, joins fixed host.toml, rejects final symlink/non-file. Its current CodeQL barrier only models the function return and cannot sanitize the sink inside that function. Inspect source security proof and move validation/modeling to an actual narrow boundary before deriving/probing the fixed child, retaining fail-closed behavior and documented aliases. No broad model, dismissal, or query suppression. No open covering task found in current workspace inventory; predecessor12004 is done. Orchestrator owns hosted rescan after merge.

## Additional verified read-boundary requirement
Confirmed current source host_identity.rs177-204 checks fixed host.toml under canonical selected root, then inspect_host_identity219-224 separately read_to_string follows the path. Choosing an authorized root/alias does not authorize reading an unintended symlink target. Require a read-only opened-descriptor boundary rejecting a final symlink at open time; retain missing/legacy states and supported root aliases.

### Acceptance Criteria

- Establish a narrowly scoped validated existing canonical global-root value before deriving/probing host.toml; preserve missing/current/legacy host identity behavior, trustworthy configured aliases, and symlink/non-regular-file rejection.
- Add focused tests for normal/missing roots, trusted root aliases, final host.toml symlinks and outside-target cases; verify no unintended target read/write. Any model entry corresponds to demonstrated source validation and applies before the internal sink.
- Run registry host-identity and command-prefix regressions, make ci-fast and make ci-lint; validate extension schema if changed. No security rule suppression or alert dismissal.
- Orchestrator confirms hosted Rust CodeQL alert406 fixed on merged repair revision; leaf explicitly records hosted scan as pending rather than treating source-only checks as closure.
- The content read rejects a swapped final symlink at open time via a read-only descriptor or equivalent validated handle, with a deterministic check-to-swap regression proving no external content is read. Supported root aliases remain valid; Unix/non-Unix behavior and parent/ancestor mutation boundaries are explicit rather than claiming leaf no-follow protects mutable ancestors.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced the post-derivation path barrier with narrowly scoped validated_existing_global_root, which canonicalizes an existing configured root before deriving or probing the fixed host.toml child and preserves trusted root aliases plus absent-root behavior.
- Reads now use a read-only descriptor. Unix applies O_NOFOLLOW and Windows opens the reparse point itself; descriptor metadata must still identify a regular file before any bytes are read. The source explicitly limits the guarantee for mutable ancestors and platforms without a no-follow primitive.
- Added normal/missing-root, trusted alias, final-symlink/outside-target, non-regular-file, and deterministic check-to-symlink-swap coverage. The swap regression would parse the valid outside identity if it were followed, but instead fails at descriptor open and verifies both files remain unchanged.
- Moved the narrow CodeQL barrier model to validated_existing_global_root so it applies before the internal symlink_metadata and open sinks. Added orbit-registry direct use of the existing workspace libc dependency and recorded Cargo.lock in task scope.

Acceptance criteria:
1. Satisfied: canonical existing-root validation precedes fixed-child derivation/probing; focused tests preserve absent/current/legacy behavior, aliases, and rejection behavior.
2. Satisfied: focused boundary tests cover required root and target cases; the only model change corresponds to the demonstrated canonical-root validator and precedes sinks.
3. Satisfied: registry host-identity tests, command-prefix tests, extension schema validation, ci-fast, and ci-lint passed; no suppression or dismissal was added.
4. Leaf responsibility satisfied: hosted Rust CodeQL alert 406 rescan is explicitly pending and remains orchestrator-owned after merge.
5. Satisfied on the exercised Unix environment: O_NOFOLLOW rejects the deterministic swapped final symlink before reading. Windows uses FILE_FLAG_OPEN_REPARSE_POINT plus descriptor type validation; other non-Unix platforms retain pre/post type checks but cannot close the check/open race. Canonical root aliases remain supported, and documentation does not claim final-component no-follow protects mutable ancestors.

Validation:
- cargo fmt --all -- --check: initially failed on formatting of newly edited code; cargo fmt --all corrected it, and make ci-fast subsequently passed the formatting check.
- cargo test -p orbit-registry host_identity: passed, 22 tests.
- cargo test -p orbit-cmd task_prefix: passed, 3 tests.
- python3 scripts/check-codeql-extension-schema.py: passed with exit 0.
- make ci-fast: passed; compiler-cache namespace probe reported its documented sandbox skip while the guardrail completed successfully.
- make ci-lint: passed workspace all-target clippy with warnings denied.
- git diff --check: passed.
- git status --short: five task-scoped modified files, all accounted for.

Assessment: The source validation now occurs at the boundary CodeQL can model before internal sinks, while the actual read is bound to a checked descriptor. Existing behavior is preserved and the race regression exercises the original weakness deterministically.

Remaining risks:
- Hosted CodeQL alert 406 closure cannot be established from source-only checks; orchestrator must confirm it on the merged repair revision.
- Windows and uncommon non-Unix behavior was source-reviewed but not executed in this Linux run.
- A privileged concurrent replacement of a canonical root or ancestor remains outside the final-component no-follow guarantee and is explicitly documented.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12019-6aa2551a`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra