### PR TITLE
[code-review] Use the active drain's custom candidate-pool limit in readiness diagnostics

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
@@ -376,6 +376,109 @@ fn readiness_uses_the_classifier_candidate_pool() {
 }
 
 #[test]
+fn readiness_uses_the_active_drain_candidate_pool_for_a_conflict_free_tail() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "crates/shared/src/lib.rs");
+    write_workspace_file(&repo_root, "crates/outside/src/lib.rs");
+
+    let mut task_ids = (0..50)
+        .map(|index| {
+            seed_list_backlog_task(
+                &runtime,
+                &format!("Conflicting candidate {index}"),
+                TaskStatus::Backlog,
+                TaskPriority::Medium,
+                TaskType::Chore,
+                None,
+                vec!["crates/shared/src/lib.rs"],
+            )
+            .id
+        })
+        .collect::<Vec<_>>();
+    let outside_pool = seed_list_backlog_task(
+        &runtime,
+        "Conflict-free task after the candidate pool",
+        TaskStatus::Backlog,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        None,
+        vec!["crates/outside/src/lib.rs"],
+    );
+    task_ids.push(outside_pool.id.clone());
+
+    let drain_run_id = seed_running_drain_input(
+        &runtime,
+        json!({ "max_active_leaf_runs": 4, "max_tasks": "51" }),
+    );
+    let classified = classify_with(
+        &runtime,
+        json!({
+            "run_id": drain_run_id,
+            "max_active_leaf_runs": 4,
+            "max_tasks": "51",
+        }),
+    );
+    let readiness = runtime
+        .workspace_auto_readiness(&task_ids, None, 51, &[])
+        .expect("explain readiness");
+    let readiness_admitted = readiness["tasks"]
+        .as_array()
+        .expect("readiness tasks")
+        .iter()
+        .filter(|task| task["eligible"] == true)
+        .map(|task| task["task_id"].clone())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        &readiness_admitted,
+        classified["loose_task_ids"]
+            .as_array()
+            .expect("classified task ids")
+    );
+    assert_eq!(readiness["capacity"]["candidate_pool_size"], 51);
+    assert_eq!(readiness["capacity"]["candidate_pool_truncated"], false);
+    assert_eq!(
+        readiness_task(&readiness, &outside_pool.id)["reason"],
+        "ready"
+    );
+    assert_eq!(
+        readiness_task(&readiness, &outside_pool.id)["eligible"],
+        true
+    );
+}
+
+#[test]
+fn readiness_candidate_pool_parsing_matches_classifier_for_numeric_and_string_one() {
+    for max_tasks in [json!(1), json!("1")] {
+        let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+        let tasks = seed_backlog_leaves(&runtime, 2);
+        let drain_run_id = seed_running_drain_input(
+            &runtime,
+            json!({ "max_active_leaf_runs": 2, "max_tasks": max_tasks }),
+        );
+        let input = json!({
+            "run_id": drain_run_id,
+            "max_active_leaf_runs": 2,
+            "max_tasks": max_tasks,
+        });
+
+        let classified = classify_with(&runtime, input);
+        let readiness = runtime
+            .workspace_auto_readiness(&tasks, None, tasks.len(), &[])
+            .expect("explain readiness");
+
+        assert_eq!(classified["candidate_pool_size"], 1);
+        assert_eq!(readiness["capacity"]["candidate_pool_size"], 1);
+        assert_eq!(classified["loose_task_ids"], json!([tasks[0]]));
+        assert_eq!(readiness_task(&readiness, &tasks[0])["reason"], "ready");
+        assert_eq!(
+            readiness_task(&readiness, &tasks[1])["reason"],
+            "outside_candidate_pool"
+        );
+    }
+}
+
+#[test]
 fn epic_descendants_are_dependency_then_dispatch_ordered_and_terminal_tasks_are_skipped() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
     let epic = runtime

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
@@ -429,7 +429,11 @@ pub fn explain_workspace_auto_readiness(
     // [ORB-11973] Use the classifier's identical ordered prefix and admission
     // routine, so readiness explains the wave the drain would actually admit
     // rather than a second guess at it.
-    let candidate_pool_size = usize::try_from(DEFAULT_CANDIDATE_POOL).unwrap_or(usize::MAX);
+    let candidate_pool_size = match active_drain.as_ref() {
+        Some(drain) => candidate_pool_limit("explain_workspace_auto_readiness", &drain.input)
+            .map_err(|error| OrbitError::InvalidInput(error.to_string()))?,
+        None => usize::try_from(DEFAULT_CANDIDATE_POOL).unwrap_or(usize::MAX),
+    };
     let examined = &pending[..pending.len().min(candidate_pool_size)];
     let workspace_root = runtime.paths().repo_root.as_path();
     let claimed = claimed_by_task.keys().cloned().collect::<BTreeSet<_>>();
@@ -716,6 +720,7 @@ fn live_admissions_stop(runtime: &OrbitRuntime, input: &Value) -> Option<DrainAd
 /// an operator has since set.
 struct ActiveDrain {
     run_id: String,
+    input: Value,
     submitted: u32,
     limit: Option<DrainWorkerLimit>,
     stop: Option<DrainAdmissionsStop>,
@@ -747,10 +752,9 @@ fn active_drain(runtime: &OrbitRuntime) -> Result<Option<ActiveDrain>, OrbitErro
     else {
         return Ok(None);
     };
-    let submitted = run
-        .input
-        .as_ref()
-        .and_then(|input| input.get("max_active_leaf_runs"))
+    let input = run.input.unwrap_or_else(|| json!({}));
+    let submitted = input
+        .get("max_active_leaf_runs")
         .and_then(json_u32)
         .unwrap_or(DEFAULT_MAX_ACTIVE_LEAF_RUNS as u32);
     let state = runtime
@@ -763,15 +767,10 @@ fn active_drain(runtime: &OrbitRuntime) -> Result<Option<ActiveDrain>, OrbitErro
         .as_ref()
         .and_then(|state| state.drain_worker_limit.clone());
     let stop = state.and_then(|state| state.drain_admissions_stop);
-    let operation = run
-        .input
-        .as_ref()
-        .map(OperationAdmission::from_run_input)
-        .transpose()
-        .map_err(OrbitError::InvalidInput)?
-        .flatten();
+    let operation = OperationAdmission::from_run_input(&input).map_err(OrbitError::InvalidInput)?;
     Ok(Some(ActiveDrain {
         run_id: run.run_id,
+        input,
         submitted,
         limit,
         stop,


### PR DESCRIPTION
## Task

[ORB-12044](https://orbit-cli.com/tasks/ORB-12044) — [code-review] Use the active drain's custom candidate-pool limit in readiness diagnostics

### Description

ORB12041 review notes a residual readiness/classifier mismatch after11993. Independent current-source verification at b930cd317 confirms the supported generic CLI `orbit run job workspace_auto_pipeline --input max_tasks=51 --input max_active_leaf_runs=2` persists supplied inputs. Shipped workspace_auto_pipeline.yaml45-64,94-106 passes max_tasks to classifier; workspace_auto.rs184-205,831-840 clamps/uses1..500. Readiness429-450 always truncates DEFAULT_CANDIDATE_POOL50 even though active_drain734-773 reads the same run input for concurrency.

With51 ordered tasks, first50 mutually conflicting on one file and51 conflict-free, active drain max_tasks51 selects1and51, while readiness reports51 outside_candidate_pool. max_tasks1 can invert mismatch. This is a supported generic-job diagnostic defect; default `run auto` unaffected. Honor the live active drain's validated candidate-pool limit in readiness using shared parsing/clamping/default behavior. Keep no-active-drain default50 and existing capacity/context/dependency precedence. Scope diagnosis only; no scheduling change or newly invented CLI input. No open duplicate found;11993 predecessor done and12041 deliberately left residual unfiled.

### Acceptance Criteria

- Persist an active workspace drain with max_tasks51 and the51-task conflict fixture; readiness and classifier agree that task51 is eligible/ready when capacity permits.
- Cover custom max_tasks1 plus missing/default input and string-or-number input parsing using the same clamp/default contract as classifier.
- Existing candidate-pool, capacity, dependency and context-conflict readiness regressions remain green; make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- ActiveDrain now retains the persisted workspace-auto run input.
- Readiness derives its candidate-pool limit from that live input through the classifier's existing templated parsing and 1..500 clamp, while retaining the default 50 limit when no drain is active.
- Added readiness/classifier regression coverage for the 51-task conflict-free tail with max_tasks=51 and for numeric/string max_tasks=1.

Acceptance criteria:
- Active max_tasks=51 drain: passed; readiness and classifier both admit the conflict-free task 51 when capacity permits.
- max_tasks parsing/default contract: passed; numeric and string 1 are covered, and existing no-drain missing/default coverage remains green through the shared helper/default.
- Existing readiness regressions and required gates: passed; targeted workspace-auto tests, make ci-fast, and make ci-lint all pass.

Validation:
- cargo fmt --check: passed.
- cargo test -p orbit-core workspace_auto --lib: passed (43 passed, 0 failed).
- make ci-fast: passed; the repository's compiler-cache namespace probe was skipped because this environment cannot create a mount namespace, as reported by the guardrail.
- make ci-lint: passed (workspace clippy with warnings denied).
- git diff --check: passed.
- git status --short: passed; only the two scoped files are modified.

Assessment: Small, boundary-owned fix reuses the classifier parser and preserves existing precedence and no-drain behavior. No known remaining risks or deviations.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12044-6aa26407`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra