### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/auditability/specs/actor-identity.md
+++ b/docs/design/auditability/specs/actor-identity.md
@@ -2,7 +2,7 @@
 type: design
 summary: "Spec: Canonical Audit Actor Identity"
 tags: ["auditability"]
-last_validated: 2026-08-16
+last_validated: 2026-09-10
 ---
 
 # Spec: Canonical Audit Actor Identity

--- a/docs/design/auditability/specs/self-reported-actor.md
+++ b/docs/design/auditability/specs/self-reported-actor.md
@@ -2,7 +2,7 @@
 type: design
 summary: "Spec: Self-Reported Actor Identity for Unauthenticated MCP Calls"
 tags: ["auditability"]
-last_validated: 2026-08-16
+last_validated: 2026-09-10
 ---
 
 # Spec: Self-Reported Actor Identity for Unauthenticated MCP Calls

--- a/docs/design/resident-orchestrator/1_overview.md
+++ b/docs/design/resident-orchestrator/1_overview.md
@@ -1,8 +1,8 @@
 ---
 title: Resident Orchestrator — Overview
 owner: codex, grok, claude
-last_updated: 2026-08-15
-last_validated: 2026-08-15
+last_updated: 2026-09-10
+last_validated: 2026-09-10
 status: Draft
 feature: resident-orchestrator
 doc_role: overview
@@ -17,11 +17,9 @@ related_artifacts: [ORB-10332, ORB-10775, ORB-10776, ORB-10779, ORB-10788, ORB-1
 # Resident Orchestrator — Overview
 
 > **Status: Draft, landing incrementally.** This folder specifies the v2 contract ([ORB-10815]).
-> The epic worktree and the sequential child drain are **live** ([ORB-10816]); the epic agent,
-> epic-scoped completion with inlined delivery, and the drain window are **not yet built**. Until
-> they are, one auto tick still takes one action and `decision: hold` still freezes auto-ship
-> behind an in-progress epic. Each child task flips its own section's claims to live behavior in
-> the PR that implements it — see the status column in [§3](#3-at-a-glance).
+> The epic worktree, sequential child drain, epic finisher, epic-scoped completion, and drain
+> window are live. Each child task can still flip its own section's claims as behavior changes —
+> see the status column in [§3](#3-at-a-glance).
 > [§10](./2_design.md#10-what-v1-did-and-why-it-changed) records what v1 did.
 
 V1 is two Orbit jobs, not one command. V2 keeps that split and changes what each job *is*.
@@ -41,9 +39,11 @@ The window gates starting new work, never in-flight work. Loose leaves and an ep
 concurrently whenever their `context_files` do not overlap; the epic excludes what it actually
 touches by holding one reservation, not by freezing the workspace.
 
-The **clock** that fires either job is not an Orbit routine. A cron (or a human, or a front-door
-session) on a separate knowledgebase checkout, with Orbit MCP wired in, calls `orbit run auto` or
-`orbit run job epic_pipeline`. Selection still lives there.
+The **resident supervisor clock** that fires `epic_pipeline` directly is not an Orbit routine. A
+cron (or a human, or a front-door session) on a separate knowledgebase checkout, with Orbit MCP
+wired in, calls `orbit run auto` or `orbit run job epic_pipeline`. A workspace may instead opt
+into the existing `ship_sweep` routine, which invokes the `workspace_ship_pipeline` wrapper.
+Selection still lives there.
 
 ## 1. Motivation
 
@@ -86,15 +86,18 @@ children finish on their own.
 
 **Conflict admission.** An `epic`-tagged root holds one reservation over the union of its
 descendants' `context_files` — live since [ORB-10816] via `lock_context_files_for_task`. Loose
-leaves are then admitted by the ordinary overlap check. Deleting `decision: hold` so that check is
-the *only* gate is [ORB-10819]; until then `hold` still short-circuits it.
+leaves are then admitted by the ordinary overlap check. The former `decision: hold` gate was
+deleted by [ORB-10819], so conflict-free leaves continue while an epic is active.
 
 **Session log.** Workspace-scoped append-only notebook, kinds `status`, `note`, `check_later`.
 Unresolved `check_later` rows are a scan wake reason. This is the memory between fires;
 conversation resume stays out of scope. The store is an internal Core capability; the
-`orbit.session_log.*` agent tools were withdrawn ([ORB-11097]).
+`orbit.session_log.*` agent tools were withdrawn ([ORB-11097]). In the v2 epic path, the finisher
+may edit its owned worktree directly; children remain optional.
 
-**External clock.** Cron / knowledgebase supervisor / front door. Not a seeded Orbit routine.
+**External clock.** Cron / knowledgebase supervisor / front door for a resident supervisor. No
+seeded routine directly targets the resident jobs; the optional `ship_sweep` routine wraps the
+workspace drain.
 
 **Epic tag.** Supervisor delegation for a root body of work ([Epic tag is a supervisor delegation signal, not the job predicate](./4_decisions.md#epic-tag-is-a-supervisor-delegation-signal-not-the-job-predicate)). It is **not** `epic_pipeline`'s pickup
 key. It **is** the leaf-ship exclusion key: auto `list_backlog` skips the root and its descendants,
@@ -111,9 +114,9 @@ and explicit ship of the root is refused.
 | `scan_unresolved_work` + `epic_pipeline` v1 | catalog | [ORB-10779] | live |
 | Epic owns one worktree; children land sequentially | [An epic owns one worktree and one branch](./4_decisions.md#an-epic-owns-one-worktree-and-one-branch) | [ORB-10816] | live |
 | Epic reservation over the descendant context union | `lock_context_files_for_task` | [ORB-10816] | live |
-| Epic agent edits the tree instead of dispatching | [The epic agent works in the worktree instead of dispatching](./4_decisions.md#the-epic-agent-works-in-the-worktree-instead-of-dispatching) | [ORB-10817] | planned |
-| Epic-scoped completion + inlined delivery | [Epic completion is epic-scoped](./4_decisions.md#epic-completion-is-epic-scoped-not-workspace-scoped) | [ORB-10818] | planned |
-| Drain window, no `hold`, detached epic dispatch | [Auto drains for a window instead of taking one action](./4_decisions.md#auto-drains-for-a-window-instead-of-taking-one-action) | [ORB-10819] | planned |
+| Epic agent edits the tree instead of dispatching | [The epic agent works in the worktree instead of dispatching](./4_decisions.md#the-epic-agent-works-in-the-worktree-instead-of-dispatching) | [ORB-10817] | live |
+| Epic-scoped completion + inlined delivery | [Epic completion is epic-scoped](./4_decisions.md#epic-completion-is-epic-scoped-not-workspace-scoped) | [ORB-10818] | live |
+| Drain window, no `hold`, detached epic dispatch | [Auto drains for a window instead of taking one action](./4_decisions.md#auto-drains-for-a-window-instead-of-taking-one-action) | [ORB-10819] | live |
 | Child delivery inside an epic | `task_local_pipeline` onto the epic branch | [ORB-10816] | live |
 | HTTP epic retirement | removed assets | [ORB-10332] | live |
 

--- a/docs/design/resident-orchestrator/3_vision.md
+++ b/docs/design/resident-orchestrator/3_vision.md
@@ -2,7 +2,7 @@
 title: Resident Orchestrator — Vision
 owner: codex, grok, claude
 last_updated: 2026-08-15
-last_validated: 2026-08-15
+last_validated: 2026-09-10
 status: Draft
 feature: resident-orchestrator
 doc_role: vision

--- a/docs/design/resident-orchestrator/4_decisions.md
+++ b/docs/design/resident-orchestrator/4_decisions.md
@@ -1,8 +1,8 @@
 ---
 title: Resident Orchestrator — Decisions
 owner: codex, grok, claude
-last_updated: 2026-08-15
-last_validated: 2026-08-15
+last_updated: 2026-09-10
+last_validated: 2026-09-10
 status: Draft
 feature: resident-orchestrator
 doc_role: decisions
@@ -85,14 +85,17 @@ wake the scan forever. A file in the knowledgebase cron repo is the wrong worksp
 
 Give the workspace an append-only `orbit.session_log` with kinds `status`, `note`, and
 `check_later`. Unresolved `check_later` entries are a `scan_unresolved_work` wake reason.
-`status`/`note` are not. Resolve is the only mutation besides append. The orchestrator
-does not edit repository files; code changes are child tasks it creates and ships.
+`status`/`note` are not. Resolve is the only mutation besides append. The session log is an
+internal Core capability; the `orbit.session_log.*` agent tools are not part of the public tool
+surface. In the v2 epic path, the finisher may edit its owned worktree directly, while child tasks
+remain the decomposition path when useful.
 
 ### Consequences
 
-- Next fire starts with `session_log.list` + the task/run scan, not a provider session id.
-- Cost: another noun and three tools. Reminders the orchestrator forgets to `resolve`
-  will keep waking the drain until someone does.
+- The workspace scan still includes unresolved `check_later` entries; no provider session id is
+  required to resume the durable work state.
+- Cost: another internal noun and durable store. Unresolved reminders still keep waking the
+  drain until the owning operator resolves them; the former public agent tools are withdrawn.
 
 ## Drain scan excludes `epic_pipeline` runs
 
@@ -140,16 +143,17 @@ Keep `orbit run ship` a leaf implementer. Auto `list_backlog` skips any task tha
 is `tag: epic` or has such an ancestor (`epic_root` / `epic_child`). Explicit ship
 of an epic root is refused before worktree setup; explicit ship of an epic child
 stays allowed (the orchestrator path). Logistics live in a new job,
-`workspace_auto_pipeline`, invoked as `orbit run auto`: drain loose leaves first;
-if an epic root is `in-progress`, hold; else start exactly one backlog epic via
-`epic_pipeline`. Do not seed a routine ([The supervisor clock is not an Orbit primitive](#the-supervisor-clock-is-not-an-orbit-primitive) still holds). Do not scope
+`workspace_auto_pipeline`, invoked as `orbit run auto`: each window iteration re-lists and drains
+loose leaves; when no epic run is active, it starts at most one backlog epic via
+`epic_pipeline`. Do not seed a routine that directly targets these resident jobs ([The supervisor clock is not an Orbit primitive](#the-supervisor-clock-is-not-an-orbit-primitive) still holds). Do not scope
 `scan_unresolved_work` to one epic in this change.
 
 ### Consequences
 
 - Two auto verbs. Muscle memory `orbit run ship` no longer starts an epic; operators
   who want logistics use `orbit run auto`.
-- An in-progress epic blocks all auto-ship, including late-arriving loose chores.
+- An in-progress epic blocks only overlapping loose leaves; conflict-free chores can continue
+  during the drain window.
 - Cost: a third catalog job and a new CLI verb. Untagged backlog can still race if
   someone fires both `orbit run ship` and `epic_pipeline` on the same workspace.
 
@@ -201,7 +205,7 @@ race that fast-forward.
 
 ## The epic agent works in the worktree instead of dispatching
 
-**Recorded:** 2026-08 · [ORB-10817] · **Not yet implemented**
+**Recorded:** 2026-08 · [ORB-10817] · **Implemented**
 
 ### Context
 
@@ -259,7 +263,7 @@ worktree via its own `worktree_setup`.
 
 ## Auto drains for a window instead of taking one action
 
-**Recorded:** 2026-08 · [ORB-10819] · **Not yet implemented** (the epic reservation it relies on is live from [ORB-10816])
+**Recorded:** 2026-08 · [ORB-10819] · **Implemented** (the epic reservation it relies on is live from [ORB-10816])
 
 ### Context
 
@@ -276,8 +280,9 @@ mid-tick.
 `orbit run auto --for <duration>` drains for a caller-supplied window: re-list admissible
 work each iteration, ship it, sleep when idle, stop starting new work when the deadline
 passes. Absent or zero preserves the one-tick behavior. The deadline gates starting work
-only; in-flight children finish because `invoke_and_wait` blocks on them. `epic_pipeline`
-is dispatched **detached** and re-observed each iteration. `decision: hold` is deleted —
+only; in-flight children finish on their own because detached child runs are not cancelled.
+`epic_pipeline` and leaf pipelines are dispatched **detached** and re-observed each iteration.
+`decision: hold` is deleted —
 an in-progress epic holds one reservation over the union of its descendants'
 `context_files`, and loose leaves are admitted by the existing overlap check.
 

--- a/docs/design/routines/1_overview.md
+++ b/docs/design/routines/1_overview.md
@@ -1,8 +1,8 @@
 ---
 title: Routines — Overview
 owner: claude
-last_updated: 2026-08-15
-last_validated: 2026-08-15
+last_updated: 2026-09-10
+last_validated: 2026-09-10
 status: Accepted
 feature: routines
 doc_role: overview
@@ -17,10 +17,11 @@ related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ORB-1
 # Routines — Overview
 
 Routines make Orbit the constellation's single scheduler. A **routine** is a durable,
-git-versioned definition of recurring work — a cron trigger, a target from the existing
-activity/job catalog, host pinning, and a retry/overlap policy. A stateless **`orbit sweep`**
-pass, invoked every minute by the OS scheduler (launchd on macOS, a systemd timer on Linux),
-fires whatever is due on the current host through the existing v2 run machinery. Definitions
+git-versioned definition of recurring work — a cron trigger, a job target from the existing
+catalog, host pinning, and a retry/overlap policy. A stateless **`orbit sweep`**
+pass, invoked on the configured OS schedule (one minute by default, via launchd on macOS or a
+systemd timer on Linux), fires whatever is due on the current host through the existing v2 run
+machinery. Definitions
 are shared across hosts via git; all scheduler state (last fires, pauses, locks, run history)
 is host-local and never synced. [2_design.md](./2_design.md) is the v1 contract;
 [3_vision.md](./3_vision.md) holds what is deliberately out of scope for v1.
@@ -32,7 +33,8 @@ is host-local and never synced. [2_design.md](./2_design.md) is the v1 contract;
 > scheduler, validation, and dispatch kernels.
 
 `orbit workspace init` creates the complete default set (`auto_task_scheduler`,
-`task_triage`, `task_pilot`, `ship_sweep`, `worktree_gc`, and `ci_failure_sweep`) under
+`ci_failure_sweep`, `dependabot_alert_sweep`, `task_triage`, `task_pilot`, `ship_sweep`, and
+`worktree_gc`) under
 `.orbit/routines/`. Every default is `enabled: false`: scheduled execution is an explicit,
 versioned opt-in made by changing the reviewed definition to `enabled: true`. Re-init
 creates newly introduced missing defaults but never rewrites existing routine files; those
@@ -74,8 +76,8 @@ fragmentation this feature exists to end.
   `job:<name>`; `activity:<name>` is reserved (wrap the activity in a one-step job — see
   [Routine targets are catalog references only — no inline command payloads](./4_decisions.md#routine-targets-are-catalog-references-only-no-inline-command-payloads)). Routines carry no inline commands; the `shell` activity variant was
   removed fail-closed in [ORB-00374] (see [The v2 shell activity surface is removed, not sandboxed](../activity-job/4_decisions.md#the-v2-shell-activity-surface-is-removed-not-sandboxed)), and routines inherit that posture.
-- **Sweep** — `orbit sweep`, the stateless due-check pass the OS clock invokes every minute.
-  Loads definitions, filters for this host, fires due routines, records state, exits.
+- **Sweep** — `orbit sweep`, the stateless due-check pass the OS clock invokes on its configured
+  cadence. Loads definitions, filters for this host, fires due routines, records state, exits.
 - **Routine source** — a registered workspace whose config opts in with
   `[routines] role = "source"`. The constellation convention is a single source (polaris),
   but the mechanism permits several.
@@ -92,14 +94,14 @@ fragmentation this feature exists to end.
 
 | Concern | File | Task |
 |---------|------|------|
-| Routine definition type + fail-closed YAML parse | `crates/orbit-common/src/types/routine.rs` | [ORB-10021] |
+| Routine definition type + fail-closed YAML parse | `crates/orbit-types/src/workflow/routine.rs` | [ORB-10021] |
 | Registry-neutral loading, due computation, dispatch, status, and pin validation | `crates/orbit-core/src/application/routines/` | [ORB-10021], [ORB-10270] |
 | Local identity/catalog composition, workspace discovery, and runtime construction | `crates/orbit-cmd/src/registry_routines.rs`, `crates/orbit-cmd/src/registry_runtime.rs`, `crates/orbit-registry/src/` | [ORB-10270], [ORB-10319] |
 | Host-local scheduler state (fires, pauses) | `crates/orbit-store/src/sqlite/routine_store/` | [ORB-10021] |
 | Sweep advisory lock (flock, host-global) | `crates/orbit-store/src/sqlite/routine_store/mod.rs` | [ORB-10021] |
 | `orbit sweep` CLI entrypoint | `crates/orbit-cli/src/command/sweep.rs` | [ORB-10021] |
-| `orbit routine` CLI (`list/show/pause/resume/init`) | `crates/orbit-cli/src/command/routine/` | [ORB-10021] |
-| launchd/systemd unit templates + installer | `crates/orbit-core/assets/clock/` + `src/routines/clock.rs` | [ORB-10021] |
+| `orbit routine` CLI (`list/show/pause/resume/init/clock`) | `crates/orbit-cli/src/command/routine/` | [ORB-10021] |
+| launchd/systemd unit templates + installer | `crates/orbit-core/assets/clock/` + `crates/orbit-core/src/application/routines/clock.rs` | [ORB-10021] |
 | `[routines] role = "source"` config key | `crates/orbit-config/src/{raw,resolved}.rs` | [ORB-10021] |
 | Disabled default routine seeding + workspace ship wrapper | `crates/orbit-core/assets/{routines,jobs}/` | [ORB-10207] / [Delegate workspace ship routines through a synchronous wrapper job](./4_decisions.md#delegate-workspace-ship-routines-through-a-synchronous-wrapper-job) |
 


### PR DESCRIPTION
## Task

[ORB-11894](https://orbit-cli.com/tasks/ORB-11894) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: completed the exact six-document batch selected by missing-then-oldest last_validated. Enumeration of in-scope docs showed the six declared context files were the oldest dated entries: docs/design/resident-orchestrator/1_overview.md, 3_vision.md, and 4_decisions.md (2026-08-15), docs/design/routines/1_overview.md (2026-08-15), then docs/design/auditability/specs/actor-identity.md and self-reported-actor.md (2026-08-16 path-order tie break). All six already had schema-compatible frontmatter; no frontmatter migration was needed. Each selected document now has last_validated: 2026-09-10.

Verification and changes:
- resident-orchestrator/1_overview.md: checked current epic_pipeline.yaml, workspace_auto_pipeline.yaml, epic_orchestrator.yaml, drain_window.yaml, backlog admission/lock code, public session-log tests, and orbit run auto --help. Corrected stale not-built/planned claims, current epic finisher and drain-window status, conflict-free leaf admission, session-log/public-tool wording, and the external resident clock versus optional ship_sweep wrapper.
- resident-orchestrator/3_vision.md: checked the current resident-orchestrator assets and implementation surface; no prose drift requiring correction was found, so only the earned validation stamp changed.
- resident-orchestrator/4_decisions.md: checked current epic/workspace pipeline assets, workspace_auto.rs, admission/lock behavior, dispatch code, and public-tool tests. Corrected implemented status, internal/withdrawn session-log tooling, epic-scoped completion behavior, detached window draining, and overlapping-leaf behavior.
- routines/1_overview.md: checked orbit-types workflow/routine.rs, application/routine.rs and routines/clock.rs, routine assets, and orbit routine --help. Corrected the routine type and clock paths, the seven seeded defaults including dependabot_alert_sweep, configured OS cadence wording, and the clock command entry. The existing summary was retained because docs/INDEX.md is generated and forbidden by scope to modify.
- auditability/specs/actor-identity.md: checked audit_actor.rs, migration ledger/current migration modules, audit event aggregation, and web/CLI audit consumers; no prose correction was needed.
- auditability/specs/self-reported-actor.md: checked self-reported actor normalization, MCP initialize claim precedence, migration, CLI output, and web attribution consumers; no prose correction was needed.

Claims not observable from this checkout, including production 30-day percentages/counts in the audit docs, were left unchanged and are explicitly unvalidated; no selected document was stamped without source-based verification of its implementation claims. No frontmatter-less document was selected. No new metadata field, sidecar, document, or section was introduced; prose was not reflowed. Only the six selected docs changed, and no forbidden/generated path changed.

Validation:
- make ci-fast: passed (exit 0). The compiler-cache namespace guard reported its bounded environment skip because bwrap could not create a non-privileged mount namespace; the guard suite still passed.
- git diff --check: passed.
- git diff --name-only and GIT_OPTIONAL_LOCKS=0 git status --short: passed; both show only the six selected documentation files.
- Full merge-gate make ci was not run because workspace guidance reserves it for CI; remaining risk is limited to that CI-only environment coverage.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11894-6aa25b6a`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra