### PR TITLE
[code-review] Rebase redo runs `git reset --hard` without requiring a clean worktree, silently destroying uncommitted work

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/freshness.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/freshness.rs
@@ -8,7 +8,8 @@ use crate::context::RuntimeHost;
 use super::super::input::{input_string_field, required_input_string};
 use super::git::{
     BaseSyncMode, GitTimeoutBudget, GitTimeoutBudgetGuard, git_command_success, git_failure_error,
-    git_output, git_run, git_success, git_timeout_error, resolve_worktree_start_point,
+    git_output, git_output_raw, git_run, git_success, git_timeout_error,
+    resolve_worktree_start_point,
 };
 use super::handoff::{
     FailedHandoffPhase, HandoffContext, load_handoff_context, rebase_in_progress,
@@ -297,16 +298,48 @@ fn perform_rebase_onto_base(
 /// Discard a changed HEAD that could not be authenticated as a certified
 /// recovery, restoring the worktree to the last durable pre-rewrite
 /// checkpoint so the ordinary rebase path can redo the work from there.
+///
+/// `git reset --hard` has no concept of "safe to discard": it silently drops
+/// staged changes, unstaged changes, and any untracked file or directory in
+/// the way, with nothing recorded afterward. Refuse instead of resetting
+/// whenever the worktree is not already clean, naming every dirty path so an
+/// operator can recover the state themselves before retrying.
 fn discard_unauthenticated_rewrite(
     workspace_path: &Path,
     head_sha_before: &str,
 ) -> Result<(), OrbitError> {
+    let dirty_paths = dirty_worktree_paths(workspace_path)?;
+    if !dirty_paths.is_empty() {
+        return Err(OrbitError::Execution(format!(
+            "git_rebase: refusing to discard an unauthenticated rewritten HEAD before redoing \
+             the rebase from checkpoint '{head_sha_before}': the worktree has uncommitted \
+             changes that a reset would destroy: {}",
+            dirty_paths.join(", ")
+        )));
+    }
     git_success(workspace_path, &["reset", "--hard", head_sha_before]).map_err(|error| {
         OrbitError::Execution(format!(
             "git_rebase: failed to discard an unauthenticated rewritten HEAD before redoing the \
              rebase from checkpoint '{head_sha_before}': {error}"
         ))
     })
+}
+
+/// Every path `git status --porcelain` reports as staged, unstaged, or
+/// untracked. A nonempty result means a hard reset could destroy something
+/// that is not recorded anywhere else.
+///
+/// Uses [`git_output_raw`] rather than [`git_output`]: the latter trims the
+/// whole output, which would eat the leading status column of a single-line
+/// result (` M path` -> `M path`) and misalign every path by one byte.
+fn dirty_worktree_paths(workspace_path: &Path) -> Result<Vec<String>, OrbitError> {
+    Ok(git_output_raw(workspace_path, &["status", "--porcelain"])?
+        .lines()
+        .filter_map(|line| line.get(3..))
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(ToOwned::to_owned)
+        .collect())
 }
 
 fn refuse_or_recover_existing_rebase(

--- a/crates/orbit-engine/src/executor/automation/vcs/tests/freshness.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/tests/freshness.rs
@@ -8,7 +8,7 @@ use tempfile::tempdir;
 
 use super::super::freshness::{prepare_pr_handoff, rebase_pr_branch};
 use super::super::pr::tests::test_support::{
-    PrOpenTestHost, batch_task, pr_workspace, rebase_conflict_pr_workspace,
+    PrOpenTestHost, PrWorkspace, batch_task, pr_workspace, rebase_conflict_pr_workspace,
 };
 #[cfg(unix)]
 use super::with_fake_git;
@@ -334,6 +334,148 @@ fn uncertified_pre_boundary_checkpoint_redoes_the_rebase_instead_of_failing_resu
     let retried =
         rebase_pr_branch(&host, &rebase_input(&common, &reprepared)).expect("retry after redo");
     assert_eq!(retried["decision"], json!("skipped_current"));
+}
+
+// ORB-12032: `discard_unauthenticated_rewrite` used to run `git reset --hard`
+// unconditionally, silently destroying any uncommitted work in the delivery
+// worktree. These three tests pin the dirty-tree shapes named by the fix:
+// an unstaged edit, a staged-only edit, and an untracked file the redo must
+// not clobber. Each drives the same uncertified-checkpoint redo path as
+// `uncertified_pre_boundary_checkpoint_redoes_the_rebase_instead_of_failing_resume`,
+// but with the worktree left dirty first.
+fn setup_uncertified_redo(
+    task_id: &str,
+) -> (
+    PrWorkspace,
+    PrOpenTestHost,
+    serde_json::Value,
+    serde_json::Value,
+    String,
+) {
+    let workspace = pr_workspace();
+    advance_base(&workspace.repo);
+    let host = PrOpenTestHost::new(
+        vec![batch_task(
+            task_id,
+            "Dirty tree redo",
+            "Outcome: success\nChanges:\n- Candidate remains mergeable.",
+        )],
+        workspace.repo.clone(),
+    );
+    let common = json!({
+        "workspace_path": workspace.repo,
+        "job_run_id": "batch-1",
+        "completed_task_ids": [task_id],
+        "base": "agent-main",
+        "base_sync": "local",
+    });
+    let prepared = prepare_pr_handoff(&host, &common).expect("prepare");
+    assert_eq!(prepared["sync_required"], json!(true));
+
+    git(&workspace.repo, &["rebase", "agent-main"]);
+    let rewritten_head = git(&workspace.repo, &["rev-parse", "HEAD"]);
+    assert_ne!(rewritten_head, prepared["head_sha"].as_str().unwrap());
+    write_sync_base_checkpoint(
+        &host,
+        uncertified_recovery_checkpoint(task_id, &workspace.repo, &prepared, &rewritten_head),
+    );
+
+    (workspace, host, common, prepared, rewritten_head)
+}
+
+fn assert_dirty_redo_is_refused(
+    workspace: &PrWorkspace,
+    host: &PrOpenTestHost,
+    common: &serde_json::Value,
+    prepared: &serde_json::Value,
+    rewritten_head: &str,
+    expected_path: &str,
+) {
+    let error = rebase_pr_branch(host, &rebase_input(common, prepared))
+        .expect_err("a dirty worktree must be refused, not silently reset away");
+    assert!(
+        !matches!(error, OrbitError::RecoverableVcsConflict(_)),
+        "an uncommitted local change is not a merge conflict: {error}"
+    );
+    let message = error.to_string();
+    assert!(
+        message.contains(expected_path),
+        "refusal must name the dirty path '{expected_path}': {message}"
+    );
+    assert_eq!(
+        git(&workspace.repo, &["rev-parse", "HEAD"]),
+        rewritten_head,
+        "a refused redo must not move HEAD"
+    );
+}
+
+#[test]
+fn uncertified_redo_refuses_on_unstaged_tracked_modification() {
+    let (workspace, host, common, prepared, rewritten_head) =
+        setup_uncertified_redo("ORB-12032-UNSTAGED-DIRTY");
+
+    let tracked_file = workspace.repo.join("src/lib.rs");
+    fs::write(&tracked_file, "pub fn changed() { /* operator fix */ }\n").unwrap();
+
+    assert_dirty_redo_is_refused(
+        &workspace,
+        &host,
+        &common,
+        &prepared,
+        &rewritten_head,
+        "src/lib.rs",
+    );
+    assert_eq!(
+        fs::read_to_string(&tracked_file).unwrap(),
+        "pub fn changed() { /* operator fix */ }\n",
+        "the refused redo must leave the uncommitted edit in place"
+    );
+}
+
+#[test]
+fn uncertified_redo_refuses_on_staged_tracked_modification() {
+    let (workspace, host, common, prepared, rewritten_head) =
+        setup_uncertified_redo("ORB-12032-STAGED-DIRTY");
+
+    let tracked_file = workspace.repo.join("src/lib.rs");
+    fs::write(&tracked_file, "pub fn changed() { /* staged fix */ }\n").unwrap();
+    git(&workspace.repo, &["add", "src/lib.rs"]);
+
+    assert_dirty_redo_is_refused(
+        &workspace,
+        &host,
+        &common,
+        &prepared,
+        &rewritten_head,
+        "src/lib.rs",
+    );
+    assert_eq!(
+        fs::read_to_string(&tracked_file).unwrap(),
+        "pub fn changed() { /* staged fix */ }\n",
+        "the refused redo must leave the staged edit in place"
+    );
+}
+
+#[test]
+fn uncertified_redo_refuses_on_untracked_obstruction() {
+    let (workspace, host, common, prepared, rewritten_head) =
+        setup_uncertified_redo("ORB-12032-UNTRACKED-DIRTY");
+
+    let untracked_file = workspace.repo.join("recovery-notes.txt");
+    fs::write(&untracked_file, "do not discard\n").unwrap();
+
+    assert_dirty_redo_is_refused(
+        &workspace,
+        &host,
+        &common,
+        &prepared,
+        &rewritten_head,
+        "recovery-notes.txt",
+    );
+    assert!(
+        untracked_file.exists(),
+        "the refused redo must not remove the untracked file"
+    );
 }
 
 // The redo is only automatic when it is safe: when the discarded rewrite


### PR DESCRIPTION
## Task

[ORB-12032](https://orbit-cli.com/tasks/ORB-12032) — [code-review] Rebase redo runs `git reset --hard` without requiring a clean worktree, silently destroying uncommitted work

### Description

ORB-12015 (commit `18a08c190`, PR #1849) added a redo path for an uncertified rebase-recovery checkpoint. The redo begins with `git reset --hard`, and nothing on the way in establishes that the worktree has no uncommitted changes, so any modification to a tracked file in the delivery worktree is destroyed with no record and no refusal.

This is the only `git reset --hard` in production (non-test) code in the workspace — `grep -rn '"reset"' crates/ --include=*.rs | grep -v tests` returns exactly one hit. Every other unexpected-state branch in the same function refuses and preserves; this one deletes.

## Evidence (verified against live code at `18a08c190688bc5c6be12876ed057a0177bb8307`)

**1. The only tree-state gate before the redo checks unmerged files, nothing else.**

`crates/orbit-engine/src/executor/automation/vcs/freshness.rs:155-165` is the sole worktree-cleanliness probe in `rebase_pr_branch_inner`:

```rust
if !git_command_success(
    &context.workspace_path,
    &["diff", "--quiet", "--diff-filter=U"],
)? {
```

`--diff-filter=U` restricts the diff to *unmerged* entries. A worktree with ordinary staged or unstaged modifications passes this check. A repo-wide grep for a general dirty-tree probe in the module finds none:

```
$ grep -rn 'diff --quiet\|"diff", "--quiet"\|status --porcelain\|is_dirty\|clean_worktree' \
    crates/orbit-engine/src/executor/automation/vcs/*.rs
crates/orbit-engine/src/executor/automation/vcs/freshness.rs:158:        &["diff", "--quiet", "--diff-filter=U"],
```

**2. The redo path resets unconditionally.**

`crates/orbit-engine/src/executor/automation/vcs/freshness.rs:205`:

```rust
discard_unauthenticated_rewrite(&context.workspace_path, head_sha_before)?;
perform_rebase_onto_base(&context.workspace_path, head, head_sha_before, base_ref, base_sha)?
```

`crates/orbit-engine/src/executor/automation/vcs/freshness.rs:299-309`:

```rust
fn discard_unauthenticated_rewrite(
    workspace_path: &Path,
    head_sha_before: &str,
) -> Result<(), OrbitError> {
    git_success(workspace_path, &["reset", "--hard", head_sha_before]).map_err(...)
}
```

`git_success` (`crates/orbit-engine/src/executor/automation/vcs/git.rs:303-305`) only reports the command's own failure; `reset --hard` succeeds against a dirty tree and discards its contents.

**3. The pre-change behavior on a dirty tree was a safe refusal, not a loss.**

Before this commit the `sync_required && current_sha != head_sha_before` arm called `validate_recovered_rewrite(...)?` and either reused the recovery or propagated a hard error (`recovered_head_checkpoint`'s "carries no host recovery certificate" refusal — the exact error ORB-12015 replaced). No git mutation ran. And in the *other* rebase arm (`crates/orbit-engine/src/executor/automation/vcs/freshness.rs:225-231`), which reaches `perform_rebase_onto_base` with no preceding reset, `git rebase` itself refuses a dirty tree ("cannot rebase: You have unstaged changes", with `rebase.autoStash` off by default). So the new path is the only one that converts a dirty worktree from a refusal into a silent deletion followed by a reported success.

**4. No coverage.**

The four tests added with the change (`crates/orbit-engine/src/executor/automation/vcs/tests/freshness.rs:285`, `:345`, `:395`, `:439`) all build a clean worktree. None writes an uncommitted modification before invoking the redo, so the discard is never exercised against work it would destroy.

## Failure scenario

A `task_pr_pipeline` run reaches `sync_base`, the rebase conflicts, and the run fails. The recovery agent (or an operator inspecting the failure) resolves the conflicts, completes the rebase so HEAD moves off `head_sha_before` and the branch is no longer behind the base, and leaves a handful of unstaged fixes in other files — a corrected test, a doc line — uncommitted in the worktree. The recovery checkpoint carries no host certificate (a pre-authority-boundary run, exactly ORB-12015's motivating case).

The run is resumed:

1. `crates/orbit-engine/src/executor/automation/vcs/freshness.rs:155-165` passes — there are no *unmerged* paths, only modified ones.
2. `validate_recovered_rewrite` returns `Ok(false)` (uncertified).
3. `crates/orbit-engine/src/executor/automation/vcs/freshness.rs:205` runs `git reset --hard <head_sha_before>`. Every uncommitted edit to a tracked file is gone, recoverable only from the operator's own memory — `reset --hard` writes nothing to the reflog for worktree state.
4. The redo rebase succeeds, the step reports `decision: "performed"`, and the run continues. Nothing in the output, the error path, or the failed-handoff record mentions that work was discarded.

Ordinary non-obstructing untracked files survive, but git reset --hard can delete untracked files/directories obstructing a tracked checkpoint path. Staged changes are also discarded. All three loss classes require coverage.

## Suggested direction

Require the state to be discardable before discarding it, at the same boundary that already probes for unmerged paths:

- In `discard_unauthenticated_rewrite`, probe for a dirty tree first (`git status --porcelain`, or `git diff --quiet` plus `git diff --cached --quiet`) and return a refusal naming the dirty paths instead of resetting. A dirty tree in this arm is an unexplained state, and the file's own convention for unexplained state is to refuse — see the `"branch state no longer matches the durable pre-rewrite checkpoint"` and `"without a recorded rewrite decision"` refusals in the same `match`.
- If discarding is genuinely wanted, preserve the state first so it is recoverable (a tag or `git stash create` object recorded in the step output / failed-handoff record), and say so in the output rather than only in a doc comment.
- Add a regression that writes an uncommitted tracked-file modification before the redo and asserts the chosen contract — the four new tests all start from a clean tree, so the behavior is currently unpinned either way.

### Acceptance Criteria

- A rebase redo triggered by an uncertified recovery checkpoint no longer destroys uncommitted tracked-file modifications in the delivery worktree: it either refuses with an error naming the dirty paths, or preserves the state in a recoverable, reported artifact before resetting.
- A regression test writes an uncommitted tracked-file modification into the worktree, drives the uncertified-checkpoint redo path, and fails against the current `git reset --hard` behavior.
- The clean-tree redo behavior added by ORB-12015 is unchanged: the existing tests at `crates/orbit-engine/src/executor/automation/vcs/tests/freshness.rs:285`, `:345`, `:395`, and `:439` still pass.
- `make ci-fast` and `make ci-lint` pass.
- Before discarding an unauthenticated rewrite, refuse with named paths on any staged/unstaged tracked change or untracked file/directory that could be lost; a conservative refusal on any nonempty git status is acceptable. Regressions cover staged-only edits, unstaged edits, and an untracked obstruction of a tracked checkpoint path.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed: `discard_unauthenticated_rewrite` in crates/orbit-engine/src/executor/automation/vcs/freshness.rs (line ~305) now calls a new `dirty_worktree_paths` helper that runs `git status --porcelain` before the `git reset --hard`. Any nonempty result (staged, unstaged, or untracked) causes a refusal (`OrbitError::Execution`) naming every dirty path, instead of resetting. This is the conservative "refuse on any nonempty git status" option permitted by AC5, applied at the same boundary that already probes for unmerged paths.

Criteria:
1. Rebase redo no longer destroys uncommitted tracked-file modifications — met: dirty tree now refuses with named paths before any reset runs; no preservation artifact was added since refusal was the simpler, AC-permitted option.
2/5. Regression tests added: `uncertified_redo_refuses_on_unstaged_tracked_modification`, `uncertified_redo_refuses_on_staged_tracked_modification`, `uncertified_redo_refuses_on_untracked_obstruction` (crates/orbit-engine/src/executor/automation/vcs/tests/freshness.rs). Verified each fails against the pre-fix `git reset --hard` behavior (manually reverted freshness.rs to the prior committed version, confirmed all three tests fail with `decision: "performed"`, i.e. the reset silently succeeded; restored the fix, all three then pass).
3. Existing ORB-12015 clean-tree tests (freshness.rs:285/345/395/439, line numbers shifted by the new tests but same test functions) still pass unchanged.
4. `make ci-fast` — passed. `make ci-lint` (workspace clippy, warnings denied) — passed.

Full `cargo test -p orbit-engine --lib` — 675 passed, 0 failed, 3 ignored (pre-existing, unrelated).

Non-obvious gotcha hit during implementation: `git_output` (crates/orbit-engine/src/executor/automation/vcs/git.rs) calls `.trim()` on the *whole* multi-line stdout, not per line. For a single-line `git status --porcelain` result this eats the leading status-column character (` M path` -> `M path`), misaligning every parsed path by one byte. Switched to `git_output_raw` (untrimmed) for `dirty_worktree_paths` and documented why in a doc comment. Filed as friction for future callers parsing multi-line git output through `git_output`.

Diff is two files, both in original context_files scope; no scope expansion needed. Changes left uncommitted per pipeline ownership of commit/PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12032-6aa25655`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra