### PR TITLE
[code-review] Restore honest validation dates for audit documents with unverified production measurements

### DIFF
--- a/docs/design/auditability/specs/actor-identity.md
+++ b/docs/design/auditability/specs/actor-identity.md
@@ -2,7 +2,7 @@
 type: design
 summary: "Spec: Canonical Audit Actor Identity"
 tags: ["auditability"]
-last_validated: 2026-09-10
+last_validated: 2026-08-16
 ---
 
 # Spec: Canonical Audit Actor Identity

--- a/docs/design/auditability/specs/self-reported-actor.md
+++ b/docs/design/auditability/specs/self-reported-actor.md
@@ -2,7 +2,7 @@
 type: design
 summary: "Spec: Self-Reported Actor Identity for Unauthenticated MCP Calls"
 tags: ["auditability"]
-last_validated: 2026-09-10
+last_validated: 2026-08-16
 ---
 
 # Spec: Self-Reported Actor Identity for Unauthenticated MCP Calls


### PR DESCRIPTION
## Task

[ORB-12046](https://orbit-cli.com/tasks/ORB-12046) — [code-review] Restore honest validation dates for audit documents with unverified production measurements

### Description

ORB11894 PR1864/60aad249 stamped both auditability docs last_validated2026-09-10 while its own execution summary explicitly leaves production30-day percentages/counts unvalidated. Independent source audit confirms these are empirical statements: actor-identity.md10-25 says measured on production audit database; self-reported-actor.md10-27 claims92.5%,1373unverified/112attributed and provenance of those112. Source code cannot prove that production observation. The source task requires unverified docs to remain unstamped, so fresh dates incorrectly claim completed validation.

Restore only these two validation dates to their exact pre-ORB11894 values, verified from its parent diff. Preserve the existing empirical prose and other validated implementation edits; do not rewrite history, invent new production metrics or count current data as proof of an unidentified historical window. Do not query or mutate production audit data for this narrow correction. Record clearly why verification was partial. The remaining four documented validation stamps are not in this repair scope. Current resident-orchestrator/4_decisions.md is a current design doc, not a historical ADR, so no ADR-related change is requested.

### Acceptance Criteria

- Both affected last_validated values match the exact pre-ORB11894 values, or are absent only if originally absent; no fresh validation is claimed for unverified empirical observations.
- Only those two metadata values change; empirical prose, other docs and implementation remain intact. Persist explanation of unverified historical production evidence in the task summary.
- Verify parent/current diff and run make ci-fast; no production fixture or audit mutations.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Restored `last_validated` in `docs/design/auditability/specs/actor-identity.md` and `docs/design/auditability/specs/self-reported-actor.md` from the incorrect 2026-09-10 stamp to the exact pre-ORB11894 value 2026-08-16.
- No empirical prose, implementation, other documentation, or production/audit fixtures were changed. The 30-day production measurements remain historical, unverified evidence; this task did not query or mutate production data.
Assessment: All acceptance criteria are satisfied. Parent/current comparison confirmed exactly these two metadata changes and preserved the empirical claims. `make ci-fast` passed; its compiler-cache namespace subcheck reported an environment limitation (bubblewrap cannot create an unprivileged mount namespace) but the guardrail command completed successfully.
Validation:
- `git diff HEAD^ HEAD -- docs/design/auditability/specs/actor-identity.md docs/design/auditability/specs/self-reported-actor.md`: passed; parent showed 2026-08-16 and ORB-11894 changed only those two dates to 2026-09-10.
- `make ci-fast`: passed.
- `git diff --check`: passed.
- `GIT_OPTIONAL_LOCKS=0 git status --short`: passed; only the two scoped specs are modified.
Risks / deviations: Production metrics were intentionally not revalidated because the historical production window and source data are not available in this task; no fresh validation is claimed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12046-6aa26039`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra