### PR TITLE
Open docs configuration through a race-safe read boundary

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -4,12 +4,6 @@ extensions:
       extensible: barrierModel
     data:
       - [
-          "orbit_core::application::docs::config::validated_docs_config_path",
-          "ReturnValue.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]",
-          "path-injection",
-          "manual",
-        ]
-      - [
           "orbit_core::bootstrap::global_defaults::validated_stamp_path",
           "ReturnValue.Field[core::result::Result::Ok(0)]",
           "path-injection",

--- a/crates/orbit-core/src/application/docs/config.rs
+++ b/crates/orbit-core/src/application/docs/config.rs
@@ -1,5 +1,14 @@
 use std::ffi::OsStr;
-use std::path::{Path, PathBuf};
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+#[cfg(unix)]
+use std::ffi::{CString, OsString};
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd};
+#[cfg(unix)]
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
 
 use serde::Deserialize;
 
@@ -162,54 +171,254 @@ pub(super) fn read_task_context_docs_roots_from_config_path(
 }
 
 fn read_config_contents(path: &Path) -> Result<Option<String>, OrbitError> {
-    let Some(path) = validated_docs_config_path(path)? else {
+    let Some(mut file) = open_docs_config(path)? else {
         return Ok(None);
     };
 
-    let raw = std::fs::read_to_string(&path)
+    let mut raw = String::new();
+    file.read_to_string(&mut raw)
         .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
     Ok(Some(raw))
 }
 
-/// Return a canonical config path only after proving it is the regular,
-/// fixed-name file directly beneath its canonical parent.
-///
-/// The CodeQL extension models this return value as a path-injection barrier.
-/// Keep its checks and the model in sync when changing this function.
-fn validated_docs_config_path(path: &Path) -> Result<Option<PathBuf>, OrbitError> {
-    if !path.exists() {
-        return Ok(None);
+fn docs_config_parent(path: &Path) -> Result<&Path, OrbitError> {
+    if path.file_name() != Some(OsStr::new(CONFIG_FILE_NAME)) {
+        return Err(OrbitError::InvalidInput(format!(
+            "docs config path must name {CONFIG_FILE_NAME}: {}",
+            path.display()
+        )));
     }
-
     let parent = path.parent().ok_or_else(|| {
         OrbitError::InvalidInput(format!(
             "invalid config path without parent: {}",
             path.display()
         ))
     })?;
-    let canonical_parent = parent.canonicalize().map_err(|error| {
+
+    Ok(parent)
+}
+
+/// Open the fixed config leaf relative to a held descriptor for its resolved parent.
+///
+/// Existing directory aliases are deliberately resolved before the descriptor is
+/// opened. Once open, that directory inode is the authority: renaming an ancestor
+/// cannot redirect the leaf open. `O_NOFOLLOW` makes the final `config.toml` lookup
+/// atomic with opening it, while `O_NONBLOCK` prevents a planted FIFO from hanging
+/// the reader before its file type can be rejected. This does not promise that a
+/// caller-controlled parent chosen before this function is itself trustworthy.
+#[cfg(unix)]
+fn open_docs_config(path: &Path) -> Result<Option<File>, OrbitError> {
+    let parent = docs_config_parent(path)?;
+    let expected_parent = match parent.metadata() {
+        Ok(metadata) if metadata.is_dir() => metadata,
+        Ok(_) => {
+            return Err(OrbitError::InvalidInput(format!(
+                "docs config parent must be a directory: {}",
+                parent.display()
+            )));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "inspect docs config directory '{}': {error}",
+                parent.display()
+            )));
+        }
+    };
+    let canonical_parent = match parent.canonicalize() {
+        Ok(parent) => parent,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "canonicalize docs config directory '{}': {error}",
+                parent.display()
+            )));
+        }
+    };
+
+    #[cfg(test)]
+    docs_config_test_hook::run(
+        docs_config_test_hook::Phase::ParentValidated,
+        &canonical_parent,
+    );
+
+    let directory = open_docs_config_directory(&canonical_parent)?;
+    let opened_parent = directory.metadata().map_err(|error| {
         OrbitError::Io(format!(
-            "canonicalize config directory {}: {error}",
-            parent.display()
+            "inspect opened docs config directory '{}': {error}",
+            canonical_parent.display()
         ))
     })?;
