### PR TITLE
[code-review] Routine dispatch now sends a run input payload and verifies worker workspace identity, contradicting the current routines design doc

### DIFF
--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -1,8 +1,8 @@
 ---
 title: Routines — Design
 owner: claude
-last_updated: 2026-09-07
-last_validated: 2026-09-07
+last_updated: 2026-09-10
+last_validated: 2026-09-10
 status: Accepted
 feature: routines
 doc_role: design
@@ -293,7 +293,29 @@ Per pass:
    (idempotency key: routine name + scheduled slot + attempt, transactionally with the
    cursor advance), then dispatch the target via `submit_pipeline_run` in the routine's
    source workspace with actor `routine/<name>` as run provenance.
-8. Record outcomes and exit.
+   Routine dispatch supplies the run base input with exactly one reserved internal field,
+   `__routine_dispatch_orbit_dir`, containing the source workspace's `.orbit` directory.
+   This is workspace-routing metadata, not a caller parameter: routine target jobs still
+   accept no caller-supplied parameters, and every step in such a job must declare its own
+   `default_input` rather than inheriting the job base input (which would expose the
+   reserved field to the activity).
+8. The detached worker clears `ORBIT_ROOT` unconditionally. With no explicit `--root`, its
+   cwd is therefore the workspace selector; when a parent explicitly forwarded `--root`,
+   that argument is the selector. Before any step executes, the worker compares the
+   declared `__routine_dispatch_orbit_dir` directly with its resolved `orbit_dir`. A
+   mismatch is a workspace-identity refusal: the worker persists a diagnostic step with
+   error code `routine_dispatch_workspace_mismatch`, cancels the run before step execution,
+   and returns the mismatch error. The final state is intentionally `cancelled` (the
+   existing cancellation contract is preserved), but it is no longer an unexplained bare
+   cancellation. `orbit run show` exposes the persisted error code and declared-versus-
+   resolved path message; because no activity output exists, `orbit run logs` falls back to
+   the run's worker log, which also contains the diagnostic.
+9. The identity check is a direct path comparison, not a normalized workspace-equivalence
+   check. A workspace whose `.orbit/config.toml` redirects `root` to a different directory
+   is not expected to satisfy the gate unless the worker's resolved `orbit_dir` is exactly
+   the declared `.orbit` path. The gate deliberately refuses that redirected-root case so
+   routine provenance cannot silently resolve to a different store.
+10. Record outcomes and exit.
 
 `orbit routine list`, `orbit routine show`, and `orbit sweep` expose the local registry
 source (`local_workspace_registry`) plus stable diagnostic codes and severity in human and
@@ -393,9 +415,11 @@ out of v1 scope for this reason.
   outcome sync records it as `error` — terminal, never re-fired, so a make-up fire cannot race
   an orphaned run. A dispatched in-flight run is released before that timeout only when its
   recorded owner is conclusively stopped; live and unprobeable owners remain protected.
-- **Routines carry no input payload.** v1 dispatches every target with an empty input
-  object; jobs meant for routines must run with defaults. Parameterized fires would be a
-  schema addition.
+- **Routines carry no caller input payload.** v1 dispatch injects only the reserved internal
+  `__routine_dispatch_orbit_dir` field naming the owning workspace's `.orbit` directory.
+  Jobs meant for routines still take no caller-supplied parameters, and each step should
+  declare its own `default_input` so that this routing field is never inherited as activity
+  input. Parameterized fires would be a schema addition.
 
 ---
 


### PR DESCRIPTION
## Task

[ORB-12033](https://orbit-cli.com/tasks/ORB-12033) — [code-review] Routine dispatch now sends a run input payload and verifies worker workspace identity, contradicting the current routines design doc

### Description

ORB-11998 (commit `444927a3b`, PR #1845) changed two documented facts about routine dispatch and changed no file under `docs/`. `CLAUDE.md` § Design Docs: "Change affected current docs in the same PR as the code. Stale descriptions of live behavior are a review blocker."

## Evidence (verified against live code at `18a08c190688bc5c6be12876ed057a0177bb8307`)

**1. `docs/design/routines/2_design.md:396-398` is now false.**

The doc still states, as a design decision:

> - **Routines carry no input payload.** v1 dispatches every target with an empty input
>   object; jobs meant for routines must run with defaults. Parameterized fires would be a
>   schema addition.

`RuntimeDispatch::submit` no longer dispatches an empty object. `crates/orbit-core/src/application/routines/sweep.rs:77-82`:

```rust
let mut input = json!({});
input[crate::application::job::pipeline::ROUTINE_DISPATCH_ORBIT_DIR_FIELD] =
    json!(source_orbit_dir.to_string_lossy());
runtime
    .submit_pipeline_run(job_name, input, None, Some(actor))
```

The field is `"__routine_dispatch_orbit_dir"` (`crates/orbit-core/src/application/job/pipeline.rs:71`). The pre-change call was `submit_pipeline_run(job_name, json!({}), None, Some(actor))`.

This is not cosmetic: the run input becomes the job's `base_input` (`crates/orbit-engine/src/activity_job/job_executor/mod.rs:143`, `merge_job_input`), and `render_input` falls back to `base_input` verbatim for any step that declares no `default_input` (`crates/orbit-engine/src/activity_job/job_executor/templating.rs:10` — `let src = default_input.cloned().unwrap_or_else(|| base_input.clone())`). Every step in every shipped routine-dispatched job does declare `default_input` today, so no shipped activity receives the field — but the doc's decision is precisely what tells a future author they may omit `default_input` safely, and that is no longer true.

**2. The new hard workspace-identity gate is undocumented.**

`docs/design/routines/2_design.md:294-295` describes dispatch as "then dispatch the target via `submit_pipeline_run` in the routine's source workspace with actor `routine/<name>` as run provenance", and the doc's dispatch-failure taxonomy (`:120-126`, `:384-396`) enumerates synchronous `submit_pipeline_run` errors, timeouts, and reclaimed stale intents. There is now a third terminal outcome it does not mention: a run whose declared owning workspace does not match the workspace the detached worker resolved is **cancelled before any step executes**.

`crates/orbit-core/src/application/job/pipeline.rs:1051-1054`:

```rust
if let Err(error) = self.verify_routine_dispatch_workspace(&run) {
    let _ = self.cancel_job_run(&run.run_id);
    return Err(error);
}
```

`crates/orbit-core/src/application/job/pipeline.rs:1077-1099` implements the check, comparing the declared `.orbit` directory against `self.paths().orbit_dir` and returning `OrbitError::WorkspaceError`. The change's own test asserts the terminal state is `JobRunState::Cancelled` (`crates/orbit-core/src/application/tests/job_pipeline.rs:1035-1045`). An operator reading the routines design doc to interpret a cancelled routine run has nothing to match it against.

Related and also undocumented: `configure_pipeline_worker_command` now unconditionally clears `ORBIT_ROOT` for every pipeline worker, not only when `--root` is forwarded (`crates/orbit-core/src/application/job/pipeline.rs:1928`). The doc at `:256` describes the sweep as one that "never bootstraps a workspace from the caller's cwd" but says nothing about how the *worker* gets its workspace identity, which is the surface the incident was in.

## Failure scenario

An author adds a new routine target job and, following `docs/design/routines/2_design.md:396`, writes a step with no `default_input` because "routines dispatch an empty input object" — so the step should see `{}`. At runtime the step's rendered input is instead `{"__routine_dispatch_orbit_dir": "/path/to/repo/.orbit"}`, an internal field the activity contract never declared. For an agent activity that input is what the activity is handed, so an internal implementation detail reaches agent-visible input; for a deterministic activity whose schema declares `additionalProperties: false` (for example `crates/orbit-core/assets/activities/pr_conflict_recovery.yaml:14`) the input silently violates its own published schema, since nothing validates activity input against `input_schema_json` at dispatch.

Separately, an operator investigating a routine that reports `cancelled` with no steps consults the routines design doc, finds only the dispatch-error / timeout / stale-intent outcomes, and has no documented explanation for a workspace-identity refusal.

## Suggested direction

Docs-only change, no behavior:

- Replace the "Routines carry no input payload" decision at `docs/design/routines/2_design.md:396-398` with the actual contract: routine dispatch injects exactly one reserved, internal field naming the owning workspace's `.orbit` directory; jobs meant for routines still carry no caller-supplied parameters, and every step should declare its own `default_input` rather than inheriting the job base input.
- Document the worker workspace-identity gate as a named terminal outcome in the dispatch section: what is declared, what the worker compares it against, that a mismatch cancels the run before the first step, and that `ORBIT_ROOT` is cleared for every worker so cwd (or a forwarded `--root`) is the sole workspace selector.
- Note in the same pass that the comparison is a direct path comparison of the declared `.orbit` directory against the worker's resolved `orbit_dir`, so a workspace whose `.orbit/config.toml` redirects `root` to a different directory (honored by `resolve_orbit_dir_candidate`, `crates/orbit-core/src/runtime/resolve.rs:313-321`, but not by the registry-opened runtime the sweep uses) will not satisfy it. Whether that should be normalized or is a configuration the gate is right to refuse is a design statement worth making explicitly next to the check.

### Acceptance Criteria

- `docs/design/routines/2_design.md` no longer states that routines dispatch every target with an empty input object; it describes the reserved internal workspace field that `RuntimeDispatch::submit` injects and states that routine target jobs still take no caller-supplied parameters and that each step should declare its own `default_input`.
- The docs describe the final workspace-identity gate outcome implemented by ORB-12038, including persisted diagnostics, how run show/logs expose it, and unconditional worker ORBIT_ROOT clearing; they do not freeze the pre-repair unexplained cancelled behavior.
- The doc states whether a workspace whose `.orbit/config.toml` redirects `root` is expected to satisfy the identity gate, so the direct path comparison is a stated decision rather than an unexamined one.
- No source behavior changes; `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated docs/design/routines/2_design.md only.
- Documented the reserved __routine_dispatch_orbit_dir base-input field, no caller parameters, and the requirement for per-step default_input.
- Documented unconditional worker ORBIT_ROOT clearing, the direct workspace-identity comparison, persisted routine_dispatch_workspace_mismatch diagnostics, cancelled-before-step terminal behavior, run show exposure, and run logs worker-log fallback.
- Stated that redirected .orbit/config.toml root paths are not accepted unless the worker's resolved orbit_dir exactly matches the declared .orbit path.

Assessment: The design doc now matches the repaired runtime contract and remains a docs-only change.

Acceptance criteria:
- Reserved dispatch input contract: met; the obsolete empty-input statement is replaced and the old wording is absent.
- Workspace identity gate: met; final cancelled state, persisted diagnostics, run show/logs behavior, and unconditional ORBIT_ROOT clearing are documented.
- Redirected root decision: met; direct path comparison and refusal of a different resolved root are explicit.
- No source behavior changes and ci-fast: met; only the requested documentation file changed and make ci-fast passed.

Validation:
- make ci-fast: passed (exit 0; the compiler-cache namespace subcheck reported an environment-limited skip because bubblewrap could not create an unprivileged mount namespace).
- git diff --check: passed.
- GIT_OPTIONAL_LOCKS=0 git status --short: passed; only docs/design/routines/2_design.md is modified.
- Complete diff review: passed; no source files or unrelated materials changed.

Remaining risks or deviations: None. Changes left uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12033-6aa25a92`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra