### PR TITLE
Read lock-holder metadata atomically without following swapped symlinks

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -160,7 +160,7 @@ extensions:
           "manual",
         ]
       - [
-          "orbit_common::fs::file_lock::validated_lock_holder_path",
+          "orbit_common::fs::file_lock::validated_lock_holder_parent",
           "ReturnValue.Field[core::option::Option::Some(0)]",
           "path-injection",
           "manual",

--- a/crates/orbit-common/src/fs/file_lock.rs
+++ b/crates/orbit-common/src/fs/file_lock.rs
@@ -161,32 +161,114 @@ pub(crate) fn acquire_shared_file_lock(
 /// Read advisory holder metadata. Missing, empty, torn, and legacy files are
 /// intentionally reported as no metadata because the OS lock is authoritative.
 pub fn read_file_lock_holder(lock_path: &Path) -> Option<FileLockHolderInfo> {
-    let validated = validated_lock_holder_path(lock_path)?;
+    read_file_lock_holder_with_hook(lock_path, |_| {})
+}
+
+/// Test-only seam that runs `before_open` between path resolution and the
+/// no-follow open, so a test can deterministically swap the resolved final
+/// component for a symlink and prove the open still rejects it [ORB-12029].
+#[cfg(test)]
+pub(crate) fn read_file_lock_holder_after_resolve<F>(
+    lock_path: &Path,
+    before_open: F,
+) -> Option<FileLockHolderInfo>
+where
+    F: FnOnce(&Path),
+{
+    read_file_lock_holder_with_hook(lock_path, before_open)
+}
+
+fn read_file_lock_holder_with_hook(
+    lock_path: &Path,
+    before_open: impl FnOnce(&Path),
+) -> Option<FileLockHolderInfo> {
+    let mut file = open_lock_holder_file(lock_path, before_open)?;
     let mut raw = String::new();
-    File::open(validated).ok()?.read_to_string(&mut raw).ok()?;
+    file.read_to_string(&mut raw).ok()?;
     serde_json::from_str(&raw).ok()
 }
 
-/// Resolve `lock_path` through its canonical parent directory and require the
-/// final component to already exist as a regular, non-symlinked file.
+/// Resolve `lock_path`'s parent directory to its canonical form.
 ///
-/// `lock_path` reaches this function as a caller-selected value (a task lock,
-/// a store lock) with no upstream containment check, so canonicalizing the
-/// parent and rejecting a symlinked or non-regular final component keeps the
-/// read confined to the resolved parent directory instead of a planted
-/// symlink's target [ORB-11953]. `None` covers "nothing to read", matching
-/// this function's existing no-metadata-on-missing-file semantics.
-fn validated_lock_holder_path(lock_path: &Path) -> Option<PathBuf> {
+/// `lock_path` reaches this crate as a caller-selected value (a task lock, a
+/// store lock) with no upstream containment check. Canonicalizing only the
+/// parent — not the final component — keeps the read confined to the
+/// resolved parent directory while still accepting a trusted parent alias
+/// (for example a checkout projection symlink) [ORB-11953]. Deciding whether
+/// the final component itself is safe to read is [`open_lock_holder_file`]'s
+/// job, not this function's: resolving that here and handing back a path
+/// left a window between this check and the caller's open where the final
+/// component could be swapped for a symlink [ORB-12029].
+fn validated_lock_holder_parent(lock_path: &Path) -> Option<PathBuf> {
+    lock_path.parent()?.canonicalize().ok()
+}
+
+/// Open `lock_path`'s final component for a read-only diagnostic read
+/// without following a symlink planted there.
+///
+/// The pathname `symlink_metadata` check below is a fast rejection for the
+/// common case (missing file, directory, or already-a-symlink) so this
+/// avoids blocking on an exotic node such as a FIFO; it is *not* the security
+/// boundary. That boundary is the open immediately after: on Unix,
+/// `O_NOFOLLOW` makes the open itself fail if the final component is a
+/// symlink, and the follow-up `metadata()` call is an `fstat` on the
+/// already-open descriptor, re-checking the file that was actually opened
+/// rather than a path that could have changed again. Folding the check and
+/// the open into one function, with the open re-validating its own
+/// descriptor, closes the window a caller-visible "validated path" handed to
+/// a separate `File::open` left open [ORB-12029]. `None` covers "nothing to
+/// read", matching this function's existing no-metadata-on-missing/malformed
+/// -target semantics.
+///
+/// This secures only the final path component. [`validated_lock_holder_parent`]
+/// resolving the parent supports a trusted parent alias; it does not claim to
+/// stop a party who can write to that parent from renaming or replacing the
+/// lock file's directory entry through some other, ancestor-level race —
+/// only the leaf-symlink swap this closes.
+///
+/// The no-follow open is atomic against the leaf swap on Unix (`O_NOFOLLOW`)
+/// and on Windows (`FILE_FLAG_OPEN_REPARSE_POINT`, which opens a reparse
+/// point itself instead of its target). On any other platform the open
+/// follows a symlink normally, so the pathname pre-check above is the only
+/// protection and a swap landing between that check and the open is not
+/// covered there.
+fn open_lock_holder_file(lock_path: &Path, before_open: impl FnOnce(&Path)) -> Option<File> {
     let file_name = lock_path.file_name()?;
-    let parent = lock_path.parent()?;
-    let canonical_parent = parent.canonicalize().ok()?;
+    let canonical_parent = validated_lock_holder_parent(lock_path)?;
     let candidate = canonical_parent.join(file_name);
 
     match std::fs::symlink_metadata(&candidate) {
-        Ok(metadata) if metadata.is_file() => Some(candidate),
-        _ => None,
+        Ok(metadata) if metadata.is_file() => {}
+        _ => return None,
     }
+
+    before_open(&candidate);
+
+    let mut options = OpenOptions::new();
+    options.read(true);
+    apply_read_only_no_follow(&mut options);
+    let file = options.open(&candidate).ok()?;
+    let metadata = file.metadata().ok()?;
+    metadata.is_file().then_some(file)
 }
+
+#[cfg(unix)]
+fn apply_read_only_no_follow(options: &mut OpenOptions) {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    options.custom_flags(libc::O_NOFOLLOW);
+}
+
+#[cfg(windows)]
+fn apply_read_only_no_follow(options: &mut OpenOptions) {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+}
+
+#[cfg(not(any(unix, windows)))]
+fn apply_read_only_no_follow(_options: &mut OpenOptions) {}
 
 fn open_lock_file(lock_path: &Path, label: &str) -> io::Result<File> {
     let mut options = OpenOptions::new();

--- a/crates/orbit-common/src/fs/tests/io.rs
+++ b/crates/orbit-common/src/fs/tests/io.rs
@@ -121,6 +121,99 @@ fn private_append_rejects_a_final_symlink() {
     );
 }
 
+#[test]
+fn read_file_lock_holder_parses_a_regular_holder_file() {
+    let temp = TempDir::new().expect("tempdir");
+    let lock_path = temp.path().join(".task.yaml.lock");
+    std::fs::write(
+        &lock_path,
+        br#"{"pid":7,"acquired_at":"2026-01-01T00:00:00Z","label":"holder"}"#,
+    )
+    .expect("write holder file");
+
+    let holder = read_file_lock_holder(&lock_path).expect("holder metadata");
+    assert_eq!(holder.pid, 7);
+    assert_eq!(holder.label, "holder");
+}
+
+/// Platform-neutral coverage for the supported non-Unix path: without
+/// `O_NOFOLLOW`, the reject-a-non-regular-final-component behavior still
+/// comes from the pathname pre-check and the post-open `fstat`, so a
+/// directory at the lock path is refused everywhere, not just on Unix.
+#[test]
+fn read_file_lock_holder_returns_none_for_a_directory_lock_path() {
+    let temp = TempDir::new().expect("tempdir");
+    let lock_path = temp.path().join("dir.lock");
+    std::fs::create_dir(&lock_path).expect("create directory");
+
+    assert!(
+        read_file_lock_holder(&lock_path).is_none(),
+        "a directory must never be read as holder metadata"
+    );
+}
+
+#[test]
+fn read_file_lock_holder_returns_none_for_malformed_json() {
+    let temp = TempDir::new().expect("tempdir");
+    let lock_path = temp.path().join(".task.yaml.lock");
+    std::fs::write(&lock_path, b"not json").expect("write malformed holder");
+
+    assert!(read_file_lock_holder(&lock_path).is_none());
+}
+
+#[test]
+fn read_file_lock_holder_returns_none_for_a_missing_lock_file() {
+    let temp = TempDir::new().expect("tempdir");
+    let lock_path = temp.path().join(".missing.lock");
+
+    assert!(read_file_lock_holder(&lock_path).is_none());
+}
+
+/// [ORB-12029]: the previous implementation checked `symlink_metadata` on the
+/// resolved candidate and opened it in a later, unguarded `File::open` — a
+/// final component swapped to a symlink in between would be followed by that
+/// open, exposing the swapped target's content. This deterministically
+/// installs that swap between path resolution and the open (rather than
+/// relying on a real race window) to prove `O_NOFOLLOW` rejects it instead of
+/// reading through.
+#[cfg(unix)]
+#[test]
+fn read_file_lock_holder_rejects_a_final_symlink_swapped_after_the_path_check() {
+    use crate::fs::file_lock::read_file_lock_holder_after_resolve;
+
+    let root = tempfile::tempdir().expect("root tempdir");
+    let lock_path = root.path().join(".task.yaml.lock");
+    let checked_body = br#"{"pid":1,"acquired_at":"2026-01-01T00:00:00Z","label":"checked"}"#;
+    std::fs::write(&lock_path, checked_body).expect("write checked holder");
+
+    let outside = tempfile::tempdir().expect("outside tempdir");
+    let outside_path = outside.path().join("outside.json");
+    let outside_body = br#"{"pid":2,"acquired_at":"2026-01-01T00:00:00Z","label":"outside"}"#;
+    std::fs::write(&outside_path, outside_body).expect("write outside holder");
+
+    let preserved_path = root.path().join("checked-holder.json");
+
+    let holder = read_file_lock_holder_after_resolve(&lock_path, |checked_path| {
+        std::fs::rename(checked_path, &preserved_path).expect("preserve checked holder");
+        std::os::unix::fs::symlink(&outside_path, checked_path).expect("install swapped symlink");
+    });
+
+    assert!(
+        holder.is_none(),
+        "the no-follow open must reject the swapped final symlink"
+    );
+    assert_eq!(
+        std::fs::read(&preserved_path).expect("read preserved checked holder"),
+        checked_body,
+        "the originally checked file must be untouched"
+    );
+    assert_eq!(
+        std::fs::read(&outside_path).expect("read outside holder"),
+        outside_body,
+        "the outside file must never be read or written through the swap"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn read_file_lock_holder_rejects_a_symlinked_lock_file() {


### PR DESCRIPTION
## Task

[ORB-12029](https://orbit-cli.com/tasks/ORB-12029) — Read lock-holder metadata atomically without following swapped symlinks

### Description

Current agent-main18a08c190 contains ORB-11953 commit105d0e0b8, yet CodeQL414 at file_lock.rs166 and415 at185 remain. validated_lock_holder_path canonicalizes a parent and symlink_metadata checks a regular final component, then read_file_lock_holder separately File::open follows the pathname. A swapped final symlink between check and open can expose external metadata; helper-internal pre-probe flow also remains. Repair the actual open/read boundary using a read-only opened descriptor and appropriate no-follow/containment mechanics. Inspect parent/ancestor races too and clearly state the supported authority boundary; do not claim leaf O_NOFOLLOW secures mutable ancestors by itself. Preserve trusted parent aliases and advisory None behavior. Do not reuse open_private_file, which chmods, for read-only metadata diagnostics. Keep modeling narrow and source-proven, no broad taint barriers or alert suppression.

### Acceptance Criteria

- Regular lock-holder metadata still parses; absent/malformed/unreadable targets retain documented advisory behavior without mutating file mode/content.
- Initial final symlinks and deterministic validation-to-open symlink swaps cannot expose external content; tests exercise the opened-descriptor boundary and supported parent-alias/ancestor behavior.
- Unix read-only no-follow semantics are atomic, with explicit supported behavior and coverage for non-Unix paths rather than an unqualified cross-platform claim.
- Focused tests, make ci-fast and make ci-lint pass; hosted CodeQL414/415 closes on the merged repair without relocating the same unvalidated flow.

## Execution Summary

<details>
<summary>Click to expand</summary>

Closed the check-then-open race CodeQL414/415 flagged in `crates/orbit-common/src/fs/file_lock.rs`.

Root cause: `validated_lock_holder_path` canonicalized the parent and `symlink_metadata`-checked the final component, then returned a `PathBuf` that `read_file_lock_holder` opened in a separate, unguarded `File::open` — a final component swapped to a symlink between those two calls would be followed, exposing external content.

Fix (mirrors the same-day ORB-12019 pattern in `orbit-registry::host_identity`):
- Split `validated_lock_holder_path` into `validated_lock_holder_parent` (canonicalizes only the parent — the containment/parent-alias boundary) and a new `open_lock_holder_file` that folds the final-component check and the read into one function: a pathname `symlink_metadata` pre-check (fast-path only, avoids blocking opens on exotic nodes like FIFOs) is followed immediately by an open with `O_NOFOLLOW` (Unix) / `FILE_FLAG_OPEN_REPARSE_POINT` (Windows), then a post-open `fstat`-based `metadata().is_file()` re-check on the *opened descriptor* — the actual security boundary, since it re-validates the file that was really opened rather than a path that could have changed again. No pathname is round-tripped through a public "validated path" anymore, and no chmod/mutation is applied (does not reuse `open_private_file`).
- Added a `#[cfg(test)]` `read_file_lock_holder_after_resolve` hook (same seam pattern as `open_existing_host_toml_with_hook`) so a test can deterministically install a symlink swap between path resolution and the open, rather than relying on a real race window.
- Documented the supported boundary: parent canonicalization intentionally accepts trusted parent aliases (checkout-projection symlinks); it does not claim to stop an ancestor-directory-level rename/replace race, only the leaf-symlink swap. The no-follow open is atomic on Unix/Windows; other platforms fall back to the pathname pre-check only, stated explicitly rather than claimed as cross-platform-atomic.
- Updated `.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml`: renamed the manual barrier-model entry from `validated_lock_holder_path` to `validated_lock_holder_parent` to track the actual containment boundary in the new code shape (no broad taint suppression added).

Acceptance criteria:
1. Regular/absent/malformed/non-regular lock-holder targets: covered by new platform-neutral tests `read_file_lock_holder_parses_a_regular_holder_file`, `read_file_lock_holder_returns_none_for_a_directory_lock_path`, `read_file_lock_holder_returns_none_for_malformed_json`, `read_file_lock_holder_returns_none_for_a_missing_lock_file` in `crates/orbit-common/src/fs/tests/io.rs`. No file mode/content mutation (plain `.read(true)` open, no `open_private_file`).
2. Initial-final-symlink and deterministic validation-to-open swap: existing `read_file_lock_holder_rejects_a_symlinked_lock_file` plus new `read_file_lock_holder_rejects_a_final_symlink_swapped_after_the_path_check` (uses the hook to swap the checked file for a symlink between resolution and open, asserts `None` and that neither the preserved original nor the outside target is read/written). Parent-alias/ancestor behavior covered by existing `read_file_lock_holder_reads_through_a_symlinked_parent_route`.
3. Unix no-follow semantics documented and proven atomic via the deterministic swap test (Unix-gated, since only Unix/Windows have the syscall-level primitive); non-Unix behavior documented explicitly in doc comments (no unqualified cross-platform claim) and covered by the new platform-neutral (non-`cfg(unix)`) tests above, which exercise the same function on any host.
4. `cargo test -p orbit-common` (255 passed, including all fs::tests::io cases), `make ci-fast` (fmt-check + guardrails) and `make ci-lint` (workspace clippy, warnings denied) all passed locally. `git status --short` / `git diff --check` clean — only the three intended files changed, no stray artifacts.

Scope: touched exactly the three context_files (file_lock.rs, path-validation.yml, tests/io.rs); no other files modified.

Remaining risk: hosted CodeQL414/415 closure is orchestrator-verified post-merge per the task's standing note (hosted security/CI verification is orchestrator-owned), not locally reproducible from this workspace.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12029-6aa25b4a`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra