### PR TITLE
Prevent task delivery from silently committing unintended untracked files

### DIFF
--- a/.orbit/resources/activities/agent_implement.yaml
+++ b/.orbit/resources/activities/agent_implement.yaml
@@ -162,7 +162,14 @@ spec:
         the declared scope requires reconciliation rather than this exemption.
 
         Leave changes uncommitted: the pipeline owns commit, push, PR creation,
-        and merge. Do not invoke another agent or dispatch additional work.
+        and merge. After creating an intended new source file, append its exact
+        `file:` selector through `orbit.task.update`; a containing directory
+        selector is not new-file intent. Tracked modifications, deletions, and
+        renames need no declaration beyond existing task scope, and temporary
+        evidence or scratch files must remain outside the worktree. The
+        delivery boundary refuses every untracked path without exact durable
+        intent and never parses the execution summary as an oracle. Do not
+        invoke another agent or dispatch additional work.
         In the execution summary, map criteria to results, list validation
         commands as passed/failed/not run with reasons, and disclose remaining
         risks or deviations. Do not claim a skipped check passed or mark

--- a/.orbit/resources/activities/agent_review_repair.yaml
+++ b/.orbit/resources/activities/agent_review_repair.yaml
@@ -151,7 +151,10 @@ spec:
 
        Attach the report for every task id in `task_ids`.
     7. Return one Orbit response envelope whose result carries `summary` and
-       `verdict`. Leave your repairs uncommitted in the worktree.
+       `verdict`. Leave your repairs uncommitted in the worktree. The host
+       treats every changed or untracked path you leave there as an intended
+       reviewer repair and commits it under your identity, so create temporary
+       reports, logs, and scratch files outside the worktree.
   tools:
     - orbit.task.*
     - orbit.search

--- a/.orbit/resources/activities/git_commit.yaml
+++ b/.orbit/resources/activities/git_commit.yaml
@@ -4,7 +4,10 @@ metadata:
   name: git_commit
 spec:
   type: deterministic
-  description: Commit pending shared worktree changes on the active task branch.
+  description: >
+    Commit the active task candidate: every tracked change plus new paths with
+    exact durable file intent. Refuse unknown untracked paths before changing
+    the index.
   input_schema_json:
     type: object
     properties:

--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -162,7 +162,14 @@ spec:
         the declared scope requires reconciliation rather than this exemption.
 
         Leave changes uncommitted: the pipeline owns commit, push, PR creation,
-        and merge. Do not invoke another agent or dispatch additional work.
+        and merge. After creating an intended new source file, append its exact
+        `file:` selector through `orbit.task.update`; a containing directory
+        selector is not new-file intent. Tracked modifications, deletions, and
+        renames need no declaration beyond existing task scope, and temporary
+        evidence or scratch files must remain outside the worktree. The
+        delivery boundary refuses every untracked path without exact durable
+        intent and never parses the execution summary as an oracle. Do not
+        invoke another agent or dispatch additional work.
         In the execution summary, map criteria to results, list validation
         commands as passed/failed/not run with reasons, and disclose remaining
         risks or deviations. Do not claim a skipped check passed or mark

--- a/crates/orbit-core/assets/activities/agent_review_repair.yaml
+++ b/crates/orbit-core/assets/activities/agent_review_repair.yaml
@@ -151,7 +151,10 @@ spec:
 
        Attach the report for every task id in `task_ids`.
     7. Return one Orbit response envelope whose result carries `summary` and
-       `verdict`. Leave your repairs uncommitted in the worktree.
+       `verdict`. Leave your repairs uncommitted in the worktree. The host
+       treats every changed or untracked path you leave there as an intended
+       reviewer repair and commits it under your identity, so create temporary
+       reports, logs, and scratch files outside the worktree.
   tools:
     - orbit.task.*
     - orbit.search

--- a/crates/orbit-core/assets/activities/git_commit.yaml
+++ b/crates/orbit-core/assets/activities/git_commit.yaml
@@ -4,7 +4,10 @@ metadata:
   name: git_commit
 spec:
   type: deterministic
-  description: Commit pending shared worktree changes on the active task branch.
+  description: >
+    Commit the active task candidate: every tracked change plus new paths with
+    exact durable file intent. Refuse unknown untracked paths before changing
+    the index.
   input_schema_json:
     type: object
     properties:

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/git_ops.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/git_ops.rs
@@ -25,6 +25,31 @@ pub(super) fn git_commit_with_identity(
     git_success_dynamic_with_identity(workspace_path, &args, &author, &committer)
 }
 
+/// Commit only the explicitly supplied paths while preserving other staged
+/// candidates for their owning task.
+pub(super) fn git_commit_paths_with_identity(
+    workspace_path: &Path,
+    message: &str,
+    resolved_model: Option<&str>,
+    paths: &[String],
+) -> Result<(), OrbitError> {
+    let author = resolved_model
+        .map(GitAuthor::resolved_model)
+        .unwrap_or_else(GitAuthor::orbit);
+    let committer = GitAuthor::orbit();
+    let mut args = vec![
+        "commit".to_string(),
+        "--only".to_string(),
+        "--author".to_string(),
+        author.spec(),
+        "-m".to_string(),
+        message.to_string(),
+        "--".to_string(),
+    ];
+    args.extend(paths.iter().cloned());
+    git_success_dynamic_with_identity(workspace_path, &args, &author, &committer)
+}
+
 /// Commit with an explicit author; the workflow committer stays Orbit.
 pub(super) fn git_commit_as(
     workspace_path: &Path,

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
@@ -20,11 +20,11 @@ use super::git::{git_output, git_success};
 use super::handoff::reject_failed_delivery;
 use author::{append_co_author_trailers, commit_author_for_tasks, reviewer_author};
 use git_ops::{
-    ensure_named_branch, ensure_no_unmerged_changes, git_commit_as, git_commit_with_identity,
-    stage_paths, staged_changed_files,
+    ensure_named_branch, ensure_no_unmerged_changes, git_commit_as, git_commit_paths_with_identity,
+    git_commit_with_identity, stage_paths, staged_changed_files,
 };
 use message::{batch_commit_message, finalize_commit_message, task_commit_message};
-use scope::{changed_files_for_task, collect_worktree_changes, filter_changed_files_for_task};
+use scope::{ensure_candidate_ownership, filter_changed_files_for_task, task_candidate_paths};
 use summary::ensure_durable_execution_summary;
 
 pub(in crate::executor::automation) fn git_commit<H: RuntimeHost + ?Sized>(
@@ -76,8 +76,6 @@ pub(super) fn commit_task_artifact_changes<H: RuntimeHost + ?Sized>(
     let workspace_path = resolve_workspace_path(host, input, batch_id)?;
     ensure_named_branch(&workspace_path)?;
     ensure_no_unmerged_changes(&workspace_path)?;
-    let resolved_model = host.resolved_crew_model(batch_id)?;
-
     let task_ids = match explicit_completed_task_ids {
         Some(task_ids) => task_ids,
         None => fallback_batch_tasks
@@ -86,27 +84,32 @@ pub(super) fn commit_task_artifact_changes<H: RuntimeHost + ?Sized>(
             .map(|task| task.id)
             .collect(),
     };
+    let tasks = task_ids
+        .iter()
+        .map(|task_id| host.get_task(task_id))
+        .collect::<Result<Vec<_>, _>>()?;
+    let resolved_model = host.resolved_crew_model(batch_id)?;
+    let candidate_paths = task_candidate_paths(&workspace_path, &tasks)?;
+    ensure_candidate_ownership(&candidate_paths, &workspace_path, &tasks, true)?;
 
     let mut committed_task_ids = Vec::new();
     let mut skipped_task_ids = Vec::new();
 
-    for task_id in task_ids {
-        let task = host.get_task(&task_id)?;
-        let changed_files = changed_files_for_task(&workspace_path, &task)?;
+    for task in tasks {
+        let changed_files = filter_changed_files_for_task(&candidate_paths, &workspace_path, &task);
         if changed_files.is_empty() {
-            skipped_task_ids.push(task_id);
-            continue;
-        }
-
-        stage_paths(&workspace_path, &changed_files)?;
-        let staged_files = staged_changed_files(&workspace_path)?;
-        if staged_files.is_empty() {
             skipped_task_ids.push(task.id);
             continue;
         }
 
+        stage_paths(&workspace_path, &changed_files)?;
         let message = task_commit_message(&task);
-        git_commit_with_identity(&workspace_path, &message, resolved_model.as_deref())?;
+        git_commit_paths_with_identity(
+            &workspace_path,
+            &message,
+            resolved_model.as_deref(),
+            &changed_files,
+        )?;
         committed_task_ids.push(task.id);
     }
 
@@ -131,10 +134,11 @@ pub(super) fn commit_finalize_artifact_changes<H: RuntimeHost + ?Sized>(
     ensure_named_branch(&workspace_path)?;
     ensure_no_unmerged_changes(&workspace_path)?;
 
-    let changed_files = collect_worktree_changes(&workspace_path)?;
+    let changed_files = task_candidate_paths(&workspace_path, &batch_tasks)?;
     if changed_files.is_empty() {
         return Ok(json!({}));
     }
+    ensure_candidate_ownership(&changed_files, &workspace_path, &batch_tasks, false)?;
 
     let mut affected_tasks = Vec::new();
     let mut files_to_commit = BTreeSet::new();
@@ -153,21 +157,21 @@ pub(super) fn commit_finalize_artifact_changes<H: RuntimeHost + ?Sized>(
 
     let files_to_commit: Vec<String> = files_to_commit.into_iter().collect();
     stage_paths(&workspace_path, &files_to_commit)?;
-    let staged_files = staged_changed_files(&workspace_path)?;
-    if staged_files.is_empty() {
-        return Ok(json!({}));
-    }
-
     let mut message = finalize_commit_message(&affected_tasks);
     let (_, coauthors) = commit_author_for_tasks(&affected_tasks);
     append_co_author_trailers(&mut message, &coauthors);
     let resolved_model = host.resolved_crew_model(batch_id)?;
-    git_commit_with_identity(&workspace_path, &message, resolved_model.as_deref())?;
+    git_commit_paths_with_identity(
+        &workspace_path,
+        &message,
+        resolved_model.as_deref(),
+        &files_to_commit,
+    )?;
 
     Ok(json!({
         "workspace_path": workspace_path.to_string_lossy().to_string(),
         "committed_task_ids": affected_tasks.into_iter().map(|task| task.id).collect::<Vec<_>>(),
-        "committed_files": staged_files,
+        "committed_files": files_to_commit,
     }))
 }
 
@@ -243,13 +247,12 @@ pub(super) fn commit_batch_changes<H: RuntimeHost + ?Sized>(
         }
     };
 
-    // A proposed ADR the run allocated lives in an ignored partition, so
-    // `git add --all` below would skip it and ship the code without the
-    // decision documenting it. Hand it off first: this is the step that can
-    // fail on read-only worktree metadata, and going first means that failure
-    // names the bundle instead of surfacing as a bare `git add` error.
-
-    git_success(&workspace_path, &["add", "--all", "--", "."])?;
+    // Tracked paths carry repository identity. New paths require exact durable
+    // file intent (or a pre-staged writable index). Resolve and validate that
+    // set before mutating the index, then stage exactly those paths.
+    let candidate_paths = task_candidate_paths(&workspace_path, std::slice::from_ref(&task))?;
+    let candidate_paths = candidate_paths.into_iter().collect::<Vec<_>>();
+    stage_paths(&workspace_path, &candidate_paths)?;
 
     let changed_files = staged_changed_files(&workspace_path)?;
     if changed_files.is_empty() {
@@ -345,7 +348,11 @@ pub(super) fn commit_failure_candidate<H: RuntimeHost + ?Sized>(
 ) -> Result<(String, Vec<String>), OrbitError> {
     ensure_named_branch(workspace_path)?;
     ensure_no_unmerged_changes(workspace_path)?;
-    git_success(workspace_path, &["add", "--all", "--", "."])?;
+    let candidate_paths = task_candidate_paths(workspace_path, std::slice::from_ref(task))?;
+    stage_paths(
+        workspace_path,
+        &candidate_paths.into_iter().collect::<Vec<_>>(),
+    )?;
     let changed_files = staged_changed_files(workspace_path)?;
     if !changed_files.is_empty() {
         let message = batch_commit_message(task);

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/scope.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/scope.rs
@@ -7,18 +7,6 @@ use orbit_types::task::Task;
 
 use super::super::git::git_output_paths;
 
-pub(super) fn changed_files_for_task(
-    workspace_path: &Path,
-    task: &Task,
-) -> Result<Vec<String>, OrbitError> {
-    let changed_files = collect_worktree_changes(workspace_path)?;
-    Ok(filter_changed_files_for_task(
-        &changed_files,
-        workspace_path,
-        task,
-    ))
-}
-
 pub(super) fn filter_changed_files_for_task(
     changed_files: &BTreeSet<String>,
     workspace_path: &Path,
@@ -36,28 +24,118 @@ pub(super) fn filter_changed_files_for_task(
         .collect()
 }
 
-pub(super) fn collect_worktree_changes(
+/// Resolve the concrete paths a task worker authorized for delivery.
+///
+/// Tracked changes already have repository identity. A new file has no such
+/// identity, so its exact task file selector (or a pre-staged index entry from
+/// a writable caller) supplies intent. Refusing unknown untracked paths before
+/// staging preserves both their bytes and the exact index the worker left
+/// behind.
+pub(super) fn task_candidate_paths(
     workspace_path: &Path,
+    tasks: &[Task],
 ) -> Result<BTreeSet<String>, OrbitError> {
-    let mut files = BTreeSet::new();
-    for path in git_output_paths(
+    let staged = git_output_paths(
         workspace_path,
-        &["diff", "--name-only", "-z", "--relative", "HEAD", "--"],
-    )? {
-        files.insert(path);
-    }
-    for path in git_output_paths(
+        &["diff", "--cached", "--name-only", "-z", "--relative"],
+    )?
+    .into_iter()
+    .collect::<BTreeSet<_>>();
+    let untracked = git_output_paths(
         workspace_path,
         &["ls-files", "--others", "--exclude-standard", "-z", "--"],
-    )? {
-        files.insert(path);
+    )?;
+    let declared_new_paths = tasks
+        .iter()
+        .flat_map(|task| exact_file_scopes(task, workspace_path))
+        .collect::<BTreeSet<_>>();
+    let unknown = untracked
+        .iter()
+        .filter(|path| !staged.contains(*path) && !declared_new_paths.contains(*path))
+        .cloned()
+        .collect::<Vec<_>>();
+    if !unknown.is_empty() {
+        return Err(OrbitError::Execution(format!(
+            "task delivery refused unknown untracked paths: {unknown:?}. Declare every intended new \
+             source path with an exact `file:` task selector (or stage it explicitly on a writable \
+             index), and leave scratch and evidence outside the worktree. Orbit did not change the \
+             index or any listed file"
+        )));
     }
-    Ok(files)
+
+    let mut candidates = git_output_paths(
+        workspace_path,
+        &["diff", "--name-only", "-z", "--relative", "HEAD", "--"],
+    )?
+    .into_iter()
+    .collect::<BTreeSet<_>>();
+    candidates.extend(
+        untracked
+            .into_iter()
+            .filter(|path| declared_new_paths.contains(path)),
+    );
+    Ok(candidates)
+}
+
+pub(super) fn ensure_candidate_ownership(
+    candidate_paths: &BTreeSet<String>,
+    workspace_path: &Path,
+    tasks: &[Task],
+    require_unique_owner: bool,
+) -> Result<(), OrbitError> {
+    let scopes = tasks
+        .iter()
+        .map(|task| {
+            (
+                task.id.as_str(),
+                task_scopes(task, workspace_path)
+                    .into_iter()
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let mut unowned = Vec::new();
+    let mut ambiguous = Vec::new();
+    for path in candidate_paths {
+        let owners = scopes
+            .iter()
+            .filter(|(_, scopes)| scopes.iter().any(|scope| path_matches_scope(path, scope)))
+            .map(|(task_id, _)| *task_id)
+            .collect::<Vec<_>>();
+        if owners.is_empty() {
+            unowned.push(path.clone());
+        } else if require_unique_owner && owners.len() > 1 {
+            ambiguous.push((path.clone(), owners));
+        }
+    }
+    if unowned.is_empty() && ambiguous.is_empty() {
+        return Ok(());
+    }
+
+    Err(OrbitError::Execution(format!(
+        "task delivery refused candidate paths without deterministic task ownership: \
+         unowned={unowned:?}, ambiguous={ambiguous:?}. Update the participating tasks' explicit \
+         file or directory selectors so every path has {} owner before publication. Orbit did not \
+         change the index or any listed file",
+        if require_unique_owner {
+            "exactly one"
+        } else {
+            "at least one"
+        }
+    )))
 }
 
 fn task_scopes(task: &Task, workspace_path: &Path) -> Vec<String> {
     task.context_files
         .iter()
+        .filter_map(|raw| normalize_task_scope(raw, workspace_path))
+        .collect()
+}
+
+fn exact_file_scopes(task: &Task, workspace_path: &Path) -> Vec<String> {
+    task.context_files
+        .iter()
+        .filter(|raw| raw.starts_with("file:"))
         .filter_map(|raw| normalize_task_scope(raw, workspace_path))
         .collect()
 }

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/author.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/author.rs
@@ -24,6 +24,7 @@ fn git_commit_uses_resolved_model_author_without_mutating_local_human_config() {
             format!("implemented by {crew_alias}\n"),
         )
         .unwrap();
+        git_success(workspace, &["add", "--", "src/task.txt"]).unwrap();
 
         let task = task_with_file("T1", "Implement one task", "src/task.txt", crew_alias);
         let host = CommitTestHost::new(vec![task], workspace.to_path_buf())
@@ -109,6 +110,7 @@ fn git_commit_without_resolved_model_uses_generic_fallback_and_no_local_config()
     let workspace = temp.path();
     fs::create_dir_all(workspace.join("src")).unwrap();
     fs::write(workspace.join("src/task.txt"), "codex work\n").unwrap();
+    git_success(workspace, &["add", "--", "src/task.txt"]).unwrap();
 
     let task = task_with_file("T1", "Implement one task", "src/task.txt", "gpt-5.5");
     let host = CommitTestHost::new(vec![task], workspace.to_path_buf());
@@ -141,6 +143,7 @@ fn git_commit_per_task_preserves_orchestration_attribution_in_the_source_message
     let workspace = temp.path();
     fs::create_dir_all(workspace.join("src")).unwrap();
     fs::write(workspace.join("src/task.txt"), "orchestrated work\n").unwrap();
+    git_success(workspace, &["add", "--", "src/task.txt"]).unwrap();
 
     let mut task = task_with_file("T1", "Implement one task", "src/task.txt", "gpt-5.6-terra");
     task.orchestrator = Some("sol".to_string());
@@ -168,6 +171,7 @@ fn git_commit_treats_bare_configured_model_as_opaque() {
     let workspace = temp.path();
     fs::create_dir_all(workspace.join("src")).unwrap();
     fs::write(workspace.join("src/task.txt"), "bare model config\n").unwrap();
+    git_success(workspace, &["add", "--", "src/task.txt"]).unwrap();
 
     let task = task_with_file("T1", "Implement one task", "src/task.txt", "claude");
     let host = CommitTestHost::new(vec![task], workspace.to_path_buf()).with_crew_model("opus");
@@ -193,6 +197,7 @@ fn git_commit_preserves_model_author_and_coauthors_without_commit_hooks() {
     fs::create_dir_all(workspace.join("src")).unwrap();
     fs::write(workspace.join("src/one.txt"), "one\n").unwrap();
     fs::write(workspace.join("src/two.txt"), "two\n").unwrap();
+    git_success(workspace, &["add", "--", "src/one.txt", "src/two.txt"]).unwrap();
 
     let tasks = vec![
         task_with_file("T1", "Implement one task", "src/one.txt", "claude-opus-5"),
@@ -229,6 +234,7 @@ fn git_commit_batch_uses_templated_single_task_message() {
     let workspace = temp.path();
     fs::create_dir_all(workspace.join("src")).unwrap();
     fs::write(workspace.join("src/bug.txt"), "bug fix\n").unwrap();
+    git_success(workspace, &["add", "--", "src/bug.txt"]).unwrap();
 
     let title = "a".repeat(145);
     let mut task = task_with_file("ORB-00107", &title, "src/bug.txt", "claude");

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/base_checkpoint.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/base_checkpoint.rs
@@ -112,6 +112,7 @@ fn commit_survives_the_shared_base_ref_moving_after_worktree_setup() {
     move_shared_base_ref(workspace, &advanced_base);
     git_success(workspace, &["checkout", "orbit/T1"]).expect("return to the task branch");
     fs::write(workspace.join("task.txt"), "task work\n").unwrap();
+    git_success(workspace, &["add", "--", "task.txt"]).unwrap();
     assert_ne!(
         git_output(workspace, &["rev-parse", MOVING_BASE_REF]).expect("read moved base"),
         base_sha,
@@ -198,6 +199,7 @@ fn commit_accepts_only_the_exact_orbit_preservation_head_for_a_resume() {
     fs::write(workspace.join("candidate.txt"), "preserved candidate\n").unwrap();
     let preserved_head = commit_all(workspace, "[T1] Orbit failure preservation");
     fs::write(workspace.join("task.txt"), "resumed edit\n").unwrap();
+    git_success(workspace, &["add", "--", "task.txt"]).unwrap();
 
     let host = host_with_preservation(workspace, &base_sha, &preserved_head);
     let mut input = batch_input(workspace, &base_sha);
@@ -482,6 +484,7 @@ fn allow_moved_head_commits_leftover_finisher_work() {
     fs::write(workspace.join("child.txt"), "landed child\n").unwrap();
     commit_all(workspace, "child landed into epic");
     fs::write(workspace.join("finisher.txt"), "leftover finisher work\n").unwrap();
+    git_success(workspace, &["add", "--", "finisher.txt"]).unwrap();
 
     let task = task_with_file("T1", "Epic root", "finisher.txt", "claude");
     let host = CommitTestHost::new(vec![task], workspace.to_path_buf());

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/candidate_paths.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/candidate_paths.rs
@@ -1,0 +1,196 @@
+use std::fs;
+
+use serde_json::json;
+
+use super::super::git_commit;
+use super::test_support::{CommitTestHost, initialized_git_repo, task_with_file};
+use crate::executor::automation::vcs::git::{git_output, git_success};
+
+#[test]
+fn singleton_refuses_unknown_untracked_paths_without_mutating_files_or_index() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+    fs::write(workspace.join("README.md"), "intended tracked edit\n").unwrap();
+    fs::create_dir_all(workspace.join("src")).unwrap();
+    fs::write(workspace.join("src/new.rs"), "pub fn intended() {}\n").unwrap();
+    git_success(workspace, &["add", "--", "src/new.rs"]).unwrap();
+    fs::write(workspace.join("screenshot.png"), b"scratch screenshot").unwrap();
+    fs::write(workspace.join("browser-path.txt"), b"/tmp/browser").unwrap();
+
+    let mut task = task_with_file("T1", "Deliver source only", "README.md", "codex");
+    task.context_files.clear();
+    task.execution_summary = "Outcome: success\nChanges:\n- Source updated.".to_string();
+    let host = CommitTestHost::new(vec![task], workspace.to_path_buf());
+    let index_before = git_output(workspace, &["diff", "--cached", "--binary"]).unwrap();
+    let readme_before = fs::read(workspace.join("README.md")).unwrap();
+    let new_source_before = fs::read(workspace.join("src/new.rs")).unwrap();
+    let screenshot_before = fs::read(workspace.join("screenshot.png")).unwrap();
+    let marker_before = fs::read(workspace.join("browser-path.txt")).unwrap();
+    let head_before = git_output(workspace, &["rev-parse", "HEAD"]).unwrap();
+
+    let error = git_commit(
+        &host,
+        &json!({
+            "scope": "all",
+            "job_run_id": "batch-1",
+            "workspace_path": workspace,
+        }),
+    )
+    .expect_err("unknown untracked evidence must refuse delivery");
+    let message = error.to_string();
+    assert!(message.contains("browser-path.txt"), "{message}");
+    assert!(message.contains("screenshot.png"), "{message}");
+    assert!(message.contains("exact `file:` task selector"), "{message}");
+
+    assert_eq!(
+        git_output(workspace, &["rev-parse", "HEAD"]).unwrap(),
+        head_before
+    );
+    assert_eq!(
+        git_output(workspace, &["diff", "--cached", "--binary"]).unwrap(),
+        index_before
+    );
+    assert_eq!(
+        fs::read(workspace.join("README.md")).unwrap(),
+        readme_before
+    );
+    assert_eq!(
+        fs::read(workspace.join("src/new.rs")).unwrap(),
+        new_source_before
+    );
+    assert_eq!(
+        fs::read(workspace.join("screenshot.png")).unwrap(),
+        screenshot_before
+    );
+    assert_eq!(
+        fs::read(workspace.join("browser-path.txt")).unwrap(),
+        marker_before
+    );
+}
+
+#[test]
+fn singleton_commits_tracked_changes_and_exactly_declared_new_source() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+    for (path, contents) in [
+        ("delete.txt", "delete me\n"),
+        ("rename-from.txt", "rename me\n"),
+    ] {
+        fs::write(workspace.join(path), contents).unwrap();
+    }
+    git_success(workspace, &["add", "--", "delete.txt", "rename-from.txt"]).unwrap();
+    git_success(workspace, &["commit", "-m", "tracked fixtures"]).unwrap();
+
+    fs::write(workspace.join("README.md"), "tracked edit\n").unwrap();
+    fs::remove_file(workspace.join("delete.txt")).unwrap();
+    git_success(workspace, &["mv", "--", "rename-from.txt", "rename-to.txt"]).unwrap();
+    fs::create_dir_all(workspace.join("src")).unwrap();
+    fs::write(workspace.join("src/new.rs"), "pub fn added() {}\n").unwrap();
+
+    let mut task = task_with_file("T1", "Candidate paths", "README.md", "codex");
+    task.context_files.push("file:src/new.rs".to_string());
+    let host = CommitTestHost::new(vec![task], workspace.to_path_buf());
+    git_commit(
+        &host,
+        &json!({
+            "scope": "all",
+            "job_run_id": "batch-1",
+            "workspace_path": workspace,
+        }),
+    )
+    .expect("the explicit candidate is committed");
+
+    assert_eq!(
+        git_output(workspace, &["show", "--format=", "--name-status", "HEAD"]).unwrap(),
+        "M\tREADME.md\nD\tdelete.txt\nR100\trename-from.txt\trename-to.txt\nA\tsrc/new.rs"
+    );
+    assert!(
+        git_output(
+            workspace,
+            &["status", "--porcelain", "--untracked-files=all"]
+        )
+        .unwrap()
+        .is_empty()
+    );
+}
+
+#[test]
+fn per_task_commits_only_each_tasks_explicit_candidate_paths() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+    fs::create_dir_all(workspace.join("one")).unwrap();
+    fs::create_dir_all(workspace.join("two")).unwrap();
+    fs::write(workspace.join("one/new.rs"), "pub fn one() {}\n").unwrap();
+    fs::write(workspace.join("two/new.rs"), "pub fn two() {}\n").unwrap();
+
+    let mut one = task_with_file("T1", "First candidate", "one/new.rs", "codex");
+    one.context_files = vec!["file:one/new.rs".to_string()];
+    let mut two = task_with_file("T2", "Second candidate", "two/new.rs", "claude");
+    two.context_files = vec!["file:two/new.rs".to_string()];
+    let host = CommitTestHost::new(vec![one, two], workspace.to_path_buf());
+
+    let result = git_commit(
+        &host,
+        &json!({
+            "scope": "per_task",
+            "job_run_id": "batch-1",
+            "workspace_path": workspace,
+            "completed_task_ids": ["T1", "T2"],
+        }),
+    )
+    .expect("both explicitly scoped task candidates are committed");
+
+    assert_eq!(result["committed_task_ids"], json!(["T1", "T2"]));
+    assert_eq!(
+        git_output(workspace, &["show", "--format=", "--name-only", "HEAD^"]).unwrap(),
+        "one/new.rs"
+    );
+    assert_eq!(
+        git_output(workspace, &["show", "--format=", "--name-only", "HEAD"]).unwrap(),
+        "two/new.rs"
+    );
+}
+
+#[test]
+fn per_task_refuses_ambiguous_or_unowned_candidates_before_index_mutation() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+    fs::create_dir_all(workspace.join("shared")).unwrap();
+    fs::create_dir_all(workspace.join("orphan")).unwrap();
+    fs::write(workspace.join("shared/new.rs"), "pub fn shared() {}\n").unwrap();
+    fs::write(workspace.join("orphan/new.rs"), "pub fn orphan() {}\n").unwrap();
+    git_success(workspace, &["add", "--", "shared/new.rs", "orphan/new.rs"]).unwrap();
+
+    let mut one = task_with_file("T1", "First candidate", "shared", "codex");
+    one.context_files = vec!["dir:shared".to_string()];
+    let mut two = task_with_file("T2", "Second candidate", "shared", "claude");
+    two.context_files = vec!["dir:shared".to_string()];
+    let host = CommitTestHost::new(vec![one, two], workspace.to_path_buf());
+    let index_before = git_output(workspace, &["diff", "--cached", "--binary"]).unwrap();
+
+    let error = git_commit(
+        &host,
+        &json!({
+            "scope": "per_task",
+            "job_run_id": "batch-1",
+            "workspace_path": workspace,
+            "completed_task_ids": ["T1", "T2"],
+        }),
+    )
+    .expect_err("candidate ownership must be deterministic");
+    let message = error.to_string();
+    assert!(message.contains("orphan/new.rs"), "{message}");
+    assert!(message.contains("shared/new.rs"), "{message}");
+    assert!(
+        message.contains("T1") && message.contains("T2"),
+        "{message}"
+    );
+    assert_eq!(
+        git_output(workspace, &["diff", "--cached", "--binary"]).unwrap(),
+        index_before
+    );
+    assert_eq!(
+        git_output(workspace, &["rev-list", "--count", "HEAD"]).unwrap(),
+        "1"
+    );
+}

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/delivery_gate.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/delivery_gate.rs
@@ -17,7 +17,7 @@ use serde_json::{Value, json};
 use super::super::git_commit;
 use super::test_support::*;
 
-use super::super::super::git::git_output;
+use super::super::super::git::{git_output, git_success};
 use super::super::super::handoff::reject_failed_delivery;
 
 const GATED_TASK_ID: &str = "ORB-10313-GATE";
@@ -143,6 +143,7 @@ fn commit_batch_allows_meaningful_non_failed_outcomes() {
         let workspace = temp.path();
         fs::create_dir_all(workspace.join("src")).unwrap();
         fs::write(workspace.join("src/change.txt"), "delivered\n").unwrap();
+        git_success(workspace, &["add", "--", "src/change.txt"]).unwrap();
 
         let host = CommitTestHost::new(vec![task_with_summary(summary)], workspace.to_path_buf());
         let result = git_commit(&host, &batch_input(workspace))

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/mod.rs
@@ -3,6 +3,7 @@
 mod already_landed;
 mod author;
 mod base_checkpoint;
+mod candidate_paths;
 mod delivery_gate;
 mod git_ops;
 mod message;

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/summary.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/summary.rs
@@ -15,7 +15,7 @@ use super::super::summary::{
 };
 use super::test_support::*;
 
-use super::super::super::git::git_output;
+use super::super::super::git::{git_output, git_success};
 
 const DERIVED_TASK_ID: &str = "ORB-10603-DERIVE";
 
@@ -44,6 +44,7 @@ fn stage_worktree_change(workspace: &Path) {
     fs::create_dir_all(workspace.join("src")).unwrap();
     fs::write(workspace.join("src/change.txt"), "delivered\n").unwrap();
     fs::write(workspace.join("README.md"), "base\nedited\n").unwrap();
+    git_success(workspace, &["add", "--", "src/change.txt"]).unwrap();
 }
 
 /// The wedge this task fixes: implementation completed, the agent wrote no

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/handoff.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/handoff.rs
@@ -612,6 +612,7 @@ fn non_fast_forward_drift_handoff_commits_dirty_work_and_raises_pr() {
         "pub fn recovered() {}\n",
     )
     .expect("write uncommitted candidate");
+    git(&workspace.repo, &["add", "--", "src/recovered.rs"]);
     let task_id = "ORB-DIRTY-HANDOFF";
     let host = PrOpenTestHost::new(
         vec![batch_task(

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_failure.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_failure.rs
@@ -87,6 +87,7 @@ impl RuntimeHost for ResumeFailureHost {
                     action: action.to_string(),
                     message: format!("write fixture partial repair: {error}"),
                 })?;
+                git(Path::new(workspace_path), &["add", "--", "src/repaired.rs"]);
                 Err(DispatchError::DeterministicActionFailed {
                     action: action.to_string(),
                     message: "repaired two ownership calls; required macOS validation remains unavailable"
@@ -782,6 +783,7 @@ fn original_run_ownership_still_authorizes_failure_handoff() {
     let workspace = no_diff_pr_workspace();
     fs::write(workspace.repo.join("original.txt"), "original candidate\n")
         .expect("write original candidate");
+    git(&workspace.repo, &["add", "--", "original.txt"]);
     let host = PrOpenTestHost::new(
         vec![task_owned_by(CHECKPOINT_RUN_ID)],
         workspace.repo.clone(),

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/setup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/setup.rs
@@ -534,6 +534,7 @@ fn stale_setup_retry_stays_refused_until_operator_recovers_the_branch() {
     assert_eq!(git(&workspace, &["rev-parse", "HEAD"]), second_base);
 
     fs::write(workspace.join("task.txt"), "recovered work\n").unwrap();
+    git(&workspace, &["add", "--", "task.txt"]);
     let commit = git_commit(
         &host,
         &json!({

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -547,12 +547,37 @@ After [ORB-10603] / [Derive the delivery execution summary from the change, not 
 ordinary case, because the commit step fills the field it reads. When — and only
 when — durable state carries no meaningful summary, `commit_batch_changes`
 derives one from `git status` in the delivery worktree (the same file set
-`git add --all` will stage), persists it to the task record with an
+`git_commit` will validate), persists it to the task record with an
 `execution_summary_derived` event, and then meets the unchanged gate. The
 derivation reads durable, re-checkable state and never the agent's advisory
 response envelope ([L-0115]); an agent-authored summary is always preserved; and
 a worktree with nothing to describe still yields no summary and is still
 refused.
+
+After [ORB-12050], task delivery has a concrete path-intent contract at that
+same deterministic boundary. Every tracked modification, deletion, or rename
+is a candidate because Git already identifies it as repository content. A new
+path is a candidate only when the implementing worker appends its exact
+`file:` selector to durable task state after creating it. This ordering
+respects the authoring rule that selectors name existing paths and also works
+in managed workers whose Git metadata is read-only. An explicitly staged path
+remains accepted for callers with a writable index, but staging is not required
+of managed workers. Directory selectors are ownership boundaries, not
+new-file intent. Before staging anything, `git_commit` compares all untracked
+paths with those explicit signals and refuses every unknown path by exact name.
+It therefore cannot be bypassed by a persuasive summary, empty selectors, or
+one legitimate file already in the index, and refusal preserves the prior
+index and every worktree byte. Accepted candidates are staged by explicit path;
+per-task publication commits only the paths assigned to that task so an
+already-populated index cannot leak a sibling candidate.
+
+Failure-candidate preservation uses the same task-candidate boundary. The
+before-PR reviewer is deliberately different: it starts from a committed,
+pinned candidate, is forbidden to run staging commands, and its activity
+contract makes every path it leaves changed an intended reviewer repair.
+Reviewer scratch, logs, and attachment staging files must live outside the
+worktree; the host may therefore stage that reviewer's entire repair delta
+without heuristically forcing implementer task selectors onto it.
 
 **Declared exceptions.** No shipped `agent_loop` activity opts out of
 `require_completion_envelope`. Every seeded agent step performs work whose


### PR DESCRIPTION
## Task

[ORB-12050](https://orbit-cli.com/tasks/ORB-12050) — Prevent task delivery from silently committing unintended untracked files

### Description

## Problem
ORB-12011's worker explicitly left eight temporary website screenshot/path-marker files untracked and reported they must not enter delivery. Nevertheless PR1869/commit39965dccb/merge3df2ca09672adbc984e12cbba917e834b0e47b5b included all eight alongside the intended install.md edit. ORB-12049 removes this residue; this task fixes the delivery boundary.

## Evidence
Current crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs commit_batch_changes single-task scope=all executes git add --all -- . (around174-252), then commits the entire index. A scoped filter exists in scope.rs but the normal singleton path bypasses it. Reviewer repair staging also uses stage_everything and must be assessed with its distinct intended scope.

## Required behavior
Establish and enforce a concrete intended candidate path set at the deterministic staging/commit boundary. Out-of-candidate untracked scratch/evidence must not silently become product source. Refuse with actionable paths when intent cannot be established, preserving bytes and the prior index. Explicitly stage accepted paths; do not rely on matching filenames, ignored screenshot patterns, or parsing a prose execution summary as a correctness oracle.

## Constraints
Task context_files intentionally names existing modification/deletion targets only: legitimate new source files cannot be required to preexist in context_files. Preserve supported new-file additions through an explicit reviewable candidate-path mechanism or another justified source of intent, plus scoped modifications/deletions/renames and multi-task behavior. Do not silently drop legitimate untracked source files or stage everything as fallback. Honor preexisting staged changes; avoid cross-task scope leakage. No destructive cleanup of unknown files. Diagnose reviewer repair staging separately and either apply a justified boundary or document its explicit caller contract rather than indiscriminately forcing task scope onto it.

### Acceptance Criteria

- A regression recreating a legitimate task source edit plus untracked screenshot and path-marker files fails on current code and proves unintended files cannot enter the delivered commit; refusal identifies exact paths and preserves source bytes and the prior index.
- Positive regressions prove intended new source files, tracked edits/deletions/renames, and supported singleton/multi-task candidate publication continue to work using explicit paths without blanket git add --all fallback.
- Candidate validation and staging are enforced deterministically before commit; an unknown or ambiguous path cannot bypass via a clean-looking summary, empty context_files, or an already populated index. Document the concrete path-intent contract and caller responsibilities.
- Assess reviewer repair staging and other callers for the same failure, covering applicable boundaries without narrowing valid scope heuristically. Focused tests, make ci-fast, make ci-lint and git diff --check pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced blanket task/failure-handoff staging with a deterministic candidate set: tracked changes plus untracked files carrying exact durable file intent (or an already-staged writable-index signal). Unknown untracked paths are refused by exact name before index mutation.
- Made multi-task publication validate ownership before staging and commit each task explicit paths with Git --only, preserving sibling index entries and preventing unowned or ambiguous candidate leakage.
- Added regressions for the screenshot/path-marker incident, byte/index preservation, exact-declared additions, tracked edits/deletions/renames, singleton and multi-task publication, and ambiguous/unowned paths.
- Updated deployed and embedded implementer, reviewer-repair, and git_commit contracts plus the activity-job design. Failure candidate preservation uses the task boundary; reviewer repair retains its full-delta staging only under an explicit isolated-reviewer ownership contract.
Acceptance criteria:
1. The singleton regression combines a tracked source edit, a legitimate populated-index addition, and untracked screenshot/path-marker files; it asserts exact refusal paths, unchanged HEAD/index, and byte-for-byte preservation.
2. Positive regressions cover exact-declared new files, tracked modification/deletion/rename, singleton delivery, and path-isolated multi-task commits without git add --all.
3. Candidate and ownership validation run before staging; tests cover meaningful summaries, empty context_files, populated indexes, and ambiguous/unowned multi-task paths. The durable exact-file contract and caller duties are documented.
4. Failure handoff uses the same candidate resolver. Reviewer repair remains intentionally full-delta and its isolated caller ownership/scratch-file rules are explicit in synchronized activity assets.
Validation:
- cargo test -p orbit-engine executor::automation::vcs::commit::tests — passed (68 tests).
- make ci-fast — passed.
- make ci-lint — passed (workspace/all targets, warnings denied).
- git diff --check — passed.
- git status --short — inspected; 18 tracked task files modified and one intended new regression file present and declared as an exact task selector.
- git add -- crates/orbit-engine/src/executor/automation/vcs/commit/tests/candidate_paths.rs — denied by the managed worktree read-only Git metadata (index.lock); no retry or workaround. The exact durable file selector is the supported managed-worker intent signal and is persisted on this task.
Assessment: The delivery seam now fails closed without filename heuristics or prose parsing, while preserving valid tracked and explicit-new-file workflows.
Deviations from original plan:
- Explicit Git staging cannot be the primary managed-worker signal because managed .git metadata is read-only. Exact file selectors appended after file creation provide durable, reviewable intent; pre-staging remains supported for writable callers.
Remaining risks: None identified.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12050-6aa26537`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*