### PR TITLE
[qa-sweep] A routine-dispatch workspace mismatch cancels the run with no reason on any CLI inspection path

### DIFF
--- a/crates/orbit-cli/src/command/run/logs.rs
+++ b/crates/orbit-cli/src/command/run/logs.rs
@@ -1,6 +1,7 @@
 use clap::Args;
-use orbit_core::OrbitRuntime;
+use orbit_core::application::job::PipelineWorkerLogSnapshot;
 use orbit_core::runtime::run_audit::RunCliInvocationRecord;
+use orbit_core::{JobRun, OrbitRuntime};
 use serde_json::{Value, json};
 
 use crate::command::{CommandOut, Execute, Payload};
@@ -30,7 +31,7 @@ impl Execute for RunLogsArgs {
     }
 }
 
-fn run_logs_payload(
+pub(crate) fn run_logs_payload(
     runtime: &OrbitRuntime,
     run_id: Option<&str>,
     step_id: Option<&str>,
@@ -42,15 +43,16 @@ fn run_logs_payload(
         runtime.collect_run_cli_invocations(&run.run_id)?,
         step_filter.as_deref(),
     );
+
+    if records.is_empty() {
+        return worker_log_fallback_payload(runtime, &run);
+    }
+
     let doc = json!({
         "run_id": run.run_id,
         "job_id": run.job_id,
         "records": records.iter().map(cli_invocation_record_to_json).collect::<Vec<_>>(),
     });
-
-    if records.is_empty() {
-        return Ok(Payload::detail(doc, "No raw stdout/stderr blobs recorded.").into());
-    }
 
     // Subprocess stderr is diagnostic: keep it off the record stream so
     // `--format json` stdout stays parseable.
@@ -62,6 +64,37 @@ fn run_logs_payload(
         .map(|record| record.stdout.as_str())
         .collect::<String>();
     Ok(Payload::detail(doc, text).into())
+}
+
+/// [ORB-12038] `records` is empty for a run that never reached step
+/// execution — most notably a routine-dispatch workspace mismatch, which
+/// fails the run before any step can run and so has no audited CLI
+/// invocation to show. That worker still writes its own
+/// `<run_id>.worker.log` directly; fall back to it instead of reporting no
+/// logs when the file is actually sitting on disk.
+fn worker_log_fallback_payload(runtime: &OrbitRuntime, run: &JobRun) -> CommandOut {
+    let worker_log = runtime.read_pipeline_worker_log(&run.run_id)?;
+    let doc = json!({
+        "run_id": run.run_id,
+        "job_id": run.job_id,
+        "records": Value::Array(Vec::new()),
+        "worker_log_path": worker_log.as_ref().map(|snapshot| snapshot.path.display().to_string()),
+    });
+    let detail = match worker_log {
+        Some(PipelineWorkerLogSnapshot {
+            path,
+            content: Some(content),
+        }) => format!("worker log ({}):\n{content}", path.display()),
+        Some(PipelineWorkerLogSnapshot {
+            path,
+            content: None,
+        }) => format!(
+            "worker log recorded with no readable content: {}",
+            path.display()
+        ),
+        None => "No raw stdout/stderr blobs recorded.".to_string(),
+    };
+    Ok(Payload::detail(doc, detail).into())
 }
 
 fn filter_cli_invocation_records(

--- a/crates/orbit-cli/src/command/run/tests/mod.rs
+++ b/crates/orbit-cli/src/command/run/tests/mod.rs
@@ -491,6 +491,79 @@ fn parses_run_logs_step() {
     }
 }
 
+/// [ORB-12038] A run that fails before any step runs — a routine-dispatch
+/// workspace mismatch, most notably — has no audited CLI-invocation blob to
+/// show, so `records` is empty. Before this fix `orbit run logs` reported "No
+/// raw stdout/stderr blobs recorded." even when the worker's own
+/// `<run_id>.worker.log` sat on disk with the actual cause. It must fall back
+/// to that file's content instead.
+#[test]
+fn run_logs_falls_back_to_worker_log_when_no_cli_invocations_are_recorded() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    let workspace_id = runtime.workspace_id().expect("workspace id");
+    let scheduled_at = Utc::now();
+    let run = JobRun {
+        run_id: "jrun-cli-worker-log".to_string(),
+        job_id: "task_gate_pipeline".to_string(),
+        attempt: 1,
+        state: JobRunState::Cancelled,
+        scheduled_at,
+        started_at: None,
+        finished_at: Some(scheduled_at),
+        duration_ms: None,
+        created_at: scheduled_at,
+        pid: None,
+        pid_start_time: None,
+        input: None,
+        retry_source_run_id: None,
+        knowledge_metrics: None,
+        resolved_crew: None,
+        crew_model: None,
+        steps: Vec::new(),
+    };
+    runtime
+        .sqlite_store()
+        .expect("store")
+        .upsert_job_run_for_workspace(&workspace_id, &run, None)
+        .expect("insert run");
+
+    std::fs::create_dir_all(&runtime.paths().logs_dir).expect("create logs dir");
+    let worker_log_path = runtime
+        .paths()
+        .logs_dir
+        .join(format!("{}.worker.log", run.run_id));
+    std::fs::write(
+        &worker_log_path,
+        "error: workspace error: run 'jrun-cli-worker-log' was dispatched for workspace \
+         '/fixture/caseB/.orbit' but this worker resolved workspace '/fixture/caseA/.orbit'; \
+         refusing to execute against a mismatched workspace context",
+    )
+    .expect("write worker log");
+
+    let output =
+        super::logs::run_logs_payload(&runtime, Some(&run.run_id), None).expect("logs payload");
+    let CommandOutput::Payload(payload) = output else {
+        panic!("logs should produce a payload");
+    };
+    let (document, view) = payload.into_view();
+    assert_eq!(
+        document["worker_log_path"].as_str(),
+        Some(worker_log_path.to_string_lossy().as_ref())
+    );
+
+    let crate::output::payload::View::Blocks(blocks) = view else {
+        panic!("logs should keep a human view");
+    };
+    let crate::output::payload::Block::Text(text) = &blocks[0] else {
+        panic!("logs human view is prose");
+    };
+    assert!(text.contains("mismatched workspace"), "{text}");
+    assert!(
+        text.contains(&worker_log_path.display().to_string()),
+        "expected the worker log path to be named in the fallback text: {text}"
+    );
+}
+
 #[test]
 fn parses_run_events_latest() {
     let command = parse_run(&["orbit", "run", "events"]);

--- a/crates/orbit-core/src/application/job/mod.rs
+++ b/crates/orbit-core/src/application/job/mod.rs
@@ -16,7 +16,9 @@ pub use agent_invoke::{
 pub(crate) use catalog::{DEFAULT_JOB_FILES, seed_default_jobs};
 pub use catalog::{JobCatalogEntry, JobCatalogFilter};
 pub use exec::V2JobRunResult;
-pub use pipeline::{PipelineInvokeResult, PipelineWaitEntry, PipelineWaitResult};
+pub use pipeline::{
+    PipelineInvokeResult, PipelineWaitEntry, PipelineWaitResult, PipelineWorkerLogSnapshot,
+};
 #[cfg(test)]
 pub(crate) use run::TERMINAL_OUTCOME_CONFLICT_CODE;
 pub use run::{

--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -79,6 +79,12 @@ const SHIP_IN_FLIGHT_SCAN_LIMIT: usize = 200;
 /// visibly failed run instead of a silent no-op success.
 pub(crate) const ROUTINE_DISPATCH_ORBIT_DIR_FIELD: &str = "__routine_dispatch_orbit_dir";
 
+/// [ORB-12038] `error_code` recorded on the diagnostic step for a routine-
+/// dispatch workspace mismatch, so `orbit run show` names the cause rather
+/// than an operator finding only a bare `cancelled` state.
+pub(crate) const ROUTINE_DISPATCH_WORKSPACE_MISMATCH_ERROR_CODE: &str =
+    "routine_dispatch_workspace_mismatch";
+
 /// The refusal for a submission that supplied the reserved trusted-host
 /// admission key it is not entitled to write [ORB-11354].
 ///
@@ -187,6 +193,15 @@ pub struct PipelineInvokeResult {
     pub job_name: String,
     pub submitted_at: String,
     pub queued: bool,
+}
+
+/// [ORB-12038] A run's own `<run_id>.worker.log`, read for inspection when no
+/// audited CLI-invocation blob exists to explain a terminal outcome. See
+/// [`OrbitRuntime::read_pipeline_worker_log`].
+#[derive(Debug, Clone, Serialize)]
+pub struct PipelineWorkerLogSnapshot {
+    pub path: PathBuf,
+    pub content: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1058,6 +1073,7 @@ impl OrbitRuntime {
             }
 
             if let Err(error) = self.verify_routine_dispatch_workspace(&run) {
+                self.record_routine_dispatch_workspace_mismatch(&run, &error);
                 let _ = self.cancel_job_run(&run.run_id);
                 return Err(error);
             }
@@ -1084,6 +1100,17 @@ impl OrbitRuntime {
     /// than silently execute (or vacuously succeed) against the wrong scope.
     /// A run with no declared field is not routine-dispatched and is
     /// unaffected.
+    ///
+    /// [ORB-12038] The refusal terminalizes the run as `cancelled`, not
+    /// `failed`. It reuses [`Self::cancel_job_run`] unchanged — the same
+    /// request/signal/completion audit trail, reservation release, and
+    /// child-cascade settlement that every other cancellation gets — because
+    /// nothing about that machinery is wrong here; only the missing
+    /// diagnostic was. `failed` would read more accurately for a routing
+    /// refusal than an operator action, but that relabeling is a wider
+    /// contract change than this diagnostics fix and is deliberately left
+    /// alone; see [`Self::record_routine_dispatch_workspace_mismatch`] for the
+    /// diagnostic itself.
     fn verify_routine_dispatch_workspace(&self, run: &JobRun) -> Result<(), OrbitError> {
         let Some(declared) = run
             .input
@@ -1105,6 +1132,30 @@ impl OrbitRuntime {
             declared_dir.display(),
             actual_dir.display(),
         )))
+    }
+
+    /// [ORB-12038] Persist the guard's own message as a diagnostic step before
+    /// [`Self::cancel_job_run`] terminalizes the run.
+    ///
+    /// The run is still `pending` here (`execute_pipeline_run_worker` has not
+    /// reached `execute_pipeline_run_now`, so there is no `running` step to
+    /// attach an error to), and cancellation itself records no error detail —
+    /// it is written for an operator-requested stop, which carries no
+    /// message. Without this, the guard's declared-vs-resolved diagnostic
+    /// existed only in the worker process's own stderr and its
+    /// `<run_id>.worker.log`, never on the run `orbit run show` displays.
+    /// Best-effort: a failure to persist the diagnostic must not stop the
+    /// run from being cancelled or the original error from propagating.
+    fn record_routine_dispatch_workspace_mismatch(&self, run: &JobRun, error: &OrbitError) {
+        let now = Utc::now();
+        let _ = self.record_pipeline_diagnostic_step(
+            run,
+            run.scheduled_at,
+            now,
+            Some(ROUTINE_DISPATCH_WORKSPACE_MISMATCH_ERROR_CODE),
+            &error.to_string(),
+            JobRunState::Cancelled,
+        );
     }
 
     /// Reopen the shared SQLite store before the worker claims a run.
@@ -1306,6 +1357,35 @@ impl OrbitRuntime {
             .jobs()
             .complete_job_run_step(&run.run_id, &params)?;
         Ok(())
+    }
+
+    /// [ORB-12038] Read a run's own `<run_id>.worker.log`, for a caller (`orbit
+    /// run logs`) that found no audited CLI-invocation blobs to show. A run
+    /// that fails before any step runs — a routine-dispatch workspace
+    /// mismatch, a worker that could not start at all — has no step-scoped
+    /// output to audit; the worker log is where that process wrote its own
+    /// stderr, and it is the only place the cause exists.
+    ///
+    /// `Ok(None)` means no such file exists (the ordinary case for a run that
+    /// reached step execution). `Some` with `content: None` means the file
+    /// exists but its content could not be recovered (unreadable or empty);
+    /// the caller still has the path to name where to look by hand.
+    pub fn read_pipeline_worker_log(
+        &self,
+        run_id: &str,
+    ) -> Result<Option<PipelineWorkerLogSnapshot>, OrbitError> {
+        let path = pipeline_worker_log_path(&self.paths().logs_dir, run_id)?;
+        if !path.is_file() {
+            return Ok(None);
+        }
+        let mut file = File::open(&path).map_err(|error| {
+            OrbitError::Io(format!(
+                "open pipeline worker log '{}': {error}",
+                path.display()
+            ))
+        })?;
+        let content = read_pipeline_worker_log_tail(&mut file);
+        Ok(Some(PipelineWorkerLogSnapshot { path, content }))
     }
 
     fn collect_pipeline_wait_entries(

--- a/crates/orbit-core/src/application/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/application/tests/job_pipeline.rs
@@ -18,10 +18,11 @@ use crate::application::job::JobRunListParams;
 #[cfg(unix)]
 use crate::application::job::pipeline::pipeline_worker_log_test_hook::{self, Phase};
 use crate::application::job::pipeline::{
-    ROUTINE_DISPATCH_ORBIT_DIR_FIELD, configure_pipeline_worker_command,
-    configure_pipeline_worker_stdio, pipeline_worker_log_path, pipeline_worker_profile_file,
-    pipeline_worker_root_override, resolve_pipeline_worker_executable,
-    run_definition_snapshot_path, worker_command_override, worker_observer_read_counter,
+    ROUTINE_DISPATCH_ORBIT_DIR_FIELD, ROUTINE_DISPATCH_WORKSPACE_MISMATCH_ERROR_CODE,
+    configure_pipeline_worker_command, configure_pipeline_worker_stdio, pipeline_worker_log_path,
+    pipeline_worker_profile_file, pipeline_worker_root_override,
+    resolve_pipeline_worker_executable, run_definition_snapshot_path, worker_command_override,
+    worker_observer_read_counter,
 };
 use crate::application::task::TaskAddParams;
 use crate::application::workflow::{CompletionPolicy, ShipMode};
@@ -1181,6 +1182,14 @@ spec:
 /// workspace — the exact failure mode behind the original incident, where an
 /// inherited `ORBIT_ROOT` silently redirected the worker — the run must fail
 /// visibly instead of vacuously succeeding against the wrong (or empty) scope.
+///
+/// [ORB-12038] Visible to the *caller* was never the gap: the guard already
+/// returns `Err` from `execute_pipeline_run_worker`. The gap was that nothing
+/// persisted the guard's declared-vs-resolved diagnostic onto the cancelled
+/// run, so `orbit run show` (backed by `JobRun::steps`) had only a bare
+/// `cancelled` state to display, with `error_code`/`error_message` both null.
+/// This assertion is the regression check: before the fix it fails because no
+/// step carries an error at all.
 #[test]
 fn routine_dispatch_workspace_mismatch_fails_the_run_before_it_executes() {
     let (_root, runtime) = test_runtime();
@@ -1205,6 +1214,32 @@ fn routine_dispatch_workspace_mismatch_fails_the_run_before_it_executes() {
         terminal.state,
         JobRunState::Cancelled,
         "a workspace-routing failure must be a visible terminal outcome, not success"
+    );
+
+    let diagnostic = terminal
+        .steps
+        .iter()
+        .find(|step| step.error_message.is_some())
+        .expect(
+            "the cancelled run must carry the guard's declared-vs-resolved diagnostic on a \
+             step, so `orbit run show` can display it instead of a bare `cancelled` with no \
+             error_message",
+        );
+    let diagnostic_message = diagnostic
+        .error_message
+        .as_deref()
+        .expect("step matched on error_message.is_some()");
+    assert!(
+        diagnostic_message.contains(mismatched_dir),
+        "{diagnostic_message}"
+    );
+    assert!(
+        diagnostic_message.contains("mismatched workspace"),
+        "{diagnostic_message}"
+    );
+    assert_eq!(
+        diagnostic.error_code.as_deref(),
+        Some(ROUTINE_DISPATCH_WORKSPACE_MISMATCH_ERROR_CODE)
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-12038](https://orbit-cli.com/tasks/ORB-12038) — [qa-sweep] A routine-dispatch workspace mismatch cancels the run with no reason on any CLI inspection path

### Description

## Problem

ORB-11998 added `verify_routine_dispatch_workspace` so a workspace-routing failure "must fail the run **visibly** rather than silently execute (or vacuously succeed) against the wrong scope" (its own doc comment, `crates/orbit-core/src/application/job/pipeline.rs`).

The guard fires correctly, but its diagnostic never reaches any CLI inspection surface. An operator sees a run that is simply `cancelled`, with no error, no events, and an explicit denial that logs exist.

## Evidence

Verified against installed `~/.orbit/bin/orbit` 0.20.0 (`agent-main` @ `18a08c190688bc5c6be12876ed057a0177bb8307`) in an isolated fixture root with two registered workspaces (`ws_casea`, `ws_caseb`).

Dispatch from `caseA` while declaring `caseB`'s `.orbit`:

```
$ orbit run job worktree_gc_pipeline \
    --input "__routine_dispatch_orbit_dir=<fixture>/caseB/.orbit" --wait
Job: worktree_gc_pipeline
Run ID: jrun-20260910-0642-3
State: cancelled
Inspect: orbit run history -j worktree_gc_pipeline | orbit run show jrun-20260910-0642-3
(exit 1)
```

Nothing is printed on stdout or stderr beyond the above (checked with the streams separated).

Following the command's own suggested inspection path yields no cause:

```
$ orbit run show jrun-20260910-0642-3        # state=cancelled, error_code=null, error_message=null, exit_code=null
$ orbit run events jrun-20260910-0642-3      # no audit events recorded
$ orbit run logs jrun-20260910-0642-3        # No raw stdout/stderr blobs recorded.
```

The exact cause **is** on disk the whole time, in the per-run worker log:

```
$ cat <workspace>/.orbit/state/logs/jrun-20260910-0642-3.worker.log
orbit pipeline worker spawn
program: /…/orbit
args: job run-pipeline-worker jrun-20260910-0642-3
cwd: <fixture>/caseA
error: workspace error: run 'jrun-20260910-0642-3' was dispatched for workspace '<fixture>/caseB/.orbit' but this worker resolved workspace '<fixture>/caseA/.orbit'; refusing to execute against a mismatched workspace context
```

Control case (same command declaring `caseA`'s own `.orbit`) succeeds, exit 0 — so the guard's decision is right; only its reporting is lost.

## Why it matters

`verify_routine_dispatch_workspace` returns the error to the submitting caller, but nothing persists it onto the run:

```rust
if let Err(error) = self.verify_routine_dispatch_workspace(&run) {
    let _ = self.cancel_job_run(&run.run_id);
    return Err(error);
}
```

The scenario ORB-11998 exists for is the **scheduled** sweep, where there is no interactive caller reading a return value. In that case the operator's only artifacts are the run record and the CLI — all of which report an unexplained `cancelled`. That is close to the silent no-op the fix set out to replace: the failure is detectable but not diagnosable.

Two separable gaps:

1. The guard's message is not persisted to `error_message`/`error_code` on the cancelled run, and no audit event is recorded.
2. `orbit run logs` reports "No raw stdout/stderr blobs recorded." even when `<run_id>.worker.log` exists next to it with the cause. A worker that fails before claiming the run can only ever report through that file.

Also worth deciding deliberately: `cancelled` reads as an operator action. A routing refusal is a failure, and `failed` would carry that meaning better — but that is a contract change, so it is called out rather than assumed.

## Reproduction

1. `orbit init` a throwaway root; `orbit workspace init` two checkouts (A and B).
2. From A: `orbit run job worktree_gc_pipeline --input "__routine_dispatch_orbit_dir=<B>/.orbit" --wait`.
3. Observe exit 1 and `State: cancelled`; then `orbit run show`, `run events`, `run logs` — none names a cause.
4. `cat <A>/.orbit/state/logs/<run_id>.worker.log` — the cause is there.

## Provenance

Found during the ORB-12009 QA sweep while validating the ORB-11998 `target_run_id` / workspace-routing contract. The positive path is sound: a real scheduled `worktree-gc` fire recorded `initial_input = {"__routine_dispatch_orbit_dir": "<A>/.orbit"}` and succeeded.

### Acceptance Criteria

- A run cancelled by `verify_routine_dispatch_workspace` persists the guard's message (declared vs resolved workspace) where `orbit run show` displays it, so the cause is recoverable without reading files by hand.
- `orbit run logs <run_id>` surfaces the per-run `<run_id>.worker.log` content, or states where that log is, instead of reporting that no logs were recorded when the file exists.
- A regression test drives a routine-dispatch workspace mismatch end to end and asserts the persisted run carries the diagnostic — failing against current behavior, where `error_message` is null.
- The terminal state for a routing refusal is confirmed deliberate (kept `cancelled` or changed to `failed`), with the choice stated next to the guard.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed the two diagnosability gaps and documented the terminal-state decision.

**AC1 (guard message reaches `orbit run show`).** `execute_pipeline_run_worker` in `crates/orbit-core/src/application/job/pipeline.rs` now calls a new `record_routine_dispatch_workspace_mismatch(run, error)` before `cancel_job_run`. It persists the guard's declared-vs-resolved message as a `JobRunStep` (state=`Cancelled`, error_code=`routine_dispatch_workspace_mismatch`) via the existing `record_pipeline_diagnostic_step` helper, so `orbit run show`'s step table (backed by `JobRun::steps`) displays the cause instead of null error_code/error_message. Best-effort: a failure to persist never blocks cancellation or swallows the original error.

**AC2 (`orbit run logs` surfaces the worker log).** Added `OrbitRuntime::read_pipeline_worker_log(run_id)` (new `PipelineWorkerLogSnapshot { path, content }`, re-exported from `orbit_core::application::job`), which reads `<run_id>.worker.log` via the existing `pipeline_worker_log_path`/`read_pipeline_worker_log_tail` machinery. `crates/orbit-cli/src/command/run/logs.rs`'s `run_logs_payload` now falls back to this when `records` (audited CLI-invocation blobs) is empty: shows the log content when present, names the path when the file exists but is unreadable/empty, and only prints "No raw stdout/stderr blobs recorded." when neither exists. The JSON doc gained a `worker_log_path` field in that fallback branch.

**AC3 (regression test).** Extended `routine_dispatch_workspace_mismatch_fails_the_run_before_it_executes` in `crates/orbit-core/src/application/tests/job_pipeline.rs` to assert the persisted run carries a step with `error_message` naming both the mismatched dir and "mismatched workspace", and `error_code == routine_dispatch_workspace_mismatch`. Verified this fails against pre-fix code (no step had an error). Also added `run_logs_falls_back_to_worker_log_when_no_cli_invocations_are_recorded` in `crates/orbit-cli/src/command/run/tests/mod.rs`, exercising `run_logs_payload` end to end against a real worker-log file on disk (via `OrbitRuntime::in_memory()`), asserting both the JSON `worker_log_path` and the rendered text contain the log content.

**AC4 (terminal-state decision).** Kept `cancelled` (did not change to `failed`). Documented directly on `verify_routine_dispatch_workspace`'s doc comment: cancellation's request/signal/completion audit trail, reservation release, and child-cascade settlement are all correct as-is for this refusal; only the missing diagnostic was a bug. Relabeling to `failed` would be a wider run-state contract change than this diagnostics fix, so it's called out but deliberately not made.

Scope: touched `crates/orbit-core/src/application/job/pipeline.rs`, `crates/orbit-core/src/application/job/mod.rs` (re-export), `crates/orbit-core/src/application/tests/job_pipeline.rs`, `crates/orbit-cli/src/command/run/logs.rs`, `crates/orbit-cli/src/command/run/tests/mod.rs`. Also made `run_logs_payload` `pub(crate)` (was private to its module) so the new CLI test can call it directly, matching the existing `run_show_payload` convention — no behavior change. No new cross-crate dependency edges. Did not touch `docs/runbooks/stuck-job-runs.md` or the `run-debugging.md` skill reference: both describe `orbit run logs` generically ("preferred way to read captured stdout/stderr") and are not made stale by an additional fallback for the no-blobs case.

Validation:
- `cargo test -p orbit-core --lib` — 1341 passed, 0 failed, 2 ignored (pre-existing ignores, unrelated).
- `cargo test -p orbit-cli --bin orbit` — 493 passed, 0 failed.
- `make ci-fast` — passed (fmt-check + guardrail scripts).
- `make ci-lint` — passed (workspace clippy, warnings denied).
- Did not run full `make ci` per workspace policy (CI's own merge-gate job).

Remaining risk: none identified. The fallback path in `orbit run logs` only activates when no audited CLI-invocation records exist, so ordinary agent-step runs are unaffected (confirmed by full CLI/core test suites passing unchanged).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12038-6aa2549c`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra