### PR TITLE
Keep runtime sandbox directory and SQLite grants safe through creation and mount consumption

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -82,12 +82,6 @@ extensions:
           "manual",
         ]
       - [
-          "orbit_core::adapter::engine_host::v2_host::sandbox::validated_linux_runtime_descendant",
-          "ReturnValue.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]",
-          "path-injection",
-          "manual",
-        ]
-      - [
           "orbit_common::storage::sqlite::validated_sqlite_path",
           "ReturnValue.Field[core::result::Result::Ok(0)]",
           "path-injection",

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
@@ -1,10 +1,16 @@
 #[cfg(target_os = "linux")]
-use std::ffi::OsString;
+use std::ffi::{CString, OsString};
+#[cfg(target_os = "linux")]
+use std::fs::File;
+#[cfg(target_os = "linux")]
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+#[cfg(target_os = "linux")]
+use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::path::PathBuf;
 
 use orbit_engine::RuntimeHost;
-use orbit_engine::{DispatchError, ResolvedSandbox};
+use orbit_engine::{DispatchError, LinuxRuntimeWriteAuthority, ResolvedSandbox};
 use orbit_types::policy::{ResolvedFsProfile, UNRESTRICTED_FS_PROFILE};
 use orbit_types::workflow::ExecutorSandboxKind;
 
@@ -40,6 +46,7 @@ pub(crate) fn resolve_executor_sandbox(
             },
             allow_fallback: false,
             managed_worktree: false,
+            runtime_write_authority: Vec::new(),
         })),
         ExecutorSandboxKind::MacosSandboxExec => {
             #[cfg(not(target_os = "macos"))]
@@ -76,6 +83,7 @@ pub(crate) fn resolve_executor_sandbox(
                     fs_profile: resolved,
                     allow_fallback: executor.allow_fallback,
                     managed_worktree: false,
+                    runtime_write_authority: Vec::new(),
                 }))
             }
         }
@@ -107,11 +115,13 @@ pub(crate) fn resolve_executor_sandbox(
                 if grants_workspace_modify {
                     append_codex_side_write_roots(runtime, provider, &mut resolved)?;
                 }
+                let mut runtime_write_authority = Vec::new();
                 append_linux_runtime_write_roots(
                     runtime,
                     subprocess_cwd,
                     grants_workspace_modify,
                     &mut resolved,
+                    &mut runtime_write_authority,
                 )?;
                 append_linux_provider_state_roots(provider, &mut resolved)?;
                 append_recovery_authority_deny(runtime, &mut resolved)?;
@@ -136,6 +146,7 @@ pub(crate) fn resolve_executor_sandbox(
                     fs_profile: resolved,
                     allow_fallback: executor.allow_fallback,
                     managed_worktree,
+                    runtime_write_authority,
                 }))
             }
         }
