### PR TITLE
Give GC routing integration fixture a valid explicit crew

### DIFF
--- a/crates/orbit-cli/tests/worktree_gc_routing.rs
+++ b/crates/orbit-cli/tests/worktree_gc_routing.rs
@@ -81,6 +81,7 @@ fn routine_dispatch_ignores_ambient_orbit_root_and_reaps_only_the_owning_workspa
             "WG",
         ],
     );
+    configure_fixture_crew(&home.join(".orbit"));
     let workspace_a = register_workspace(&repo_a, &home, "workspace-a");
     let workspace_b = register_workspace(&repo_b, &home, "workspace-b");
 
@@ -300,6 +301,11 @@ spec:
             fixture_job.to_str().expect("fixture job path is utf-8"),
             "--input",
             &format!("task_id={task_id}"),
+            // The isolated CI environment has no detected agent CLI, so its
+            // workspace config intentionally has no default crew. Select a
+            // built-in configured crew explicitly for this deterministic job.
+            "--input",
+            "crew=sol",
             "--wait",
             "--json",
         ],
@@ -348,6 +354,31 @@ fn zero_worktree_gc_age_floor(home: &Path) {
         path.display()
     );
     fs::write(&path, updated).unwrap_or_else(|error| panic!("write {}: {error}", path.display()));
+}
+
+fn configure_fixture_crew(root: &Path) {
+    let path = root.join("config.toml");
+    let mut config = fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+
+    if !config
+        .lines()
+        .any(|line| line.trim_start().starts_with("default_crew ="))
+    {
+        if let Some(workflow) = config.find("[workflow]\n") {
+            config.insert_str(workflow + "[workflow]\n".len(), "default_crew = \"sol\"\n");
+        } else {
+            config.push_str("\n[workflow]\ndefault_crew = \"sol\"\n");
+        }
+    }
+
+    if !config.contains("[crews.sol]") {
+        config.push_str(
+            "\n[crews.sol]\nprovider = \"codex\"\nmodel = \"gpt-5.6-sol\"\nbackend = \"cli\"\n",
+        );
+    }
+
+    fs::write(&path, config).unwrap_or_else(|error| panic!("write {}: {error}", path.display()));
 }
 
 fn enable_worktree_gc_routine(workspace: &Workspace) {


### PR DESCRIPTION
## Task

[ORB-12031](https://orbit-cli.com/tasks/ORB-12031) — Give GC routing integration fixture a valid explicit crew

### Description

GC routing test introduced by ORB-11998 PR1845 fails hosted Coverage: CI34443721685 at1db90a9 reports worktree_gc_routing::routine_dispatch_ignores_ambient_orbit_root_and_reaps_only_the_owning_workspaces_worktree failed because spawned orbit run job --wait returned invalid input: no crew selected. The test fixture YAML declares kind workflow but no crew. Source comparison confirms latest18a08c190 test is byte-identical, and latestCI34445169420 Coverage failed too (retrieve current log before assuming its exact error). Correct fixture job/crew setup using current schema and fully isolated fixture configuration; don't change production default crew semantics or weaken routing/GC assertions. Actual CLI child HOME/USERPROFILE and inherited-authority isolation must remain correct. Existing managed production GC job now successfully enumerates ws_orbit in installed run0634-3; this is validation-fixture repair.

### Acceptance Criteria

- The exact routing integration test passes from an isolated environment with no inherited user crew configuration, including the coverage invocation that failed CI.
- Fixture dispatch uses a valid explicit configured crew consistent with its deterministic steps and keeps correct workspace selection, deletion/retention and attribution assertions intact.
- No live user task/config fixtures are created or modified; inherited authority is cleared and child fixture identity is asserted.
- Relevant tests and required ci-fast/ci-lint pass; latest merged-head hosted Coverage is verified by the orchestrator.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented the isolated GC routing fixture repair in crates/orbit-cli/tests/worktree_gc_routing.rs.

Criteria evidence:
1. PASS — with PATH=/usr/bin to remove inherited agent CLI/crew discovery, the exact routing integration test passed (1 passed, 0 failed). The fixture now configures its temporary HOME's .orbit/config.toml with explicit [workflow].default_crew and [crews.sol], and dispatch passes crew=sol.
2. PASS — the run job uses the valid explicit sol crew; existing workspace selection, GC deletion/retention, and attribution assertions were unchanged.
3. PASS — only the temporary fixture root is written; existing authority-clearing environment setup and child fixture identity assertions remain unchanged. No live user task/config fixture was touched.
4. PASS — cargo fmt --all -- --check, make ci-fast, make ci-lint, and cargo test --tests --workspace --locked all passed on the final runs. ci-fast reported its documented test-compiler-cache-namespaces guard as skipped because this environment cannot create a mount namespace; the guard command itself exited successfully. Hosted merged-head Coverage is not run here and remains orchestrator-owned.

Validation commands:
- env PATH=/usr/bin ~/.cargo/bin/cargo test -p orbit-cli --test worktree_gc_routing routine_dispatch_ignores_ambient_orbit_root_and_reaps_only_the_owning_workspaces_worktree -- --nocapture — passed.
- cargo fmt --all -- --check — passed.
- make ci-fast — passed; mount-namespace guard skipped by environment capability.
- make ci-lint — passed.
- cargo test --tests --workspace --locked — passed on rerun (672 unit tests in orbit-engine plus all integration/workspace suites; 3 ignored in that crate run).
- git diff --check — passed.
- git status --short — one intended modified file only.

The first workspace-wide attempt had one unrelated temporary-PATH race in an orbit-engine already-landed test; that test passed alone and the exact workspace command passed on rerun. Changes are intentionally uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12031-6aa2528e`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra