### PR TITLE
[code-review] Bubblewrap authority fd remap clobbers Command's own descriptors, so a failed bwrap exec is reported as a successful spawn

### DIFF
--- a/crates/orbit-exec/src/linux_sandbox.rs
+++ b/crates/orbit-exec/src/linux_sandbox.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::fs::OpenOptions;
 #[cfg(unix)]
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsRawFd, FromRawFd};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 
@@ -710,7 +710,10 @@ pub fn compile_linux_bwrap_argv_with_authority(
     authority: Vec<LinuxBwrapMountAuthority>,
 ) -> Result<LinuxBwrapPlan, OrbitError> {
     let mut plan = compile_linux_bwrap_argv(profile, program, args, cwd, managed_worktree)?;
-    for (descriptor_index, grant) in authority.into_iter().enumerate() {
+    for grant in authority {
+        let source = prepare_mount_source(grant.source)?;
+        #[cfg(unix)]
+        let source_fd = source.as_raw_fd();
         let rendered = grant.destination.display().to_string();
         let mut replaced = false;
         for index in 0..plan.args.len().saturating_sub(2) {
@@ -719,7 +722,13 @@ pub fn compile_linux_bwrap_argv_with_authority(
                 && plan.args[index + 2] == rendered
             {
                 plan.args[index] = "--bind-fd".to_string();
-                plan.args[index + 1] = (descriptor_index + 3).to_string();
+                // The retained File reserves this exact descriptor while
+                // Command builds its pipes. Rendering that descriptor here
+                // keeps argv and child inheritance on one source of truth.
+                #[cfg(unix)]
+                {
+                    plan.args[index + 1] = source_fd.to_string();
+                }
                 replaced = true;
             }
         }
@@ -729,9 +738,57 @@ pub fn compile_linux_bwrap_argv_with_authority(
                 grant.destination.display()
             )));
         }
-        plan.mount_sources.push(grant.source);
+        plan.mount_sources.push(source);
     }
     Ok(plan)
+}
+
+#[cfg(unix)]
+fn prepare_mount_source(source: File) -> Result<File, OrbitError> {
+    if source.as_raw_fd() >= 3 {
+        return Ok(source);
+    }
+
+    let descriptor = unsafe { libc::fcntl(source.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 3) };
+    if descriptor < 0 {
+        return Err(OrbitError::Execution(format!(
+            "duplicate Linux runtime grant descriptor: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+
+    Ok(unsafe { File::from_raw_fd(descriptor) })
+}
+
+#[cfg(not(unix))]
+fn prepare_mount_source(_source: File) -> Result<File, OrbitError> {
+    Err(OrbitError::Execution(
+        "descriptor-backed Linux runtime grants require Unix file descriptors".to_string(),
+    ))
+}
+
+#[cfg(unix)]
+fn inherit_mount_sources(command: &mut Command, mount_sources: &[File]) {
+    use std::os::unix::process::CommandExt;
+
+    let source_fds = mount_sources
+        .iter()
+        .map(AsRawFd::as_raw_fd)
+        .collect::<Vec<_>>();
+    unsafe {
+        command.pre_exec(move || {
+            // Keep each source at its already-occupied descriptor. Remapping
+            // into a conventional low range can overwrite Command's private
+            // exec-error pipe, causing exec failures to look like success.
+            for source in &source_fds {
+                let flags = libc::fcntl(*source, libc::F_GETFD);
+                if flags < 0 || libc::fcntl(*source, libc::F_SETFD, flags & !libc::FD_CLOEXEC) < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            }
+            Ok(())
+        });
+    }
 }
 
 pub fn spawn_under_linux_bwrap(request: LinuxBwrapSpawnRequest<'_>) -> Result<Child, OrbitError> {
@@ -767,31 +824,7 @@ pub fn spawn_under_linux_bwrap(request: LinuxBwrapSpawnRequest<'_>) -> Result<Ch
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
-        let source_fds = plan
-            .mount_sources
-            .iter()
-            .map(AsRawFd::as_raw_fd)
-            .collect::<Vec<_>>();
-        let mut temporary_fds = vec![-1; source_fds.len()];
-        unsafe {
-            command.pre_exec(move || {
-                let minimum = 3 + source_fds.len() as libc::c_int;
-                for (index, source) in source_fds.iter().copied().enumerate() {
-                    let duplicate = libc::fcntl(source, libc::F_DUPFD_CLOEXEC, minimum);
-                    if duplicate < 0 {
-                        return Err(std::io::Error::last_os_error());
-                    }
-                    temporary_fds[index] = duplicate;
-                }
-                for (index, duplicate) in temporary_fds.iter().copied().enumerate() {
-                    if libc::dup2(duplicate, 3 + index as libc::c_int) < 0 {
-                        return Err(std::io::Error::last_os_error());
-                    }
-                    libc::close(duplicate);
-                }
-                Ok(())
-            });
-        }
+        inherit_mount_sources(&mut command, &plan.mount_sources);
         command.process_group(0);
     }
     command.spawn().map_err(|error| {

--- a/crates/orbit-exec/src/tests/linux_sandbox.rs
+++ b/crates/orbit-exec/src/tests/linux_sandbox.rs
@@ -256,8 +256,11 @@ fn descriptor_mount_plan_holds_the_validated_object_and_closes_it_on_drop() {
         }],
     )
     .expect("descriptor-backed plan");
+    let retained_fd = plan.mount_sources[0].as_raw_fd();
     assert!(plan.args.windows(3).any(|args| {
-        args[0] == "--bind-fd" && args[1] == "3" && args[2] == target.display().to_string()
+        args[0] == "--bind-fd"
+            && args[1] == retained_fd.to_string()
+            && args[2] == target.display().to_string()
     }));
     assert!(unsafe { libc::fcntl(source_fd, libc::F_GETFD) } >= 0);
 
@@ -267,6 +270,93 @@ fn descriptor_mount_plan_holds_the_validated_object_and_closes_it_on_drop() {
         std::io::Error::last_os_error().raw_os_error(),
         Some(libc::EBADF)
     );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn descriptor_inheritance_preserves_the_command_exec_error_pipe() {
+    use std::process::{Command, Stdio};
+
+    use super::{
+        LinuxBwrapMountAuthority, compile_linux_bwrap_argv_with_authority, inherit_mount_sources,
+    };
+
+    const ISOLATED_CHILD: &str = "ORBIT_DESCRIPTOR_EXEC_ERROR_CHILD";
+    if std::env::var_os(ISOLATED_CHILD).is_none() {
+        let status = Command::new(std::env::current_exe().expect("current test executable"))
+            .arg("descriptor_inheritance_preserves_the_command_exec_error_pipe")
+            .env(ISOLATED_CHILD, "1")
+            .status()
+            .expect("spawn isolated descriptor test");
+        assert!(
+            status.success(),
+            "isolated descriptor test failed: {status}"
+        );
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().canonicalize().expect("canonical root");
+    let fillers = (0..16)
+        .map(|_| fs::File::open("/dev/null").expect("open filler descriptor"))
+        .collect::<Vec<_>>();
+    let highest_filler = fillers
+        .iter()
+        .map(AsRawFd::as_raw_fd)
+        .max()
+        .expect("filler descriptor");
+
+    let mut modify = Vec::new();
+    let mut authority = Vec::new();
+    for index in 0..8 {
+        let destination = root.join(format!("authority-{index}"));
+        fs::write(&destination, b"authority").expect("write authority fixture");
+        let source = fs::File::open(&destination).expect("open authority source");
+        assert!(
+            source.as_raw_fd() > highest_filler,
+            "authority source must be opened above the occupied low range"
+        );
+        modify.push(destination.display().to_string());
+        authority.push(LinuxBwrapMountAuthority {
+            destination,
+            source,
+        });
+    }
+
+    let plan = compile_linux_bwrap_argv_with_authority(
+        &profile(modify),
+        "/bin/true",
+        &[],
+        Some(&root),
+        false,
+        authority,
+    )
+    .expect("compile descriptor-backed plan");
+    let inherited_fds = plan
+        .mount_sources
+        .iter()
+        .map(AsRawFd::as_raw_fd)
+        .collect::<Vec<_>>();
+    let compiled_fds = plan
+        .args
+        .windows(2)
+        .filter(|args| args[0] == "--bind-fd")
+        .map(|args| args[1].parse::<i32>().expect("numeric bind descriptor"))
+        .collect::<Vec<_>>();
+    assert_eq!(compiled_fds, inherited_fds);
+
+    drop(fillers);
+    let mut command = Command::new("/orbit/nonexistent/bwrap");
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    inherit_mount_sources(&mut command, &plan.mount_sources);
+
+    let error = command
+        .spawn()
+        .expect_err("a nonexistent wrapper must return a spawn error");
+    assert_eq!(error.raw_os_error(), Some(libc::ENOENT));
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Task

[ORB-12063](https://orbit-cli.com/tasks/ORB-12063) — [code-review] Bubblewrap authority fd remap clobbers Command's own descriptors, so a failed bwrap exec is reported as a successful spawn

### Description

`spawn_under_linux_bwrap` now forces the `--bind-fd` mount-source descriptors onto file descriptors 3..3+N inside a `pre_exec` closure (`crates/orbit-exec/src/linux_sandbox.rs:770-794`). The argv compiled by `compile_linux_bwrap_argv_with_authority` hard-codes those numbers (`crates/orbit-exec/src/linux_sandbox.rs:722`, `(descriptor_index + 3).to_string()`), so the child must place source *i* exactly at fd `3 + i`.

Nothing reserves that range. `std::process::Command::spawn` allocates its stdio pipes and its internal CLOEXEC exec-failure-reporting pipe at the lowest free descriptors immediately before `fork`, and std's `do_exec` runs user `pre_exec` closures *after* the stdio dup2 to 0/1/2 but *before* `execvp`. When any of those internal descriptors lands inside [3, 3+N), the second loop's `libc::dup2(duplicate, 3 + index)` overwrites it. The remap survives because the two-phase `F_DUPFD_CLOEXEC` staging protects the *authority* descriptors from each other — it does not protect std's.

The mounts themselves stay correct; what breaks is failure reporting. Losing the error pipe means the parent reads EOF and concludes exec succeeded.

## Reproduction (run at HEAD `53c854dcf44d9fbfefc24178e83ff4906d953a21` on Linux 6.8.0-139-generic)

A standalone binary reproducing exactly the closure's shape — N sources opened, then the low fds freed so the pipes land inside the forced range — spawning a nonexistent program:

```
--- control (pre_exec returns Ok(()) immediately), n=8
source fds: [15, 16, 17, 18, 19, 20, 21, 22] (fds 3..15 are now free)
spawn correctly reported exec failure: No such file or directory (os error 2)

--- with the shipped remap loop, n=8
source fds: [15, 16, 17, 18, 19, 20, 21, 22] (fds 3..15 are now free)
SPAWN REPORTED OK (exec failure hidden); child status: ExitStatus(unix_wait_status(134))
```

Same process, same fd layout, same spawn: only the remap loop differs. `spawn()` returns `Ok`, and the child dies on SIGABRT (134) instead of the caller receiving `ENOENT`.

With the sources sitting at 3..3+N (the incidental layout of a freshly started process) the loop is a no-op shuffle and nothing breaks — which is why the shipped tests do not see it. A long-running daemon that has opened and closed descriptors since resolving the sandbox has no such guarantee: `runtime_write_authority` is populated for every `linux-bwrap` executor (`crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs:118-149`), roughly 10 grants per dispatch, so this is the ordinary Linux agent dispatch path rather than an exotic one. The path-only `compile_linux_bwrap_argv` leaves `mount_sources` empty, so `minimum` is 3, both loops are empty, and that path is unaffected.

## Impact

A `bwrap` exec failure (missing binary, denied namespace, bad argv) is surfaced to the engine as a successfully started child that then dies without a diagnostic, instead of as the `SpawnError` the caller is written to handle.

## Suggested direction

Make the destination range unambiguous rather than assuming it is free: stage every source above the highest descriptor std can have allocated and rewrite argv from the numbers actually obtained, or dup the sources to a reserved high range before `spawn` and emit those numbers at compile time. Bubblewrap accepts any descriptor number in `--bind-fd`, so 3..3+N is a convention, not a requirement.

### Acceptance Criteria

- A Bubblewrap spawn whose wrapper program cannot be exec'd returns a spawn error to the caller even when the runtime authority descriptors do not already occupy fds 3..3+N.
- A regression test constructs the colliding descriptor layout (authority sources opened high, low descriptors free) and fails against the current remap loop.
- The compiled `--bind-fd` numbers and the descriptors the child actually installs are derived from one source of truth rather than both assuming the 3..3+N convention independently.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Compiled each --bind-fd argument from the exact File descriptor retained by the plan.
- Removed the fd 3..3+N pre_exec remap; the child now clears CLOEXEC on already-occupied authority descriptors, so Command cannot allocate its private exec-error pipe on them.
- Added an isolated Linux regression that opens eight authority descriptors above an occupied low range, frees the low descriptors before spawn, and verifies a nonexistent wrapper returns ENOENT. The test also asserts compiled bind descriptor numbers equal the retained descriptors.
Assessment: The fix keeps object authority intact while eliminating writes to unrelated child descriptors. The pre_exec closure performs only fcntl operations over storage allocated before fork.

Acceptance criteria:
1. Passed: the isolated spawn regression receives ENOENT with high authority descriptors and low descriptors free.
2. Passed: temporarily restoring the prior remap loop made the regression fail with exit 101 because spawn returned Child instead of ENOENT; the fixed implementation passes.
3. Passed: argv descriptor values are read from the same retained File objects inherited by the child, and the regression asserts exact equality.

Validation:
- cargo fmt --all -- --check: passed.
- cargo test -p orbit-exec descriptor_inheritance_preserves_the_command_exec_error_pipe -- --nocapture: passed.
- cargo test -p orbit-exec: passed; 127 tests passed and 2 live Bubblewrap tests were ignored by their existing annotations.
- make ci-fast: passed; its mount-namespace cache check reported the existing environment skip because unprivileged namespaces are unavailable.
- make ci-lint: passed.
- git diff --check: passed.
- git status --short: only crates/orbit-exec/src/linux_sandbox.rs and crates/orbit-exec/src/tests/linux_sandbox.rs are modified.

Deviations from original plan:
- The regression lives in the existing sibling unit-test module rather than the public integration module because exercising a nonexistent wrapper requires access to the private descriptor-inheritance seam; the public API intentionally rejects arbitrary wrapper paths.

Remaining risk:
- The live descriptor-backed Bubblewrap mount test remains ignored because this runner cannot create Bubblewrap namespaces. The regression exercises the actual Linux Command spawn and exec-error channel without requiring a namespace.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12063-6aa275f2`
- Behind base: 0
- Ahead of base: 1