### PR TITLE
[code-review] Three no-follow reads omit O_NONBLOCK, so a FIFO planted in the check→open window hangs the caller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2336,7 +2336,6 @@ version = "0.20.0"
 dependencies = [
  "chrono",
  "hostname",
- "libc",
  "orbit-common",
  "orbit-types",
  "serde",

--- a/crates/orbit-common/src/fs/file_lock.rs
+++ b/crates/orbit-common/src/fs/file_lock.rs
@@ -211,7 +211,8 @@ fn validated_lock_holder_parent(lock_path: &Path) -> Option<PathBuf> {
 /// avoids blocking on an exotic node such as a FIFO; it is *not* the security
 /// boundary. That boundary is the open immediately after: on Unix,
 /// `O_NOFOLLOW` makes the open itself fail if the final component is a
-/// symlink, and the follow-up `metadata()` call is an `fstat` on the
+/// symlink and `O_NONBLOCK` prevents a swapped FIFO from hanging the caller;
+/// the follow-up `metadata()` call is an `fstat` on the
 /// already-open descriptor, re-checking the file that was actually opened
 /// rather than a path that could have changed again. Folding the check and
 /// the open into one function, with the open re-validating its own
@@ -227,8 +228,9 @@ fn validated_lock_holder_parent(lock_path: &Path) -> Option<PathBuf> {
 /// only the leaf-symlink swap this closes.
 ///
 /// The no-follow open is atomic against the leaf swap on Unix (`O_NOFOLLOW`)
-/// and on Windows (`FILE_FLAG_OPEN_REPARSE_POINT`, which opens a reparse
-/// point itself instead of its target). On any other platform the open
+/// and nonblocking for a swapped FIFO. On Windows,
+/// `FILE_FLAG_OPEN_REPARSE_POINT` opens a reparse point itself instead of its
+/// target. On any other platform the open
 /// follows a symlink normally, so the pathname pre-check above is the only
 /// protection and a swap landing between that check and the open is not
 /// covered there.
@@ -244,31 +246,10 @@ fn open_lock_holder_file(lock_path: &Path, before_open: impl FnOnce(&Path)) -> O
 
     before_open(&candidate);
 
-    let mut options = OpenOptions::new();
-    options.read(true);
-    apply_read_only_no_follow(&mut options);
-    let file = options.open(&candidate).ok()?;
+    let file = super::open_read_only_no_follow(&candidate).ok()?;
     let metadata = file.metadata().ok()?;
     metadata.is_file().then_some(file)
 }
-
-#[cfg(unix)]
-fn apply_read_only_no_follow(options: &mut OpenOptions) {
-    use std::os::unix::fs::OpenOptionsExt;
-
-    options.custom_flags(libc::O_NOFOLLOW);
-}
-
-#[cfg(windows)]
-fn apply_read_only_no_follow(options: &mut OpenOptions) {
-    use std::os::windows::fs::OpenOptionsExt;
-
-    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-    options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
-}
-
-#[cfg(not(any(unix, windows)))]
-fn apply_read_only_no_follow(_options: &mut OpenOptions) {}
 
 fn open_lock_file(lock_path: &Path, label: &str) -> io::Result<File> {
     let mut options = OpenOptions::new();

--- a/crates/orbit-common/src/fs/io.rs
+++ b/crates/orbit-common/src/fs/io.rs
@@ -568,6 +568,19 @@ pub(crate) fn open_private_file(path: &Path, options: &mut OpenOptions) -> io::R
     Ok(file)
 }
 
+/// Open `path` for a read-only inspection without following its final component.
+///
+/// On Unix the open is nonblocking as well as no-follow, so a FIFO swapped in
+/// after a caller's pathname check cannot indefinitely block the reader. The
+/// caller remains responsible for checking the opened descriptor's type and
+/// mapping errors into its domain-specific behavior.
+pub fn open_read_only_no_follow(path: &Path) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    apply_read_only_no_follow(&mut options);
+    options.open(path)
+}
+
 /// Resolve a private file's parent before opening it and reject a final
 /// component that would redirect the operation through a symlink.
 ///
@@ -625,6 +638,24 @@ fn apply_no_follow_final_component(options: &mut OpenOptions) {
 
     options.custom_flags(libc::O_NOFOLLOW);
 }
+
+#[cfg(unix)]
+fn apply_read_only_no_follow(options: &mut OpenOptions) {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+}
+
+#[cfg(windows)]
+fn apply_read_only_no_follow(options: &mut OpenOptions) {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+}
+
+#[cfg(not(any(unix, windows)))]
+fn apply_read_only_no_follow(_options: &mut OpenOptions) {}
 
 #[cfg(not(unix))]
 fn apply_no_follow_final_component(_options: &mut OpenOptions) {}

--- a/crates/orbit-common/src/fs/mod.rs
+++ b/crates/orbit-common/src/fs/mod.rs
@@ -5,5 +5,7 @@ pub mod path;
 pub mod selector;
 pub mod task_io;
 
+pub use io::open_read_only_no_follow;
+
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-common/src/fs/tests/io.rs
+++ b/crates/orbit-common/src/fs/tests/io.rs
@@ -216,6 +216,38 @@ fn read_file_lock_holder_rejects_a_final_symlink_swapped_after_the_path_check() 
 
 #[cfg(unix)]
 #[test]
+fn read_file_lock_holder_does_not_block_on_a_fifo_swapped_after_the_path_check() {
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    use crate::fs::file_lock::read_file_lock_holder_after_resolve;
+
+    let root = tempfile::tempdir().expect("root tempdir");
+    let lock_path = root.path().join(".task.yaml.lock");
+    std::fs::write(&lock_path, br#"{"pid":1}"#).expect("write checked holder");
+    let (sender, receiver) = mpsc::channel();
+
+    thread::spawn(move || {
+        let holder = read_file_lock_holder_after_resolve(&lock_path, |checked_path| {
+            std::fs::remove_file(checked_path).expect("remove checked holder");
+            let status = std::process::Command::new("mkfifo")
+                .arg(checked_path)
+                .status()
+                .expect("create FIFO");
+            assert!(status.success(), "mkfifo must succeed: {status}");
+        });
+        sender.send(holder).expect("report holder result");
+    });
+
+    let holder = receiver
+        .recv_timeout(Duration::from_secs(1))
+        .expect("FIFO swap must not block the holder reader");
+    assert!(holder.is_none(), "a swapped FIFO is not holder metadata");
+}
+
+#[cfg(unix)]
+#[test]
 fn read_file_lock_holder_rejects_a_symlinked_lock_file() {
     let root = tempfile::tempdir().expect("root tempdir");
     let outside = tempfile::tempdir().expect("outside tempdir");

--- a/crates/orbit-registry/Cargo.toml
+++ b/crates/orbit-registry/Cargo.toml
@@ -20,8 +20,5 @@ serde.workspace = true
 serde_json.workspace = true
 toml.workspace = true
 
-[target.'cfg(unix)'.dependencies]
-libc.workspace = true
-
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/orbit-registry/src/host_identity.rs
+++ b/crates/orbit-registry/src/host_identity.rs
@@ -12,7 +12,7 @@
 //! no silent fallback to the OS hostname. Routine `hosts:` pinning,
 //! the sweep, and status all resolve through [`HostIdentity::host_id`].
 
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -20,6 +20,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use orbit_common::OrbitError;
 use orbit_common::fs::io::{atomic_write_text, with_exclusive_file_lock};
+use orbit_common::fs::open_read_only_no_follow;
 use orbit_common::protocol::toml::escape_basic_string;
 use orbit_types::identity::{MACHINE_ID_PREFIX, validate_machine_id};
 use serde::Deserialize;
@@ -194,9 +195,9 @@ fn validated_existing_global_root(global_root: &Path) -> Result<Option<PathBuf>,
 /// Open the fixed identity file beneath the validated root without following a
 /// swapped final symlink.
 ///
-/// Unix uses `O_NOFOLLOW`; Windows opens the reparse point itself. The descriptor
-/// is checked for a regular file before any bytes are read. Platforms without
-/// either primitive still perform both pathname and descriptor type checks, but
+/// Unix uses `O_NOFOLLOW | O_NONBLOCK`; Windows opens the reparse point itself.
+/// The descriptor is checked for a regular file before any bytes are read.
+/// Platforms without either primitive still perform both pathname and descriptor type checks, but
 /// cannot close a final-component check/open race. Canonicalization also permits
 /// trusted root aliases, so this leaf protection does not claim to prevent a
 /// privileged concurrent rename or replacement of a mutable ancestor directory.
@@ -223,10 +224,7 @@ where
         Ok(_) => {
             before_open(&path)?;
 
-            let mut options = OpenOptions::new();
-            options.read(true);
-            apply_no_follow_final_component(&mut options);
-            let file = options.open(&path).map_err(|error| {
+            let file = open_read_only_no_follow(&path).map_err(|error| {
                 OrbitError::Io(format!("failed to open '{}': {error}", path.display()))
             })?;
             let metadata = file.metadata().map_err(|error| {
@@ -249,24 +247,6 @@ where
         ))),
     }
 }
-
-#[cfg(unix)]
-fn apply_no_follow_final_component(options: &mut OpenOptions) {
-    use std::os::unix::fs::OpenOptionsExt;
-
-    options.custom_flags(libc::O_NOFOLLOW);
-}
-
-#[cfg(windows)]
-fn apply_no_follow_final_component(options: &mut OpenOptions) {
-    use std::os::windows::fs::OpenOptionsExt;
-
-    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-    options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
-}
-
-#[cfg(not(any(unix, windows)))]
-fn apply_no_follow_final_component(_options: &mut OpenOptions) {}
 
 fn non_blank(value: &Option<String>) -> Option<String> {
     value

--- a/crates/orbit-registry/src/tests/host_identity.rs
+++ b/crates/orbit-registry/src/tests/host_identity.rs
@@ -312,6 +312,43 @@ fn host_identity_rejects_a_final_symlink_swapped_after_the_path_check() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn host_identity_does_not_block_on_a_fifo_swapped_after_the_path_check() {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let root = tempfile::tempdir().expect("create root tempdir");
+    let path = root.path().join("host.toml");
+    std::fs::write(&path, "host_id = \"checked\"\n").expect("write checked identity");
+    let (sender, receiver) = mpsc::channel();
+
+    thread::spawn(move || {
+        let result = inspect_host_identity_after_check(root.path(), |checked_path| {
+            std::fs::remove_file(checked_path).map_err(|error| {
+                orbit_common::OrbitError::Io(format!("remove checked identity: {error}"))
+            })?;
+            let status = std::process::Command::new("mkfifo")
+                .arg(checked_path)
+                .status()
+                .map_err(|error| orbit_common::OrbitError::Io(format!("create FIFO: {error}")))?;
+            if status.success() {
+                Ok(())
+            } else {
+                Err(orbit_common::OrbitError::Io(format!(
+                    "mkfifo failed: {status}"
+                )))
+            }
+        });
+        sender.send(result).expect("report identity result");
+    });
+
+    let result = receiver
+        .recv_timeout(Duration::from_secs(1))
+        .expect("FIFO swap must not block the identity reader");
+    assert!(result.is_err(), "a swapped FIFO must be rejected");
+}
+
 #[test]
 fn incomplete_current_schema_file_is_rejected() {
     let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/orbit-store/src/driver/file/auto_task/mod.rs
+++ b/crates/orbit-store/src/driver/file/auto_task/mod.rs
@@ -16,12 +16,13 @@
 //! following the final component, so the path check and the read cannot be
 //! separated by a swap [ORB-12026].
 
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, File};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use orbit_common::OrbitError;
 use orbit_common::fs::io::{atomic_write_text, with_exclusive_file_lock};
+use orbit_common::fs::open_read_only_no_follow;
 use orbit_types::workflow::{AutoTaskCursor, AutoTaskCursorState};
 
 #[cfg(test)]
@@ -138,8 +139,8 @@ fn validated_cursor_state_dir(path: &Path) -> Result<Option<PathBuf>, OrbitError
 ///
 /// Both the directory and the final component are validated before the first
 /// metadata probe, so no sink here ever sees the raw caller path. Unix opens
-/// with `O_NOFOLLOW` and Windows opens the reparse point itself; the resulting
-/// descriptor is re-checked for a regular file, so a symlink planted between
+/// with `O_NOFOLLOW | O_NONBLOCK` and Windows opens the reparse point itself.
+/// The resulting descriptor is re-checked for a regular file, so a symlink planted between
 /// the probe and the open fails instead of redirecting the read. A platform
 /// with neither primitive still performs the pathname and descriptor checks
 /// but cannot close that final-component race. Because ancestors are
@@ -178,10 +179,7 @@ where
 
     before_open(&candidate)?;
 
-    let mut options = OpenOptions::new();
-    options.read(true);
-    apply_no_follow_final_component(&mut options);
-    let file = match options.open(&candidate) {
+    let file = match open_read_only_no_follow(&candidate) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) if is_symlink_open_refusal(&error) => {
@@ -237,24 +235,6 @@ fn is_symlink_open_refusal(error: &std::io::Error) -> bool {
 fn is_symlink_open_refusal(_error: &std::io::Error) -> bool {
     false
 }
-
-#[cfg(unix)]
-fn apply_no_follow_final_component(options: &mut OpenOptions) {
-    use std::os::unix::fs::OpenOptionsExt;
-
-    options.custom_flags(libc::O_NOFOLLOW);
-}
-
-#[cfg(windows)]
-fn apply_no_follow_final_component(options: &mut OpenOptions) {
-    use std::os::windows::fs::OpenOptionsExt;
-
-    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-    options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
-}
-
-#[cfg(not(any(unix, windows)))]
-fn apply_no_follow_final_component(_options: &mut OpenOptions) {}
 
 fn parse_state(raw: &str, path: &Path) -> Result<AutoTaskCursorState, OrbitError> {
     serde_json::from_str(raw.trim()).map_err(|error| {

--- a/crates/orbit-store/src/driver/file/auto_task/tests/mod.rs
+++ b/crates/orbit-store/src/driver/file/auto_task/tests/mod.rs
@@ -281,6 +281,42 @@ fn load_cursor_state_rejects_a_symlink_swapped_in_after_the_check() {
     fs::remove_file(&outside_target).expect("cleanup outside target");
 }
 
+#[cfg(unix)]
+#[test]
+fn load_cursor_state_does_not_block_on_a_fifo_swapped_after_the_check() {
+    use std::sync::mpsc;
+
+    let root = tempdir().expect("tempdir");
+    let path = cursor_state_path(root.path());
+    fs::write(&path, state_json("local")).expect("seed regular state file");
+    let (sender, receiver) = mpsc::channel();
+
+    thread::spawn(move || {
+        let result = load_cursor_state_after_check(&path, |checked_path| {
+            fs::remove_file(checked_path).map_err(|error| {
+                orbit_common::OrbitError::Io(format!("remove checked state file: {error}"))
+            })?;
+            let status = std::process::Command::new("mkfifo")
+                .arg(checked_path)
+                .status()
+                .map_err(|error| orbit_common::OrbitError::Io(format!("create FIFO: {error}")))?;
+            if status.success() {
+                Ok(())
+            } else {
+                Err(orbit_common::OrbitError::Io(format!(
+                    "mkfifo failed: {status}"
+                )))
+            }
+        });
+        sender.send(result).expect("report cursor result");
+    });
+
+    let result = receiver
+        .recv_timeout(Duration::from_secs(1))
+        .expect("FIFO swap must not block the cursor reader");
+    assert!(result.is_err(), "a swapped FIFO must be rejected");
+}
+
 #[test]
 fn concurrent_upserts_for_different_definitions_preserve_both_cursors() {
     let root = tempdir().expect("tempdir");


### PR DESCRIPTION
## Task

[ORB-12054](https://orbit-cli.com/tasks/ORB-12054) — [code-review] Three no-follow reads omit O_NONBLOCK, so a FIFO planted in the check→open window hangs the caller

### Description

## Problem

Four path-hardening changes merged into this window each rewrote a
"`symlink_metadata` check, then open" read into a no-follow open that re-checks
its own descriptor. Three of them open with `O_NOFOLLOW` alone. `O_NOFOLLOW`
rejects a symlink but not a FIFO, and the pathname pre-check that would have
rejected a FIFO is — by these functions' own design — no longer trusted, because
the whole point of the change is that the final component can be swapped after
that check. Opening a FIFO read-only with no `O_NONBLOCK` blocks until a writer
appears, so the same attacker who could plant the symlink these changes now
refuse can instead plant a FIFO and hang the caller indefinitely.

The fourth change in the same window, `open_docs_config_at`, guards exactly this
and is the correct reference:
`crates/orbit-core/src/application/docs/config.rs:298` —
`libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK`.

## The three that do not

- `crates/orbit-common/src/fs/file_lock.rs:239-256` — `open_lock_holder_file`
  checks `symlink_metadata(&candidate).is_file()` at `:240-243`, then opens at
  `:249-252` via `apply_read_only_no_follow` (`:257-261`, `O_NOFOLLOW` only).
  Its own doc comment at `:207-211` states the pathname check exists "so this
  avoids blocking on an exotic node such as a FIFO" while also stating it "is
  *not* the security boundary" — the two claims cannot both hold across the
  race the function was written to close. Reached by `read_file_lock_holder`,
  a diagnostic read on caller-selected task and store lock paths.
- `crates/orbit-registry/src/host_identity.rs:215-228` —
  `open_existing_host_toml_with_hook`, `apply_no_follow_final_component` at
  `:254-258`.
- `crates/orbit-store/src/driver/file/auto_task/mod.rs:180-190` —
  `open_cursor_state_file`, `apply_no_follow_final_component` at `:242-246`.

## Secondary: the shim is now duplicated four ways

The same `apply_no_follow_final_component` platform shim now exists in four
crates, three of them added in this window:

- `crates/orbit-common/src/fs/io.rs:620-628` (pre-existing, private, Unix-only arm)
- `crates/orbit-common/src/fs/file_lock.rs:256-271` (named `apply_read_only_no_follow`)
- `crates/orbit-registry/src/host_identity.rs:253-268`
- `crates/orbit-store/src/driver/file/auto_task/mod.rs:241-256`

The divergence above is the predictable consequence: with four copies there is
no single place to fix the flag set. `CLAUDE.md` § Simplicity and ownership
requires moving a helper duplicated across crates to its lowest appropriate
owner rather than adding another copy; `orbit-common` is that owner and both
`orbit-registry` and `orbit-store` already depend on it. Both crates also
picked up a new `libc` dependency (`crates/orbit-registry/Cargo.toml:23-24`,
`crates/orbit-store/Cargo.toml`) purely for this shim.

## Suggested direction

Publish one no-follow read-open helper from `orbit-common::fs` that sets
`O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK` on Unix and `FILE_FLAG_OPEN_REPARSE_POINT`
on Windows, verifies the resulting descriptor is a regular file, and clears
`O_NONBLOCK` (or is documented as unnecessary for a regular file, where it has
no effect on subsequent reads). Move the three call sites onto it and delete the
local copies. Keep each caller's own error mapping — only the open primitive is
shared.

## Scope note

This is a residual in the threat model these changes chose for themselves: it
requires write access to the containing directory, the same precondition as the
symlink swap they now refuse. It is not reachable by a remote or unprivileged
caller.

### Acceptance Criteria

- A single no-follow read-open helper is exposed from `orbit-common::fs` and used by the lock-holder, host-identity, and auto-task cursor readers; the per-crate `apply_no_follow_final_component` / `apply_read_only_no_follow` copies are deleted.
- Opening a FIFO planted at the final component after the pathname check no longer blocks: a test using each reader's existing before-open test hook replaces the checked regular file with a FIFO and asserts the read returns an error or no-metadata within a bounded time instead of hanging.
- Each reader keeps its current behavior for a missing file, a symlinked final component, and a non-regular final component, with its existing error messages and tests unchanged.
- `make ci-fast` and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Exposed `orbit_common::fs::open_read_only_no_follow`, which applies `O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK` on Unix and opens Windows reparse points directly.
- Moved lock-holder, host-identity, and auto-task cursor reads to the shared helper; removed their duplicated platform shims and the now-unused registry `libc` dependency.
- Added bounded Unix FIFO-swap tests at each existing before-open hook.

Criteria evidence:
1. The one shared fs helper is re-exported by `orbit_common::fs` and all three readers call it; local read-shim copies are removed.
2. Each FIFO test swaps the checked regular file for a FIFO, receives the reader result through a one-second bounded channel, and asserts no metadata/error behavior.
3. Existing missing-file, final-symlink, and non-regular-file tests remain and passed in the targeted suites; caller-specific descriptor checks and error mappings remain in place.
4. `make ci-fast` and `make ci-lint` completed successfully.

Validation:
- `cargo test -p orbit-common fs::tests::io` — passed (24 tests).
- `cargo test -p orbit-registry host_identity` — passed (23 tests).
- `cargo test -p orbit-store auto_task` — passed (17 tests).
- `cargo fmt --all --check` — passed.
- `git diff --check` — passed.
- `make ci-fast` — passed.
- `make ci-lint` — passed.

Assessment: focused shared-primitive repair with deterministic regression coverage. Remaining risk: the FIFO regression relies on the standard Unix `mkfifo` utility and is therefore Unix-gated, matching the Unix-only `O_NONBLOCK` behavior.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12054-6aa26a34`
- Behind base: 0
- Ahead of base: 1