### PR TITLE
Restore full core CI coverage for scanner and operation fixtures after task-pilot assessment changes

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dependabot_alert_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dependabot_alert_tasks.rs
@@ -575,8 +575,8 @@ fn unavailable_family_does_not_hide_findings_from_collected_family() {
     );
 }
 
-/// The location ORB-11779 was filed from: alert #165 reported this path at
-/// line 426, and the minted task must already carry it as scope.
+/// Alert #165 reports this workspace file at line 426. Its location remains
+/// evidence at minting time; task-pilot supplies a selector after preparation.
 const ALERT_165_PATH: &str =
     "crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs";
 
@@ -682,7 +682,7 @@ fn code_scanning_locations_outside_the_workspace_produce_no_scope() {
 }
 
 #[test]
-fn an_absolute_in_workspace_location_is_stored_as_a_workspace_relative_selector() {
+fn an_absolute_in_workspace_location_remains_evidence_without_initial_scope() {
     let (_root, runtime, repo) = runtime_with_workspace_layout();
     write_workspace_file(&repo, ALERT_165_PATH);
     let absolute = repo.join(ALERT_165_PATH).to_string_lossy().into_owned();
@@ -696,9 +696,13 @@ fn an_absolute_in_workspace_location_is_stored_as_a_workspace_relative_selector(
         ),
         json!({}),
     );
-    assert_eq!(
-        code_task(&runtime, &output).context_files,
-        vec![format!("file:{ALERT_165_PATH}")]
+    let task = code_task(&runtime, &output);
+    assert!(task.context_files.is_empty());
+    assert!(
+        task.description
+            .contains(&format!("Location: `{absolute}` line 426")),
+        "absolute location evidence lost: {}",
+        task.description
     );
 }
 
@@ -720,7 +724,16 @@ fn resweeping_the_same_alert_preserves_the_scoped_task_without_duplicating_it() 
     let first = file(&runtime, snapshot.clone(), json!({}));
     let task = code_task(&runtime, &first);
     let expected = vec![format!("file:{ALERT_165_PATH}")];
-    assert_eq!(task.context_files, expected);
+    assert!(task.context_files.is_empty());
+    runtime
+        .update_task(
+            &task.id,
+            crate::application::task::TaskUpdateParams {
+                context_files: Some(expected.clone()),
+                ..Default::default()
+            },
+        )
+        .expect("prepare scoped task");
 
     let second = file(&runtime, snapshot, json!({}));
     assert_eq!(second["filed_count"], json!(0));

--- a/crates/orbit-core/src/application/operation/tests/pipeline.rs
+++ b/crates/orbit-core/src/application/operation/tests/pipeline.rs
@@ -245,6 +245,17 @@ fn grant_bound_drain_inherits_the_snapshot_and_rechecks_the_grant_per_child() {
             },
         )
         .expect("give B a footprint of its own");