@@ -310,15 +321,16 @@ fn append_linux_runtime_write_roots(
     _subprocess_cwd: Option<&Path>,
     grants_workspace_modify: bool,
     resolved: &mut ResolvedFsProfile,
+    authority: &mut Vec<LinuxRuntimeWriteAuthority>,
 ) -> Result<(), DispatchError> {
     let global = validated_linux_runtime_root(&runtime.paths().global_dir)?;
     let workspace = validated_linux_runtime_root(&runtime.paths().orbit_dir)?;
 
     for relative in ["state/logs", "state/audit", "tasks"] {
-        append_runtime_directory_grant(&global, relative, resolved)?;
+        append_runtime_directory_grant(&global, relative, resolved, authority)?;
     }
     for relative in ["orbit.db", "orbit.db-wal", "orbit.db-shm"] {
-        append_runtime_sidecar_grant(&global, relative, resolved)?;
+        append_runtime_sidecar_grant(&global, relative, resolved, authority)?;
     }
 
     if !grants_workspace_modify {
@@ -332,21 +344,21 @@ fn append_linux_runtime_write_roots(
         "state/logs",
         "state/job-runs",
     ] {
-        append_runtime_directory_grant(&workspace, relative, resolved)?;
+        append_runtime_directory_grant(&workspace, relative, resolved, authority)?;
     }
     for relative in [
         "state/semantic.db",
         "state/semantic.db-wal",
         "state/semantic.db-shm",
     ] {
-        append_runtime_sidecar_grant(&workspace, relative, resolved)?;
+        append_runtime_sidecar_grant(&workspace, relative, resolved, authority)?;
     }
 
     // Language-neutral host cache for toolchain artifacts shared across
     // worktrees (compiler caches, etc.). Implementer-only so read-only
     // profiles stay non-writers. Not a workspace `.orbit` path and not a
     // shared Cargo target directory. [ORB-11259]
-    append_runtime_directory_grant(&global, "cache", resolved)?;
+    append_runtime_directory_grant(&global, "cache", resolved, authority)?;
 
     Ok(())
 }
@@ -364,6 +376,7 @@ pub(super) fn append_runtime_directory_grant(
     root: &Path,
     relative: &str,
     resolved: &mut ResolvedFsProfile,
+    authority: &mut Vec<LinuxRuntimeWriteAuthority>,
 ) -> Result<(), DispatchError> {
     let Some(directory) = validated_linux_runtime_descendant(root, relative)? else {
         tracing::warn!(
@@ -374,13 +387,12 @@ pub(super) fn append_runtime_directory_grant(
         return Ok(());
     };
 
-    std::fs::create_dir_all(&directory).map_err(|error| {
-        DispatchError::CliInvocationPermanent(format!(
-            "create Linux sandbox runtime store `{}`: {error}",
-            directory.display()
-        ))
-    })?;
+    let handle = open_or_create_runtime_directory(root, &directory)?;
     append_unique_modify_root(resolved, directory.display().to_string());
+    authority.push(LinuxRuntimeWriteAuthority {
+        path: directory,
+        handle: std::sync::Arc::new(File::from(handle)),
+    });
     Ok(())
 }
 
@@ -397,6 +409,7 @@ pub(super) fn append_runtime_sidecar_grant(
     root: &Path,
     relative: &str,
     resolved: &mut ResolvedFsProfile,
+    authority: &mut Vec<LinuxRuntimeWriteAuthority>,
 ) -> Result<(), DispatchError> {
     let Some(file) = validated_linux_runtime_descendant(root, relative)? else {
         tracing::warn!(
@@ -409,7 +422,12 @@ pub(super) fn append_runtime_sidecar_grant(
 
     match std::fs::symlink_metadata(&file) {
         Ok(metadata) if metadata.is_file() => {
+            let handle = open_runtime_file(root, &file)?;
             append_unique_modify_root(resolved, file.display().to_string());
+            authority.push(LinuxRuntimeWriteAuthority {
+                path: file,
+                handle: std::sync::Arc::new(File::from(handle)),
+            });
             Ok(())
         }
         Ok(_) => Ok(()),
@@ -419,6 +437,106 @@ pub(super) fn append_runtime_sidecar_grant(
             file.display()
         ))),
     }
+}
+
+#[cfg(target_os = "linux")]
+pub(super) fn open_or_create_runtime_directory(
+    root: &Path,
+    directory: &Path,
+) -> Result<OwnedFd, DispatchError> {
+    let relative = directory.strip_prefix(root).map_err(|_| {
+        DispatchError::CliInvocationPermanent(format!(
+            "Linux sandbox runtime store `{}` escaped `{}`",
+            directory.display(),
+            root.display()
+        ))
+    })?;
+    let mut current =
+        open_directory_at(None, root).map_err(|error| runtime_open_error(root, error))?;
+    for component in relative.components() {
+        let std::path::Component::Normal(name) = component else {
+            return Err(DispatchError::CliInvocationPermanent(format!(
+                "Linux sandbox runtime store `{}` contains an invalid component",
+                directory.display()
+            )));
+        };
+        match open_directory_at(Some(&current), Path::new(name)) {
+            Ok(next) => current = next,
+            Err(error) if error.raw_os_error() == Some(libc::ENOENT) => {
+                mkdir_at(&current, name, directory)?;
+                current = open_directory_at(Some(&current), Path::new(name))
+                    .map_err(|error| runtime_open_error(directory, error))?;
+            }
+            Err(error) => return Err(runtime_open_error(directory, error)),
+        }
+    }
+    Ok(current)
+}
+
+#[cfg(target_os = "linux")]
+fn open_runtime_file(root: &Path, file: &Path) -> Result<OwnedFd, DispatchError> {
+    let relative = file
+        .strip_prefix(root)
+        .map_err(|_| runtime_open_error(file, std::io::Error::from_raw_os_error(libc::EXDEV)))?;
+    let parent = relative.parent().unwrap_or_else(|| Path::new(""));
+    let parent_path = root.join(parent);
+    let directory = open_or_create_runtime_directory(root, &parent_path)?;
+    let name = relative
+        .file_name()
+        .ok_or_else(|| runtime_open_error(file, std::io::Error::from_raw_os_error(libc::EINVAL)))?;
+    let name = CString::new(name.as_bytes())
+        .map_err(|_| runtime_open_error(file, std::io::Error::from_raw_os_error(libc::EINVAL)))?;
+    let flags = libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK;
+    let raw = unsafe { libc::openat(directory.as_raw_fd(), name.as_ptr(), flags) };
+    if raw < 0 {
+        return Err(runtime_open_error(file, std::io::Error::last_os_error()));
+    }
+    let opened = File::from(unsafe { OwnedFd::from_raw_fd(raw) });
+    let metadata = opened
+        .metadata()
+        .map_err(|error| runtime_open_error(file, error))?;
+    if !metadata.is_file() {
+        return Err(runtime_open_error(
+            file,
+            std::io::Error::from_raw_os_error(libc::EINVAL),
+        ));
+    }
+    Ok(opened.into())
+}
+
+#[cfg(target_os = "linux")]
+fn open_directory_at(parent: Option<&OwnedFd>, path: &Path) -> std::io::Result<OwnedFd> {
+    let path = CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::from_raw_os_error(libc::EINVAL))?;
+    let flags = libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW;
+    let raw = match parent {
+        Some(parent) => unsafe { libc::openat(parent.as_raw_fd(), path.as_ptr(), flags) },
+        None => unsafe { libc::open(path.as_ptr(), flags) },
+    };
+    if raw < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(unsafe { OwnedFd::from_raw_fd(raw) })
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn mkdir_at(parent: &OwnedFd, name: &std::ffi::OsStr, path: &Path) -> Result<(), DispatchError> {
+    let name = CString::new(name.as_bytes())
+        .map_err(|_| runtime_open_error(path, std::io::Error::from_raw_os_error(libc::EINVAL)))?;
+    let result = unsafe { libc::mkdirat(parent.as_raw_fd(), name.as_ptr(), 0o777) };
+    if result < 0 && std::io::Error::last_os_error().raw_os_error() != Some(libc::EEXIST) {
+        return Err(runtime_open_error(path, std::io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn runtime_open_error(path: &Path, error: std::io::Error) -> DispatchError {
+    DispatchError::CliInvocationPermanent(format!(
+        "open Linux sandbox runtime object `{}` without following links: {error}",
+        path.display()
+    ))
 }
 
 /// Resolve a store Orbit owns beneath an already-validated runtime root.

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
@@ -1332,7 +1332,7 @@ mod runtime_store_grants {
 
     use crate::adapter::engine_host::v2_host::sandbox::{
         append_runtime_directory_grant, append_runtime_sidecar_grant,
-        validated_linux_runtime_descendant,
+        open_or_create_runtime_directory, validated_linux_runtime_descendant,
     };
 
     fn canonical_root(root: &Path) -> std::path::PathBuf {
@@ -1428,7 +1428,9 @@ mod runtime_store_grants {
         let root = canonical_root(root.path());
         let mut profile = empty_profile();
 
-        append_runtime_directory_grant(&root, "state/logs", &mut profile).expect("grant store");
+        let mut authority = Vec::new();
+        append_runtime_directory_grant(&root, "state/logs", &mut profile, &mut authority)
+            .expect("grant store");
 
         assert!(
             root.join("state/logs").is_dir(),
@@ -1438,6 +1440,7 @@ mod runtime_store_grants {
             profile.modify,
             vec![root.join("state/logs").display().to_string()]
         );
+        assert_eq!(authority[0].path, root.join("state/logs"));
     }
 
     /// A store whose parent is redirected out of the runtime root must not be
@@ -1453,14 +1456,35 @@ mod runtime_store_grants {
         symlink(&outside, root.join("state")).expect("redirect the state store");
         let mut profile = empty_profile();
 
-        append_runtime_directory_grant(&root, "state/logs", &mut profile)
+        let mut authority = Vec::new();
+        append_runtime_directory_grant(&root, "state/logs", &mut profile, &mut authority)
             .expect("a redirected store is skipped, not a dispatch failure");
 
         assert!(profile.modify.is_empty(), "grants: {:?}", profile.modify);
+        assert!(authority.is_empty());
         assert!(
             !outside.join("logs").exists(),
             "the redirect target must be left untouched"
         );
+    }
+
+    #[test]
+    fn directory_creation_rejects_parent_replaced_after_validation() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let outside = tempfile::tempdir().expect("outside");
+        let root = canonical_root(root.path());
+        std::fs::create_dir(root.join("state")).expect("state");
+        let validated = validated_linux_runtime_descendant(&root, "state/logs")
+            .expect("validate")
+            .expect("in-root path");
+        std::fs::remove_dir(root.join("state")).expect("remove state");
+        symlink(outside.path(), root.join("state")).expect("replace state");
+
+        let error = open_or_create_runtime_directory(&root, &validated)
+            .expect_err("descriptor walk must reject replacement");
+
+        assert!(error.to_string().contains("without following links"));
+        assert!(!outside.path().join("logs").exists());
     }
 
     #[test]
@@ -1470,13 +1494,17 @@ mod runtime_store_grants {
         std::fs::write(root.join("orbit.db-wal"), b"").expect("create sidecar");
         let mut profile = empty_profile();
 
-        append_runtime_sidecar_grant(&root, "orbit.db-wal", &mut profile).expect("grant sidecar");
-        append_runtime_sidecar_grant(&root, "orbit.db-shm", &mut profile).expect("skip sidecar");
+        let mut authority = Vec::new();
+        append_runtime_sidecar_grant(&root, "orbit.db-wal", &mut profile, &mut authority)
+            .expect("grant sidecar");
+        append_runtime_sidecar_grant(&root, "orbit.db-shm", &mut profile, &mut authority)
+            .expect("skip sidecar");
 
         assert_eq!(
             profile.modify,
             vec![root.join("orbit.db-wal").display().to_string()]
         );
+        assert_eq!(authority[0].path, root.join("orbit.db-wal"));
     }
 
     /// SQLite writes its sidecars next to the database it opens, so a sidecar
@@ -1492,10 +1520,12 @@ mod runtime_store_grants {
         symlink(&target, root.join("orbit.db-wal")).expect("redirect the sidecar");
         let mut profile = empty_profile();
 
-        append_runtime_sidecar_grant(&root, "orbit.db-wal", &mut profile)
+        let mut authority = Vec::new();
+        append_runtime_sidecar_grant(&root, "orbit.db-wal", &mut profile, &mut authority)
             .expect("a redirected sidecar is skipped, not a dispatch failure");
 
         assert!(profile.modify.is_empty(), "grants: {:?}", profile.modify);
+        assert!(authority.is_empty());
     }
 
     #[test]
@@ -1505,10 +1535,27 @@ mod runtime_store_grants {
         symlink(root.join("never-created"), root.join("orbit.db-wal")).expect("dangling sidecar");
         let mut profile = empty_profile();
 
-        append_runtime_sidecar_grant(&root, "orbit.db-wal", &mut profile)
+        let mut authority = Vec::new();
+        append_runtime_sidecar_grant(&root, "orbit.db-wal", &mut profile, &mut authority)
             .expect("a dangling sidecar is skipped, not a dispatch failure");
 
         assert!(profile.modify.is_empty(), "grants: {:?}", profile.modify);
+        assert!(authority.is_empty());
+    }
+
+    #[test]
+    fn sidecar_grant_skips_a_nonregular_object() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let root = canonical_root(root.path());
+        std::fs::create_dir(root.join("orbit.db-wal")).expect("nonregular sidecar");
+        let mut profile = empty_profile();
+        let mut authority = Vec::new();
+
+        append_runtime_sidecar_grant(&root, "orbit.db-wal", &mut profile, &mut authority)
+            .expect("a nonregular sidecar is skipped");
+
+        assert!(profile.modify.is_empty());
+        assert!(authority.is_empty());
     }
 }
 

--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -5,9 +5,9 @@ use std::process::{Child, Command, Stdio};
 
 use orbit_common::OrbitError;
 use orbit_exec::{
-    BwrapProbeOutcome, LinuxBwrapSpawnRequest, MacosLoginKeychainAccess, MacosSandboxSpawnRequest,
-    UnsatisfiedWriteGrant, compile_linux_bwrap_argv, compile_macos_sandbox_profile,
-    linux_bwrap_write_grant_diagnostic, macos_login_keychain_access,
+    BwrapProbeOutcome, LinuxBwrapMountAuthority, LinuxBwrapSpawnRequest, MacosLoginKeychainAccess,
+    MacosSandboxSpawnRequest, UnsatisfiedWriteGrant, compile_linux_bwrap_argv_with_authority,
+    compile_macos_sandbox_profile, linux_bwrap_write_grant_diagnostic, macos_login_keychain_access,
     prepare_linux_bwrap_write_grants, probe_bwrap, sandbox_exec_available,
     sandbox_exec_unavailable_message, spawn_under_linux_bwrap, spawn_under_macos_sandbox,
 };
@@ -502,12 +502,32 @@ fn spawn_linux_bwrap(
         }
         report_unsatisfied_grants(&prepared.unsatisfied);
     }
-    let plan = compile_linux_bwrap_argv(
+    let authority = sandbox
+        .runtime_write_authority
+        .iter()
+        .map(|grant| {
+            grant
+                .handle
+                .try_clone()
+                .map(|source| LinuxBwrapMountAuthority {
+                    destination: grant.path.clone(),
+                    source,
+                })
+                .map_err(|error| {
+                    SpawnError::permanent(format!(
+                        "duplicate Linux runtime grant descriptor `{}`: {error}",
+                        grant.path.display()
+                    ))
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let plan = compile_linux_bwrap_argv_with_authority(
         &sandbox.fs_profile,
         program,
         args,
         cwd,
         sandbox.managed_worktree,
+        authority,
     )
     .map_err(|error| SpawnError::permanent(error.to_string()))?;
     reject_unsatisfiable_managed_grants(sandbox.managed_worktree, &plan.dropped_grants)?;

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/argv.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/argv.rs
@@ -175,6 +175,7 @@ fn task_pilot_reviewer_profile_starts_direct_linux_invocation_with_env_denies() 
         fs_profile: effective.clone(),
         allow_fallback: false,
         managed_worktree: false,
+        runtime_write_authority: Vec::new(),
     };
     let argv = try_audit_argv_for_dispatch("/bin/true", &[], Some(&sandbox), Some(&workspace))
         .expect("direct task-pilot Bubblewrap plan must compile");
@@ -295,6 +296,7 @@ fn triage_reviewer_profile_starts_direct_linux_invocation_and_protects_env_paths
         fs_profile: effective.clone(),
         allow_fallback: false,
         managed_worktree: false,
+        runtime_write_authority: Vec::new(),
     };
     let argv = try_audit_argv_for_dispatch("/bin/true", &[], Some(&sandbox), Some(&workspace))
         .expect("direct triage Bubblewrap plan must compile");

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -1519,6 +1519,7 @@ fn linux_bwrap_failed_invocation_names_ungranted_write_path_and_deny() {
             fs_profile: profile,
             allow_fallback: false,
             managed_worktree: true,
+            runtime_write_authority: Vec::new(),
         }),
         task_context: Some(serde_json::json!({
             "workspace_path": workspace.display().to_string()
@@ -1631,6 +1632,7 @@ fn linux_bwrap_exit_zero_without_an_envelope_still_names_the_denied_write() {
             fs_profile: profile,
             allow_fallback: false,
             managed_worktree: true,
+            runtime_write_authority: Vec::new(),
         }),
         task_context: Some(serde_json::json!({
             "workspace_path": workspace.display().to_string()

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -41,6 +41,7 @@ pub(in crate::activity_job::cli_runner) fn sandbox_for_test() -> ResolvedSandbox
         },
         allow_fallback: false,
         managed_worktree: false,
+        runtime_write_authority: Vec::new(),
     }
 }
 

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -1,4 +1,6 @@
 use std::collections::BTreeMap;
+use std::fs::File;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use orbit_types::workflow::activity_job::V2AuditEventKind;
@@ -45,6 +47,25 @@ pub struct ResolvedShellExecutor {
     pub timeout_seconds: Option<u64>,
 }
 
+/// Open host object backing a Linux runtime convenience grant.
+///
+/// The descriptor is acquired while the runtime path is validated and remains
+/// alive until Bubblewrap consumes the mount plan. The displayed path is only
+/// the namespace destination; it is never reopened as the mount source.
+#[derive(Clone, Debug)]
+pub struct LinuxRuntimeWriteAuthority {
+    pub path: PathBuf,
+    pub handle: Arc<File>,
+}
+
+impl PartialEq for LinuxRuntimeWriteAuthority {
+    fn eq(&self, other: &Self) -> bool {
+        self.path == other.path && Arc::ptr_eq(&self.handle, &other.handle)
+    }
+}
+
+impl Eq for LinuxRuntimeWriteAuthority {}
+
 /// Sandbox descriptor for a CLI invocation. The host resolves the executor's
 /// `sandbox` declaration and the activity's `fsProfile` against the active
 /// policy and workspace root; the engine compiles the OS-specific payload
@@ -62,6 +83,9 @@ pub struct ResolvedSandbox {
     /// Whether the subprocess runs in an Orbit-owned disposable worktree.
     /// Linux may snapshot-expand non-subtree deny globs only in this case.
     pub managed_worktree: bool,
+    /// Linux runtime grants whose host objects were opened by the resolving
+    /// host. Empty for other backends and ordinary policy-derived grants.
+    pub runtime_write_authority: Vec<LinuxRuntimeWriteAuthority>,
 }
 
 /// Input bundle for a single v2 activity dispatch.

--- a/crates/orbit-engine/src/activity_job/mod.rs
+++ b/crates/orbit-engine/src/activity_job/mod.rs
@@ -21,8 +21,9 @@ mod tests;
 pub use audit_writer::V2AuditWriter;
 pub use crew::{ResolvedAgentSettings, inject_system_crew_input, resolve_crew_settings};
 pub use dispatcher::{
-    DispatchError, DispatchOutcome, ResolvedCliExecutor, ResolvedSandbox, ResolvedShellExecutor,
-    V2DispatchInput, dispatch_error_to_orbit, dispatch_v2_activity,
+    DispatchError, DispatchOutcome, LinuxRuntimeWriteAuthority, ResolvedCliExecutor,
+    ResolvedSandbox, ResolvedShellExecutor, V2DispatchInput, dispatch_error_to_orbit,
+    dispatch_v2_activity,
 };
 pub use job_executor::{
     JobOutcome, execute_job_with_resume, resolve_job_catalog_refs_for_execution, validate_job,

--- a/crates/orbit-engine/src/lib.rs
+++ b/crates/orbit-engine/src/lib.rs
@@ -40,12 +40,13 @@ mod tests;
 
 pub use activity_job::{
     ActivityAsset, AssetLoadError, CatalogDirectory, CatalogDirectoryList, CatalogError,
-    DispatchError, DispatchOutcome, EnforcedAuditSink, JobAsset, JobOutcome, ResolveError,
-    ResolvedAgentSettings, ResolvedCliExecutor, ResolvedSandbox, ResolvedShellExecutor,
-    V2ActivityCatalog, V2AuditWriter, V2DispatchInput, V2JobCatalog, V2SqliteSink,
-    catalog_error_to_orbit, dispatch_error_to_orbit, dispatch_v2_activity, execute_job_with_resume,
-    inject_system_crew_input, load_activity_asset, load_activity_catalog_asset, load_job_asset,
-    resolve_crew_settings, resolve_job_catalog_refs_for_execution, resolve_job_target_refs,
+    DispatchError, DispatchOutcome, EnforcedAuditSink, JobAsset, JobOutcome,
+    LinuxRuntimeWriteAuthority, ResolveError, ResolvedAgentSettings, ResolvedCliExecutor,
+    ResolvedSandbox, ResolvedShellExecutor, V2ActivityCatalog, V2AuditWriter, V2DispatchInput,
+    V2JobCatalog, V2SqliteSink, catalog_error_to_orbit, dispatch_error_to_orbit,
+    dispatch_v2_activity, execute_job_with_resume, inject_system_crew_input, load_activity_asset,
+    load_activity_catalog_asset, load_job_asset, resolve_crew_settings,
+    resolve_job_catalog_refs_for_execution, resolve_job_target_refs,
     validate_catalog_activity_tools, validate_job, validate_job_deterministic_actions,
 };
 pub use context::{

--- a/crates/orbit-exec/src/lib.rs
+++ b/crates/orbit-exec/src/lib.rs
@@ -53,11 +53,13 @@ pub use linux_landlock::{
     linux_landlock_read_boundary, probe_landlock, spawn_under_linux_landlock,
 };
 pub use linux_sandbox::{
-    BwrapProbeOutcome, LINUX_STABLE_BUILD_MOUNT, LINUX_STABLE_WORKSPACE_MOUNT, LinuxBwrapPlan,
-    LinuxBwrapPostRunGuard, LinuxBwrapSpawnRequest, PreparedWriteGrants, UnsatisfiedWriteGrant,
-    WriteAnchorKind, WriteGrant, bwrap_path, bwrap_program_for_audit, bwrap_unavailable_message,
-    compile_linux_bwrap_argv, linux_bwrap_write_grant_diagnostic, linux_bwrap_write_grants,
-    prepare_linux_bwrap_write_grants, probe_bwrap, spawn_under_linux_bwrap,
+    BwrapProbeOutcome, LINUX_STABLE_BUILD_MOUNT, LINUX_STABLE_WORKSPACE_MOUNT,
+    LinuxBwrapMountAuthority, LinuxBwrapPlan, LinuxBwrapPostRunGuard, LinuxBwrapSpawnRequest,
+    PreparedWriteGrants, UnsatisfiedWriteGrant, WriteAnchorKind, WriteGrant, bwrap_path,
+    bwrap_program_for_audit, bwrap_unavailable_message, compile_linux_bwrap_argv,
+    compile_linux_bwrap_argv_with_authority, linux_bwrap_write_grant_diagnostic,
+    linux_bwrap_write_grants, prepare_linux_bwrap_write_grants, probe_bwrap,
+    spawn_under_linux_bwrap,
 };
 pub use macos_sandbox::{
     MacosLoginKeychainAccess, MacosSandboxSpawnRequest, claude_state_dir_from_env,

--- a/crates/orbit-exec/src/linux_sandbox.rs
+++ b/crates/orbit-exec/src/linux_sandbox.rs
@@ -5,7 +5,10 @@
 //! write confinement, not a general read-policy implementation.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::fs::File;
 use std::fs::OpenOptions;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 
@@ -29,7 +32,7 @@ pub struct BwrapProbeOutcome {
     pub detail: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct LinuxBwrapPlan {
     pub wrapper: String,
     pub args: Vec<String>,
@@ -37,6 +40,26 @@ pub struct LinuxBwrapPlan {
     /// because their anchor does not exist. Never silently discarded: the
     /// caller reports each one against the rule that granted it.
     pub dropped_grants: Vec<UnsatisfiedWriteGrant>,
+    /// Mount-source descriptors retained until Bubblewrap has consumed argv.
+    /// Empty for ordinary path-based plans and audit rendering.
+    mount_sources: Vec<File>,
+}
+
+impl PartialEq for LinuxBwrapPlan {
+    fn eq(&self, other: &Self) -> bool {
+        self.wrapper == other.wrapper
+            && self.args == other.args
+            && self.dropped_grants == other.dropped_grants
+    }
+}
+
+impl Eq for LinuxBwrapPlan {}
+
+/// A host object already validated and opened by the runtime owner.
+#[derive(Debug)]
+pub struct LinuxBwrapMountAuthority {
+    pub destination: PathBuf,
+    pub source: File,
 }
 
 #[derive(Debug)]
@@ -499,6 +522,19 @@ pub fn probe_bwrap() -> BwrapProbeOutcome {
             detail: bwrap_unavailable_message(),
         };
     };
+    let supports_bind_fd = Command::new(&path)
+        .arg("--help")
+        .output()
+        .map(|output| String::from_utf8_lossy(&output.stdout).contains("--bind-fd"))
+        .unwrap_or(false);
+    if !supports_bind_fd {
+        return BwrapProbeOutcome {
+            available: false,
+            trusted_path: path.display().to_string(),
+            detail: "Bubblewrap does not support the required --bind-fd object-authority mount"
+                .to_string(),
+        };
+    }
     let args = base_namespace_args();
     let output = Command::new(&path)
         .args(&args)
@@ -655,7 +691,47 @@ pub fn compile_linux_bwrap_argv(
         wrapper: TRUSTED_BWRAP_PATH.to_string(),
         args: out,
         dropped_grants,
+        mount_sources: Vec::new(),
     })
+}
+
+/// Compile a plan whose selected writable mount sources are descriptor-backed.
+///
+/// The authority descriptors name the validated objects even if their host
+/// paths are subsequently replaced. Bubblewrap receives only inherited
+/// `--bind-fd` sources for those grants; a missing matching bind fails
+/// closed because the runtime authority would otherwise be silently unused.
+pub fn compile_linux_bwrap_argv_with_authority(
+    profile: &ResolvedFsProfile,
+    program: &str,
+    args: &[String],
+    cwd: Option<&Path>,
+    managed_worktree: bool,
+    authority: Vec<LinuxBwrapMountAuthority>,
+) -> Result<LinuxBwrapPlan, OrbitError> {
+    let mut plan = compile_linux_bwrap_argv(profile, program, args, cwd, managed_worktree)?;
+    for (descriptor_index, grant) in authority.into_iter().enumerate() {
+        let rendered = grant.destination.display().to_string();
+        let mut replaced = false;
+        for index in 0..plan.args.len().saturating_sub(2) {
+            if plan.args[index] == "--bind"
+                && plan.args[index + 1] == rendered
+                && plan.args[index + 2] == rendered
+            {
+                plan.args[index] = "--bind-fd".to_string();
+                plan.args[index + 1] = (descriptor_index + 3).to_string();
+                replaced = true;
+            }
+        }
+        if !replaced {
+            return Err(OrbitError::PolicyDenied(format!(
+                "validated Linux runtime grant `{}` had no writable mount in the final sandbox plan",
+                grant.destination.display()
+            )));
+        }
+        plan.mount_sources.push(grant.source);
+    }
+    Ok(plan)
 }
 
 pub fn spawn_under_linux_bwrap(request: LinuxBwrapSpawnRequest<'_>) -> Result<Child, OrbitError> {
@@ -691,6 +767,31 @@ pub fn spawn_under_linux_bwrap(request: LinuxBwrapSpawnRequest<'_>) -> Result<Ch
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
+        let source_fds = plan
+            .mount_sources
+            .iter()
+            .map(AsRawFd::as_raw_fd)
+            .collect::<Vec<_>>();
+        let mut temporary_fds = vec![-1; source_fds.len()];
+        unsafe {
+            command.pre_exec(move || {
+                let minimum = 3 + source_fds.len() as libc::c_int;
+                for (index, source) in source_fds.iter().copied().enumerate() {
+                    let duplicate = libc::fcntl(source, libc::F_DUPFD_CLOEXEC, minimum);
+                    if duplicate < 0 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                    temporary_fds[index] = duplicate;
+                }
+                for (index, duplicate) in temporary_fds.iter().copied().enumerate() {
+                    if libc::dup2(duplicate, 3 + index as libc::c_int) < 0 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                    libc::close(duplicate);
+                }
+                Ok(())
+            });
+        }
         command.process_group(0);
     }
     command.spawn().map_err(|error| {

--- a/crates/orbit-exec/src/tests/linux_sandbox.rs
+++ b/crates/orbit-exec/src/tests/linux_sandbox.rs
@@ -5,6 +5,8 @@
 
 use std::collections::BTreeSet;
 use std::fs;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
 use std::path::PathBuf;
 
 use super::{LinuxBwrapPostRunGuard, expand_rule, expand_rules, walk_paths};
@@ -225,4 +227,156 @@ fn managed_aliases_replay_denies_and_pin_replaceable_parents() {
         assert_eq!(final_mount[0], mode);
         assert_eq!(final_mount[1], source.display().to_string());
     }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn descriptor_mount_plan_holds_the_validated_object_and_closes_it_on_drop() {
+    use super::{LinuxBwrapMountAuthority, compile_linux_bwrap_argv_with_authority};
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().canonicalize().expect("canonical root");
+    let target = root.join("orbit.db-wal");
+    fs::write(&target, b"validated").expect("sidecar");
+    let source = fs::File::open(&target).expect("open authority");
+    let source_fd = source.as_raw_fd();
+    fs::rename(&target, root.join("validated-sidecar")).expect("replace name");
+    fs::write(&target, b"replacement").expect("replacement");
+    let resolved = profile(vec![target.display().to_string()]);
+
+    let plan = compile_linux_bwrap_argv_with_authority(
+        &resolved,
+        "/bin/true",
+        &[],
+        Some(&root),
+        false,
+        vec![LinuxBwrapMountAuthority {
+            destination: target.clone(),
+            source,
+        }],
+    )
+    .expect("descriptor-backed plan");
+    assert!(plan.args.windows(3).any(|args| {
+        args[0] == "--bind-fd" && args[1] == "3" && args[2] == target.display().to_string()
+    }));
+    assert!(unsafe { libc::fcntl(source_fd, libc::F_GETFD) } >= 0);
+
+    drop(plan);
+    assert_eq!(unsafe { libc::fcntl(source_fd, libc::F_GETFD) }, -1);
+    assert_eq!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(libc::EBADF)
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn descriptor_mount_plan_rejects_an_external_symlink_replacement() {
+    use std::os::unix::fs::symlink;
+
+    use super::{LinuxBwrapMountAuthority, compile_linux_bwrap_argv_with_authority};
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().join("root");
+    let outside = temp.path().join("outside");
+    fs::create_dir_all(&root).expect("root");
+    fs::create_dir_all(&outside).expect("outside");
+    let target = root.join("orbit.db-wal");
+    let secret = outside.join("secret");
+    fs::write(&target, b"validated").expect("sidecar");
+    fs::write(&secret, b"outside").expect("secret");
+    let source = fs::File::open(&target).expect("open authority");
+    fs::remove_file(&target).expect("remove validated name");
+    symlink(&secret, &target).expect("external replacement");
+    let resolved = profile(vec![target.display().to_string()]);
+
+    let error = compile_linux_bwrap_argv_with_authority(
+        &resolved,
+        "/bin/true",
+        &[],
+        Some(&root),
+        false,
+        vec![LinuxBwrapMountAuthority {
+            destination: target,
+            source,
+        }],
+    )
+    .expect_err("replacement must fail closed");
+
+    assert!(matches!(error, OrbitError::PolicyDenied(_)));
+    assert_eq!(fs::read(&secret).expect("outside content"), b"outside");
+}
+
+/// Control for the original fault: path-only compilation follows the name at
+/// consumption time. Keep this executable finding beside the descriptor-safe
+/// case so the latter cannot become a model-only assertion.
+#[cfg(target_os = "linux")]
+#[test]
+fn path_only_mount_plan_follows_an_external_sidecar_replacement() {
+    use std::os::unix::fs::symlink;
+
+    use super::compile_linux_bwrap_argv;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().join("root");
+    let outside = temp.path().join("outside");
+    fs::create_dir_all(&root).expect("root");
+    fs::create_dir_all(&outside).expect("outside");
+    let target = root.join("orbit.db-wal");
+    let secret = outside.join("secret");
+    fs::write(&target, b"validated").expect("sidecar");
+    fs::write(&secret, b"outside").expect("secret");
+    fs::remove_file(&target).expect("remove validated name");
+    symlink(&secret, &target).expect("external replacement");
+    let resolved = profile(vec![target.display().to_string()]);
+
+    let plan = compile_linux_bwrap_argv(&resolved, "/bin/true", &[], Some(&root), false)
+        .expect("path-only control compiles");
+    let outside = secret.canonicalize().expect("canonical outside");
+
+    assert!(plan.args.windows(3).any(|args| {
+        args[0] == "--bind"
+            && args[1] == outside.display().to_string()
+            && args[2] == outside.display().to_string()
+    }));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn descriptor_directory_mount_rejects_an_external_symlink_replacement() {
+    use std::os::unix::fs::symlink;
+
+    use super::{LinuxBwrapMountAuthority, compile_linux_bwrap_argv_with_authority};
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().join("root");
+    let outside = temp.path().join("outside");
+    let target = root.join("state/logs");
+    fs::create_dir_all(&target).expect("runtime directory");
+    fs::create_dir_all(&outside).expect("outside");
+    let source = fs::File::open(&target).expect("open directory authority");
+    fs::remove_dir(&target).expect("remove validated directory name");
+    symlink(&outside, &target).expect("external replacement");
+    let resolved = profile(vec![format!("{}/**", target.display())]);
+
+    let error = compile_linux_bwrap_argv_with_authority(
+        &resolved,
+        "/bin/true",
+        &[],
+        Some(&root),
+        false,
+        vec![LinuxBwrapMountAuthority {
+            destination: target,
+            source,
+        }],
+    )
+    .expect_err("directory replacement must fail closed");
+
+    assert!(matches!(error, OrbitError::PolicyDenied(_)));
+    assert!(
+        fs::read_dir(&outside)
+            .expect("outside directory")
+            .next()
+            .is_none()
+    );
 }

--- a/crates/orbit-exec/tests/linux_sandbox.rs
+++ b/crates/orbit-exec/tests/linux_sandbox.rs
@@ -7,10 +7,11 @@ use std::process::Stdio;
 
 use orbit_common::OrbitError;
 use orbit_exec::{
-    LINUX_STABLE_BUILD_MOUNT, LINUX_STABLE_WORKSPACE_MOUNT, LinuxBwrapPostRunGuard,
-    LinuxBwrapSpawnRequest, WriteAnchorKind, bwrap_path, bwrap_program_for_audit,
-    compile_linux_bwrap_argv, linux_bwrap_write_grant_diagnostic, linux_bwrap_write_grants,
-    prepare_linux_bwrap_write_grants, probe_bwrap, spawn_under_linux_bwrap,
+    LINUX_STABLE_BUILD_MOUNT, LINUX_STABLE_WORKSPACE_MOUNT, LinuxBwrapMountAuthority,
+    LinuxBwrapPostRunGuard, LinuxBwrapSpawnRequest, WriteAnchorKind, bwrap_path,
+    bwrap_program_for_audit, compile_linux_bwrap_argv, compile_linux_bwrap_argv_with_authority,
+    linux_bwrap_write_grant_diagnostic, linux_bwrap_write_grants, prepare_linux_bwrap_write_grants,
+    probe_bwrap, spawn_under_linux_bwrap,
 };
 use orbit_types::policy::ResolvedFsProfile;
 
@@ -78,6 +79,60 @@ fn bwrap_child_gets_only_the_supplied_environment() {
             "{leaked} must not reach a Bubblewrap-confined provider child: {child_env}"
         );
     }
+}
+
+/// Explicit live regression for the validation-to-mount boundary. The host
+/// name is replaced after its descriptor is opened; the child may modify only
+/// that opened object, never the replacement now visible at the name.
+#[test]
+#[ignore = "requires a Linux host with working Bubblewrap user/mount namespaces"]
+fn kernel_descriptor_mount_never_writes_the_replacement_object() {
+    let probe = probe_bwrap();
+    assert!(
+        probe.available,
+        "live boundary unvalidated: {}",
+        probe.detail
+    );
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().canonicalize().expect("canonical root");
+    let target = root.join("orbit.db-wal");
+    let original = root.join("original-wal");
+    std::fs::write(&target, b"validated").expect("validated file");
+    let source = std::fs::File::open(&target).expect("open validated authority");
+    std::fs::rename(&target, &original).expect("move validated object");
+    std::fs::write(&target, b"replacement").expect("replacement file");
+    let resolved = profile(vec![target.display().to_string()]);
+    let plan = compile_linux_bwrap_argv_with_authority(
+        &resolved,
+        "/bin/sh",
+        &[
+            "-c".to_string(),
+            format!("printf child > '{}'", target.display()),
+        ],
+        Some(&root),
+        false,
+        vec![LinuxBwrapMountAuthority {
+            destination: target.clone(),
+            source,
+        }],
+    )
+    .expect("compile descriptor plan");
+
+    let status = spawn_under_linux_bwrap(LinuxBwrapSpawnRequest {
+        plan: &plan,
+        env: &[],
+        cwd: Some(&root),
+        stdin: Stdio::null(),
+        stdout: Stdio::null(),
+        stderr: Stdio::piped(),
+    })
+    .expect("spawn")
+    .wait()
+    .expect("wait");
+
+    assert!(status.success());
+    assert_eq!(std::fs::read(&original).expect("held object"), b"child");
+    assert_eq!(std::fs::read(&target).expect("replacement"), b"replacement");
 }
 
 #[test]

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -240,6 +240,26 @@ The ADR authoring exception follows that same ordering: trusted host setup ensur
 
 `spawn_linux_bwrap` prepares mount anchors immediately before compiling argv, from the same `ResolvedFsProfile` that compiles it. The grant set is every positive exact/subtree `modify` rule that is a narrow re-allow beneath an earlier deny and remains writable at its anchor after the full ordered rule list is evaluated. A later deny covering the anchor therefore prevents materialization, while a narrower deny below a writable subtree leaves the remaining subtree grant intact. Broad writable roots are excluded; they are host-owned and must already exist, so an absent one still fails closed at compile.
 
+Linux runtime-store conveniences have a stronger source contract than ordinary
+policy paths. Core resolves them beneath a canonical runtime root, creates
+missing directory components with descriptor-relative `mkdirat`/`openat`
+operations that refuse symlinks, and opens the final directory or regular
+SQLite object. Engine retains those descriptors through dispatch. The actual
+Bubblewrap plan uses inherited `--bind-fd` mount sources; the mutable pathname
+is only the mount destination. Bubblewrap consumes and closes these setup
+descriptors rather than preserving them for the provider process. A path
+replacement that prevents the descriptor grant from matching the final plan is
+rejected before spawn. This assumes the already-open runtime-root object and
+its ancestors cannot be remounted by an unprivileged concurrent writer; name
+renames and symlink replacement below that object do not change descriptor
+authority. Descriptor closure occurs when the plan is dropped after spawn.
+
+This descriptor handoff is Linux-only. macOS continues to compile Seatbelt
+rules from canonical paths and other platforms reject a Linux Bubblewrap
+executor. The generic path-only Bubblewrap compiler remains available for
+ordinary policy rules and audit rendering; it is intentionally not a sanitizer
+for mutable runtime sidecars.
+
 The policy grammar is the explicit anchor-type contract: an exact rule denotes a file, while `<root>/**` denotes a directory subtree. Filename punctuation is never type evidence, so an extensionless exact rule materializes a file and a dotted subtree root materializes a directory without any hardcoded path inventory. An existing target whose filesystem type contradicts its rule fails closed.
 
 Creation is confined to the canonical managed worktree, which is trusted and disposable. Every worktree-owned component is checked for symlinks before both existing- and absent-target handling, the resolved existing anchor (or newly created parent) must remain inside the canonical root, and files use create-new semantics. Anchors outside that root are the host's to create and are reported, not invented. Creating an anchor grants nothing new — the final effective profile already decided the path is writable — so this is materialization, not policy.

--- a/docs/design/policy-sandbox/specs/sandbox-exec-contract.md
+++ b/docs/design/policy-sandbox/specs/sandbox-exec-contract.md
@@ -209,6 +209,21 @@ silently amend the original mandate.
 | Hardlinks | Names do not track secret provenance. AppArmor's subset rule can reject a child creating a more permissive alias, but an already existing allowed-name hardlink is a different case. Define resolved-path semantics consistently with the current evaluator, or require an isolated backing tree with no external hardlink writers. Neither is byte-provenance tracking. |
 | File opened while allowed, then renamed; existing mmap | The Landlock probes retain access. Linux 6.8 AppArmor caches granted FD permissions and does not provide general rename-based revocation. A mapping can already expose bytes without another pathname syscall. If revocation after rename is required, neither candidate is a full solution; specify stronger mutation isolation or a narrower acquisition contract explicitly. |
 | Inherited FD, cwd/dirfd, SCM_RIGHTS and pidfd acquisition | Close all nonessential descriptors before untrusted exec; use owned stdin pipes/null rather than arbitrary inherited files. Restrict Unix-socket FD donors, ptrace/process-memory and other access channels. AppArmor transition revalidation is not a substitute for descriptor hygiene. The deliberate inherited-FD probe demonstrates the Landlock hole. |
+
+Linux runtime directories and SQLite sidecars are an object-authority exception
+to path-only compilation. The host must open each accepted object while it is
+validating or descriptor-relatively creating it, carry that descriptor through
+engine dispatch, and supply `--bind-fd` as Bubblewrap's bind source. The
+pathname remains the namespace destination only. Replacing a validated name
+with a symlink or different object must either leave the held object as the sole
+writable source or reject the plan before spawn. A second canonicalization or
+metadata check without a retained descriptor does not meet this contract.
+
+The guarantee covers renames and link replacement beneath the opened runtime
+root. It assumes an unprivileged peer cannot remount the runtime root or its
+host ancestors. Bubblewrap consumes and closes the inherited setup descriptors
+before provider exec; the parent closes its copies with the plan after spawn.
+Non-Linux backends do not consume this authority representation.
 | Descendants and detached sessions | Enforce before the first untrusted instruction; use inherited/stacked confinement across fork/exec. `setsid` does not remove Landlock or AppArmor. Termination of processes escaping the original PGID is a separate supervision problem; the probe's detached child exits and is waited for explicitly. |
 | External writers or already known bytes | A denied name cannot undo copies, prior reads or malicious externally supplied hardlinks. Record the trusted-writer/acquisition boundary; do not advertise retroactive secrecy. |
 

--- a/docs/runbooks/linux-sandbox.md
+++ b/docs/runbooks/linux-sandbox.md
@@ -146,3 +146,23 @@ affected services/connections and verify ordinary reads again. Do not launch
 an old MCP server or drain against shared executor files that still contain
 `off`. These steps change Orbit processes and resources, not host AppArmor
 settings.
+
+### Runtime grant race regression
+
+Runtime directory and SQLite sidecar grants are passed to Bubblewrap as held
+file descriptors using `--bind-fd`; the capability probe rejects older builds
+that do not advertise this option. Run the explicit kernel regression on an
+authorized Linux host after building the candidate revision:
+
+```sh
+cargo test -p orbit-exec --test linux_sandbox \
+  kernel_descriptor_mount_never_writes_the_replacement_object -- --ignored --exact
+```
+
+The test deliberately replaces a regular sidecar name after its descriptor is
+opened and proves that the replacement is unchanged. Namespace denial is a
+test failure, not a skip. Ordinary tests also cover descriptor closure and
+fail-closed external-symlink replacement without requiring user namespaces.
+The contract assumes concurrent writers cannot perform privileged remounts of
+the already-open runtime root or its ancestors. macOS uses its existing
+Seatbelt path rules; other platforms reject `linux-bwrap` at dispatch.


### PR DESCRIPTION
## Task

[ORB-12042](https://orbit-cli.com/tasks/ORB-12042) — Keep runtime sandbox directory and SQLite grants safe through creation and mount consumption

### Description

Hosted Rust analysis1753057681 at dac03e79888e6bd5524181514029c5f0ad0b9c70 introduces alert417 at crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs:410. Current6d5070eee retains append_runtime_sidecar_grant: validated_linux_runtime_descendant returns a PathBuf, symlink_metadata checks a regular file, append_unique_modify_root stores only a mutable path. Eventual Linux bwrap plan emits host-source --bind paths. A concurrent runtime-root writer can replace the checked file with an external symlink before sandbox setup. ORB12016 tests initial symlinks but not this validation-to-use boundary. Verify full compilation/consumption path and demonstrate the gap before selecting repair; source inspection is not an executed exploit.

Bind actual grant consumption to validated object identity using a descriptor/FD handoff or another design holding authority through setup. Preserve SQLite main/WAL/SHM behavior, supported root aliases and recovery authority denies. Do not widen writable runtime roots/parents, drop necessary sidecars, or claim a timing-only recheck is atomic. Review and narrow/remove the validated_linux_runtime_descendant CodeQL barrier where it blesses mutable paths.12040 model participation cannot substitute for runtime safety. Task-pilot must locate actual sandbox plan/executor owners beyond the initial metadata sink. Root owns hosted confirmation and live bwrap testing if nested leaf namespace capability is unavailable.

Further source verification extends this same boundary to directory grants. append_runtime_directory_grant at sandbox.rs363-384 validates then create_dir_all then stores a mutable name: with R/state missing, swapping it to /outside after validation can create /outside/logs; post-create swaps can redirect the bind. Include both directory and sidecar grants in this repair. Final mount_paths_for_rule in crates/orbit-exec/src/linux_sandbox.rs797-805 canonicalizes but does not recheck runtime containment or hold an FD: a swapped R/orbit.db-wal can become --bind /outside/secret /outside/secret. Parent bind anchors577-602 protect already-mounted child namespace entries, not host source races before bind. Core sandbox helpers, orbit-exec Linux plan/spawn and potentially engine cli_runner/spawn.rs own the needed object handoff. Do not claim extra last-moment path checks are race-safe. Preserve descriptor/authority through actual creation and final kernel consumption, or fail closed under explicit demonstrated constraints.

### Acceptance Criteria

- Deterministically replace a regular in-root sidecar with an external symlink after validation but before sandbox consumption. Actual bwrap or faithful FD/source-boundary test proves outside content is never granted writable; establish pre-fix failure where capability permits.
- Hold intended object authority through grant consumption or reject replacement. Preserve normal/missing/nonregular/dangling/outside-symlink/in-root-alias cases, SQLite operation and recovery-authority denies, without broader writable directories.
- Test Linux descriptor lifetime/close behavior and state ancestor-mutation assumptions and non-Linux behavior explicitly. Extra path rechecks alone do not close the race; unavailable live namespace tests remain unrun.
- Model changes reflect proven source safety, preserving an unsafe sidecar control as a finding. No rule suppression/dismissal/global sanitizer; root verifies hosted417 on merged revision.
- Focused adversarial sandbox/execution tests and make ci-fast/ci-lint pass; document compatibility/platform limits.
- Directory-grant regressions deterministically swap a missing/intermediate or final component before creation and before mount consumption: no outside mkdir/write/chmod or writable bind occurs. Preserve legitimate missing-directory creation and supported aliases with descriptor-anchored authority through the final boundary.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Runtime directory creation now walks from an opened canonical runtime root with no-follow openat/mkdirat operations. Missing components are created only beneath the held parent; in-root aliases remain supported after canonical resolution, while escaping, dangling, nonregular, and symlink replacements fail closed or retain their documented skip behavior.
- Core opens every accepted runtime directory and regular SQLite database/sidecar object and carries the descriptors in ResolvedSandbox through engine dispatch. The final orbit-exec plan rewrites only matching writable binds to Bubblewrap --bind-fd sources; path replacement either leaves the held object as the sole source or makes compilation reject the unused authority. The capability probe now requires --bind-fd.
- Removed validated_linux_runtime_descendant from the CodeQL barrier model. The generic path-only compiler remains deliberately untrusted and has an executable control showing that an external sidecar replacement is followed, while the production descriptor path rejects it. No suppression or sanitizer was added.
- Added sidecar and directory replacement regressions, missing/intermediate creation protection, descriptor lifetime/closure checks, and a live ignored Bubblewrap regression; updated design, contract, and runbook platform/ancestor assumptions and the exact operator command.
Criteria evidence:
1. Deterministic unit control proves path-only compilation follows an external sidecar replacement; descriptor compilation rejects that replacement. The live kernel fixture is committed, but this managed worker cannot create a namespace.
2. Open descriptors are retained from Core validation through actual spawn compilation; existing regular/missing/nonregular/dangling/outside-symlink/in-root-alias tests pass, and focused sandbox/recovery tests preserve runtime grants and authority denies.
3. Unit coverage proves the plan owns descriptors and closes them on drop. Bubblewrap --bind-fd consumes setup descriptors rather than preserving them into the provider. Docs state privileged ancestor-remount assumptions and Linux-only behavior.
4. The overbroad descendant barrier was removed; the unsafe path-only sidecar control remains an executed finding. Hosted alert 417 verification is deferred to root on the merged revision as required.
5. Focused Core, Engine, and orbit-exec tests pass; make ci-fast and make ci-lint pass. Compatibility and platform limits are documented.
6. A deterministic validation-to-create parent swap is rejected without creating outside/logs; a final directory-to-external-symlink swap is rejected at mount-plan consumption. Legitimate missing directories and in-root aliases pass.
Validation:
- cargo test -p orbit-exec descriptor_ -- --nocapture: passed (3 descriptor tests; live ignored fixture remained ignored).
- cargo test -p orbit-exec path_only_mount_plan_follows_an_external_sidecar_replacement -- --nocapture: passed (pre-fix control).
- cargo test -p orbit-exec --test linux_sandbox -- --nocapture: passed, 20 passed and 2 explicit live tests ignored due namespace requirements.
- cargo test -p orbit-core adapter::engine_host::v2_host::tests::sandbox -- --nocapture: passed, 48 tests.
- cargo test -p orbit-core recovery_authority_sandbox -- --nocapture: passed, 2 tests; live namespace branch reported unavailable.
- cargo test -p orbit-engine activity_job::cli_runner::tests::spawn -- --nocapture: passed, 32 tests.
- cargo test -p orbit-exec --test linux_sandbox kernel_descriptor_mount_never_writes_the_replacement_object -- --ignored --exact: unavailable in this managed worker; failed at the explicit capability assertion with bwrap No permissions to create new namespace. Exact command is in the runbook for the verified operator host.
- make ci-fast: passed; its namespace cache probe explicitly skipped for the same bwrap denial.
- make ci-lint: passed.
- cargo fmt --all -- --check: passed.
- git diff --check: passed.
Assessment: Production grant consumption is object-bound rather than timing-rechecked, directory creation is descriptor-anchored, and the change preserves narrow policy semantics without broader writable roots.
Remaining risks: Live --bind-fd mount behavior and SQLite execution inside Bubblewrap require the root-owned operator run outside this nested worker. Hosted CodeQL alert 417 must be checked on the merged revision. No non-Linux runtime execution was available; cfg compilation behavior and documentation state that Linux authority is not consumed by other backends.
Deviations from original plan: Live bwrap validation and hosted CodeQL could not be completed in the managed leaf; both are explicitly reserved for root/operator by the task comments and remain unclaimed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12042-6aa264bd`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra