### PR TITLE
Make FIFO lock-holder regression stage-aware and leak-free

### DIFF
--- a/crates/orbit-common/src/fs/tests/io.rs
+++ b/crates/orbit-common/src/fs/tests/io.rs
@@ -1,6 +1,9 @@
 use std::fs::File;
 use std::io;
 
+#[cfg(unix)]
+use std::time::{Duration, Instant};
+
 use tempfile::TempDir;
 
 use crate::OrbitError;
@@ -217,32 +220,152 @@ fn read_file_lock_holder_rejects_a_final_symlink_swapped_after_the_path_check() 
 #[cfg(unix)]
 #[test]
 fn read_file_lock_holder_does_not_block_on_a_fifo_swapped_after_the_path_check() {
-    use std::sync::mpsc;
-    use std::thread;
-    use std::time::Duration;
-
-    use crate::fs::file_lock::read_file_lock_holder_after_resolve;
-
     let root = tempfile::tempdir().expect("root tempdir");
     let lock_path = root.path().join(".task.yaml.lock");
     std::fs::write(&lock_path, br#"{"pid":1}"#).expect("write checked holder");
-    let (sender, receiver) = mpsc::channel();
+    let stage_path = root.path().join("fifo-reader-stage");
+    let mut child = start_fifo_reader(&lock_path, &stage_path, false);
 
-    thread::spawn(move || {
-        let holder = read_file_lock_holder_after_resolve(&lock_path, |checked_path| {
-            std::fs::remove_file(checked_path).expect("remove checked holder");
-            let status = std::process::Command::new("mkfifo")
-                .arg(checked_path)
-                .status()
-                .expect("create FIFO");
-            assert!(status.success(), "mkfifo must succeed: {status}");
-        });
-        sender.send(holder).expect("report holder result");
+    wait_for_fifo_stage(&mut child, &stage_path, Duration::from_secs(1));
+    wait_for_fifo_reader_completion(&mut child, Duration::from_secs(1));
+}
+
+/// A deliberately blocking open exercises the timeout cleanup path used by
+/// the FIFO regression without leaving a test worker behind.
+#[cfg(unix)]
+#[test]
+fn read_file_lock_holder_fifo_controlled_block_is_terminated_and_joined() {
+    let root = tempfile::tempdir().expect("root tempdir");
+    let lock_path = root.path().join(".task.yaml.lock");
+    std::fs::write(&lock_path, br#"{"pid":1}"#).expect("write checked holder");
+
+    let stage_path = root.path().join("fifo-reader-stage");
+    let mut child = start_fifo_reader(&lock_path, &stage_path, true);
+
+    wait_for_fifo_stage(&mut child, &stage_path, Duration::from_secs(1));
+    assert_fifo_reader_times_out_and_is_joined(&mut child, Duration::from_millis(100));
+}
+
+#[cfg(unix)]
+fn start_fifo_reader(
+    lock_path: &std::path::Path,
+    stage_path: &std::path::Path,
+    use_unsafe_blocking_open: bool,
+) -> std::process::Child {
+    let test_binary = std::env::current_exe().expect("locate test binary");
+    let mut command = std::process::Command::new(test_binary);
+    command
+        .arg("fs::tests::io::read_file_lock_holder_fifo_reader_child")
+        .arg("--exact")
+        .arg("--ignored")
+        .arg("--nocapture")
+        .env("ORBIT_FIFO_READER_LOCK_PATH", lock_path)
+        .env("ORBIT_FIFO_READER_STAGE_PATH", stage_path);
+    if use_unsafe_blocking_open {
+        command.env("ORBIT_FIFO_READER_UNSAFE_BLOCKING_OPEN", "1");
+    }
+    command.spawn().expect("start controlled FIFO reader")
+}
+
+#[cfg(unix)]
+fn wait_for_fifo_stage(
+    child: &mut std::process::Child,
+    stage_path: &std::path::Path,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Ok(stage) = std::fs::read_to_string(stage_path) {
+            if stage == "fifo-ready" {
+                return;
+            }
+            terminate_fifo_reader(child);
+            panic!("FIFO setup failed before mkfifo readiness: {stage}");
+        }
+
+        if let Some(status) = child.try_wait().expect("poll FIFO reader") {
+            panic!("FIFO setup exited before mkfifo readiness: {status}");
+        }
+        if Instant::now() >= deadline {
+            terminate_fifo_reader(child);
+            panic!("FIFO setup (remove/mkfifo) did not report readiness before timeout");
+        }
+
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(unix)]
+fn wait_for_fifo_reader_completion(child: &mut std::process::Child, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait().expect("poll FIFO reader") {
+            assert!(
+                status.success(),
+                "FIFO reader failed after the swap completed: {status}"
+            );
+            return;
+        }
+        if Instant::now() >= deadline {
+            terminate_fifo_reader(child);
+            panic!("FIFO reader did not complete after the swap before timeout");
+        }
+
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(unix)]
+fn assert_fifo_reader_times_out_and_is_joined(child: &mut std::process::Child, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait().expect("poll FIFO reader") {
+            panic!("unsafe FIFO reader unexpectedly completed: {status}");
+        }
+        if Instant::now() >= deadline {
+            terminate_fifo_reader(child);
+            return;
+        }
+
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(unix)]
+fn terminate_fifo_reader(child: &mut std::process::Child) {
+    child.kill().expect("terminate FIFO reader after timeout");
+    child.wait().expect("join terminated FIFO reader");
+}
+
+/// Runs only as the controlled child of the FIFO regression. Keeping the
+/// potentially blocking read in a child lets the parent terminate and join it
+/// if a future change drops `O_NONBLOCK`.
+#[cfg(unix)]
+#[test]
+#[ignore = "runs only inside the controlled FIFO regression child process"]
+fn read_file_lock_holder_fifo_reader_child() {
+    use crate::fs::file_lock::read_file_lock_holder_after_resolve;
+
+    let Ok(lock_path) = std::env::var("ORBIT_FIFO_READER_LOCK_PATH") else {
+        return;
+    };
+    let stage_path = std::env::var("ORBIT_FIFO_READER_STAGE_PATH")
+        .expect("controlled FIFO reader needs a stage path");
+
+    let holder = read_file_lock_holder_after_resolve(lock_path.as_ref(), |checked_path| {
+        std::fs::remove_file(checked_path).expect("remove checked holder");
+        let status = std::process::Command::new("mkfifo")
+            .arg(checked_path)
+            .status()
+            .expect("start mkfifo");
+        assert!(status.success(), "mkfifo must succeed: {status}");
+        std::fs::write(&stage_path, "fifo-ready").expect("report FIFO setup completion");
     });
 
-    let holder = receiver
-        .recv_timeout(Duration::from_secs(1))
-        .expect("FIFO swap must not block the holder reader");
+    if std::env::var_os("ORBIT_FIFO_READER_UNSAFE_BLOCKING_OPEN").is_some() {
+        let _ = std::fs::File::open(&lock_path).expect("unsafe FIFO open");
+    }
+
     assert!(holder.is_none(), "a swapped FIFO is not holder metadata");
 }
 


### PR DESCRIPTION
## Task

[ORB-12065](https://orbit-cli.com/tasks/ORB-12065) — Make FIFO lock-holder regression stage-aware and leak-free

### Description

## Evidence
CI34457516104/job102807265068 at53c854dcf44d9fbfefc24178e83ff4906d953a21 failed only fs::tests::io::read_file_lock_holder_does_not_block_on_a_fifo_swapped_after_the_path_check: FAIL+LEAK1.208s, io.rs245 Timeout;5333tests passed. Source at4f29985 is unchanged from12054. Child removes regular file, starts mkfifo, then reads; parent waits1s immediately, without knowing setup completed. Failure cannot distinguish scheduler/subprocess setup delay from blocked read. Root utility ran exact test10/10understrace and each FIFO open used O_RDONLY|O_NONBLOCK|O_NOFOLLOW|O_CLOEXEC; this does not prove hosted failure cause.

## Repair
Preserve metadata→FIFO-swap→open regression and nofollow/nonblocking guarantees. Add stage-aware bounded synchronization/diagnostics, propagate setup errors, and ensure a true blocked read cannot leak a worker on timeout (a controlled helper process if necessary). Do not simply extend/remove timeout or weaken assertion. Keep source changes limited to proven actual runtime fault if instrumented evidence reveals one. Existing51is model-only;54done; duplicate search found no owner.

### Acceptance Criteria

- Failure reports distinguish setup/mkfifo phase from post-swap read completion; test still proves swapped FIFO is refused without blocking.
- Timeout/failure path terminates and joins its controlled child without nextest LEAK; setup errors are surfaced.
- Actual helper boundary retains O_NONBLOCK and O_NOFOLLOW with opened-descriptor regular-file checks; unsafe blocking control demonstrates test catches the intended regression if feasible without leaks.
- Repeat exact Linux test and run relevant orbit-common tests, make ci-fast/ci-lint; root verifies complete hosted CI postmerge. Do not call unrun CI green.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced the detached FIFO-reader thread with a controlled child test process and stage file. Failures now identify setup/mkfifo readiness separately from post-swap reader completion.
- Timeout paths kill and wait for the child. Added a controlled raw blocking-open test that exercises that cleanup path without a lingering worker.
- The production helper was intentionally unchanged: its Unix boundary continues to use O_NONBLOCK | O_NOFOLLOW and validates the opened descriptor is a regular file.

Acceptance criteria:
1. Met: readiness is reported only after remove+mkfifo; parent diagnostics distinguish setup exit/timeout from reader completion failure/timeout.
2. Met: every timeout calls kill then wait; setup exits surface their child status; nextest exact regression passed with no LEAK.
3. Met: existing helper boundary remains unchanged and the controlled unsafe blocking open reaches the timeout-and-join assertion.
4. Met locally: repeated exact Linux regression (3/3), orbit-common suite, nextest exact regression, make ci-fast, and make ci-lint passed. Hosted CI was not run; postmerge verification remains owned by root/pipeline.

Validation:
- cargo test -p orbit-common fs::tests::io::read_file_lock_holder_does_not_block_on_a_fifo_swapped_after_the_path_check -- --exact --nocapture (passed, repeated 3/3)
- cargo test -p orbit-common fs::tests::io::read_file_lock_holder_fifo_controlled_block_is_terminated_and_joined -- --exact --nocapture (passed)
- cargo nextest run -p orbit-common -E test(fs::tests::io::read_file_lock_holder_does_not_block_on_a_fifo_swapped_after_the_path_check) (passed; no LEAK)
- cargo test -p orbit-common (passed: 257 unit tests, 1 intentional ignored child helper, and integration fixture)
- make ci-fast (passed)
- make ci-lint (passed)
- cargo fmt --check and git diff --check (passed)

Assessment: scoped test-only change; no production helper behavior changed.
Risk: test process orchestration is Unix-only, matching the FIFO-specific regression; hosted CI remains pending pipeline execution.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12065-6aa275f3`
- Behind base: 0
- Ahead of base: 1