+    for task_id in [&a.id, &b.id] {
+        runtime
+            .update_task(
+                task_id,
+                crate::application::task::TaskUpdateParams {
+                    complexity: Some(orbit_types::task::TaskComplexity::Medium),
+                    ..Default::default()
+                },
+            )
+            .expect("assess eligible work");
+    }
     let grant = enable(
         runtime,
         &[a.id.clone(), b.id.clone()],
@@ -354,6 +365,17 @@ fn promotion_needs_fresh_positive_evidence_and_the_promote_right() {
     let stale = seed_task(runtime, "stale", TaskStatus::Proposed);
     let unready = seed_task(runtime, "unready", TaskStatus::Proposed);
     let missing = seed_task(runtime, "missing", TaskStatus::Proposed);
+    for task_id in [&fresh.id, &stale.id, &unready.id, &missing.id] {
+        runtime
+            .update_task(
+                task_id,
+                crate::application::task::TaskUpdateParams {
+                    complexity: Some(orbit_types::task::TaskComplexity::Medium),
+                    ..Default::default()
+                },
+            )
+            .expect("assess promotion candidate complexity");
+    }
     seed_assessment(
         &fixture,
         &fresh.id,
@@ -426,6 +448,15 @@ fn promotion_needs_fresh_positive_evidence_and_the_promote_right() {
     // Without the promote right, fresh evidence alone promotes nothing.
     stop(runtime, &grant.id);
     let second = seed_task(runtime, "second fresh", TaskStatus::Proposed);
+    runtime
+        .update_task(
+            &second.id,
+            crate::application::task::TaskUpdateParams {
+                complexity: Some(orbit_types::task::TaskComplexity::Medium),
+                ..Default::default()
+            },
+        )
+        .expect("assess fresh candidate complexity");
     seed_assessment(
         &fixture,
         &second.id,


### PR DESCRIPTION
## Task

[ORB-12056](https://orbit-cli.com/tasks/ORB-12056) — Restore full core CI coverage for scanner and operation fixtures after task-pilot assessment changes

### Description

## Problem
Fresh hosted CI34452952306 at5f91cc08131e36ac751c1f7bcfcbf8e164b7ad1f failed both Check/Clippy/Test job102792666124 and Coverage job102792666102 on the same four orbit-core tests after11991. Linux Sandbox and MSRV passed. Full logs captured at /tmp/orbit-ci-102792666124.log and /tmp/orbit-ci-102792666102.log on owning host; GitHub job logs are authoritative.

## Exact failures
- dependabot_alert_tasks::an_absolute_in_workspace_location_is_stored_as_a_workspace_relative_selector at tests/dependabot_alert_tasks.rs699 expects a file selector but receives[].
- dependabot_alert_tasks::resweeping_the_same_alert_preserves_the_scoped_task_without_duplicating_it at723 has the same obsolete first-mint expectation.
- application::operation::tests::pipeline::grant_bound_drain_inherits_the_snapshot_and_rechecks_the_grant_per_child at308 expects eligible B but receives[].
- application::operation::tests::pipeline::promotion_needs_fresh_positive_evidence_and_the_promote_right at415 expects eligible fresh task but receives[].
Coverage reports1368passed,4failed,2ignored. Current source still contains these assertions.11991 intentionally moved source locations into evidence-only until pilot and requires assessed complexity before admission; its filtered tests missed these names.

## Repair
Bring the fixtures into the real preparation contract without weakening the behaviors under test. Scanner absolute-path coverage must still prove complete location evidence and no invented initial selector. Re-sweep coverage must actually prepare/set a legitimate scoped task before verifying dedupe preserves its selectors/identity. Operation fixtures that represent ready work must carry real assessed complexity consistent with their preparation evidence; retain grant inheritance, scope/claim refusal, stale/unready evidence, promotion rights, and stop/revocation assertions. Diagnose whether a product defect exists rather than blindly changing expected outputs;53 separately owns no-diff auto-task admission and must not be duplicated.

### Acceptance Criteria

- All four named regressions pass for their intended contract: evidence-only scanner mint, preserved prepared scope under re-sweep, grant-bound eligible assessed work, and fresh positive preparation/promotion.
- Negative fixtures still prove unassessed ordinary implementation work is withheld and stale/unready/missing preparation or missing rights cannot admit/promote. Do not globally mark every task assessed or remove assertions to obtain green.
- Run the entire orbit-core library test suite, not only task_pilot/code_scanning name filters, plus focused changed tests, make ci-fast and make ci-lint; all pass. Report exact command/counts and any environment skips.
- Fresh hosted main CI and coverage must pass after merge; leave this as an explicit operator-owned post-merge verification if unavailable in the worker, not a claimed local pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated Code scanning fixtures so absolute in-workspace locations remain complete path-and-line evidence with no initial selector, and re-sweep starts from an explicitly prepared scoped task before confirming dedupe preserves that scope.
- Marked only the operation candidates under test with assessed Medium complexity: grant-bound backlog work can be admitted, while fresh/stale/unready/missing proposed candidates still exercise their distinct preparation outcomes and a fresh candidate without promote rights remains withheld.

Criteria:
1. All four repaired regressions passed as focused tests; scanner mint is evidence-only, prepared scope survives re-sweep, assessed grant-bound work is eligible, and fresh positive evidence promotes only with rights.
2. Negative assertions remain: initial scanner scope is empty; stale/unready/missing assessment reasons are asserted; promote-right absence is asserted. No global fixture assessment or assertion removal was used.
3. Passed `cargo test -p orbit-core --lib` (1376 passed, 0 failed, 2 ignored); all four focused commands passed (1 test each); `make ci-fast` and `make ci-lint` passed. `make ci-fast` reported its existing environment skip for mount-namespace compiler-cache testing because bwrap cannot create an unprivileged namespace; it also reported Cursor headless unavailable while validating the local plugin contract.
4. Hosted main CI and coverage were not available in this worker and remain operator-owned post-merge verification.

Validation:
- PASS: cargo test -p orbit-core --lib an_absolute_in_workspace_location_remains_evidence_without_initial_scope
- PASS: cargo test -p orbit-core --lib resweeping_the_same_alert_preserves_the_scoped_task_without_duplicating_it
- PASS: cargo test -p orbit-core --lib grant_bound_drain_inherits_the_snapshot_and_rechecks_the_grant_per_child
- PASS: cargo test -p orbit-core --lib promotion_needs_fresh_positive_evidence_and_the_promote_right
- PASS: cargo test -p orbit-core --lib (1376 passed, 2 ignored)
- PASS: make ci-fast (bounded environment skips noted above)
- PASS: make ci-lint
- PASS: git diff --check

Assessment: Two task-scoped test files changed; final diff reviewed and no unrelated worktree changes are present.

Remaining risk: Fresh hosted main CI and coverage must be verified after merge by an operator.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12056-6aa26bc4`
- Behind base: 0
- Ahead of base: 1