### PR TITLE
[BLOCKED] Publish and activate an effective Rust path-validation CodeQL model

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yml
@@ -46,12 +46,6 @@ extensions:
           "manual",
         ]
       - [
-          "orbit_core::application::job::pipeline::validate_pipeline_worker_log_directory_input",
-          "ReturnValue.Field[core::result::Result::Ok(0)]",
-          "path-injection",
-          "manual",
-        ]
-      - [
           "orbit_core::application::routines::clock::validated_clock_settings_path",
           "ReturnValue.Field[core::result::Result::Ok(0)]",
           "path-injection",
@@ -150,6 +144,17 @@ extensions:
       - [
           "orbit_common::fs::file_lock::validated_lock_holder_parent",
           "ReturnValue.Field[core::option::Option::Some(0)]",
+          "path-injection",
+          "manual",
+        ]
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: barrierGuardModel
+    data:
+      - [
+          "orbit_core::application::job::pipeline::pipeline_worker_log_directory_input_is_valid",
+          "Argument[0]",
+          "true",
           "path-injection",
           "manual",
         ]

--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -2393,23 +2393,34 @@ pub(crate) mod pipeline_worker_log_test_hook {
 /// phase below. Keeping this phase free of filesystem operations makes the
 /// trust boundary explicit to both reviewers and CodeQL.
 fn validate_pipeline_worker_log_directory_input(path: &Path) -> Result<PathBuf, OrbitError> {
+    if pipeline_worker_log_directory_input_is_valid(path) {
+        return Ok(path.to_path_buf());
+    }
+
     if !path.is_absolute() {
         return Err(OrbitError::InvalidInput(format!(
             "pipeline worker log directory must be absolute: {}",
             path.display()
         )));
     }
-    if path
-        .components()
-        .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
-    {
-        return Err(OrbitError::InvalidInput(format!(
-            "pipeline worker log directory must not contain traversal components: {}",
-            path.display()
-        )));
-    }
 
-    Ok(path.to_path_buf())
+    Err(OrbitError::InvalidInput(format!(
+        "pipeline worker log directory must not contain traversal components: {}",
+        path.display()
+    )))
+}
+
+/// Report whether a worker-log directory has the lexical shape required by
+/// the filesystem-resolution phase.
+///
+/// This boolean guard is kept separate because CodeQL's Rust model API can
+/// represent conditional validation directly, unlike a successful `Result`
+/// projection.
+fn pipeline_worker_log_directory_input_is_valid(path: &Path) -> bool {
+    path.is_absolute()
+        && !path
+            .components()
+            .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
 }
 
 /// Canonicalize the nearest existing ancestor of `parent` and rejoin any

--- a/scripts/check-codeql-extension-schema.py
+++ b/scripts/check-codeql-extension-schema.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
+import re
 import sys
 from typing import Any
 
@@ -29,6 +30,11 @@ RUST_ALL_PREDICATES = {
 SUPPORTED_PACKS = {RUST_ALL_PACK: RUST_ALL_PREDICATES}
 EXTENSIONS_ROOT = Path(".github/codeql/extensions")
 PACK_FILENAME = "codeql-pack.yml"
+CANONICAL_CALLABLE = re.compile(r"^orbit_[a-z0-9_]+(?:::[A-Za-z_][A-Za-z0-9_]*)+$")
+ACCESS_PATH = re.compile(
+    r"^(?:ReturnValue|Argument\[(?:self|[0-9]+)\])"
+    r"(?:\.(?:Future|Field\[[A-Za-z0-9_:()]+\]))*$"
+)
 
 
 class YamlError(Exception):
@@ -399,6 +405,48 @@ def _error(path: str, message: str) -> str:
     return f"check-codeql-extension-schema: {path}: {message}"
 
 
+def _validate_repository_model_scope(
+    path: str,
+    predicate: str,
+    fields: tuple[str, ...],
+    row: list[str],
+    location: str,
+) -> list[str]:
+    """Reject valid CodeQL syntax that is too broad for this first-party pack."""
+    errors: list[str] = []
+    values = dict(zip(fields, row))
+    callable_path = values["path"]
+    if not CANONICAL_CALLABLE.fullmatch(callable_path):
+        errors.append(
+            _error(
+                path,
+                f"{location} field 1 (path): expected an exact Orbit callable path; "
+                "wildcards, trait-wide selectors, and external crates are not allowed",
+            )
+        )
+
+    for field_name in ("input", "output"):
+        access_path = values.get(field_name)
+        if access_path is not None and not ACCESS_PATH.fullmatch(access_path):
+            field_index = fields.index(field_name) + 1
+            errors.append(
+                _error(
+                    path,
+                    f"{location} field {field_index} ({field_name}): expected an exact access path",
+                )
+            )
+
+    if values.get("kind") != "path-injection":
+        errors.append(_error(path, f"{location}: only the 'path-injection' model kind is allowed"))
+    if values.get("provenance") != "manual":
+        errors.append(_error(path, f"{location}: only 'manual' provenance is allowed"))
+    if predicate == "barrierGuardModel" and values.get("acceptingValue") not in {"true", "false"}:
+        errors.append(
+            _error(path, f"{location}: acceptingValue must be exactly 'true' or 'false'")
+        )
+    return errors
+
+
 def validate_data_extension(path: str, document: Any) -> list[str]:
     """Return schema errors for one loaded data-extension document."""
     errors: list[str] = []
@@ -474,6 +522,10 @@ def validate_data_extension(path: str, document: Any) -> list[str]:
                             f"expected a non-empty string, found {_type_name(value)}",
                         )
                     )
+            if all(isinstance(value, str) and value.strip() for value in row):
+                errors.extend(
+                    _validate_repository_model_scope(path, predicate, fields, row, location)
+                )
     return errors
 
 

--- a/scripts/test-codeql-extension-schema.py
+++ b/scripts/test-codeql-extension-schema.py
@@ -114,6 +114,34 @@ INVALID_ROW_TYPES = """extensions:
         ]
 """
 
+OVERBROAD_CALLABLE = """extensions:
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: barrierGuardModel
+    data:
+      - [
+          "orbit_core::application::job::pipeline::*",
+          "Argument[0]",
+          "true",
+          "path-injection",
+          "manual",
+        ]
+"""
+
+OVERBROAD_ACCESS_PATH = """extensions:
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: barrierGuardModel
+    data:
+      - [
+          "orbit_core::application::job::pipeline::is_safe",
+          "Argument[*]",
+          "true",
+          "path-injection",
+          "manual",
+        ]
+"""
+
 
 class CodeqlExtensionSchemaTests(unittest.TestCase):
     def setUp(self):
@@ -174,6 +202,18 @@ class CodeqlExtensionSchemaTests(unittest.TestCase):
         self.assertIn("kind", errors[0])
         self.assertIn("expected a non-empty string", errors[0])
         self.assertIn("boolean", errors[0])
+
+    def test_overbroad_callable_path_fails_clearly(self):
+        self.write_pack(OVERBROAD_CALLABLE)
+        errors = self.errors()
+        self.assertEqual(len(errors), 1, errors)
+        self.assertIn("expected an exact Orbit callable path", errors[0])
+
+    def test_overbroad_access_path_fails_clearly(self):
+        self.write_pack(OVERBROAD_ACCESS_PATH)
+        errors = self.errors()
+        self.assertEqual(len(errors), 1, errors)
+        self.assertIn("expected an exact access path", errors[0])
 
     def test_current_extension_files_pass(self):
         self.assertEqual(CHECK.validate_root(REPO_ROOT), [])


### PR DESCRIPTION
## Delivery failure handoff

Orbit preserved and pushed this task's candidate after the shipment pipeline failed. This PR is intentionally blocked; inspect the recorded failure before retrying delivery.

- Task: `ORB-12048`
- Run: `jrun-20260910-0836-6`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `77db26f715a467d791904966e0c4ae459b18e0cc`
- Target base: `4f29985af0d7bce812a81a12e59227a72caf9c9b`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess reported declared envelope status="failed" despite exit 0: error.code=operator_publication_required; error.message=Publishing constellation-works/orbit-rust-path-validation@0.0.1 requires unavailable operator package authority; pinning and hosted verification cannot safely proceed before publication.
```