### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/operations-as-data/4_decisions.md
+++ b/docs/design/operations-as-data/4_decisions.md
@@ -2,14 +2,14 @@
 title: Operations as Data — Decisions
 owner: claude
 last_updated: 2026-08-16
-last_validated: 2026-08-16
+last_validated: 2026-09-10
 status: Accepted
 feature: operations-as-data
 doc_role: decisions
 type: design
 summary: Decision log for the operations-as-data registry — the split spec/handler table, what stayed hand-written, and the touch-it-move-it ratchet.
 tags: [operations-as-data, architecture, adr-0209]
-paths: ["crates/orbit-common/src/operation.rs", "crates/orbit-common/src/authorization.rs", "crates/orbit-common/src/friction/**", "crates/orbit-tools/src/builtin/orbit/tests/authorization.rs"]
+paths: ["crates/orbit-common/src/governance/operation.rs", "crates/orbit-common/src/governance/authorization.rs", "crates/orbit-common/src/governance/friction/**", "crates/orbit-tools/src/builtin/orbit/tests/authorization.rs"]
 related_features: [operations-as-data]
 related_artifacts: [ORB-10358, ORB-10453, ORB-10478]
 ---
@@ -33,7 +33,7 @@ the ratchet.
 ## Split spec/handler table joined by a typed verb enum
 
 **Recorded:** 2026-07-26 00:55:47.755882Z · [ORB-10358]