-    let canonical_path = path.canonicalize().map_err(|error| {
-        OrbitError::Io(format!(
-            "canonicalize config path {}: {error}",
+    use std::os::unix::fs::MetadataExt;
+    if expected_parent.dev() != opened_parent.dev() || expected_parent.ino() != opened_parent.ino()
+    {
+        return Err(OrbitError::InvalidInput(format!(
+            "docs config directory changed while it was opened: {}",
+            parent.display()
+        )));
+    }
+
+    #[cfg(test)]
+    docs_config_test_hook::run(docs_config_test_hook::Phase::BeforeLeafOpen, path);
+
+    open_docs_config_at(&directory, path)
+}
+
+#[cfg(unix)]
+fn open_docs_config_directory(path: &Path) -> Result<File, OrbitError> {
+    let path_c = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        OrbitError::InvalidInput(format!(
+            "docs config directory contains an invalid null byte: {}",
             path.display()
         ))
     })?;
-    if !canonical_path.starts_with(&canonical_parent)
-        || canonical_path.file_name() != Some(OsStr::new(CONFIG_FILE_NAME))
-        || !canonical_path.is_file()
-    {
+    let flags = libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW;
+    let fd = unsafe { libc::open(path_c.as_ptr(), flags) };
+    if fd < 0 {
+        let error = std::io::Error::last_os_error();
+        if matches!(error.raw_os_error(), Some(code) if code == libc::ELOOP || code == libc::ENOTDIR)
+        {
+            return Err(OrbitError::InvalidInput(format!(
+                "docs config directory changed or became a symlink while it was opened: {}",
+                path.display()
+            )));
+        }
+        return Err(OrbitError::Io(format!(
+            "open docs config directory '{}': {error}",
+            path.display()
+        )));
+    }
+
+    Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+#[cfg(unix)]
+fn open_docs_config_at(directory: &File, path: &Path) -> Result<Option<File>, OrbitError> {
+    let file_name = c"config.toml";
+    let flags = libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK;
+    let fd = unsafe { libc::openat(directory.as_raw_fd(), file_name.as_ptr(), flags) };
+    if fd < 0 {
+        let error = std::io::Error::last_os_error();
+        if error.kind() == std::io::ErrorKind::NotFound {
+            return Ok(None);
+        }
+        if error.raw_os_error() == Some(libc::ELOOP) {
+            let destination = read_docs_config_symlink_target(directory)
+                .map(|target| format!(" -> {}", target.to_string_lossy()))
+                .unwrap_or_default();
+            return Err(OrbitError::InvalidInput(format!(
+                "docs config path must not be a symlink: {}{destination}",
+                path.display()
+            )));
+        }
+        return Err(OrbitError::Io(format!(
+            "open docs config '{}': {error}",
+            path.display()
+        )));
+    }
+
+    let file = unsafe { File::from_raw_fd(fd) };
+    let metadata = file.metadata().map_err(|error| {
+        OrbitError::Io(format!("inspect docs config '{}': {error}", path.display()))
+    })?;
+    if !metadata.is_file() {
         return Err(OrbitError::InvalidInput(format!(
             "docs config path must be a regular {CONFIG_FILE_NAME} file: {}",
             path.display()
         )));
     }
 
-    Ok(Some(canonical_path))
+    Ok(Some(file))
+}
+
+#[cfg(unix)]
+fn read_docs_config_symlink_target(directory: &File) -> Option<OsString> {
+    let file_name = c"config.toml";
+    let mut bytes = vec![0_u8; 256];
+    loop {
+        let length = unsafe {
+            libc::readlinkat(
+                directory.as_raw_fd(),
+                file_name.as_ptr(),
+                bytes.as_mut_ptr().cast(),
+                bytes.len(),
+            )
+        };
+        if length < 0 {
+            return None;
+        }
+        let length = usize::try_from(length).ok()?;
+        if length < bytes.len() {
+            bytes.truncate(length);
+            return Some(OsString::from_vec(bytes));
+        }
+        if bytes.len() >= 65_536 {
+            return None;
+        }
+        bytes.resize(bytes.len() * 2, 0);
+    }
+}
+
+/// Non-Unix platforms lack the descriptor-relative no-follow primitive used
+/// above. Reject an initially visible symlink or non-regular leaf, then open it
+/// read-only. A concurrent replacement between inspection and open can still be
+/// followed on these platforms; callers that require the Unix race guarantee
+/// must not treat this fallback as an authority boundary.
+#[cfg(not(unix))]
+fn open_docs_config(path: &Path) -> Result<Option<File>, OrbitError> {
+    docs_config_parent(path)?;
+    match path.symlink_metadata() {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(OrbitError::InvalidInput(
+            format!("docs config path must not be a symlink: {}", path.display()),
+        )),
+        Ok(metadata) if !metadata.is_file() => Err(OrbitError::InvalidInput(format!(
+            "docs config path must be a regular {CONFIG_FILE_NAME} file: {}",
+            path.display()
+        ))),
+        Ok(_) => File::open(path).map(Some).map_err(|error| {
+            OrbitError::Io(format!("open docs config '{}': {error}", path.display()))
+        }),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(OrbitError::Io(format!(
+            "inspect docs config '{}': {error}",
+            path.display()
+        ))),
+    }
+}
+
+#[cfg(all(test, unix))]
+pub(super) mod docs_config_test_hook {
+    use std::cell::RefCell;
+    use std::path::Path;
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    pub(crate) enum Phase {
+        ParentValidated,
+        BeforeLeafOpen,
+    }
+
+    type Hook = Box<dyn FnOnce(&Path)>;
+
+    thread_local! {
+        static HOOK: RefCell<Option<(Phase, Hook)>> = RefCell::new(None);
+    }
+
+    pub(crate) fn set(phase: Phase, hook: impl FnOnce(&Path) + 'static) {
+        HOOK.with(|slot| *slot.borrow_mut() = Some((phase, Box::new(hook))));
+    }
+
+    pub(super) fn run(phase: Phase, path: &Path) {
+        HOOK.with(|slot| {
+            let should_run = slot
+                .borrow()
+                .as_ref()
+                .is_some_and(|(hook_phase, _)| *hook_phase == phase);
+            if should_run {
+                let (_, hook) = slot.borrow_mut().take().expect("hook checked as present");
+                hook(path);
+            }
+        });
+    }
 }
 
 /// Parse the task-context docs roots (used by related_docs_for_task and its tests).

--- a/crates/orbit-core/src/application/docs/tests/config.rs
+++ b/crates/orbit-core/src/application/docs/tests/config.rs
@@ -2,10 +2,14 @@
 
 use std::fs;
 #[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
 use std::os::unix::fs::symlink;
 
 use tempfile::tempdir;
 
+#[cfg(unix)]
+use super::super::config::docs_config_test_hook::{self, Phase};
 use super::super::config::{
     DocsRoot, parse_docs_roots_from_config_toml, parse_docs_search_config_from_config_toml,
     parse_task_context_docs_roots_from_config_toml, read_docs_roots_from_config_path,
@@ -107,14 +111,26 @@ fn config_reader_accepts_the_workspace_config_file() {
 }
 
 #[test]
-fn config_reader_rejects_an_existing_non_config_file() {
+fn config_reader_preserves_defaults_when_config_is_missing() {
+    let root = tempdir().expect("create tempdir");
+
+    let roots = read_docs_roots_from_config_path(&root.path().join("config.toml"))
+        .expect("missing config uses defaults");
+
+    assert_eq!(root_paths(&roots), vec!["docs/"]);
+}
+
+#[test]
+fn config_reader_rejects_a_non_config_file_name_even_when_missing() {
     let root = tempdir().expect("create tempdir");
     let path = root.path().join("secrets.txt");
-    fs::write(&path, "[docs]\nroots = [\"guides/\"]\n").expect("write fixture");
 
     let error = read_docs_roots_from_config_path(&path).expect_err("reject non-config path");
 
-    assert!(error.to_string().contains("config.toml"));
+    assert!(
+        error.to_string().contains("must name config.toml"),
+        "{error}"
+    );
 }
 
 #[cfg(unix)]
@@ -128,5 +144,181 @@ fn config_reader_rejects_a_config_symlink_to_another_file() {
 
     let error = read_docs_roots_from_config_path(&path).expect_err("reject config symlink");
 
-    assert!(error.to_string().contains("config.toml"));
+    assert!(
+        error.to_string().contains("must not be a symlink"),
+        "{error}"
+    );
+    assert!(error.to_string().contains("secrets.toml"), "{error}");
+}
+
+#[cfg(unix)]
+#[test]
+fn config_reader_rejects_a_config_symlink_to_same_named_external_file() {
+    let root = tempdir().expect("create tempdir");
+    let outside = tempdir().expect("create outside tempdir");
+    let target = outside.path().join("config.toml");
+    let path = root.path().join("config.toml");
+    fs::write(&target, "[docs]\nroots = [\"external/\"]\n").expect("write fixture");
+    symlink(&target, &path).expect("create config symlink");
+
+    let error = read_docs_roots_from_config_path(&path).expect_err("reject config symlink");
+    let diagnostic = error.to_string();
+
+    assert!(diagnostic.contains("must not be a symlink"), "{diagnostic}");
+    assert!(
+        diagnostic.contains(&target.to_string_lossy().into_owned()),
+        "{diagnostic}"
+    );
+    assert!(!diagnostic.contains("regular config.toml"), "{diagnostic}");
+}
+
+#[cfg(unix)]
+#[test]
+fn config_reader_accepts_a_directory_alias_for_the_fixed_config_leaf() {
+    let root = tempdir().expect("create tempdir");
+    let real = root.path().join("real");
+    let alias = root.path().join("alias");
+    fs::create_dir(&real).expect("create real config directory");
+    fs::write(real.join("config.toml"), "[docs]\nroots = [\"aliased/\"]\n").expect("write config");
+    symlink(&real, &alias).expect("create directory alias");
+
+    let roots = read_docs_roots_from_config_path(&alias.join("config.toml"))
+        .expect("read through supported directory alias");
+
+    assert_eq!(root_paths(&roots), vec!["aliased/"]);
+}
+
+#[cfg(unix)]
+#[test]
+fn config_reader_rejects_a_leaf_swapped_for_a_symlink_before_open() {
+    let root = tempdir().expect("create tempdir");
+    let outside = tempdir().expect("create outside tempdir");
+    let path = root.path().join("config.toml");
+    let target = outside.path().join("config.toml");
+    fs::write(&path, "[docs]\nroots = [\"inside/\"]\n").expect("write inside config");
+    fs::write(&target, "[docs]\nroots = [\"external/\"]\n").expect("write outside config");
+    let path_for_hook = path.clone();
+    let target_for_hook = target.clone();
+    docs_config_test_hook::set(Phase::BeforeLeafOpen, move |_| {
+        fs::remove_file(&path_for_hook).expect("remove validated config");
+        symlink(&target_for_hook, &path_for_hook).expect("swap config for symlink");
+    });
+
+    let error = read_docs_roots_from_config_path(&path).expect_err("reject swapped symlink");
+
+    assert!(
+        error.to_string().contains("must not be a symlink"),
+        "{error}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn config_reader_rejects_a_parent_swapped_after_validation() {
+    let root = tempdir().expect("create tempdir");
+    let authority = root.path().join("authority");
+    let moved_authority = root.path().join("moved-authority");
+    let outside = root.path().join("outside");
+    fs::create_dir(&authority).expect("create authority");
+    fs::create_dir(&outside).expect("create outside directory");
+    fs::write(
+        authority.join("config.toml"),
+        "[docs]\nroots = [\"inside/\"]\n",
+    )
+    .expect("write inside config");
+    fs::write(
+        outside.join("config.toml"),
+        "[docs]\nroots = [\"external/\"]\n",
+    )
+    .expect("write outside config");
+    let authority_for_hook = authority.clone();
+    let moved_for_hook = moved_authority.clone();
+    let outside_for_hook = outside.clone();
+    docs_config_test_hook::set(Phase::ParentValidated, move |_| {
+        fs::rename(&authority_for_hook, &moved_for_hook).expect("move validated authority");
+        symlink(&outside_for_hook, &authority_for_hook).expect("redirect authority path");
+    });
+
+    let error = read_docs_roots_from_config_path(&authority.join("config.toml"))
+        .expect_err("reject changed parent authority");
+
+    assert!(
+        error.to_string().contains("changed or became a symlink")
+            || error
+                .to_string()
+                .contains("directory changed while it was opened"),
+        "{error}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn config_reader_keeps_the_opened_parent_authority_when_its_path_is_swapped() {
+    let root = tempdir().expect("create tempdir");
+    let authority = root.path().join("authority");
+    let moved_authority = root.path().join("moved-authority");
+    let outside = root.path().join("outside");
+    fs::create_dir(&authority).expect("create authority");
+    fs::create_dir(&outside).expect("create outside directory");
+    fs::write(
+        authority.join("config.toml"),
+        "[docs]\nroots = [\"inside/\"]\n",
+    )
+    .expect("write inside config");
+    fs::write(
+        outside.join("config.toml"),
+        "[docs]\nroots = [\"external/\"]\n",
+    )
+    .expect("write outside config");
+    let authority_for_hook = authority.clone();
+    let moved_for_hook = moved_authority.clone();
+    let outside_for_hook = outside.clone();
+    docs_config_test_hook::set(Phase::BeforeLeafOpen, move |_| {
+        fs::rename(&authority_for_hook, &moved_for_hook).expect("move opened authority");
+        symlink(&outside_for_hook, &authority_for_hook).expect("redirect former authority path");
+    });
+
+    let roots = read_docs_roots_from_config_path(&authority.join("config.toml"))
+        .expect("read from held parent authority");
+
+    assert_eq!(root_paths(&roots), vec!["inside/"]);
+}
+
+#[cfg(unix)]
+#[test]
+fn config_reader_rejects_non_regular_leaf_without_blocking() {
+    let root = tempdir().expect("create tempdir");
+    let path = root.path().join("config.toml");
+    let path_c = std::ffi::CString::new(path.as_os_str().as_encoded_bytes())
+        .expect("fixture path contains no null");
+    let result = unsafe { libc::mkfifo(path_c.as_ptr(), 0o600) };
+    assert_eq!(
+        result,
+        0,
+        "create fifo: {}",
+        std::io::Error::last_os_error()
+    );
+
+    let error = read_docs_roots_from_config_path(&path).expect_err("reject fifo config");
+
+    assert!(error.to_string().contains("regular config.toml"), "{error}");
+}
+
+#[cfg(unix)]
+#[test]
+fn config_reader_opens_read_only_without_changing_permissions() {
+    let root = tempdir().expect("create tempdir");
+    let path = root.path().join("config.toml");
+    fs::write(&path, "[docs]\nroots = [\"readonly/\"]\n").expect("write config");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o400)).expect("make config read-only");
+
+    let roots = read_docs_roots_from_config_path(&path).expect("read read-only config");
+    let mode = fs::metadata(&path)
+        .expect("inspect config")
+        .permissions()
+        .mode()
+        & 0o777;
+
+    assert_eq!(root_paths(&roots), vec!["readonly/"]);
+    assert_eq!(mode, 0o400);
 }


### PR DESCRIPTION
## Task

[ORB-12030](https://orbit-cli.com/tasks/ORB-12030) — Open docs configuration through a race-safe read boundary

### Description

Current agent-main18a08c190 contains ORB-11960 commit5d592fee5, but CodeQL384 remains at docs config.rs180 path.exists inside the validator. Source additionally checks a final path then separately read_to_string follows that path, so replacing it with a symlink between validation and read escapes the check. Verify the exact current owning path before implementation. Derive the trusted/canonical directory and fixed config.toml child, then open/read through a descriptor-based no-follow boundary rather than another check-then-open. Assess mutable parent/ancestor races and preserve supported aliases; leaf-only O_NOFOLLOW must not be described as protecting mutable ancestors. Missing file remains the documented default, while rejected targets/errors follow the intended config contract. Do not chmod on read or weaken CodeQL with broad barriers/suppression.

## Review finding consolidation (ORB-12036)
Keep the explicit distinction: trusted canonicalized directory aliases are supported; a final config.toml symlink is rejected at the read boundary, including when its destination is also named config.toml. Do not accept arbitrary external content solely because its basename matches. Diagnostics must identify the final symlink as the objection and safely report destination/resolution when available, rather than misleadingly calling the target non-regular. Cover this same-name target regression and keep runtime12023 consumer policy consistent.

### Acceptance Criteria

- Valid regular config parses and missing config retains default behavior; fixed config.toml naming and supported directory aliases remain compatible.
- Initial final symlinks and deterministic validation-to-read swaps cannot cause external reads; tests establish the actual parent/leaf authority boundary and non-regular handling.
- Read-only descriptor semantics do not mutate files; Unix and non-Unix guarantees/limitations are explicit and tested appropriately.
- Focused docs tests, make ci-fast and make ci-lint pass; hosted CodeQL384 closes on the merged repair without shifting an unvalidated sink.
- A final config.toml symlink to another same-named config.toml is rejected before content read with an explicit symlink diagnostic; safely report destination when available. Tests cover this distinct case and accepted canonical directory aliases. Runtime12023 shares the deliberate final-leaf policy.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced the docs config path-validation/read split with a Unix descriptor boundary: resolve accepted parent aliases, capture and verify the parent inode, open the fixed config.toml leaf with O_NOFOLLOW and O_NONBLOCK, reject non-regular leaves, and read from the already-open read-only file.
- Added an explicit non-Unix fallback contract that rejects initially visible symlinks and non-regular files while documenting that concurrent replacement cannot be excluded there.
- Added deterministic tests for parent and leaf swaps, held-parent authority, same-name external symlinks and safe target diagnostics, directory aliases, missing defaults, fixed filenames, FIFO rejection, valid parsing, and unchanged read-only permissions.
- Removed the obsolete CodeQL barrier model for validated_docs_config_path; the former path-returning validator and later path sink no longer exist.

Acceptance criteria:
1. Valid regular config parsing, missing-file defaults, fixed config.toml naming, and canonicalized directory aliases are covered by focused passing tests.
2. Initial and swapped final symlinks are rejected before read; parent swaps before descriptor acquisition fail, while swaps after acquisition continue through the held original directory descriptor. FIFO/non-regular handling is covered.
3. Unix opens are read-only/no-follow/nonblocking and a permissions-preservation test passes. The source explicitly documents the weaker non-Unix check-then-open limitation; portable valid/missing/name tests remain active there.
4. Focused docs tests, make ci-fast, and make ci-lint pass. Hosted CodeQL 384 was not run locally and remains the orchestrator-owned post-merge check; its obsolete barrier entry was removed instead of moving the sink.
5. Same-name external config.toml symlinks receive an explicit symlink diagnostic with the descriptor-relative destination when available. Runtime validated_config_path was inspected and already shares the deliberate policy of canonical directory aliases plus rejection of a final symlink, so no out-of-scope runtime edit was needed.

Validation:
- passed: cargo fmt --all -- --check
- passed: cargo test -p orbit-core application::docs::tests::config (16 passed)
- passed: make ci-fast (command exit 0; its mount-namespace cache subcheck reported the expected environment skip because unprivileged namespaces are unavailable)
- passed: make ci-lint
- passed: git diff --check
- passed: GIT_OPTIONAL_LOCKS=0 git status --short; only the three task-scoped context files are modified

Assessment: The read now has one canonical Unix execution path with the security decision enforced by open descriptors rather than a check-then-read path. The test hook exposes the precise parent-validation and leaf-open phases without production behavior.
Remaining risks: Hosted CodeQL and a real non-Unix build were not available in this Linux worker. The non-Unix race limitation is explicit and does not claim Unix-equivalent authority guarantees.
Deviations from original plan: None.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12030-6aa25daf`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra