### PR TITLE
Validate runtime config root before metadata probing and close CodeQL411

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -10,7 +10,7 @@ extensions:
           "manual",
         ]
       - [
-          "orbit_core::runtime::validated_config_path",
+          "orbit_core::runtime::validated_existing_config_root",
           "ReturnValue.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]",
           "path-injection",
           "manual",

--- a/crates/orbit-cli/src/command/config/path.rs
+++ b/crates/orbit-cli/src/command/config/path.rs
@@ -17,7 +17,7 @@ impl Execute for ConfigPathArgs {
         let path = if self.global {
             global_config_path(runtime)
         } else {
-            runtime.config_path()
+            runtime.config_path()?
         };
         println!("{}", path.to_string_lossy());
         Ok(CommandOutput::Silent)

--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -190,7 +190,16 @@ impl DoctorCommands for OrbitRuntime {
 
 /// Parse + validate the effective (workspace-over-global) `config.toml`.
 fn doctor_check_config(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
-    let path = runtime.config_path();
+    let path = match runtime.config_path() {
+        Ok(path) => path,
+        Err(error) => {
+            return check(
+                "config",
+                WorkspaceDoctorStatus::Error,
+                format!("cannot select effective config: {error}"),
+            );
+        }
+    };
     match orbit_config::validate_layered_config(&orbit_config::ConfigRoots::new(
         runtime.global_root(),
         runtime.data_root(),

--- a/crates/orbit-core/src/application/docs/mod.rs
+++ b/crates/orbit-core/src/application/docs/mod.rs
@@ -43,11 +43,13 @@ use self::walk::walk_docs_with_bodies;
 // that are mechanical (use of super:: paths). All bodies delegate to submodules.
 impl OrbitRuntime {
     pub fn docs_roots(&self) -> Result<Vec<DocsRoot>, OrbitError> {
-        read_docs_roots_from_config_path(&self.config_path())
+        let config_path = self.config_path()?;
+        read_docs_roots_from_config_path(&config_path)
     }
 
     pub fn docs_search_config(&self) -> Result<DocsSearchConfig, OrbitError> {
-        read_docs_search_config_from_config_path(&self.config_path())
+        let config_path = self.config_path()?;
+        read_docs_search_config_from_config_path(&config_path)
     }
 
     pub fn list_docs(
@@ -112,7 +114,8 @@ impl OrbitRuntime {
         task: &Task,
         limit: Option<usize>,
     ) -> Result<Vec<TaskRelatedDoc>, OrbitError> {
-        let roots = read_task_context_docs_roots_from_config_path(&self.config_path())?;
+        let config_path = self.config_path()?;
+        let roots = read_task_context_docs_roots_from_config_path(&config_path)?;
         if roots.is_empty() {
             return Ok(Vec::new());
         }

--- a/crates/orbit-core/src/application/search/tests/hybrid.rs
+++ b/crates/orbit-core/src/application/search/tests/hybrid.rs
@@ -173,7 +173,7 @@ fn global_search_doc_hybrid_uses_docs_semantic_weight() {
 
     let top_path = |weight: f32| {
         fs::write(
-            runtime.config_path(),
+            runtime.config_path().expect("resolve config path"),
             format!("[docs.search]\nsemantic_weight = {weight:.1}\n"),
         )
         .expect("write config");

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -377,17 +377,23 @@ impl OrbitRuntime {
         self.workspace_binding.as_deref()
     }
 
-    /// Returns the effective config.toml path.
-    /// Workspace config replaces global if present; otherwise global.
-    pub fn config_path(&self) -> PathBuf {
+    /// Returns the effective `config.toml` path.
+    ///
+    /// Workspace config replaces global if present; a genuinely missing
+    /// workspace config falls back to global. Rejected workspace entries and
+    /// inspection failures remain visible to the caller instead of silently
+    /// changing precedence. This pathname records selection only; readers must
+    /// still open the file through a race-safe boundary.
+    pub fn config_path(&self) -> Result<PathBuf, OrbitError> {
         let shared_root = self.shared_root();
         let global_root = self.global_root();
         if shared_root != global_root
-            && let Ok(Some(ws_config)) = validated_config_path(&shared_root)
+            && let Some(workspace_config) = existing_workspace_config_path(&shared_root)?
         {
-            return ws_config;
+            return Ok(workspace_config);
         }
-        global_root.join(CONFIG_TOML_FILE)
+
+        Ok(global_root.join(CONFIG_TOML_FILE))
     }
 
     pub fn persistence_config_json(&self) -> Value {
@@ -694,14 +700,15 @@ impl OrbitRuntime {
 
 const CONFIG_TOML_FILE: &str = "config.toml";
 
-/// Resolve an existing workspace `config.toml` through its canonical root.
+/// Resolve an existing config root to the directory selected by the caller.
 ///
-/// The workspace root may be selected by an explicit runtime override
-/// (workspace discovery, `--root`, or an env var), but the file name is
-/// fixed. Canonicalizing the root and rejecting a symlinked result keeps the
-/// resolved path inside the selected root instead of following a planted
-/// symlink to an unintended location [ORB-11931].
-fn validated_config_path(root: &Path) -> Result<Option<PathBuf>, OrbitError> {
+/// Runtime overrides and trusted directory aliases remain supported: an
+/// existing symlinked root resolves to its canonical target. Returning that
+/// validated root before deriving the fixed filename puts the validation
+/// boundary ahead of the child metadata probe. Final-component safety belongs
+/// to the descriptor-based reader; this boundary does not claim protection
+/// against privileged replacement of mutable ancestors.
+fn validated_existing_config_root(root: &Path) -> Result<Option<PathBuf>, OrbitError> {
     let canonical_root = match root.canonicalize() {
         Ok(path) => path,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -712,7 +719,20 @@ fn validated_config_path(root: &Path) -> Result<Option<PathBuf>, OrbitError> {
             )));
         }
     };
-    let candidate = canonical_root.join(CONFIG_TOML_FILE);
+
+    Ok(Some(canonical_root))
+}
+
+/// Select the fixed workspace config leaf after the root validation boundary.
+///
+/// This no-follow metadata probe decides precedence and rejects an already
+/// visible invalid leaf. It does not authorize a later pathname read; config
+/// consumers reopen the selected path through their descriptor-based boundary.
+fn existing_workspace_config_path(root: &Path) -> Result<Option<PathBuf>, OrbitError> {
+    let Some(validated_root) = validated_existing_config_root(root)? else {
+        return Ok(None);
+    };
+    let candidate = validated_root.join(CONFIG_TOML_FILE);
 
     match std::fs::symlink_metadata(&candidate) {
         Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {

--- a/crates/orbit-core/src/runtime/tests/runtime.rs
+++ b/crates/orbit-core/src/runtime/tests/runtime.rs
@@ -9,6 +9,7 @@ use orbit_common::test_env;
 use tempfile::tempdir;
 
 use crate::runtime::assets::DEFAULT_ACTIVITY_FILES;
+use crate::runtime::existing_workspace_config_path;
 
 fn test_runtime() -> (tempfile::TempDir, OrbitRuntime, PathBuf, PathBuf) {
     let root = tempdir().expect("create tempdir");
@@ -32,23 +33,22 @@ fn config_path_prefers_existing_workspace_config_over_global() {
         .canonicalize()
         .expect("canonicalize workspace root")
         .join("config.toml");
-    assert_eq!(runtime.config_path(), expected);
+    assert_eq!(runtime.config_path().expect("select config"), expected);
 }
 
 #[test]
 fn config_path_falls_back_to_global_when_workspace_config_is_absent() {
     let (_root, runtime, global_root, _workspace_root) = test_runtime();
 
-    assert_eq!(runtime.config_path(), global_root.join("config.toml"));
+    assert_eq!(
+        runtime.config_path().expect("select config"),
+        global_root.join("config.toml")
+    );
 }
 
-/// [ORB-11931] A symlinked workspace `config.toml` must not be followed:
-/// resolving through it would let a planted symlink redirect config reads
-/// outside the selected workspace root, so the runtime falls back to the
-/// global config instead of the symlink target.
 #[test]
 #[cfg(unix)]
-fn config_path_falls_back_to_global_when_workspace_config_is_a_symlink() {
+fn config_path_rejects_a_symlink_without_reading_its_external_target() {
     use std::os::unix::fs::symlink;
 
     let (_root, runtime, global_root, workspace_root) = test_runtime();
@@ -56,14 +56,85 @@ fn config_path_falls_back_to_global_when_workspace_config_is_a_symlink() {
         .parent()
         .expect("workspace root has parent")
         .join("outside-config.toml");
+    std::fs::write(
+        global_root.join("config.toml"),
+        "[docs]\nroots = [\"global/\"]\n",
+    )
+    .expect("write global config");
     std::fs::write(&outside_target, "leaked = true\n").expect("write file outside workspace root");
     symlink(&outside_target, workspace_root.join("config.toml"))
         .expect("symlink workspace config.toml");
 
-    let resolved = runtime.config_path();
+    let error = runtime
+        .docs_roots()
+        .expect_err("symlinked workspace config must fail closed");
 
-    assert_eq!(resolved, global_root.join("config.toml"));
-    assert_ne!(resolved, outside_target);
+    let diagnostic = error.to_string();
+    assert!(diagnostic.contains("regular config.toml"), "{diagnostic}");
+    assert!(diagnostic.contains(&workspace_root.display().to_string()));
+    assert!(!diagnostic.contains("invalid docs config"), "{diagnostic}");
+    assert!(global_root.join("config.toml").is_file());
+}
+
+#[test]
+fn config_path_rejects_a_non_regular_workspace_config() {
+    let (_root, runtime, _global_root, workspace_root) = test_runtime();
+    std::fs::create_dir(workspace_root.join("config.toml")).expect("create config directory");
+
+    let error = runtime
+        .config_path()
+        .expect_err("non-regular workspace config must fail closed");
+
+    assert!(error.to_string().contains("regular config.toml"), "{error}");
+}
+
+#[test]
+fn workspace_config_selection_reports_a_non_directory_root() {
+    let root = tempdir().expect("create tempdir");
+    let root_file = root.path().join("not-a-directory");
+    std::fs::write(&root_file, "not a directory").expect("write root file");
+
+    let error = existing_workspace_config_path(&root_file)
+        .expect_err("a config child cannot be selected beneath a file");
+
+    assert!(error.to_string().contains("failed to inspect config path"));
+    assert!(error.to_string().contains("not-a-directory/config.toml"));
+}
+
+#[test]
+fn config_root_validation_treats_a_missing_root_as_absent() {
+    let root = tempdir().expect("create tempdir");
+    let missing = root.path().join("missing");
+
+    assert_eq!(
+        existing_workspace_config_path(&missing).expect("select beneath missing root"),
+        None
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn workspace_config_selection_accepts_a_trusted_root_alias() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempdir().expect("create tempdir");
+    let real_root = root.path().join("real");
+    let alias_root = root.path().join("alias");
+    std::fs::create_dir(&real_root).expect("create real root");
+    std::fs::write(real_root.join("config.toml"), "").expect("write config");
+    symlink(&real_root, &alias_root).expect("create trusted root alias");
+
+    let selected_config = existing_workspace_config_path(&alias_root)
+        .expect("select through trusted alias")
+        .expect("config exists");
+
+    assert_eq!(
+        selected_config,
+        real_root
+            .canonicalize()
+            .expect("canonical root")
+            .join("config.toml")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-12023](https://orbit-cli.com/tasks/ORB-12023) — Validate runtime config root before metadata probing and close CodeQL411

### Description

Completed CodeQL34442427349 at6e7fa99cc72aeab9122785c061436bc28c5c14bb closes earlier runtime alert134 but creates411 at runtime/mod.rs:717 symlink_metadata(&candidate), inside validated_config_path added by ORB11931. Its return barrier does not sanitize the internal metadata sink. Source currently canonicalizes root, appends fixed CONFIG_TOML_FILE, rejects final symlink/non-file. Verify actual security contract and establish a narrow validated root boundary before deriving/probing that child, with accurately scoped CodeQL modeling only after source proof. Similar root-before-probe repair12019 covers registry host identity separately; don't edit its module. Preserve documented workspace-config precedence/global fallback and supported root aliases. Current search/inventory has no open runtime411 repair.

## Additional verified read-boundary requirement
Confirmed runtime/mod.rs704-731 checks canonical workspace root/fixed config.toml and returns a pathname; consumers later read it. A pathname check cannot secure a later open. Coordinate with docs-config ORB-12030, which owns the descriptor-based config reader; runtime owns correct root/precedence/error propagation and safe consumer integration. Preserve documented config_path API where needed but do not claim its returned PathBuf is a safe read capability. The already-confirmed swallowing of all validator errors into global fallback must also be corrected visibly. Wait for ORB-12030 so the existing reader boundary can be reused rather than duplicated.

### Acceptance Criteria

- Remove the unvalidated runtime-root to metadata-probe flow via a demonstrated root validation boundary before child derivation; retain missing-workspace-config fallback, existing regular config precedence, final-symlink rejection and trusted ancestor-alias support.
- Focused runtime config tests cover normal/missing/non-directory roots, trusted aliases, symlink/non-regular config children and no unintended external target access. Do not mask failures by dropping valid config behavior or treating silent fallback as blanket success.
- Run focused runtime tests, make ci-fast, make ci-lint and extension-schema checks if modeled. No broad sanitizer, rule suppression, or alert dismissal.
- Orchestrator verifies both411 and prior134 fixed in hosted Rust CodeQL on merged revision; the fix must not merely relocate the same flow into another helper sink. Record local and hosted evidence separately.
- The content read rejects a swapped final symlink at open time via a read-only descriptor or equivalent validated handle, with a deterministic check-to-swap regression proving no external content is read. Supported root aliases remain valid; Unix/non-Unix behavior and parent/ancestor mutation boundaries are explicit rather than claiming leaf no-follow protects mutable ancestors.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced the full-path CodeQL barrier with `validated_existing_config_root`; the fixed `config.toml` child is derived and probed only after that boundary, and the extension now models the validated root return.
- Made `OrbitRuntime::config_path` fallible. Only an absent workspace root/config falls back globally; symlink, non-regular, non-directory, and inspection errors now remain observable. Updated docs, doctor, CLI, and search-test callers.
- Kept pathname selection separate from read authority. Docs consumers pass the selected path into the descriptor-backed reader delivered at current HEAD by ORB-12030; Unix opens the held canonical parent and final leaf with no-follow/read-only semantics, while its documented non-Unix fallback and mutable-ancestor limitation remain explicit.
- Added focused runtime coverage for regular precedence, missing fallback, non-directory roots, trusted root aliases, non-regular leaves, and a workspace symlink to external content that must error instead of reading the target or silently selecting global config.

Acceptance evidence:
1. `validated_existing_config_root` returns the canonical trusted root before `existing_workspace_config_path` derives or metadata-probes the fixed child. Existing regular precedence and missing fallback pass; final symlinks/non-files error; root aliases pass.
2. Runtime tests cover normal/missing/non-directory/alias/symlink/non-regular cases. The external-target test invokes `docs_roots` and requires the runtime selection error, so following the external target or falling back globally would fail the assertion.
3. Focused tests, both CodeQL extension-schema checks, `make ci-fast`, and `make ci-lint` passed. No sanitizer widening, suppression, or dismissal was added.
4. Local source/model/schema evidence is complete. Hosted Rust CodeQL alerts 411 and prior 134 cannot be verified before pipeline commit/merge; the orchestrator must record that separate post-merge evidence on the merged revision.
5. The ORB-12030 descriptor-reader regression `config_reader_rejects_a_leaf_swapped_for_a_symlink_before_open` passed and proves the external leaf is not read after a deterministic swap. Its alias, parent-swap, FIFO, and read-only tests also passed in the focused reader suite. Runtime docs consumers now propagate config-selection errors into that safe reader rather than treating the PathBuf as a capability.

Validation:
- PASSED: `cargo test -p orbit-core runtime::tests::runtime::config_ -- --nocapture` (6 focused runtime config tests).
- PASSED: `cargo test -p orbit-core workspace_config_selection -- --nocapture` (2 root-boundary tests).
- PASSED: `cargo test -p orbit-core application::docs::tests::config::config_reader_ -- --nocapture` (11 descriptor-reader tests).
- PASSED: `cargo test -p orbit-core application::docs::tests::config::config_reader_rejects_a_leaf_swapped_for_a_symlink_before_open -- --exact`.
- PASSED: `cargo test -p orbit-core global_search_doc_hybrid_uses_docs_semantic_weight -- --nocapture`.
- PASSED: `cargo test -p orbit-cmd invalid_config_fails_the_config_check -- --nocapture`.
- PASSED: `scripts/test-codeql-extension-schema.py`.
- PASSED: `scripts/check-codeql-extension-schema.py` (silent success).
- PASSED: `make ci-fast`; its mount-namespace compiler-cache subcheck reported the expected environment skip because unprivileged namespaces are unavailable, while the overall required command exited successfully.
- PASSED: `make ci-lint`.
- PASSED: `git diff --check`.
- PASSED: `git status --short`; exactly seven task-scoped files are modified.

Assessment: The selection policy is explicit and fail-closed, the modeled boundary precedes the reported metadata sink, and actual content reads retain the descriptor-based final-component protection. The public `config_path` return type intentionally changes to `Result<PathBuf, OrbitError>` so validation failures cannot be silently discarded.

Remaining risk:
- Hosted CodeQL is a post-merge orchestrator gate and was not available locally; both alert identities must be checked on the merged revision.
- The deterministic no-follow race guarantee is Unix-specific. The dependency reader explicitly documents that non-Unix performs inspection plus read-only open but cannot claim the same check/open atomicity.
- No protection is claimed against privileged mutation of ancestors before authority is established; once the Unix parent descriptor is held, later pathname redirection does not change the opened authority.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12023-6aa261a9`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra