### PR TITLE
[code-review] Doc-duties stamped task-artifacts/1_overview.md validated while leaving a broken path in the table it just repaired

### DIFF
--- a/docs/design/task-artifacts/1_overview.md
+++ b/docs/design/task-artifacts/1_overview.md
@@ -111,7 +111,7 @@ The canonical bundle lives in the local task store under `~/.orbit/tasks/workspa
 | Public `Task` DTO | [crates/orbit-types/src/task/model.rs](../../../crates/orbit-types/src/task/model.rs) | — |
 | V2 bundle primitives (file layout, atomic writes, JSONL append) | [crates/orbit-store/src/driver/file/task_bundle/](../../../crates/orbit-store/src/driver/file/task_bundle/) | — |
 | V2 task backend adapter (create/get/list/search/mutations) | [crates/orbit-store/src/repository/task/v2/](../../../crates/orbit-store/src/repository/task/v2/) | — |
-| Home registry: allocator, workspace bindings, generated indexes | [crates/orbit-store/src/sqlite/task_registry/](../../../crates/orbit-store/src/sqlite/task_registry/) | — |
+| Home registry: allocator, workspace bindings, generated indexes | [crates/orbit-store/src/driver/sqlite/task_registry/](../../../crates/orbit-store/src/driver/sqlite/task_registry/) | — |
 | V2 runtime wiring (`build_v2_task_backends`) | [crates/orbit-core/src/runtime/builder.rs](../../../crates/orbit-core/src/runtime/builder.rs) | — |
 | Local task store and symlink projection | [2_design.md §6](./2_design.md#6-local-task-store-and-symlink-projection) | — |
 | Task sync design over `ORB-*` IDs (archived) | [docs/design/_archive/task-sync/2_design.md](../_archive/task-sync/2_design.md) | [T20260505-12] |


### PR DESCRIPTION
## Task

[ORB-12055](https://orbit-cli.com/tasks/ORB-12055) — [code-review] Doc-duties stamped task-artifacts/1_overview.md validated while leaving a broken path in the table it just repaired

### Description

## Problem

ORB-12045 (`29711852b`) repaired stale crate paths in the "At a Glance" table of
`docs/design/task-artifacts/1_overview.md` and set
`last_validated: 2026-09-10` (`:7`). It corrected four of the five crate rows and
left the fifth pointing at a directory that does not exist, so the document now
carries a fresh validation stamp over a link a reader following it will not find.

## Evidence

`docs/design/task-artifacts/1_overview.md:114`:

```
| Home registry: allocator, workspace bindings, generated indexes | [crates/orbit-store/src/sqlite/task_registry/](../../../crates/orbit-store/src/sqlite/task_registry/) | — |
```

`crates/orbit-store/src/sqlite/` does not exist at `e6f78e0fb`; `crates/orbit-store/src/`
contains `compose`, `contracts`, `driver`, `fs`, `repository`, `workflow`,
`json_schema.rs`, `lib.rs`, `scope.rs`. The directory now lives at
`crates/orbit-store/src/driver/sqlite/task_registry/` (`mod.rs`, `store.rs`,
`queries.rs`, `schema.rs`, `action.rs`, `util.rs`, `workspace_id.rs`).

The same commit moved the rows immediately above it to their `driver/`,
`repository/`, and `orbit-types/` homes (`:110-113`), so this is a single missed
row in a table that was otherwise brought current, not a broadly stale document.

Resolving every relative link in the eight documents the two doc-duties commits
in this window touched (`60aad249c`, `29711852b`) turns up exactly this one
broken target; the rest resolve.

## Suggested direction

Point the row at `crates/orbit-store/src/driver/sqlite/task_registry/`. If the
doc-duties activity is expected to catch this class of drift, consider whether
its validation step should resolve relative links in the documents it stamps —
that would be the durable fix, but repairing the link is the minimum.

### Acceptance Criteria

- `docs/design/task-artifacts/1_overview.md:114` links to a path that exists in the checkout.
- Every relative link in `docs/design/task-artifacts/1_overview.md` resolves to an existing file or directory.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated the Home registry link in docs/design/task-artifacts/1_overview.md to crates/orbit-store/src/driver/sqlite/task_registry/.
Assessment: The scoped documentation repair is minimal and preserves the document's existing content and validation metadata.

Acceptance criteria:
- `docs/design/task-artifacts/1_overview.md:114` now links to the existing task_registry directory; verified by the relative-link validator.
- All 16 Markdown links in the document were resolved against the document directory; every relative target exists.

Validation:
- Passed: Python link-resolution check over all Markdown links; 16 links validated and no missing targets.
- Passed: `git diff --check`.
- Passed: `git status --short` and final diff review; only the intended document is modified.

Remaining risks or deviations: None identified.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12055-6aa26a54`
- Behind base: 0
- Ahead of base: 1