-**Paths:** `crates/orbit-common/src/operation.rs`, `crates/orbit-common/src/friction/**`
+**Paths:** `crates/orbit-common/src/governance/operation.rs`, `crates/orbit-common/src/governance/friction/**`
 
 ### Context
  [North-star architecture bearing: operations as data behind an operation registry](../orbit-core/4_decisions.md#north-star-architecture-bearing-operations-as-data-behind-an-operation-registry) bearing 1 describes one operation table holding both the
@@ -72,7 +72,7 @@ verb that is declared but not implemented fails to compile.
 ## Renderers and HTTP routes stay hand-written
 
 **Recorded:** 2026-07-26 00:55:47.967899Z · [ORB-10358]
-**Paths:** `crates/orbit-common/src/operation.rs`, `crates/orbit-common/src/friction/**`
+**Paths:** `crates/orbit-common/src/governance/operation.rs`, `crates/orbit-common/src/governance/friction/**`
 
 ### Context
  Once verbs are data, the obvious next step is to make the rest of
@@ -107,7 +107,7 @@ tool names and parameter names from the registry.
 ## Freeze the pre-migration surface as fixtures before migrating
 
 **Recorded:** 2026-07-26 00:55:48.187121Z · [ORB-10358]
-**Paths:** `crates/orbit-common/src/operation.rs`, `crates/orbit-common/src/friction/**`
+**Paths:** `crates/orbit-common/src/governance/operation.rs`, `crates/orbit-common/src/governance/friction/**`
 
 ### Context
  The pilot's hard requirement was that CLI argv/output and MCP tool
@@ -144,7 +144,7 @@ same role for MCP, where an empty `git diff` is the proof.
 ## Capability chokepoint for destructive operations outside MCP
 
 **Recorded:** 2026-07-26 21:49:30.348935Z · [ORB-10453]
-**Paths:** `crates/orbit-common/src/authorization.rs`, `crates/orbit-core/src/runtime/authorization.rs`, `crates/orbit-core/src/runtime/tool_exec.rs`, `crates/orbit-cli/src/main.rs`, `crates/orbit-cli/src/command/operation.rs`
+**Paths:** `crates/orbit-common/src/governance/authorization.rs`, `crates/orbit-core/src/runtime/authorization.rs`, `crates/orbit-core/src/adapter/tool_execution.rs`, `crates/orbit-cli/src/main.rs`, `crates/orbit-cli/src/command/operation.rs`
 
 ### Context
 
@@ -160,7 +160,7 @@ This is an **accident guard, not a security boundary**. Agents on a development 
 
 1. **Extend the existing capability model; do not add a second one.** `McpCapability` is the vocabulary for every surface. MCP becomes one consumer of the model rather than its owner.
 
-2. **Declare governed operations once, as data.** `orbit_common::authorization::GOVERNED_OPERATIONS` is a const registry of `{ id, surface, allowed: &[McpCapability], rationale }`. Call sites name an operation, never a capability; the requirement is resolved from the registry. It lives in the leaf crate for the same reason the operations-as-data registry does ([North-star architecture bearing: operations as data behind an operation registry](../orbit-core/4_decisions.md#north-star-architecture-bearing-operations-as-data-behind-an-operation-registry) bearing 1): every consumer surface must read it without a new dependency edge.
+2. **Declare governed operations once, as data.** `orbit_common::governance::authorization::GOVERNED_OPERATIONS` is a const registry of `{ id, surface, allowed: &[McpCapability], rationale }`. Call sites name an operation, never a capability; the requirement is resolved from the registry. It lives in the leaf crate for the same reason the operations-as-data registry does ([North-star architecture bearing: operations as data behind an operation registry](../orbit-core/4_decisions.md#north-star-architecture-bearing-operations-as-data-behind-an-operation-registry) bearing 1): every consumer surface must read it without a new dependency edge.
 
 3. **One decision function, one chokepoint per surface.** `authorization::authorize` is the only place the rule is evaluated. It is reached from exactly two enforcement points, each of which its whole surface must traverse: `OrbitRuntime::run_tool_with_context_and_role` for every tool call (CLI `tool run`, the CLI admin bypass, MCP `tools/call`, the dashboard, the v2 deterministic dispatcher, agent loops), and the `Commands::operation` dispatch in `orbit-cli`'s `main` for CLI commands that destroy without a tool. Neither reimplements any part of the rule.
 
@@ -192,7 +192,7 @@ This is an **accident guard, not a security boundary**. Agents on a development 
 ## MCP advertisement is placement; the capability chokepoint is permission
 
 **Recorded:** 2026-08 · [ORB-10478] · **Implemented** in [ORB-10478]
-**Paths:** `crates/orbit-common/src/authorization.rs`, `crates/orbit-common/src/operation.rs`, `crates/orbit-tools/src/builtin/orbit/tests/authorization.rs`
+**Paths:** `crates/orbit-common/src/governance/authorization.rs`, `crates/orbit-common/src/governance/operation.rs`, `crates/orbit-tools/src/builtin/orbit/tests/authorization.rs`
 
 ### Context
 

--- a/docs/design/orbit-core/1_overview.md
+++ b/docs/design/orbit-core/1_overview.md
@@ -2,7 +2,7 @@
 title: Orbit Core — Overview
 owner: codex
 last_updated: 2026-08-16
-last_validated: 2026-08-16
+last_validated: 2026-09-10
 status: Accepted
 feature: orbit-core
 doc_role: overview

--- a/docs/design/routines/references/glossary.md
+++ b/docs/design/routines/references/glossary.md
@@ -1,7 +1,7 @@
 ---
 type: glossary
 summary: Vocabulary for the routines scheduler feature.
-last_validated: 2026-08-16
+last_validated: 2026-09-10
 tags: [routines, scheduler]
 ---
 

--- a/docs/design/task-artifacts/1_overview.md
+++ b/docs/design/task-artifacts/1_overview.md
@@ -4,7 +4,7 @@ type: design
 title: "Task Artifacts — Overview"
 owner: codex
 last_updated: 2026-05-17
-last_validated: 2026-08-16
+last_validated: 2026-09-10
 status: Draft
 feature: task-artifacts
 doc_role: overview
@@ -107,10 +107,10 @@ The canonical bundle lives in the local task store under `~/.orbit/tasks/workspa
 
 | Concern | File | Task |
 |---------|------|------|
-| V2 envelope, relations, JSONL rows, and manifest types | [crates/orbit-common/src/types/task_artifacts.rs](../../../crates/orbit-common/src/types/task_artifacts.rs) | — |
-| Public `Task` DTO (still flat during Phase 6 consumer wiring) | [crates/orbit-common/src/types/task.rs](../../../crates/orbit-common/src/types/task.rs) | — |
-| V2 bundle primitives (file layout, atomic writes, JSONL append) | [crates/orbit-store/src/file/task_store/v2_bundle.rs](../../../crates/orbit-store/src/file/task_store/v2_bundle.rs) | — |
-| V2 task backend adapter (create/get/list/search/mutations) | [crates/orbit-store/src/file/task_store/v2/](../../../crates/orbit-store/src/file/task_store/v2/) | — |
+| V2 envelope, relations, JSONL rows, and manifest types | [crates/orbit-types/src/task/artifacts.rs](../../../crates/orbit-types/src/task/artifacts.rs) | — |
+| Public `Task` DTO | [crates/orbit-types/src/task/model.rs](../../../crates/orbit-types/src/task/model.rs) | — |
+| V2 bundle primitives (file layout, atomic writes, JSONL append) | [crates/orbit-store/src/driver/file/task_bundle/](../../../crates/orbit-store/src/driver/file/task_bundle/) | — |
+| V2 task backend adapter (create/get/list/search/mutations) | [crates/orbit-store/src/repository/task/v2/](../../../crates/orbit-store/src/repository/task/v2/) | — |
 | Home registry: allocator, workspace bindings, generated indexes | [crates/orbit-store/src/sqlite/task_registry/](../../../crates/orbit-store/src/sqlite/task_registry/) | — |
 | V2 runtime wiring (`build_v2_task_backends`) | [crates/orbit-core/src/runtime/builder.rs](../../../crates/orbit-core/src/runtime/builder.rs) | — |
 | Local task store and symlink projection | [2_design.md §6](./2_design.md#6-local-task-store-and-symlink-projection) | — |


### PR DESCRIPTION
## Task

[ORB-12045](https://orbit-cli.com/tasks/ORB-12045) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Selected the exact six oldest in-scope docs after the completed dependency correction. Enumeration used missing-then-date-then-path frontmatter ordering. No in-scope document lacked last_validated; the tied 2026-08-16 batch was, in path order: auditability/specs/actor-identity.md; auditability/specs/self-reported-actor.md; operations-as-data/4_decisions.md; orbit-core/1_overview.md; routines/references/glossary.md; task-artifacts/1_overview.md.
- Left the two auditability specs unchanged and unstamped. Their opening claims are historical production-audit measurements (30-day percentages/counts) and cannot be verified from this checkout; this follows the task comment mandate. No other unverified claim was modified.
- Verified and stamped 2026-09-10: docs/design/operations-as-data/4_decisions.md. Source search across orbit-common governance, orbit-core, and authorization tests confirmed the registry, capability chokepoint, and placement surfaces. Updated moved governance/tool-execution paths and the governed-registry Rust path.
- Verified and stamped 2026-09-10: docs/design/orbit-core/1_overview.md. File enumeration and existence checks confirmed every table path (runtime/application/adapter/bootstrap/composition/context, orbit-cmd registry composition, orbit-registry, and command dispatch); no factual drift found.
- Verified and stamped 2026-09-10: docs/design/routines/references/glossary.md. Source search across routine CLI/core/cmd/registry/store confirmed all glossary definitions; no factual drift found.
- Verified and stamped 2026-09-10: docs/design/task-artifacts/1_overview.md. Source inspection of task types, bundle I/O, v2 repository, and runtime wiring confirmed the model and storage layout. Corrected four stale table paths from retired orbit-common/file-task-store locations to their current owners.

Assessment: The four earned stamps are backed by source inspection; historical production measurements remain deliberately out of rotation until observable evidence is available. No frontmatter-less selected document required migration, no new metadata/sidecar/section/document was introduced, and excluded historical/generated areas were untouched.

Validation:
- make ci-fast: passed (the compiler-cache namespace probe reported its documented non-fatal sandbox skip).
- git diff --check: passed.
- GIT_OPTIONAL_LOCKS=0 git status --short: four intended docs only.

Criteria mapping:
1. Exact six-doc batch selected by missing-then-oldest/date/path ordering: satisfied.
2. Four stamped docs were source-verified as named above: satisfied.
3. Both unobservable auditability docs remained unmodified and unstamped: satisfied.
4. Excluded paths were not modified: satisfied.
5. Missing-frontmatter ordering was implemented in enumeration; none existed in the eligible corpus: satisfied.
6. No selected frontmatter-less docs: not applicable.
7. Unverifiable selected documents were left unchanged: satisfied.
8. No metadata system added: satisfied.
9. No document or section authored: satisfied.
10. Diff contains only metadata/path corrections, with no prose reflow: satisfied.
11. make ci-fast passed: satisfied.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12045-6aa263ad`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra