### PR TITLE
[code-review] The new object-authority prose splits the sandbox-exec races table, orphaning its last two rows

### DIFF
--- a/docs/design/policy-sandbox/specs/sandbox-exec-contract.md
+++ b/docs/design/policy-sandbox/specs/sandbox-exec-contract.md
@@ -212,6 +212,10 @@ silently amend the original mandate.
 | Descendants and detached sessions | Enforce before the first untrusted instruction; use inherited/stacked confinement across fork/exec. `setsid` does not remove Landlock or AppArmor. Termination of processes escaping the original PGID is a separate supervision problem; the probe's detached child exits and is waited for explicitly. |
 | External writers or already known bytes | A denied name cannot undo copies, prior reads or malicious externally supplied hardlinks. Record the trusted-writer/acquisition boundary; do not advertise retroactive secrecy. |
 
+The descriptor limit above is supported by the Linux 6.8 implementation's cached
+permission path and lack of general revocation, not by an assumed property of a
+profile regex. [AppArmor file permission implementation](https://raw.githubusercontent.com/torvalds/linux/v6.8/security/apparmor/file.c).
+
 Linux runtime directories and SQLite sidecars are an object-authority exception
 to path-only compilation. The host must open each accepted object while it is
 validating or descriptor-relatively creating it, carry that descriptor through
@@ -226,10 +230,6 @@ root. It assumes an unprivileged peer cannot remount the runtime root or its
 host ancestors. Bubblewrap consumes and closes the inherited setup descriptors
 before provider exec; the parent closes its copies with the plan after spawn.
 Non-Linux backends do not consume this authority representation.
-
-The descriptor limit above is supported by the Linux 6.8 implementation's cached
-permission path and lack of general revocation, not by an assumed property of a
-profile regex. [AppArmor file permission implementation](https://raw.githubusercontent.com/torvalds/linux/v6.8/security/apparmor/file.c).
 
 ### Ownership and eventual implementation targets
 


### PR DESCRIPTION
## Task

[ORB-12064](https://orbit-cli.com/tasks/ORB-12064) — [code-review] The new object-authority prose splits the sandbox-exec races table, orphaning its last two rows

### Description

ORB-12042 appended two paragraphs describing the Linux runtime-store object-authority exception to `docs/design/policy-sandbox/specs/sandbox-exec-contract.md`, but inserted them *inside* the "Races, aliases and the contract decision" table instead of after it.

The table header is at `docs/design/policy-sandbox/specs/sandbox-exec-contract.md:203-204`. Rows run through `:211` (`| Inherited FD, cwd/dirfd, SCM_RIGHTS and pidfd acquisition | ... |`). The new prose occupies `:212-226`, and then two further table rows resume at `:227-228`:

- `:227` `| Descendants and detached sessions | ... |`
- `:228` `| External writers or already known bytes | ... |`

In GitHub-flavored Markdown a table ends at the first blank line, so `:227-228` no longer belong to the table above them and no header precedes them. They render as two literal pipe-delimited text lines rather than table rows.

The damage is not only cosmetic. `:230-232` ("The descriptor limit above is supported by the Linux 6.8 implementation's cached permission path...") refers back to the *File opened while allowed, then renamed; existing mmap* and *Inherited FD* rows, and the fifteen lines of unrelated Bubblewrap prose now sit between that sentence and the rows it qualifies. A reader following the table's case-by-case structure loses two of the seven cases and the sentence that closes the section reads as commentary on the `--bind-fd` paragraphs instead.

The content itself is correct and belongs in this document; only its placement is wrong. Moving the two paragraphs below `:228` restores the table and keeps the closing citation adjacent to the rows it supports.

### Acceptance Criteria

- The `Races, aliases and the contract decision` table in docs/design/policy-sandbox/specs/sandbox-exec-contract.md renders as one table containing every case row, including `Descendants and detached sessions` and `External writers or already known bytes`.
- The object-authority paragraphs describing the Linux runtime `--bind-fd` contract are retained verbatim in the same section, positioned so no table is interrupted.
- The closing sentence citing the Linux 6.8 AppArmor file-permission implementation still directly follows the table rows it qualifies.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Moved the Linux 6.8 AppArmor cached-permission citation paragraph immediately below the complete races table.
- Retained both Linux runtime --bind-fd object-authority paragraphs verbatim immediately after the citation.
- No other files were changed.

Acceptance criteria:
- Passed: the Races, aliases and the contract decision table has one contiguous header, separator, and eight case rows, including Descendants and detached sessions and External writers or already known bytes.
- Passed: the two object-authority paragraphs are byte-for-byte identical to their pre-change content and no longer interrupt the table.
- Passed: the Linux 6.8 AppArmor citation paragraph directly follows the table's final row.

Validation:
- Passed: targeted awk/grep checks confirmed 9 contiguous lines after the table header, both required row labels, citation placement, and citation text.
- Passed: a diff comparison against HEAD confirmed the object-authority paragraphs are unchanged.
- Passed: git diff --check.
- Passed: GIT_OPTIONAL_LOCKS=0 git status --short and complete diff review; only docs/design/policy-sandbox/specs/sandbox-exec-contract.md is modified.
- Not run: make ci-fast and make ci-lint; the task comment explicitly states full source gates need not repeat for this pure-Markdown surgical change, and the existing task evidence records those gates as passed.

Assessment: The scoped documentation defect is repaired with the smallest compatible change. Changes remain uncommitted for pipeline delivery.

Remaining risks or deviations: None material.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12064-6aa2779c`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*