### PR TITLE
Close unvalidated cursor-path fallback and pre-probe authority gaps for CodeQL412/413

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -148,8 +148,14 @@ extensions:
           "manual",
         ]
       - [
-          "orbit_store::driver::file::auto_task::validated_cursor_state_path",
+          "orbit_store::driver::file::auto_task::validated_cursor_state_dir",
           "ReturnValue.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]",
+          "path-injection",
+          "manual",
+        ]
+      - [
+          "orbit_store::driver::file::auto_task::validated_cursor_state_file_name",
+          "ReturnValue.Field[core::result::Result::Ok(0)]",
           "path-injection",
           "manual",
         ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,6 +2373,7 @@ dependencies = [
  "chrono",
  "fs2",
  "jsonschema",
+ "libc",
  "orbit-common",
  "orbit-types",
  "regex",

--- a/crates/orbit-store/Cargo.toml
+++ b/crates/orbit-store/Cargo.toml
@@ -16,6 +16,7 @@ blake3.workspace = true
 chrono.workspace = true
 fs2.workspace = true
 jsonschema.workspace = true
+libc.workspace = true
 orbit-common = { path = "../orbit-common", features = ["sqlite"] }
 orbit-types = { path = "../orbit-types" }
 regex.workspace = true

--- a/crates/orbit-store/src/driver/file/auto_task/mod.rs
+++ b/crates/orbit-store/src/driver/file/auto_task/mod.rs
@@ -12,9 +12,12 @@
 //! lock is not the inode being replaced and readers never observe truncated
 //! JSON. Missing state is an empty map (first-observation baseline). An
 //! existing unreadable or malformed file is an explicit error and is left
-//! unchanged for investigation.
+//! unchanged for investigation. Loads read through a descriptor opened without
+//! following the final component, so the path check and the read cannot be
+//! separated by a swap [ORB-12026].
 
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use orbit_common::OrbitError;
@@ -45,66 +48,213 @@ pub fn cursor_lock_path(state_path: &Path) -> PathBuf {
 /// A missing file is empty state. An existing file that cannot be read or
 /// parsed is an error; callers must not treat that as a baseline or rewrite it.
 pub fn load_cursor_state(path: &Path) -> Result<AutoTaskCursorState, OrbitError> {
-    let validated = match validated_cursor_state_path(path)? {
-        Some(validated) => validated,
-        None => return Ok(AutoTaskCursorState::default()),
+    load_cursor_state_with_hook(path, |_| Ok(()))
+}
+
+/// Load through an opened descriptor, letting a test perturb the file between
+/// the pathname probe and the open.
+#[cfg(test)]
+pub(crate) fn load_cursor_state_after_check<F>(
+    path: &Path,
+    before_open: F,
+) -> Result<AutoTaskCursorState, OrbitError>
+where
+    F: FnOnce(&Path) -> Result<(), OrbitError>,
+{
+    load_cursor_state_with_hook(path, before_open)
+}
+
+fn load_cursor_state_with_hook<F>(
+    path: &Path,
+    before_open: F,
+) -> Result<AutoTaskCursorState, OrbitError>
+where
+    F: FnOnce(&Path) -> Result<(), OrbitError>,
+{
+    let Some((resolved, mut file)) = open_cursor_state_file(path, before_open)? else {
+        return Ok(AutoTaskCursorState::default());
     };
 
-    match fs::read_to_string(&validated) {
-        Ok(raw) => parse_state(&raw, &validated),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            Ok(AutoTaskCursorState::default())
-        }
+    let mut raw = String::new();
+    file.read_to_string(&mut raw)
+        .map_err(|error| unreadable_cursor_state(&resolved, &error))?;
+
+    parse_state(&raw, &resolved)
+}
+
+/// Final component of `path`, accepted only when the caller actually named a
+/// child of some directory.
+///
+/// `Path::file_name` already yields `None` for a filesystem root, for `.`, and
+/// for anything terminating in `..`, so those shapes fail closed here rather
+/// than falling back to the unvalidated input. The contract deliberately stays
+/// "one normal component" instead of the fixed `auto-tasks.json` that
+/// [`cursor_state_path`] builds: [`load_cursor_state`] is public and callers
+/// may point it at an alternate basename.
+fn validated_cursor_state_file_name(path: &Path) -> Result<PathBuf, OrbitError> {
+    path.file_name().map(PathBuf::from).ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "auto-task cursor state path must name a file inside a state dir: {}",
+            path.display()
+        ))
+    })
+}
+
+/// Canonical directory that owns the cursor-state file.
+///
+/// `path` is built from a caller-selected state dir (workspace discovery,
+/// `--root`, or web dashboard workspace routing), so the parent is
+/// canonicalized rather than rejected and supported aliases — a symlinked
+/// state dir or checkout projection — keep resolving [ORB-11948]. This
+/// directory is the authority every later probe and open is resolved against.
+/// A bare relative filename is owned by the current directory, matching where
+/// [`CursorSession::save`] would write it. `Ok(None)` means the directory does
+/// not exist, which callers treat as empty baseline state.
+fn validated_cursor_state_dir(path: &Path) -> Result<Option<PathBuf>, OrbitError> {
+    let parent = path.parent().ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "auto-task cursor state path has no parent dir: {}",
+            path.display()
+        ))
+    })?;
+    let parent = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
+
+    match parent.canonicalize() {
+        Ok(dir) => Ok(Some(dir)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(error) => Err(OrbitError::Io(format!(
-            "unreadable auto-task cursor state {}: {error}; file left unchanged for investigation",
-            validated.display()
+            "failed to canonicalize auto-task state dir {}: {error}",
+            parent.display()
         ))),
     }
 }
 
-/// Resolve `path` through its canonical parent dir, rejecting a symlinked
-/// target. `path` is built by [`cursor_state_path`] from a caller-selected
-/// state dir (workspace discovery, `--root`, or web dashboard workspace
-/// routing), so canonicalizing the parent and refusing to follow a symlinked
-/// result keeps the read inside the selected state dir instead of a planted
-/// symlink's target [ORB-11948]. `Ok(None)` means "no existing file", which
-/// callers treat as empty baseline state, matching prior behavior for a
-/// missing state dir or a missing data file.
-fn validated_cursor_state_path(path: &Path) -> Result<Option<PathBuf>, OrbitError> {
-    let Some(parent) = path.parent() else {
-        return Ok(Some(path.to_path_buf()));
+/// Open the existing cursor-state file beneath its canonical directory without
+/// following a swapped final component.
+///
+/// Both the directory and the final component are validated before the first
+/// metadata probe, so no sink here ever sees the raw caller path. Unix opens
+/// with `O_NOFOLLOW` and Windows opens the reparse point itself; the resulting
+/// descriptor is re-checked for a regular file, so a symlink planted between
+/// the probe and the open fails instead of redirecting the read. A platform
+/// with neither primitive still performs the pathname and descriptor checks
+/// but cannot close that final-component race. Because ancestors are
+/// canonicalized rather than rejected, this leaf protection does not claim to
+/// stop a concurrent rename or replacement of a mutable ancestor directory.
+///
+/// `Ok(None)` means "no existing file", matching prior behavior for a missing
+/// state dir or a missing data file.
+fn open_cursor_state_file<F>(
+    path: &Path,
+    before_open: F,
+) -> Result<Option<(PathBuf, File)>, OrbitError>
+where
+    F: FnOnce(&Path) -> Result<(), OrbitError>,
+{
+    let file_name = validated_cursor_state_file_name(path)?;
+    let Some(canonical_dir) = validated_cursor_state_dir(path)? else {
+        return Ok(None);
     };
-    let Some(file_name) = path.file_name() else {
-        return Ok(Some(path.to_path_buf()));
-    };
-
-    let canonical_parent = match parent.canonicalize() {
-        Ok(dir) => dir,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => {
-            return Err(OrbitError::Io(format!(
-                "failed to canonicalize auto-task state dir {}: {error}",
-                parent.display()
-            )));
-        }
-    };
-    let candidate = canonical_parent.join(file_name);
+    let candidate = canonical_dir.join(file_name);
 
     match fs::symlink_metadata(&candidate) {
         Ok(metadata) if metadata.file_type().is_symlink() => {
-            Err(OrbitError::InvalidInput(format!(
-                "auto-task cursor state path must not be a symlink: {}",
-                candidate.display()
-            )))
+            return Err(symlinked_cursor_state(&candidate));
         }
-        Ok(_) => Ok(Some(candidate)),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(OrbitError::Io(format!(
+        Ok(metadata) if !metadata.is_file() => return Err(irregular_cursor_state(&candidate)),
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "failed to inspect auto-task cursor state path {}: {error}",
+                candidate.display()
+            )));
+        }
+    }
+
+    before_open(&candidate)?;
+
+    let mut options = OpenOptions::new();
+    options.read(true);
+    apply_no_follow_final_component(&mut options);
+    let file = match options.open(&candidate) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) if is_symlink_open_refusal(&error) => {
+            return Err(symlinked_cursor_state(&candidate));
+        }
+        Err(error) => return Err(unreadable_cursor_state(&candidate, &error)),
+    };
+
+    let metadata = file.metadata().map_err(|error| {
+        OrbitError::Io(format!(
             "failed to inspect auto-task cursor state path {}: {error}",
             candidate.display()
-        ))),
+        ))
+    })?;
+    if !metadata.is_file() {
+        return Err(irregular_cursor_state(&candidate));
     }
+
+    Ok(Some((candidate, file)))
 }
+
+fn symlinked_cursor_state(path: &Path) -> OrbitError {
+    OrbitError::InvalidInput(format!(
+        "auto-task cursor state path must not be a symlink: {}",
+        path.display()
+    ))
+}
+
+fn irregular_cursor_state(path: &Path) -> OrbitError {
+    OrbitError::InvalidInput(format!(
+        "auto-task cursor state path must be a regular file: {}",
+        path.display()
+    ))
+}
+
+fn unreadable_cursor_state(path: &Path, error: &std::io::Error) -> OrbitError {
+    OrbitError::Io(format!(
+        "unreadable auto-task cursor state {}: {error}; file left unchanged for investigation",
+        path.display()
+    ))
+}
+
+/// `O_NOFOLLOW` reports a symlinked final component as `ELOOP`, which has no
+/// stable [`std::io::ErrorKind`] to match on.
+#[cfg(unix)]
+fn is_symlink_open_refusal(error: &std::io::Error) -> bool {
+    error.raw_os_error() == Some(libc::ELOOP)
+}
+
+/// Elsewhere a symlinked final component is caught by the descriptor's own
+/// file-type check rather than by an open-time refusal.
+#[cfg(not(unix))]
+fn is_symlink_open_refusal(_error: &std::io::Error) -> bool {
+    false
+}
+
+#[cfg(unix)]
+fn apply_no_follow_final_component(options: &mut OpenOptions) {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    options.custom_flags(libc::O_NOFOLLOW);
+}
+
+#[cfg(windows)]
+fn apply_no_follow_final_component(options: &mut OpenOptions) {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+}
+
+#[cfg(not(any(unix, windows)))]
+fn apply_no_follow_final_component(_options: &mut OpenOptions) {}
 
 fn parse_state(raw: &str, path: &Path) -> Result<AutoTaskCursorState, OrbitError> {
     serde_json::from_str(raw.trim()).map_err(|error| {

--- a/crates/orbit-store/src/driver/file/auto_task/tests/mod.rs
+++ b/crates/orbit-store/src/driver/file/auto_task/tests/mod.rs
@@ -1,16 +1,17 @@
 //! Cursor-file load, lock, and atomic replace tests.
 
 use std::fs;
+use std::path::PathBuf;
 use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Duration;
 
-use orbit_types::workflow::AutoTaskCursor;
+use orbit_types::workflow::{AutoTaskCursor, AutoTaskCursorState};
 use tempfile::tempdir;
 
 use super::{
     cursor_lock_path, cursor_state_path, inject_cursor_save_failures, load_cursor_state,
-    upsert_cursor, with_cursor_lock,
+    load_cursor_state_after_check, upsert_cursor, with_cursor_lock,
 };
 
 fn cursor(baseline: &str, last_slot: Option<&str>) -> AutoTaskCursor {
@@ -21,6 +22,15 @@ fn cursor(baseline: &str, last_slot: Option<&str>) -> AutoTaskCursor {
         last_task_id: last_slot.map(|_| "ORB-1".to_string()),
         pending: None,
     }
+}
+
+/// One definition's state as it is stored on disk.
+fn state_json(name: &str) -> String {
+    let mut state = AutoTaskCursorState::default();
+    state
+        .definitions
+        .insert(name.to_string(), cursor("2026-01-01T00:00:00+00:00", None));
+    serde_json::to_string(&state).expect("encode state")
 }
 
 #[test]
@@ -139,6 +149,133 @@ fn load_cursor_state_rejects_a_symlinked_state_file() {
     assert!(
         error.to_string().contains("must not be a symlink"),
         "{error}"
+    );
+
+    fs::remove_file(&outside_target).expect("cleanup outside target");
+}
+
+/// [ORB-12026] A path with no normal final component names no file, so there is
+/// nothing to validate. It must fail closed instead of falling back to the raw
+/// caller input, which previously reached the metadata probe unvalidated.
+#[test]
+fn load_cursor_state_rejects_a_path_without_a_final_component() {
+    let root = tempdir().expect("tempdir");
+
+    for path in [root.path().join(".."), PathBuf::from("/")] {
+        let error = load_cursor_state(&path).expect_err("no final component");
+        assert!(
+            error
+                .to_string()
+                .contains("must name a file inside a state dir"),
+            "{path:?}: {error}"
+        );
+    }
+}
+
+/// A trailing `.` resolves to the state dir itself, which is a directory rather
+/// than a cursor file — an explicit rejection, not a silent empty baseline.
+#[test]
+fn load_cursor_state_rejects_a_dot_terminated_path() {
+    let root = tempdir().expect("tempdir");
+
+    let error = load_cursor_state(&root.path().join(".")).expect_err("dot-terminated");
+    assert!(
+        error.to_string().contains("must be a regular file"),
+        "{error}"
+    );
+}
+
+/// `load_cursor_state` is public and callers may name a basename other than the
+/// fixed one [`cursor_state_path`] builds. Validation is "one normal final
+/// component", so alternate basenames stay supported.
+#[test]
+fn load_cursor_state_supports_an_alternate_basename() {
+    let root = tempdir().expect("tempdir");
+    let path = root.path().join("alternate-cursors.json");
+    fs::write(&path, state_json("chore")).expect("write");
+
+    let loaded = load_cursor_state(&path).expect("alternate basename");
+    assert!(loaded.definitions.contains_key("chore"), "{loaded:?}");
+}
+
+#[test]
+fn missing_state_dir_is_empty_state() {
+    let root = tempdir().expect("tempdir");
+    let path = cursor_state_path(&root.path().join("never-created"));
+
+    let loaded = load_cursor_state(&path).expect("missing state dir");
+    assert!(loaded.definitions.is_empty(), "{loaded:?}");
+}
+
+/// The parent is canonicalized rather than rejected, so a symlinked state dir —
+/// a checkout projection or an operator-configured alias — keeps resolving.
+#[cfg(unix)]
+#[test]
+fn load_cursor_state_resolves_through_a_symlinked_state_dir() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempdir().expect("tempdir");
+    let real_dir = root.path().join("real-state");
+    fs::create_dir(&real_dir).expect("state dir");
+    fs::write(cursor_state_path(&real_dir), state_json("chore")).expect("write");
+    let alias_dir = root.path().join("alias-state");
+    symlink(&real_dir, &alias_dir).expect("symlink state dir");
+
+    let loaded = load_cursor_state(&cursor_state_path(&alias_dir)).expect("aliased state dir");
+    assert!(loaded.definitions.contains_key("chore"), "{loaded:?}");
+}
+
+/// A non-regular final component (here a directory) is not cursor state and is
+/// never opened for reading.
+#[test]
+fn load_cursor_state_rejects_a_non_regular_state_file() {
+    let root = tempdir().expect("tempdir");
+    let path = cursor_state_path(root.path());
+    fs::create_dir(&path).expect("directory in place of the state file");
+
+    let error = load_cursor_state(&path).expect_err("non-regular state file");
+    assert!(
+        error.to_string().contains("must be a regular file"),
+        "{error}"
+    );
+}
+
+/// [ORB-12026] The pathname probe and the read must not be separable: the read
+/// goes through a descriptor opened with final-component no-follow semantics,
+/// so a symlink swapped in after the check is refused at open time and no byte
+/// of the outside file is read.
+#[cfg(unix)]
+#[test]
+fn load_cursor_state_rejects_a_symlink_swapped_in_after_the_check() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempdir().expect("tempdir");
+    let path = cursor_state_path(root.path());
+    fs::write(&path, state_json("local")).expect("seed regular state file");
+    let outside_target = root
+        .path()
+        .parent()
+        .expect("state dir has parent")
+        .join("swapped-auto-tasks.json");
+    let outside_contents = state_json("leaked");
+    fs::write(&outside_target, &outside_contents).expect("write file outside state dir");
+
+    let swap_target = outside_target.clone();
+    let error = load_cursor_state_after_check(&path, move |checked| {
+        fs::remove_file(checked).expect("remove checked file");
+        symlink(&swap_target, checked).expect("swap in a symlink");
+        Ok(())
+    })
+    .expect_err("symlink swapped in after the check");
+
+    assert!(
+        error.to_string().contains("must not be a symlink"),
+        "{error}"
+    );
+    assert_eq!(
+        fs::read_to_string(&outside_target).expect("outside target"),
+        outside_contents,
+        "the outside file must be neither rewritten nor consumed"
     );
 
     fs::remove_file(&outside_target).expect("cleanup outside target");


### PR DESCRIPTION
## Task

[ORB-12026](https://orbit-cli.com/tasks/ORB-12026) — Close unvalidated cursor-path fallback and pre-probe authority gaps for CodeQL412/413

### Description

Completed CodeQL34443147263 at5c2ca332a8d48421d0b9807e09b65e9e02ee0dcc still reports new412 at auto_task/mod.rs:53 read_to_string(&validated), and413 at:93 symlink_metadata(&candidate), following ORB11948. Exact inspected source: validated_cursor_state_path returns Ok(Some(path.to_path_buf())) unchanged if parent() OR file_name() is missing. Those branches bypass the claimed canonical-parent/symlink boundary entirely. The normal branch canonicalizes parent and joins file_name before an internal metadata sink; a function-return barrier cannot sanitize that internal sink. Also inspect actual Result<Option<PathBuf>> model path accuracy for the outer read instead of assuming schema validity proves correct dataflow.

Repair this validator as a whole without relocating alerts or blanketmodeling unsafe branches. Preserve supported public load_cursor_state paths, missing-file empty state, malformed/unreadable error semantics and no-clobber locking behavior. Inspect filename contract before narrowing it: use validated normal basename semantics (or fixed filename only if current API truly requires it); do not assume file_name itself returns dot/dotdot. Existing12019/12023 cover analogous patterns in different crates, no opentask covers thismodule. Orchestrator verifies hostedclosure.

## Additional verified read-boundary requirement
Confirmed auto_task/mod.rs73-105 checks metadata then load_cursor_state47-62 separately fs::read_to_string follows the path. Require a read-only opened descriptor/contents obtained with final-component no-follow semantics; do not return a supposedly safe PathBuf and reopen it. Preserve supported alternate basenames, missing empty-state and malformed/unreadable errors. Keep no-clobber locking semantics; do not broaden into a rewrite redesign without concrete additional evidence.

### Acceptance Criteria

- Every successful nonempty validated path is actually validated before probe/read; eliminate raw-input success fallbacks for missing parent/basename and define observable handling of root-only, dot/dotdot and malformed shapes. Establish a precise canonical parent authority boundary before child metadata probing.
- Regression tests cover normal and supported alternate cursor paths, missing parent/file, trusted parent aliases, final symlink/non-regular file, malformed path shapes and no unintended external read/write. Preserve malformed/unreadable-state errors, locking and no-clobber behavior.
- Run auto-task/store focused tests, make ci-fast, make ci-lint and extension schema checks if changed. Validate barrier paths against actual source return shape; no dismissal, rule suppression, or blanket sanitizer on unvalidated branches.
- Orchestrator confirms original366 and new412/413 fixed in hosted Rust CodeQL on merged repair, with no replacement sink carrying the same unresolved flow. Leaf reports local proof and hosted pending status honestly.
- The content read rejects a swapped final symlink at open time via a read-only descriptor or equivalent validated handle, with a deterministic check-to-swap regression proving no external content is read. Supported root aliases remain valid; Unix/non-Unix behavior and parent/ancestor mutation boundaries are explicit rather than claiming leaf no-follow protects mutable ancestors.

## Execution Summary

<details>
<summary>Click to expand</summary>

Repaired the auto-task cursor-state read boundary in crates/orbit-store/src/driver/file/auto_task/mod.rs. Uncommitted; HEAD at start and end 2661cc308e1f2648ba9fc99530e6507647f235e1.

WHAT CHANGED

1. `validated_cursor_state_path` is gone, and with it both raw-input success fallbacks (`Ok(Some(path.to_path_buf()))` when `parent()` or `file_name()` was missing) that let unvalidated input reach the metadata probe. It is replaced by two validators that both run before any probe:
   - `validated_cursor_state_file_name(&Path) -> Result<PathBuf, OrbitError>` — the final component, accepted only when `Path::file_name` yields one. `file_name` already returns `None` for a filesystem root, for `.`, and for anything terminating in `..`, so those shapes now fail closed with `InvalidInput` instead of falling through. The contract stays "one normal final component" rather than the fixed `auto-tasks.json`, because `load_cursor_state` is public and callers may name an alternate basename; it was NOT narrowed to a constant filename.
   - `validated_cursor_state_dir(&Path) -> Result<Option<PathBuf>, OrbitError>` — the canonicalized parent, which is the authority every later probe and open resolves against. Parents are canonicalized, not rejected, so supported aliases (symlinked state dir, checkout projection, `--root`, dashboard routing) keep working. Missing dir -> `Ok(None)` -> empty baseline, as before. An empty parent (bare relative filename) resolves to `.`, matching where the save path already writes.
   `candidate = canonical_dir.join(file_name)` is therefore built only from two validated values; nothing derived from the raw caller path reaches `symlink_metadata` or `open`.

2. The read no longer reopens a returned PathBuf. `open_cursor_state_file` probes with `symlink_metadata` (symlink -> `InvalidInput` "must not be a symlink"; non-regular -> `InvalidInput` "must be a regular file"; NotFound -> `Ok(None)`), then opens read-only with final-component no-follow semantics (`O_NOFOLLOW` on Unix, `FILE_FLAG_OPEN_REPARSE_POINT` on Windows, neither elsewhere), then re-verifies the OPEN DESCRIPTOR is a regular file before a byte is read. `load_cursor_state` reads from that descriptor via `Read::read_to_string`. `ELOOP` at open is mapped back to the symlink rejection (`io::ErrorKind::FilesystemLoop` is not stable to match on).

3. Platform/boundary limits are stated in the source docs rather than implied: a platform with neither no-follow primitive still gets both the pathname and descriptor checks but cannot close the final-component race; and because ancestors are deliberately canonicalized to keep aliases working, the leaf protection explicitly does NOT claim to stop a concurrent rename or replacement of a mutable ancestor directory.

4. CodeQL extension: the single `validated_cursor_state_path` barrier row is replaced by rows for `validated_cursor_state_dir` (`Ok(0).Some(0)`) and `validated_cursor_state_file_name` (`Ok(0)`). Both barriers sit on functions whose every success path is genuinely validated, so this is a real boundary, not a relabel — no rule suppression, no blanket sanitizer, no sink relocation. The file-name barrier follows the existing `pipeline_worker_file_name` precedent; the dir barrier follows `host_identity::validated_existing_global_root` (ORB-12019).

5. `libc.workspace = true` added to crates/orbit-store/Cargo.toml for `O_NOFOLLOW`/`ELOOP` (Cargo.lock updated accordingly — appended to context_files as a generated consequence of the declared manifest change; no other unlisted file was touched). No new cross-crate edge, so ARCHITECTURE.md needs no change.

PRESERVED (verified by the pre-existing tests, all still passing unchanged): missing file/dir -> empty baseline; malformed content -> `Store` "malformed ... left unchanged for investigation"; unreadable (mode 0o000) -> `Io` "unreadable auto-task cursor state ... left unchanged for investigation" (now raised at open instead of read, same message); empty existing file is malformed, not a baseline; sidecar-lock exclusion, lock inode identity across atomic replace, no-clobber on malformed/unreadable/injected-save-failure. `with_cursor_lock`/`CursorSession::save` write behavior is untouched — no rewrite redesign.

ACCEPTANCE CRITERIA
1. Met. Both raw-input fallbacks deleted; every success path is validated before probe/read. Observable handling now defined: root-only and `..`-terminated -> `InvalidInput` "must name a file inside a state dir"; `dir/.` normalizes to the dir itself and is rejected as "must be a regular file"; missing dir/file -> empty baseline. Canonical-parent authority is established before the child probe.
2. Met. New tests: `load_cursor_state_rejects_a_path_without_a_final_component` (both `..`-terminated and `/`), `load_cursor_state_rejects_a_dot_terminated_path`, `load_cursor_state_supports_an_alternate_basename`, `missing_state_dir_is_empty_state`, `load_cursor_state_resolves_through_a_symlinked_state_dir` (trusted parent alias, unix), `load_cursor_state_rejects_a_non_regular_state_file`, `load_cursor_state_rejects_a_symlink_swapped_in_after_the_check` (unix). The last asserts the outside file is neither read nor rewritten. Pre-existing symlink/malformed/unreadable/locking/no-clobber tests kept as-is.
3. Met. Commands below.
4. Leaf cannot confirm. Local proof only; hosted Rust CodeQL closure of 366/412/413 on the merged repair is PENDING and is the orchestrator's verification. Reported honestly, not claimed.
5. Met. The read is a read-only descriptor opened with no-follow final-component semantics and re-checked as a regular file; the check-to-swap regression is deterministic via a `#[cfg(test)]` `before_open` hook (same shape as the landed `host_identity::inspect_host_identity_after_check`). Root/dir aliases remain valid (aliased-state-dir test). Unix/non-Unix behavior and the mutable-ancestor limit are documented in source rather than overclaimed.

VALIDATION (all run in this worktree, Linux x86_64, at HEAD 2661cc308)
- PASSED `cargo test -p orbit-store --lib driver::file::auto_task` — 16 passed, 0 failed.
- PASSED `cargo test -p orbit-automation --lib auto_tasks` — 35 passed.
- PASSED `cargo test -p orbit-core --lib auto_task` — 42 passed.
- PASSED `cargo test -p orbit-web --lib auto_task` — 22 passed.
- PASSED `make ci-fast` (exit 0). One internal step self-reports skip: `test-compiler-cache-namespaces` (bwrap cannot create a user namespace on this kernel) — pre-existing environment limit, unrelated to this change.
- PASSED `make ci-lint` (exit 0, warnings denied).
- PASSED `python3 scripts/check-codeql-extension-schema.py` (exit 0) and `python3 scripts/test-codeql-extension-schema.py` (7 tests OK).
- PASSED `cargo fmt --check -p orbit-store`.
- PASSED `git diff --check` (exit 0); `git status --short` shows exactly the five intended modified files, no stray artifacts.
- FAULT-DETECTION PROOF: temporarily replacing `O_NOFOLLOW` with `0` made `load_cursor_state_rejects_a_symlink_swapped_in_after_the_check` FAIL, returning the external file's `{"leaked": ...}` state. Reverted immediately; the final tree is the unmodified repair.
- NOT RUN: full `make ci` (per workspace policy, it is the PR-level merge gate, not a per-task local run). Hosted CodeQL (orchestrator-owned).

RISKS / DEVIATIONS
- Non-Unix behavior is reasoned from the API contract and the landed ORB-12019 precedent, not executed: this machine is Linux, so the Windows `FILE_FLAG_OPEN_REPARSE_POINT` path and the `not(any(unix, windows))` fallback are unexercised here. Stated as unproven rather than asserted.
- The final-component protection does not cover a privileged concurrent swap of a mutable ANCESTOR directory; that is inherent to canonicalizing parents so operator aliases keep working, and is documented in the source instead of being papered over.
- Behavior change worth noting for reviewers: paths with no normal final component now error instead of silently succeeding, and a bare relative filename now loads from `.` instead of returning empty state. No in-repo caller constructs either shape (all reach the module through `cursor_state_path(state_dir)`), and all downstream auto-task suites pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12026-6aa2584a`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra