### PR TITLE
Activate the proven Rust path-validation model through supported local CodeQL discovery

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/codeql-pack.yml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/codeql-pack.yml
@@ -6,4 +6,4 @@ extensionTargets:
   codeql/rust-all: "*"
 
 dataExtensions:
-  - path-validation.yml
+  - path-validation.yaml

--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yaml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yaml
@@ -46,12 +46,6 @@ extensions:
           "manual",
         ]
       - [
-          "orbit_core::application::job::pipeline::validate_pipeline_worker_log_directory_input",
-          "ReturnValue.Field[core::result::Result::Ok(0)]",
-          "path-injection",
-          "manual",
-        ]
-      - [
           "orbit_core::application::routines::clock::validated_clock_settings_path",
           "ReturnValue.Field[core::result::Result::Ok(0)]",
           "path-injection",
@@ -150,6 +144,17 @@ extensions:
       - [
           "orbit_common::fs::file_lock::validated_lock_holder_parent",
           "ReturnValue.Field[core::option::Option::Some(0)]",
+          "path-injection",
+          "manual",
+        ]
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: barrierGuardModel
+    data:
+      - [
+          "orbit_core::application::job::pipeline::pipeline_worker_log_directory_input_is_valid",
+          "Argument[0]",
+          "true",
           "path-injection",
           "manual",
         ]

--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -2393,23 +2393,34 @@ pub(crate) mod pipeline_worker_log_test_hook {
 /// phase below. Keeping this phase free of filesystem operations makes the
 /// trust boundary explicit to both reviewers and CodeQL.
 fn validate_pipeline_worker_log_directory_input(path: &Path) -> Result<PathBuf, OrbitError> {
+    if pipeline_worker_log_directory_input_is_valid(path) {
+        return Ok(path.to_path_buf());
+    }
+
     if !path.is_absolute() {
         return Err(OrbitError::InvalidInput(format!(
             "pipeline worker log directory must be absolute: {}",
             path.display()
         )));
     }
-    if path
-        .components()
-        .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
-    {
-        return Err(OrbitError::InvalidInput(format!(
-            "pipeline worker log directory must not contain traversal components: {}",
-            path.display()
-        )));
-    }
 
-    Ok(path.to_path_buf())
+    Err(OrbitError::InvalidInput(format!(
+        "pipeline worker log directory must not contain traversal components: {}",
+        path.display()
+    )))
+}
+
+/// Report whether a worker-log directory has the lexical shape required by
+/// the filesystem-resolution phase.
+///
+/// This boolean guard is kept separate because CodeQL's Rust model API can
+/// represent conditional validation directly, unlike a successful `Result`
+/// projection.
+fn pipeline_worker_log_directory_input_is_valid(path: &Path) -> bool {
+    path.is_absolute()
+        && !path
+            .components()
+            .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
 }
 
 /// Canonicalize the nearest existing ancestor of `parent` and rejoin any

--- a/scripts/check-codeql-extension-schema.py
+++ b/scripts/check-codeql-extension-schema.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
+import re
 import sys
 from typing import Any
 
@@ -29,6 +30,12 @@ RUST_ALL_PREDICATES = {
 SUPPORTED_PACKS = {RUST_ALL_PACK: RUST_ALL_PREDICATES}
 EXTENSIONS_ROOT = Path(".github/codeql/extensions")
 PACK_FILENAME = "codeql-pack.yml"
+GENERATED_EXTENSION_GLOB = "extensions/**/*.yaml"
+CANONICAL_CALLABLE = re.compile(r"^orbit_[a-z0-9_]+(?:::[A-Za-z_][A-Za-z0-9_]*)+$")
+ACCESS_PATH = re.compile(
+    r"^(?:ReturnValue|Argument\[(?:self|[0-9]+)\])"
+    r"(?:\.(?:Future|Field\[[A-Za-z0-9_:()]+\]))*$"
+)
 
 
 class YamlError(Exception):
@@ -399,6 +406,48 @@ def _error(path: str, message: str) -> str:
     return f"check-codeql-extension-schema: {path}: {message}"
 
 
+def _validate_repository_model_scope(
+    path: str,
+    predicate: str,
+    fields: tuple[str, ...],
+    row: list[str],
+    location: str,
+) -> list[str]:
+    """Reject valid CodeQL syntax that is too broad for this first-party pack."""
+    errors: list[str] = []
+    values = dict(zip(fields, row))
+    callable_path = values["path"]
+    if not CANONICAL_CALLABLE.fullmatch(callable_path):
+        errors.append(
+            _error(
+                path,
+                f"{location} field 1 (path): expected an exact Orbit callable path; "
+                "wildcards, trait-wide selectors, and external crates are not allowed",
+            )
+        )
+
+    for field_name in ("input", "output"):
+        access_path = values.get(field_name)
+        if access_path is not None and not ACCESS_PATH.fullmatch(access_path):
+            field_index = fields.index(field_name) + 1
+            errors.append(
+                _error(
+                    path,
+                    f"{location} field {field_index} ({field_name}): expected an exact access path",
+                )
+            )
+
+    if values.get("kind") != "path-injection":
+        errors.append(_error(path, f"{location}: only the 'path-injection' model kind is allowed"))
+    if values.get("provenance") != "manual":
+        errors.append(_error(path, f"{location}: only 'manual' provenance is allowed"))
+    if predicate == "barrierGuardModel" and values.get("acceptingValue") not in {"true", "false"}:
+        errors.append(
+            _error(path, f"{location}: acceptingValue must be exactly 'true' or 'false'")
+        )
+    return errors
+
+
 def validate_data_extension(path: str, document: Any) -> list[str]:
     """Return schema errors for one loaded data-extension document."""
     errors: list[str] = []
@@ -474,6 +523,10 @@ def validate_data_extension(path: str, document: Any) -> list[str]:
                             f"expected a non-empty string, found {_type_name(value)}",
                         )
                     )
+            if all(isinstance(value, str) and value.strip() for value in row):
+                errors.extend(
+                    _validate_repository_model_scope(path, predicate, fields, row, location)
+                )
     return errors
 
 
@@ -506,6 +559,15 @@ def _pack_data_extensions(pack_dir: Path, document: Any, pack_path: str) -> tupl
         if candidate.is_absolute() or ".." in candidate.parts:
             errors.append(
                 _error(pack_path, f"dataExtensions[{index}] must be a path inside the pack directory")
+            )
+            continue
+        if candidate.suffix != ".yaml":
+            errors.append(
+                _error(
+                    pack_path,
+                    f"dataExtensions[{index}] must end in '.yaml' to match "
+                    f"the generated CodeQL discovery glob {GENERATED_EXTENSION_GLOB!r}: {entry}",
+                )
             )
             continue
         resolved = (pack_dir / candidate).resolve()

--- a/scripts/test-codeql-extension-schema.py
+++ b/scripts/test-codeql-extension-schema.py
@@ -30,8 +30,10 @@ extensionTargets:
   codeql/rust-all: "*"
 
 dataExtensions:
-  - path-validation.yml
+  - path-validation.yaml
 """
+
+LEGACY_YML_PACK = PACK_YML.replace("path-validation.yaml", "path-validation.yml")
 
 TWO_VALID_ROWS = """extensions:
   - addsTo:
@@ -114,6 +116,34 @@ INVALID_ROW_TYPES = """extensions:
         ]
 """
 
+OVERBROAD_CALLABLE = """extensions:
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: barrierGuardModel
+    data:
+      - [
+          "orbit_core::application::job::pipeline::*",
+          "Argument[0]",
+          "true",
+          "path-injection",
+          "manual",
+        ]
+"""
+
+OVERBROAD_ACCESS_PATH = """extensions:
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: barrierGuardModel
+    data:
+      - [
+          "orbit_core::application::job::pipeline::is_safe",
+          "Argument[*]",
+          "true",
+          "path-injection",
+          "manual",
+        ]
+"""
+
 
 class CodeqlExtensionSchemaTests(unittest.TestCase):
     def setUp(self):
@@ -121,12 +151,13 @@ class CodeqlExtensionSchemaTests(unittest.TestCase):
         self.addCleanup(self.temporary.cleanup)
         self.root = Path(self.temporary.name)
 
-    def write_pack(self, data_yml, pack_yml=None):
+    def write_pack(self, data_yaml, pack_yml=None, data_filename="path-validation.yaml"):
         pack_dir = self.root / ".github/codeql/extensions/orbit-rust-path-validation"
         pack_dir.mkdir(parents=True)
         (pack_dir / "codeql-pack.yml").write_text(pack_yml or PACK_YML, encoding="utf-8")
-        (pack_dir / "path-validation.yml").write_text(data_yml, encoding="utf-8")
-        return pack_dir / "path-validation.yml"
+        data_file = pack_dir / data_filename
+        data_file.write_text(data_yaml, encoding="utf-8")
+        return data_file
 
     def errors(self):
         return CHECK.validate_root(self.root)
@@ -174,6 +205,31 @@ class CodeqlExtensionSchemaTests(unittest.TestCase):
         self.assertIn("kind", errors[0])
         self.assertIn("expected a non-empty string", errors[0])
         self.assertIn("boolean", errors[0])
+
+    def test_overbroad_callable_path_fails_clearly(self):
+        self.write_pack(OVERBROAD_CALLABLE)
+        errors = self.errors()
+        self.assertEqual(len(errors), 1, errors)
+        self.assertIn("expected an exact Orbit callable path", errors[0])
+
+    def test_overbroad_access_path_fails_clearly(self):
+        self.write_pack(OVERBROAD_ACCESS_PATH)
+        errors = self.errors()
+        self.assertEqual(len(errors), 1, errors)
+        self.assertIn("expected an exact access path", errors[0])
+
+    def test_generated_style_yaml_discovery_includes_extension(self):
+        data_file = self.write_pack(TWO_VALID_ROWS)
+        discovered = list(data_file.parent.rglob("*.yaml"))
+        self.assertEqual(discovered, [data_file])
+        self.assertEqual(self.errors(), [])
+
+    def test_yml_extension_fails_generated_discovery_gate(self):
+        self.write_pack(TWO_VALID_ROWS, LEGACY_YML_PACK, "path-validation.yml")
+        errors = self.errors()
+        self.assertEqual(len(errors), 1, errors)
+        self.assertIn("must end in '.yaml'", errors[0])
+        self.assertIn(CHECK.GENERATED_EXTENSION_GLOB, errors[0])
 
     def test_current_extension_files_pass(self):
         self.assertEqual(CHECK.validate_root(REPO_ROOT), [])


### PR DESCRIPTION
## Task

[ORB-12048](https://orbit-cli.com/tasks/ORB-12048) — Activate the proven Rust path-validation model through supported local CodeQL discovery

### Description

## Problem and verified root cause
Hosted CodeQLAction b96794f015dfd88f77b49b1c93e0fa7110f94c63/CLI2.27.0 generates an extension pack with dataExtensions extensions/**/*.yaml. Our committed path-validation.yml is silently excluded. Rust job102780959471/run34449259767 prints that exact no-match warning twice. Separately, old Result access-path barriers have zero semantic effect. Both defects must be fixed.

## Recoverable validated implementation
Prior leaf0836-6 committed243574f3211f6c3b05acd1a7b5698907aa2f9f44 in existing worktree orbit-jrun-20260910-0836-6. It contains the pipeline boolean guard/barrierGuardModel, scoped schema negatives and passing local tests. Preserve/recover that unit (cherry-pick into fresh dedicated task worktree if necessary); do not discard it. Canonical codeql-2.27.0-controlled-evidence.json proves guarded+unsafe fixture2findings withoutmodel→unsafeonly1withmodel. This partial commit has NOT merged.

## Finish through supported local discovery
Rename .github/codeql/extensions/orbit-rust-path-validation/path-validation.yml to path-validation.yaml; update sibling codeql-pack.yml dataExtensions. Operator reproduced exact generated extensions/**/*.yaml glob: .yml produced identicalhostwarning, .yaml loaded all24barrier+1guardrows. Do not add a nonexistent remote packs pin. Update schema checks and current docs as necessary so future wrong extension filenames cannot silentlypass the repository integration gate. New filename is exact durable file intent after creation; beforecreation it is not a realselector. Preserve existing four-language workflow, query suites, buildmode, permissions, actionpins and paths-ignore.

## Operator publication evidence and revised authority
Root validated model hashb6240b0f305e5dee7889ec387187f397e8a0dfec72ab7429ca3462314f5a3a6f and packdryrun; actual GHCRpublish failed403 token scopes. Nothingpublished, no credentials/permissions changed. Local discovery makes publication unnecessary. No npm/sitepublish or credentialchanges. Root verifies normal hostedCodeQL exactmergedcandidate afterdelivery. Worker must not block localdelivery solelybecause hostedscanawaitsmerge; persist precise operatorverificationhandoff.

## Scope boundary
Own pipeline416and effective localmodelintegration. Remaining caller-authority/modelcases are51. No genericpath/nofollow sanitizer, alertdismissal, suppressedqueries or unsafecontrolremoval.

### Acceptance Criteria

- Recover validated243574f changes and preserve controlled2→1 evidence with unsafe sibling retained; rerun affected source/model/schema tests.
- The same corrected model loads through a generated-style extensions/**/*.yaml discovery fixture on CodeQL2.27.0; .yml negative fixture proves the regression gate detects silent exclusion.
- Actual source extension renamed.yaml, siblingmanifestupdated, schema/discoverycheck prevents recurrence. Exactnewfileintentdeclared where needed; no remote packs pin or packagepublicationrequired.
- Four-language CodeQL workflow/defaultqueries/buildmode/actionpins/permissions/paths-ignore preserved; no generic sanitizer or alert suppression introduced.
- Localvalidation ci-fast/ci-lint and gitdiffcheck pass; attach or preserve bounded proof and report exact operator postmergechecks. Root then confirms effective hostedRustmodelparticipation and416closure with freshsameheadscan. Hostedpostmergeproof is operator-owned, not a reason to fail worker delivery.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Recovered the validated 243574f task unit only: the pipeline log-directory lexical validator now exposes a CodeQL-supported boolean guard and the model uses a scoped barrierGuardModel while retaining the deliberately unsafe sibling.
- Renamed the local extension from path-validation.yml to path-validation.yaml and updated codeql-pack.yml so the CodeQL Action's generated extensions/**/*.yaml loader discovers it.
- Tightened the repository gate for exact first-party callable/access-path rows and .yaml discovery compatibility; expanded fixtures for malformed, overbroad, generated-style .yaml positive, and silently excluded .yml negative cases.
- Added the exact created file selector after the rename; no remote pack pin, package publication, permissions, queries, workflow, build mode, action pins, paths-ignore, sanitizer, or alert state changed.

Acceptance criteria:
1. Satisfied. The recovered model has SHA-256 b6240b0f305e5dee7889ec387187f397e8a0dfec72ab7429ca3462314f5a3a6f, exactly matching the attached CodeQL 2.27.0 controlled evidence: findings [17,20] without the model become unsafe sibling [20] only with the model. Rust behavior tests and model/schema tests passed on this checkout.
2. Satisfied. Attached operator-evidence/local-discovery.tar.gz records CodeQL 2.27.0 loading the exact same hash through extensions/**/*.yaml with 24 barrierModel plus 1 barrierGuardModel tuples; its .yml arm records the no-match warning and zero data. The repository fixture now positively discovers .yaml and rejects .yml with the generated glob named in the error.
3. Satisfied. Source and manifest use path-validation.yaml; the live task scope records the exact new file. No package was published and no remote pack was pinned, as required by the revised local-discovery route.
4. Satisfied. A zero diff for .github/workflows/codeql.yml and .github/codeql/codeql-config.yml proves the four-language matrix, default queries, build-mode none, action pins, permissions, and paths-ignore are preserved. The model remains narrowly bound to one validation guard.
5. Satisfied for worker-owned validation. Existing bounded CodeQL 2.27.0 artifacts were preserved and reconciled to the current model hash. Hosted post-merge proof remains operator-owned and is not a worker-delivery blocker.

Validation:
- PASSED: cargo test -p orbit-core configure_pipeline_worker_stdio — 8 passed, 0 failed.
- PASSED: python3 scripts/test-codeql-extension-schema.py — 11 passed, 0 failed.
- PASSED: python3 scripts/check-codeql-extension-schema.py — exit 0.
- PASSED: make ci-fast — exit 0; the namespace probe emitted its documented sandbox skip while the make target passed.
- PASSED: make ci-lint — exit 0.
- PASSED: git diff --check plus a no-index whitespace check for the untracked renamed destination — exit 0.
- PASSED: git diff --exit-code HEAD -- .github/codeql/codeql-config.yml .github/workflows/codeql.yml — exit 0.
- PASSED: current path-validation.yaml SHA-256 equals both the controlled 2→1 artifact and the CodeQL 2.27.0 generated-discovery fixture payload.
- NOT RUN: a new CodeQL CLI invocation in this worker because CodeQL 2.27.0 is absent from its private filesystem; the operator-produced exact-byte artifacts cover both semantic effect and loader discovery.
- NOT RUN: hosted CodeQL because it requires the merged same-HEAD agent-main candidate and is explicitly operator-owned.

Exact operator post-merge checks:
1. git fetch origin agent-main && merged_head=$(git rev-parse origin/agent-main) && test "$(git show "$merged_head":.github/codeql/extensions/orbit-rust-path-validation/path-validation.yaml | sha256sum | cut -d' ' -f1)" = b6240b0f305e5dee7889ec387187f397e8a0dfec72ab7429ca3462314f5a3a6f
2. gh run list --repo constellation-works/orbit --workflow codeql.yml --branch agent-main --commit "$merged_head" --limit 10 --json databaseId,headSha,status,conclusion
3. run_id=<fresh successful run databaseId>; gh run watch "$run_id" --repo constellation-works/orbit --exit-status
4. rust_job=$(gh run view "$run_id" --repo constellation-works/orbit --json jobs --jq '.jobs[] | select(.name == "Analyze (rust)") | .databaseId'); gh run view "$run_id" --repo constellation-works/orbit --job "$rust_job" --log | rg 'path-validation\.yaml|barrierModel: 24 tuples|barrierGuardModel: 1 tuples'
5. gh api -X GET repos/constellation-works/orbit/code-scanning/analyses -f ref=refs/heads/agent-main -f tool_name=CodeQL --jq --arg head "$merged_head" '[.[] | select(.commit_sha == $head) | {id,commit_sha,category,error}]'
6. gh api repos/constellation-works/orbit/code-scanning/alerts/416 --jq '{number,state,rule:.rule.id,most_recent_instance}' and confirm state is fixed after that same-HEAD Rust analysis.

Final review:
- git status accounts for exactly the manifest edit, .yml deletion/.yaml creation, pipeline edit, and two schema-script edits.
- No incidental generated files appear in the patch.
- Remaining risk is limited to operator confirmation that hosted CodeQL logs show local model participation and alert 416 becomes fixed on the exact merged HEAD.

Assessment: the change is narrow, runtime-preserving, locally validated, and backed by exact-byte CodeQL 2.27.0 semantic and discovery evidence.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12048-6aa27851`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*