### PR TITLE
[code-review] The unassessed-complexity admission gate permanently blocks every shipped auto-task from automatic dispatch

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs
@@ -168,30 +168,27 @@ pub(super) fn list_backlog_tasks(
         )?;
         (snapshot.admissible_leaves, Some(snapshot.excluded))
     } else {
-        let tasks = explicit_task_ids
-            .iter()
-            .map(|task_id| {
-                runtime
-                    .get_task(task_id)
-                    .map_err(|err| DispatchError::DeterministicActionFailed {
-                        action: action.to_string(),
-                        message: format!("load task {task_id}: {err}"),
-                    })
-                    .and_then(|task| {
-                        if task.complexity.is_some_and(TaskComplexity::is_assessed) {
-                            Ok(task)
-                        } else {
-                            Err(DispatchError::DeterministicActionFailed {
-                                action: action.to_string(),
-                                message: format!(
-                                    "task {task_id} requires task-pilot preparation before implementation admission"
-                                ),
-                            })
-                        }
-                    })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        (tasks, None)
+        let mut tasks = Vec::new();
+        let mut excluded = Vec::new();
+        for task_id in &explicit_task_ids {
+            let task = runtime.get_task(task_id).map_err(|err| {
+                DispatchError::DeterministicActionFailed {
+                    action: action.to_string(),
+                    message: format!("load task {task_id}: {err}"),
+                }
+            })?;
+            if task.complexity.is_some_and(TaskComplexity::is_assessed) {
+                tasks.push(task);
+            } else {
+                excluded.push(BacklogTaskExclusion {
+                    id: task.id,
+                    reason: BacklogTaskExclusionReason::UnassessedComplexity,
+                    conflicts: Vec::new(),
+                    crew: None,
+                });
+            }
+        }
+        (tasks, Some(excluded))
     };
     tasks.truncate(max_tasks);
     let ids: Vec<String> = tasks.iter().map(|t| t.id.clone()).collect();

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
@@ -39,6 +39,8 @@ const HARD_MAX_PARTITION_SIZE: usize = 5;
 const DEFAULT_MAX_TASKS: usize = 50;
 const HARD_MAX_TASKS: usize = 500;
 const NO_DIFF_TAGS: [&str; 2] = ["no-diff-needed", "no-diff-expected"];
+const NO_DIFF_EXPECTED_TAG: &str = "no-diff-expected";
+const AUTO_TASK_TAG_PREFIX: &str = "auto-task:";
 const TASK_PILOT_JOB_ID: &str = "task_pilot_pipeline";
 /// Cap on individually itemized `excluded` entries in routine discovery output.
 /// Automatic-mode exclusions still carry full counts by reason; this bounds
@@ -404,10 +406,20 @@ fn automatic_exclusion_reason(
     if !context_files.is_empty() && complexity.is_some_and(TaskComplexity::is_assessed) {
         return Some("context_files_not_empty");
     }
-    if tags.iter().any(|tag| NO_DIFF_TAGS.contains(&tag.as_str())) {
+    if tags.iter().any(|tag| NO_DIFF_TAGS.contains(&tag.as_str()))
+        && !is_no_diff_expected_auto_task(tags)
+    {
         return Some("no_diff_task");
     }
     None
+}
+
+/// Automatically minted no-diff work still needs a complexity assessment, but
+/// it cannot honestly produce modification selectors. The mint provenance tag
+/// distinguishes it from an ordinary task that merely carries a no-diff tag.
+fn is_no_diff_expected_auto_task(tags: &[String]) -> bool {
+    tags.iter().any(|tag| tag == NO_DIFF_EXPECTED_TAG)
+        && tags.iter().any(|tag| tag.starts_with(AUTO_TASK_TAG_PREFIX))
 }
 
 fn task_snapshot(

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/backlog_exclusion.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/backlog_exclusion.rs
@@ -80,17 +80,48 @@ fn automatic_admission_withholds_unassessed_tasks_until_task_pilot_prepares_them
         excluded_entry(&output, &task.id)["reason"],
         "unassessed_complexity"
     );
-    let error = runtime
-        .run_deterministic(
-            "list_backlog_tasks",
-            &json!({}),
-            &json!({"task_ids": [task.id]}),
-            ToolContext::default(),
-        )
-        .expect_err("explicit implementation admission must not bypass preparation");
-    assert!(
-        error.to_string().contains("task-pilot preparation"),
-        "{error}"
+    let explicit = list_backlog_tasks(&runtime, json!({ "task_ids": [task.id] }));
+    assert_eq!(explicit["task_ids"], json!([]));
+    assert_eq!(
+        excluded_entry(&explicit, &task.id)["reason"],
+        "unassessed_complexity"
+    );
+}
+
+#[test]
+fn explicit_backlog_selection_keeps_assessed_tasks_when_another_is_unassessed() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let assessed = seed_list_backlog_task(
+        &runtime,
+        "Prepared task",
+        TaskStatus::Backlog,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        None,
+        vec![],
+    );
+    let unassessed = runtime
+        .add_task(TaskAddParams {
+            title: "Awaiting preparation".to_string(),
+            description: "fixture".to_string(),
+            acceptance_criteria: vec!["fixture".to_string()],
+            plan: "prepare".to_string(),
+            status: Some(TaskStatus::Backlog),
+            complexity: TaskComplexity::Unassessed,
+            task_type: Some(TaskType::Chore),
+            ..TaskAddParams::default()
+        })
+        .expect("seed unassessed task");
+
+    let output = list_backlog_tasks(
+        &runtime,
+        json!({ "task_ids": [assessed.id, unassessed.id] }),
+    );
+
+    assert_eq!(output["task_ids"], json!([assessed.id]));
+    assert_eq!(
+        excluded_entry(&output, &unassessed.id)["reason"],
+        "unassessed_complexity"
     );
 }
 
@@ -688,7 +719,7 @@ fn list_backlog_tasks_does_not_report_max_tasks_truncation_as_excluded() {
 }
 
 #[test]
-fn list_backlog_tasks_omits_excluded_for_explicit_task_ids() {
+fn list_backlog_tasks_reports_empty_exclusions_for_assessed_explicit_task_ids() {
     let (_root, runtime, repo_root) = runtime_with_workspace_layout();
     write_workspace_file(&repo_root, "crates/foo/src/lib.rs");
     seed_list_backlog_task(
@@ -723,7 +754,7 @@ fn list_backlog_tasks_omits_excluded_for_explicit_task_ids() {
 
     assert_eq!(output["task_count"], json!(2));
     assert_eq!(output["task_ids"], json!([backlog.id, corrective.id]));
-    assert!(output.get("excluded").is_none());
+    assert_eq!(output["excluded"], json!([]));
 }
 
 #[test]

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs
@@ -152,7 +152,7 @@ fn automatic_readiness_requires_selectors_and_no_deferring_finding() {
 }
 
 #[test]
-fn automatic_discovery_filters_status_context_and_no_diff_tags_then_partitions() {
+fn automatic_discovery_admits_only_provenance_tagged_no_diff_expected_auto_tasks() {
     let (_root, runtime, repo_root) = runtime_with_workspace_layout();
     write_workspace_file(&repo_root, "src/existing.rs");
     let mut eligible = Vec::new();
@@ -186,6 +186,13 @@ fn automatic_discovery_filters_status_context_and_no_diff_tags_then_partitions()
         &["no-diff-expected"],
         &[],
     );
+    let no_diff_auto_task = seed_task(
+        &runtime,
+        "no-diff-expected auto-task",
+        TaskStatus::Backlog,
+        &["no-diff-expected", "auto-task:review"],
+        &[],
+    );
     let scoped = seed_task(
         &runtime,
         "already-scoped",
@@ -211,7 +218,7 @@ fn automatic_discovery_filters_status_context_and_no_diff_tags_then_partitions()
     .expect("automatic discovery");
 
     assert_eq!(output["mode"], "automatic");
-    assert_eq!(output["task_count"], 7);
+    assert_eq!(output["task_count"], 8);
     assert_eq!(output["partition_count"], 2);
     assert_eq!(
         output["partitions"][0]["task_ids"]
@@ -225,7 +232,7 @@ fn automatic_discovery_filters_status_context_and_no_diff_tags_then_partitions()
             .as_array()
             .unwrap()
             .len(),
-        2
+        3
     );
     let selected = output["task_ids"].as_array().expect("selected task ids");
     for task in eligible {
@@ -244,6 +251,11 @@ fn automatic_discovery_filters_status_context_and_no_diff_tags_then_partitions()
                 .any(|entry| { entry["task_id"] == task.id && entry["reason"] == "no_diff_task" })
         );
     }
+    assert!(
+        selected
+            .iter()
+            .any(|value| value == &json!(no_diff_auto_task.id))
+    );
     assert!(excluded.iter().any(|entry| {
         entry["task_id"] == scoped.id && entry["reason"] == "context_files_not_empty"
     }));

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
@@ -3,14 +3,17 @@ use std::collections::BTreeSet;
 use chrono::{SecondsFormat, Utc};
 use orbit_engine::RuntimeHost;
 use orbit_tools::ToolContext;
-use orbit_types::task::{TaskComplexity, TaskPriority, TaskStatus, TaskType};
+use orbit_types::task::{Task, TaskComplexity, TaskPriority, TaskStatus, TaskType};
+use orbit_types::workflow::{AutoTaskSchedule, AutoTaskTemplate, DedupePolicy};
 use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
+use crate::adapter::engine_host::v2_host::task_pilot::{apply, prepare};
 use crate::adapter::engine_host::v2_host::test_support::{
     runtime_with_workspace_config, runtime_with_workspace_layout, seed_list_backlog_task,
     write_workspace_file,
 };
+use crate::application::auto_tasks::AutoTaskAddParams;
 use crate::application::task::{TaskAddParams, TaskUpdateParams};
 
 fn classify(runtime: &OrbitRuntime) -> Value {
@@ -26,6 +29,111 @@ fn classify_with(runtime: &OrbitRuntime, input: Value) -> Value {
             ToolContext::default(),
         )
         .expect("classify workspace auto tasks")
+}
+
+fn verified_no_diff_assessment(task: &Task) -> Value {
+    json!({
+        "task_id": task.id,
+        "context_files_before": task.context_files,
+        "context_files_after": [],
+        "disposition": "verified_no_diff",
+        "evidence": "The recurring review is an operational check and changes no repository files.",
+        "recommended_crew": "luna",
+        "recommended_complexity": "low",
+        "assessment_rationale": "The review has bounded read-only scope.",
+        "confidence": "high",
+        "evidence_gaps": [],
+        "validation_approach": "Run the configured review commands.",
+        "reassessment_triggers": ["the review scope changes"],
+        "blocked_by": [],
+        "duplicate_of": null,
+        "already_landed": null,
+        "adr_conflicts": [],
+        "utility_warnings": [],
+        "surface_warnings": [],
+    })
+}
+
+#[test]
+fn minted_no_diff_auto_task_is_prepared_without_selectors_then_admitted() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    runtime
+        .auto_task_add(AutoTaskAddParams {
+            name: "qa-review".to_string(),
+            description: "QA review".to_string(),
+            schedule: AutoTaskSchedule::Interval { every_minutes: 60 },
+            template: AutoTaskTemplate {
+                title: "QA review".to_string(),
+                description: "Review the delivered change.".to_string(),
+                acceptance_criteria: vec!["Review result is recorded.".to_string()],
+                task_type: TaskType::Chore,
+                tags: vec!["no-diff-expected".to_string()],
+                required_tools: vec![],
+                priority: TaskPriority::Medium,
+                crew: Some("opus".to_string()),
+                status: TaskStatus::Backlog,
+            },
+            dedupe: DedupePolicy::SkipIfOpen,
+        })
+        .expect("add auto-task definition");
+    let minted = runtime.auto_task_mint("qa-review").expect("mint auto-task");
+
+    assert_eq!(minted.complexity, Some(TaskComplexity::Unassessed));
+    assert_eq!(minted.crew.as_deref(), Some("opus"));
+    assert!(minted.tags.iter().any(|tag| tag == "no-diff-expected"));
+    assert!(minted.tags.iter().any(|tag| tag == "auto-task:qa-review"));
+
+    let before = classify(&runtime);
+    assert!(
+        !before["loose_task_ids"]
+            .as_array()
+            .expect("admitted tasks")
+            .iter()
+            .any(|task_id| task_id == &minted.id)
+    );
+
+    let prepared = prepare(
+        &runtime,
+        "prepare_task_pilot",
+        &json!({ "workspace_path": repo_root }),
+    )
+    .expect("automatic preparation includes minted no-diff auto-task");
+    assert!(
+        prepared["task_ids"]
+            .as_array()
+            .expect("task ids")
+            .contains(&json!(minted.id))
+    );
+
+    let applied = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": prepared,
+            "results": [{
+                "partition_index": 0,
+                "task_ids": [minted.id],
+                "tasks": [verified_no_diff_assessment(&minted)],
+                "summary": "assess no-diff auto-task",
+            }],
+            "workspace_path": repo_root,
+        }),
+    )
+    .expect("apply no-diff assessment");
+    assert_eq!(applied["status"], "succeeded");
+
+    let prepared_task = runtime.get_task(&minted.id).expect("prepared task");
+    assert_eq!(prepared_task.complexity, Some(TaskComplexity::Low));
+    assert!(prepared_task.context_files.is_empty());
+    assert_eq!(prepared_task.crew.as_deref(), Some("opus"));
+
+    let after = classify(&runtime);
+    assert!(
+        after["loose_task_ids"]
+            .as_array()
+            .expect("admitted tasks")
+            .contains(&json!(minted.id))
+    );
 }
 
 /// A live `task_auto_pipeline` run carrying `task_ids`, as `invoke_detached`


### PR DESCRIPTION
## Task

[ORB-12053](https://orbit-cli.com/tasks/ORB-12053) — [code-review] The unassessed-complexity admission gate permanently blocks every shipped auto-task from automatic dispatch

### Description

## Problem

ORB-11991 (`5f91cc081`) added a hard admission gate: automatic dispatch now drops
every backlog task whose complexity is not assessed. Auto-tasks are minted with
`TaskComplexity::Unassessed` by design, and the one mechanism that could assess
them — task-pilot — is configured to skip exactly the tasks auto-tasks are tagged
with. The result is a closed loop: once this gate ships in an installed binary,
no shipped auto-task can ever be dispatched again.

## The three links, verified against live code at `e6f78e0fb`

1. **Every auto-task is minted `Unassessed`.**
   `crates/orbit-core/src/application/auto_tasks/scheduler.rs:84` —
   `complexity: orbit_types::task::TaskComplexity::Unassessed` in
   `template_params`, the single template→task mapping used by both the
   scheduler fire and `orbit.auto_task.mint`.

2. **The drain now excludes every unassessed task.**
   `crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs:288-298`
   — `backlog_snapshot` runs `backlog.retain(|task| task.complexity.is_some_and(TaskComplexity::is_assessed))`
   before the crew filter, pushing `BacklogTaskExclusionReason::UnassessedComplexity`
   (`:47`) for everything else. `backlog_snapshot` is the drain's population source:
   `crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs:163`, whose
   `admissible_leaves` become the pending wave (`:161-176`).

3. **Task-pilot refuses to assess exactly those tasks.**
   `crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs:407-409` —
   `automatic_exclusion_reason` returns `no_diff_task` for any task carrying a
   tag in `NO_DIFF_TAGS = ["no-diff-needed", "no-diff-expected"]` (`:41`).

Every shipped auto-task definition carries `no-diff-expected`:
`crates/orbit-core/assets/auto_tasks/{code-review,delivery-code-review,delivery-qa,friction-curation,qa-sweep,security-review}.yaml`
and the workspace-local `.orbit/auto_tasks/qa-full-sweep.yaml:51`. So each one is
minted unassessed, permanently ineligible for the assessment that would clear the
gate, and permanently ineligible for the drain.

The auto-task scheduler routine only mints
(`.orbit/resources/jobs/auto_task_scheduler_pipeline.yaml` runs the single
`run_auto_task_scheduler` activity); nothing else dispatches minted tasks, so
`workspace_auto_pipeline` is the only path and there is no bypass.

## Why this is not already visible

The installed daemon binary predates the change
(`~/.orbit/bin/orbit` mtime `2026-09-10T06:31:55Z`; `5f91cc081` merged
`2026-09-10T08:01Z`), so runs minted after the merge — including ORB-12052,
which reports `"complexity": "unassessed"` — still dispatched under the old
build. The stall appears on the next rebuild/install.

## Secondary defect in the same gate

`backlog_exclusion.rs:180-191`: on the explicit-task-ID branch,
`list_backlog_tasks` returns `DispatchError::DeterministicActionFailed` for an
unassessed task. Because the branch ends in `.collect::<Result<Vec<_>, _>>()?`
(`:193`), a single unassessed ID fails the whole action rather than excluding
that one task, so an operator listing a mixed set gets no results at all.

## Suggested direction

The gate itself is the intended design (see
`docs/design/operation-mode/2_design.md` §2 and
`docs/design/automation-triggers/2_design.md`), so the fix is to give
no-diff-tagged automated work a defined answer instead of leaving it stranded —
for example, letting task-pilot assess a no-diff task's complexity without
proposing selectors, having the mint path record an assessed complexity from the
definition, or exempting system-created no-diff tasks from the admission gate.
Whichever is chosen, `automatic_exclusion_reason` and `backlog_snapshot` must not
be able to disagree about the same task forever. Do not simply drop the gate:
ORB-11991 added it deliberately to keep unprepared repair work out of
implementation lanes.

## Evidence to reproduce

Seed a backlog task with `complexity: unassessed` and tag `no-diff-expected`,
then run the drain classifier: it appears under `excluded` with reason
`unassessed_complexity` (the shape asserted by
`crates/orbit-core/src/adapter/engine_host/v2_host/tests/backlog_exclusion.rs:60-82`),
and a task-pilot discovery pass reports it excluded as `no_diff_task`.

### Acceptance Criteria

- A shipped auto-task minted with unassessed complexity and no-diff-expected has a supported end-to-end path through preparation to automatic admission, without invented modification selectors or loss of its explicit QA/review crew. An integration regression exercises mint, assessment/preparation and classifier/backlog_snapshot rather than merely exempting a tag.
- Ordinary unprepared implementation work with unassessed complexity is still withheld from automatic admission, so the ORB-11991 gate keeps its intended effect; a test covers both cases.
- `list_backlog_tasks` with an explicit ID list containing one unassessed task no longer fails the whole action; the assessed IDs are still returned and the unassessed one is reported as excluded.
- `make ci-fast` and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Allowed automatic task-pilot discovery to prepare only provenance-tagged `auto-task:*` tasks carrying `no-diff-expected`; generic no-diff work remains excluded.
- Preserved the assessment gate and added explicit mixed-ID backlog exclusions instead of failing the complete request.
- Added regressions for minted no-diff QA work through preparation, verified-no-diff assessment, classifier admission, crew preservation, ordinary unassessed withholding, and mixed explicit IDs.

Criteria:
- Shipped-style no-diff auto-task: covered end-to-end by `minted_no_diff_auto_task_is_prepared_without_selectors_then_admitted`; it mints unassessed work, prepares it without selectors, applies a verified-no-diff complexity assessment, preserves crew `opus`, and reaches `classify_workspace_auto_tasks` admission.
- Ordinary unassessed work: remains excluded in automatic and explicit backlog selection tests.
- Explicit mixed IDs: assessed work is returned while unassessed work is serialized under `excluded` with `unassessed_complexity`.
- Validation: passed `cargo fmt --check`; focused backlog-exclusion, task-pilot, and workspace-auto tests; `make ci-fast`; and `make ci-lint`.

Assessment: scope-limited change with no new dependencies. The auto-task provenance tag is required alongside `no-diff-expected`, so a no-diff tag alone cannot authorize automatic preparation.

Risks: no remaining known risks; full CI remains the merge gate.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12053-6aa269b9`
- Behind base: 0
- Ahead of base: 1