### PR TITLE
Close remaining full-QA CLI gaps and import verifiable hosted macOS evidence

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -34,6 +34,9 @@ on:
       - "crates/orbit-core/src/application/job/run/owner.rs"
       - "crates/orbit-core/src/application/job/run/tests/actions.rs"
       - "crates/orbit-core/src/application/job/run/tests/owner.rs"
+      - "scripts/check-ci-macos.sh"
+      - "scripts/qa-full-sweep-inventory.json"
+      - "scripts/test-qa-full-sweep.py"
       - "Cargo.lock"
       - ".github/workflows/ci-macos.yml"
 
@@ -90,3 +93,17 @@ jobs:
           cargo test --no-fail-fast -p orbit-common --locked process::tests::identity -- --nocapture
           cargo test --no-fail-fast -p orbit-core --locked application::job::run::tests::owner -- --nocapture
           cargo test --no-fail-fast -p orbit-core --locked application::job::run::tests::actions -- --nocapture
+
+      # This runs only after every required macOS command above succeeds. The
+      # report records the physical checkout HEAD rather than github.sha, which
+      # is an ephemeral merge commit for pull_request events.
+      - name: Emit exact-checkout macOS QA evidence
+        run: ./scripts/check-ci-macos.sh --evidence-output macos-platform-evidence.json
+
+      - name: Upload exact-checkout macOS QA evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: macos-platform-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: macos-platform-evidence.json
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/runbooks/qa-full-sweep.md
+++ b/docs/runbooks/qa-full-sweep.md
@@ -60,11 +60,38 @@ Add `--website-build` only after preparing the website dependencies through
 the isolated procedure in [website validation](website-validation.md). It
 authorizes the harness's build check, never deployment.
 
-Hosted evidence can be combined with `--platform-evidence <report.json>`. Only
-schema-version 2 reports for the exact candidate ID are accepted, and each
-imported scenario's command must exactly match the current inventory. The
-imported file hash is retained in the report. This permits a macOS runner to
-contribute its actual required check without describing a Linux run as macOS.
+Hosted evidence can be combined with `--platform-evidence <report.json>`. A
+schema-version 2 full-sweep report must name the exact candidate ID and exact
+inventory command. The macOS workflow also uploads a bounded
+`macos-platform-evidence-<run>-<attempt>` artifact after all of its required
+tests pass. That report records the physical checkout commit, exact required
+command, assertion set, workflow/run identity, and hashes of the workflow,
+checker, inventory, and importer. Import accepts it only against a clean
+checkout of that exact commit;
+stale revisions, dirty candidates, wrong commands, missing assertions, failed
+or unrun outcomes, incomplete GitHub Actions provenance, and changed source
+hashes are rejected. The imported file hash is retained in the combined
+report. This permits the hosted runner to contribute its actual macOS check
+without describing a Linux run as macOS or requiring an executor to access a
+manual Mac.
+
+After the candidate lands, an operator must select the successful hosted
+`macOS Platform` run for the landed commit, download its evidence artifact
+through the authenticated GitHub Actions interface, and run from a clean
+checkout of that same commit:
+
+```bash
+./scripts/qa-full-sweep.sh --build-candidate --run-commands \
+  --platform-evidence /absolute/path/to/macos-platform-evidence.json \
+  --output qa-full-sweep-report.json
+```
+
+The workflow creates the bounded report with
+`./scripts/check-ci-macos.sh --evidence-output macos-platform-evidence.json`.
+That emission mode deliberately refuses non-Darwin and non-GitHub-Actions
+environments. The ordinary `./scripts/check-ci-macos.sh` command remains the
+inventory contract and can be run locally to validate workflow paths and test
+filters, but on Linux it is not macOS execution evidence.
 
 ## Capability-bound legs
 
@@ -81,7 +108,9 @@ The pre-release sweep validates source builds, packaging, installers, and
 dry-run/version contracts but never deploys or publishes. Live website/npm
 freshness is reported as `PENDING` and is deliberately excluded from the
 pre-release decision, so it cannot create a version/tag cycle. Linux evidence
-does not verify the required macOS leg.
+does not verify the required macOS leg. Post-merge hosted execution and
+exact-commit artifact import remain explicit operator verification; a
+pre-merge run for an earlier commit is stale by design.
 
 ## Sign-off decision and findings
 

--- a/scripts/check-ci-macos.sh
+++ b/scripts/check-ci-macos.sh
@@ -3,24 +3,42 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 workflow="${CI_MACOS_WORKFLOW:-$repo_root/.github/workflows/ci-macos.yml}"
+evidence_output=""
+
+if [[ "${1:-}" == "--evidence-output" ]]; then
+  if [[ -z "${2:-}" || -n "${3:-}" ]]; then
+    echo "usage: $0 [--evidence-output PATH]" >&2
+    exit 2
+  fi
+  evidence_output="$2"
+elif [[ $# -ne 0 ]]; then
+  echo "usage: $0 [--evidence-output PATH]" >&2
+  exit 2
+fi
 
 if ! command -v python3 >/dev/null 2>&1; then
   echo "check-ci-macos: python3 is required; install it before running" >&2
   exit 1
 fi
 
-python3 - "$repo_root" "$workflow" <<'PY'
+python3 - "$repo_root" "$workflow" "$evidence_output" <<'PY'
 from __future__ import annotations
 
+import hashlib
+import json
+import os
+import platform
 import re
 import shlex
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 
 repo_root = Path(sys.argv[1]).resolve()
 workflow = Path(sys.argv[2]).resolve()
+evidence_output = Path(sys.argv[3]).resolve() if sys.argv[3] else None
 
 if not workflow.is_file():
     print(f"check-ci-macos: workflow does not exist: {workflow}", file=sys.stderr)
@@ -164,4 +182,69 @@ if errors:
     raise SystemExit(1)
 
 print("check-ci-macos: workflow paths and filtered tests passed")
+
+if evidence_output is not None:
+    required_environment = {
+        "GITHUB_ACTIONS": "true",
+        "RUNNER_OS": "macOS",
+    }
+    for name, expected in required_environment.items():
+        if os.environ.get(name) != expected:
+            print(
+                f"check-ci-macos: --evidence-output requires {name}={expected!r}",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+    producer_fields = [
+        "GITHUB_REPOSITORY", "GITHUB_RUN_ID", "GITHUB_RUN_ATTEMPT",
+        "GITHUB_WORKFLOW_REF", "GITHUB_WORKFLOW_SHA",
+    ]
+    missing = [name for name in producer_fields if not os.environ.get(name)]
+    if missing:
+        print(
+            "check-ci-macos: hosted evidence environment is incomplete: " + ", ".join(missing),
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    if platform.system() != "Darwin":
+        print("check-ci-macos: hosted evidence requires a Darwin runtime", file=sys.stderr)
+        raise SystemExit(1)
+
+    checked_out_commit = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=repo_root, text=True
+    ).strip()
+    source_paths = [
+        Path("scripts/check-ci-macos.sh"),
+        Path("scripts/qa-full-sweep-inventory.json"),
+        Path("scripts/test-qa-full-sweep.py"),
+        Path(".github/workflows/ci-macos.yml"),
+    ]
+    report = {
+        "schema_version": 1,
+        "evidence_type": "orbit-macos-platform",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "platform": "macos",
+        "source_revision": checked_out_commit,
+        "command": ["./scripts/check-ci-macos.sh"],
+        "outcome": "PASS",
+        "assertions": [
+            "macos-required-workflow-is-current",
+            "macos-check-ran-on-matching-revision",
+        ],
+        "producer": {
+            "system": "github-actions",
+            "repository": os.environ["GITHUB_REPOSITORY"],
+            "run_id": os.environ["GITHUB_RUN_ID"],
+            "run_attempt": os.environ["GITHUB_RUN_ATTEMPT"],
+            "workflow_ref": os.environ["GITHUB_WORKFLOW_REF"],
+            "workflow_sha": os.environ["GITHUB_WORKFLOW_SHA"],
+        },
+        "source_identity": {
+            str(path): hashlib.sha256((repo_root / path).read_bytes()).hexdigest()
+            for path in source_paths
+        },
+    }
+    evidence_output.parent.mkdir(parents=True, exist_ok=True)
+    evidence_output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(f"check-ci-macos: wrote hosted evidence to {evidence_output}")
 PY

--- a/scripts/qa-full-sweep-inventory.json
+++ b/scripts/qa-full-sweep-inventory.json
@@ -6,7 +6,7 @@
     "sha256": {"cli":"a33c8dc6ba55b451b0b81527984f33d77eb56b8e9c543dc603a390f6f6a4f203","job":"6af10624aeb648c8998765463531c3d3a5e3a473e0d7059dab91891f8b5d4ffe","activity":"1a731d7dd19ea7b0a013f2b07d82b1982676a89a62730ee6e9a7b0e952667d8b","mcp":"9792ea29b083d7e275ab2d2a44c7eebb17520be8c667d2a4f64d8774db79b2ea","api":"01520ee981457c5a7ddc50d17c30964d785c7f2deb4f8c4d7b59a872bc24f8e4","dashboard":"0f6f4e242fb3ece988b2a3192e030c002e1240af5383dd8e9ca4b7908da1be74"}
   },
   "feature_families": [
-    {"id":"bootstrap-routing","scenarios":["isolated-cli-lifecycle","workspace-boundary"]},
+    {"id":"bootstrap-routing","scenarios":["isolated-cli-lifecycle","workspace-boundary","config-transaction","host-identity-transaction","migration-lifecycle"]},
     {"id":"tasks-artifacts-navigation","scenarios":["isolated-cli-lifecycle","task-list-pagination"]},
     {"id":"mcp-tools","scenarios":["mcp-wire-boundary","mcp-process-boundary"]},
     {"id":"dashboard-api","scenarios":["dashboard-api-boundary","api-process-boundary","dashboard-browser"]},
@@ -14,7 +14,7 @@
     {"id":"automation-scheduling","scenarios":["auto-task-registration-mint","scheduler-retry"]},
     {"id":"gc","scenarios":["gc-routing-protection"]},
     {"id":"publication-recovery","scenarios":["publication-restore"]},
-    {"id":"search-docs-observability","scenarios":["search-observability-boundary","docs-process-boundary","semantic-process-boundary"]},
+    {"id":"search-docs-observability","scenarios":["search-observability-boundary","unified-log-selection","legacy-logs-compatibility","docs-process-boundary","semantic-process-boundary"]},
     {"id":"definitions-policy-operation","scenarios":["definition-policy-boundary"]},
     {"id":"installation-update-distribution","scenarios":["source-binary-provenance","installer-update","npm-package","plugin-install","website-build","macos-platform"]}
   ],
@@ -23,6 +23,11 @@
     {"id":"source-binary-provenance","required":true,"capability":"local","kind":"builtin","surfaces":[],"assertions":["binary-built-from-current-source","source-stable-through-build","binary-hash-recorded"],"behavior":["normal","failure"]},
     {"id":"isolated-cli-lifecycle","required":true,"capability":"local","kind":"builtin","surfaces":["cli:init","cli:task","cli:artifacts"],"assertions":["global-init-persists-isolated-root","workspace-init-registers-primary","task-add-returns-requested-fields","task-show-round-trips-payload","artifact-put-mutates-task","artifact-get-round-trips-exact-content","task-list-contains-created-task"],"behavior":["normal","failure","persistence"]},
     {"id":"workspace-boundary","required":true,"capability":"local","kind":"builtin","surfaces":["cli:workspace"],"assertions":["second-workspace-isolated","explicit-selector-wins-over-cwd","cross-workspace-task-read-refused"],"behavior":["normal","failure","workspace-boundary"]},
+    {"id":"config-transaction","required":true,"capability":"local","kind":"builtin","surfaces":["cli:config"],"assertions":["supported-setting-persists","exact-setting-readback","invalid-setting-refused-without-byte-change"],"behavior":["normal","failure","persistence"]},
+    {"id":"host-identity-transaction","required":true,"capability":"local","kind":"builtin","surfaces":["cli:host"],"assertions":["initialized-identity-readback","supported-rename-updates-local-records","rename-preserves-machine-id-and-reads-back","stale-rename-refused-without-mutation","invalid-rename-refused-without-mutation"],"behavior":["normal","failure","persistence"]},
+    {"id":"unified-log-selection","required":true,"capability":"local","kind":"builtin","surfaces":["cli:log"],"assertions":["exact-filtered-unified-record","nonmatching-and-malformed-records-are-excluded"],"behavior":["normal","failure"]},
+    {"id":"legacy-logs-compatibility","required":true,"capability":"local","kind":"builtin","surfaces":["cli:logs"],"assertions":["supported-run-fixture-completes","exact-legacy-compatibility-output-and-deprecation","unknown-legacy-step-is-refused"],"behavior":["normal","failure","compatibility"]},
+    {"id":"migration-lifecycle","required":true,"capability":"local","kind":"builtin","surfaces":["cli:migrate"],"assertions":["disposable-migration-fixture-initialized","legacy-dry-run-reports-pending-without-mutation","confirmed-migration-applies-known-legacy-state","repeated-migration-is-idempotent","newer-state-refused-without-mutation"],"behavior":["normal","failure","persistence","idempotency"]},
     {"id":"task-list-pagination","required":true,"capability":"local","kind":"cargo-test","surfaces":[],"command":["cargo","test","-p","orbit-web","task_pages_reach_every_match_and_reject_invalid_or_mismatched_cursors","--","--nocapture"],"assertions":["pagination-reaches-every-match","invalid-cursor-refused","cross-workspace-cursor-refused"],"behavior":["normal","failure","boundary"]},
     {"id":"mcp-wire-boundary","required":true,"capability":"local","kind":"builtin","surfaces":["cli:mcp","mcp:orbit_workspace_list","mcp:orbit_task_show"],"assertions":["initialize-negotiates-jsonrpc","tools-list-is-structured","workspace-list-returns-bound-checkout","task-show-round-trips-over-mcp","cross-workspace-mcp-read-refused"],"behavior":["normal","failure","workspace-boundary"]},
     {"id":"mcp-process-boundary","required":true,"capability":"local","kind":"cargo-test","surfaces":["cli:audit","mcp:orbit_agent_invoke","mcp:orbit_auto_task_list","mcp:orbit_auto_task_mint","mcp:orbit_command_exec","mcp:orbit_crew_list","mcp:orbit_friction_add","mcp:orbit_friction_list","mcp:orbit_friction_update","mcp:orbit_operation_enable","mcp:orbit_operation_explain","mcp:orbit_operation_list","mcp:orbit_operation_revoke","mcp:orbit_operation_stop","mcp:orbit_search","mcp:orbit_task_add","mcp:orbit_task_approve","mcp:orbit_task_artifact_get","mcp:orbit_task_artifact_put","mcp:orbit_task_list","mcp:orbit_task_start","mcp:orbit_task_update","mcp:orbit_workflow_run_list","mcp:orbit_workflow_run_resume","mcp:orbit_workflow_run_show","mcp:orbit_workflow_run_workers","mcp:orbit_workflow_ship"],"command":["cargo","test","-p","orbit-cli","--test","mcp_roundtrip","--","--nocapture"],"assertions":["real-stdio-jsonrpc-tools-cross-runtime-store-boundary","mcp-mutating-tools-persist-and-audit","mcp-routing-and-refusal-contracts"],"behavior":["normal","failure","persistence","workspace-boundary"]},
@@ -47,11 +52,5 @@
     {"id":"website-build","required":true,"capability":"website-build","kind":"command","surfaces":[],"command":["npm","--prefix","website","run","build"],"assertions":["website-builds-from-candidate-source","website-build-does-not-deploy"],"behavior":["normal","failure"]},
     {"id":"macos-platform","required":true,"capability":"macos","kind":"command","surfaces":[],"command":["./scripts/check-ci-macos.sh"],"assertions":["macos-required-workflow-is-current","macos-check-ran-on-matching-revision"],"behavior":["normal","failure"]}
   ],
-  "required_capability_gaps": {
-    "cli:config":"No isolated behavioral read/write/refusal transaction is implemented yet.",
-    "cli:host":"No isolated host identity mutation/readback/refusal transaction is implemented yet.",
-    "cli:log":"The full sweep does not yet seed and assert an exact unified-log record.",
-    "cli:logs":"The compatibility logs entry surface lacks an exact isolated output assertion.",
-    "cli:migrate":"No safe disposable legacy-state migration and rollback scenario is implemented yet."
-  }
+  "required_capability_gaps": {}
 }

--- a/scripts/test-qa-full-sweep.py
+++ b/scripts/test-qa-full-sweep.py
@@ -228,7 +228,7 @@ def run_builtins(repo: Path, orbit_bin: str, temp: Path, env: dict, candidate_id
         failure = None
         try:
             validator(evidence)
-        except (AssertionError, KeyError, TypeError, ValueError) as error:
+        except (AssertionError, KeyError, OSError, TypeError, ValueError) as error:
             failure = str(error)
         add_result(results, scenario, finalize_result(evidence, assertions, candidate_id, failure,
                                                        accept_nonzero=accept_nonzero))
@@ -317,6 +317,229 @@ def run_builtins(repo: Path, orbit_bin: str, temp: Path, env: dict, candidate_id
     checked("workspace-boundary",
             [orbit_bin, "--root", str(root), "--workspace", str(other), "task", "show", task_id, "--json"],
             other, ["cross-workspace-task-read-refused"], refused, accept_nonzero=True)
+
+    config_path = work / ".orbit/config.toml"
+    config_set = checked("config-transaction",
+                         [orbit_bin, "--root", str(root), "--workspace", str(work), "config", "set",
+                          "workflow.base_branch", "qa-candidate", "--fresh"], work,
+                         ["supported-setting-persists"], succeeds)
+    if config_set is None:
+        return results
+
+    def config_readback(evidence):
+        body = parse_json(evidence, "config get")
+        if body.get("key") != "workflow.base_branch" or body.get("value") != "qa-candidate":
+            raise ValueError("config get did not return the exact persisted value")
+        if body.get("scope") != "workspace" or Path(body.get("path", "")).resolve() != config_path.resolve():
+            raise ValueError("config get read from the wrong scope or path")
+
+    checked("config-transaction",
+            [orbit_bin, "--root", str(root), "--workspace", str(work), "config", "get",
+             "workflow.base_branch", "--scope", "workspace", "--format", "json"], work,
+            ["exact-setting-readback"], config_readback)
+    config_before_invalid = config_path.read_bytes()
+
+    def invalid_config_refused(evidence):
+        refused(evidence)
+        if config_path.read_bytes() != config_before_invalid:
+            raise ValueError("invalid config write changed config.toml bytes")
+
+    checked("config-transaction",
+            [orbit_bin, "--root", str(root), "--workspace", str(work), "config", "set",
+             "execution.codex.sandbox", "not-a-real-mode"], work,
+            ["invalid-setting-refused-without-byte-change"], invalid_config_refused,
+            accept_nonzero=True)
+
+    identity_path = root / "host.toml"
+    registry_path = root / "workspaces.json"
+
+    def host_identity(evidence):
+        body = parse_json(evidence, "host show")
+        if body.get("host_id") != "qa-host" or body.get("task_prefix") != "QAF":
+            raise ValueError("host show did not return the initialized identity")
+        machine_id = body.get("machine_id")
+        if not isinstance(machine_id, str) or not machine_id.startswith("hm_"):
+            raise ValueError("host show returned an invalid stable machine_id")
+
+    initial_host = checked("host-identity-transaction",
+                           [orbit_bin, "--root", str(root), "host", "show", "--format", "json"],
+                           work, ["initialized-identity-readback"], host_identity)
+    initial_machine_id = json.loads(initial_host["stdout"])["machine_id"] if initial_host else None
+    checked("host-identity-transaction",
+            [orbit_bin, "--root", str(root), "--workspace", str(work), "host", "rename",
+             "qa-host", "qa-renamed"], work, ["supported-rename-updates-local-records"], succeeds)
+
+    def renamed_identity(evidence):
+        body = parse_json(evidence, "renamed host show")
+        if body.get("machine_id") != initial_machine_id or body.get("host_id") != "qa-renamed":
+            raise ValueError("rename changed stable identity or failed host_id readback")
+        registry = json.loads(registry_path.read_text())
+        if registry.get("owner_host_ids", {}).get(initial_machine_id) != "qa-renamed":
+            raise ValueError("rename did not update the isolated registry owner projection")
+
+    checked("host-identity-transaction",
+            [orbit_bin, "--root", str(root), "host", "show", "--format", "json"], work,
+            ["rename-preserves-machine-id-and-reads-back"], renamed_identity)
+    host_before_invalid = identity_path.read_bytes()
+    registry_before_invalid = registry_path.read_bytes()
+
+    def invalid_host_refused(evidence):
+        refused(evidence)
+        if (identity_path.read_bytes() != host_before_invalid
+                or registry_path.read_bytes() != registry_before_invalid):
+            raise ValueError("refused host rename changed identity or registry bytes")
+
+    checked("host-identity-transaction",
+            [orbit_bin, "--root", str(root), "--workspace", str(work), "host", "rename",
+             "stale-host", "other-name"], work, ["stale-rename-refused-without-mutation"],
+            invalid_host_refused, accept_nonzero=True)
+    checked("host-identity-transaction",
+            [orbit_bin, "--root", str(root), "--workspace", str(work), "host", "rename",
+             "qa-renamed", "invalid/name"], work, ["invalid-rename-refused-without-mutation"],
+            invalid_host_refused, accept_nonzero=True)
+
+    log_path = temp / "qa-unified-log.jsonl"
+    selected_event = {
+        "timestamp": "2026-09-10T01:02:03.000000000Z", "level": "INFO",
+        "target": "orbit.qa.selected", "fields": {"message": "qa exact record", "case": 12062},
+    }
+    ignored_event = {
+        "timestamp": "2026-09-10T01:02:04.000000000Z", "level": "DEBUG",
+        "target": "orbit.qa.ignored", "fields": {"message": "must not be selected"},
+    }
+    log_path.write_text("\n".join([json.dumps(ignored_event), "not-json", json.dumps(selected_event)]) + "\n")
+
+    def exact_log_record(evidence):
+        succeeds(evidence)
+        lines = [json.loads(line) for line in evidence["stdout"].splitlines() if line.strip()]
+        if lines != [selected_event]:
+            raise ValueError(f"log tail selected the wrong records: {lines!r}")
+
+    checked("unified-log-selection",
+            [orbit_bin, "--root", str(root), "log", "tail", "-n", "10", "--target",
+             "orbit.qa.selected", "--level", "info", "--path", str(log_path), "--format", "ndjson"],
+            work, ["exact-filtered-unified-record"], exact_log_record)
+
+    def empty_log_selection(evidence):
+        succeeds(evidence)
+        if evidence["stdout"] != "":
+            raise ValueError("negative log filter returned a record")
+
+    checked("unified-log-selection",
+            [orbit_bin, "--root", str(root), "log", "tail", "-n", "10", "--target",
+             "orbit.qa.absent", "--path", str(log_path), "--format", "ndjson"], work,
+            ["nonmatching-and-malformed-records-are-excluded"], empty_log_selection)
+
+    fixture_job = temp / "qa-legacy-logs.yaml"
+    fixture_job.write_text("""schemaVersion: 2
+kind: Job
+metadata:
+  name: qa_legacy_logs_fixture
+spec:
+  state: enabled
+  kind: workflow
+  max_active_runs: 1
+  steps:
+    - id: exact_step
+      default_input:
+        seconds: 0
+      spec:
+        type: deterministic
+        action: sleep
+        config: {}
+""")
+
+    def completed_fixture_run(evidence):
+        body = parse_json(evidence, "fixture job run")
+        if body.get("state") != "succeeded" or not body.get("run_id"):
+            raise ValueError("deterministic fixture job did not succeed")
+
+    fixture_run = checked("legacy-logs-compatibility",
+                          [orbit_bin, "--root", str(root), "--workspace", str(work), "run", "job",
+                           str(fixture_job), "--input", "crew=sol", "--wait", "--format", "json"],
+                          work, ["supported-run-fixture-completes"], completed_fixture_run)
+    fixture_run_id = json.loads(fixture_run["stdout"])["run_id"] if fixture_run else "missing-run"
+
+    def legacy_logs_output(evidence):
+        body = parse_json(evidence, "legacy logs")
+        if body != []:
+            raise ValueError(f"legacy logs changed its exact detached-run compatibility output: {body!r}")
+        if "[deprecated]" not in evidence.get("stderr", ""):
+            raise ValueError("legacy logs omitted its compatibility deprecation notice")
+
+    checked("legacy-logs-compatibility",
+            [orbit_bin, "--root", str(root), "--workspace", str(work), "logs", fixture_run_id,
+             "--format", "json"], work,
+            ["exact-legacy-compatibility-output-and-deprecation"], legacy_logs_output)
+    checked("legacy-logs-compatibility",
+            [orbit_bin, "--root", str(root), "--workspace", str(work), "logs", fixture_run_id,
+             "--step", "absent-step", "--format", "json"], work,
+            ["unknown-legacy-step-is-refused"], refused, accept_nonzero=True)
+
+    migration_root = temp / "migration-root"
+    migration_init = checked(
+        "migration-lifecycle",
+        [orbit_bin, "--root", str(migration_root), "init", "--non-interactive",
+         "--host-name", "qa-migration", "--task-prefix", "QAM"],
+        temp, ["disposable-migration-fixture-initialized"], succeeds,
+    )
+    if migration_init is None:
+        return results
+    migration_marker = migration_root / "state/layout.version"
+    migration_marker.parent.mkdir(parents=True, exist_ok=True)
+    migration_marker.write_text("1\n")
+    migration_before = migration_marker.read_bytes()
+
+    def pending_migration(evidence):
+        refused(evidence)
+        if "migration(s) pending" not in evidence.get("stderr", ""):
+            raise ValueError("dry-run did not report pending migrations")
+        if migration_marker.read_bytes() != migration_before:
+            raise ValueError("migration dry-run changed the legacy marker")
+
+    checked("migration-lifecycle",
+            [orbit_bin, "--root", str(migration_root), "migrate", "--dry-run", "--json"],
+            temp, ["legacy-dry-run-reports-pending-without-mutation"], pending_migration,
+            accept_nonzero=True)
+
+    def applied_migration(evidence):
+        body = parse_json(evidence, "confirmed migration")
+        layout = body.get("layout", {})
+        if body.get("up_to_date") is not True or layout.get("current") != layout.get("supported"):
+            raise ValueError("confirmed migration did not reach the supported layout")
+        applied = body.get("applied_layout", [])
+        if not applied or applied[0].get("version") != 2:
+            raise ValueError("confirmed migration did not report the known legacy transition")
+
+    checked("migration-lifecycle",
+            [orbit_bin, "--root", str(migration_root), "migrate", "--confirm", "--json"],
+            temp, ["confirmed-migration-applies-known-legacy-state"], applied_migration)
+
+    def idempotent_migration(evidence):
+        body = parse_json(evidence, "repeated migration")
+        if body.get("up_to_date") is not True or body.get("applied_layout") != []:
+            raise ValueError("repeated migration was not idempotent")
+
+    checked("migration-lifecycle",
+            [orbit_bin, "--root", str(migration_root), "migrate", "--confirm", "--json"],
+            temp, ["repeated-migration-is-idempotent"], idempotent_migration)
+    migration_marker.write_text("99\n")
+    newer_before = migration_marker.read_bytes()
+    migration_identity_path = migration_root / "host.toml"
+    migration_identity_before = migration_identity_path.read_bytes()
+
+    def newer_migration_refused(evidence):
+        refused(evidence)
+        if "newer" not in evidence.get("stderr", ""):
+            raise ValueError("newer migration refusal did not explain the incompatibility")
+        if (migration_marker.read_bytes() != newer_before
+                or migration_identity_path.read_bytes() != migration_identity_before):
+            raise ValueError("newer migration refusal changed marker or host identity bytes")
+
+    checked("migration-lifecycle",
+            [orbit_bin, "--root", str(migration_root), "migrate", "--dry-run", "--json"],
+            temp, ["newer-state-refused-without-mutation"], newer_migration_refused,
+            accept_nonzero=True)
 
     def auto_task_show(evidence):
         body = parse_json(evidence, "auto-task show")
@@ -460,6 +683,42 @@ def run_builtins(repo: Path, orbit_bin: str, temp: Path, env: dict, candidate_id
     return results
 
 
+def validate_hosted_macos_evidence(body, scenario, candidate, repo):
+    if body.get("evidence_type") != "orbit-macos-platform" or body.get("platform") != "macos":
+        raise ValueError("hosted evidence has the wrong type or platform")
+    if candidate.get("status"):
+        raise ValueError("hosted evidence requires a clean exact-checkout candidate")
+    if body.get("source_revision") != candidate.get("head"):
+        raise ValueError("hosted evidence is stale or for a different checkout")
+    if body.get("command") != scenario.get("command"):
+        raise ValueError("hosted evidence command does not match the required check")
+    if body.get("outcome") != "PASS":
+        raise ValueError("hosted evidence check failed or was not run")
+    if body.get("assertions") != scenario.get("assertions"):
+        raise ValueError("hosted evidence assertions are missing or unexpected")
+
+    producer = body.get("producer", {})
+    required_producer = ["repository", "run_id", "run_attempt", "workflow_ref", "workflow_sha"]
+    if producer.get("system") != "github-actions" or any(not producer.get(key) for key in required_producer):
+        raise ValueError("hosted evidence lacks authenticated GitHub Actions provenance")
+    if not str(producer["run_id"]).isdigit() or not str(producer["run_attempt"]).isdigit():
+        raise ValueError("hosted evidence has invalid GitHub Actions run identity")
+    if ".github/workflows/ci-macos.yml@" not in str(producer["workflow_ref"]):
+        raise ValueError("hosted evidence came from the wrong workflow")
+    if not re.fullmatch(r"[0-9a-f]{40}", str(producer["workflow_sha"])):
+        raise ValueError("hosted evidence has an invalid workflow revision")
+
+    expected_identity = {
+        path: hashlib.sha256((repo / path).read_bytes()).hexdigest()
+        for path in [
+            "scripts/check-ci-macos.sh", "scripts/qa-full-sweep-inventory.json",
+            "scripts/test-qa-full-sweep.py", ".github/workflows/ci-macos.yml",
+        ]
+    }
+    if body.get("source_identity") != expected_identity:
+        raise ValueError("hosted evidence source identity does not match the checkout")
+
+
 def self_test():
     inventory = {"scenarios": [{"id":"required", "required":True,
                                 "assertions":["exact-json", "persisted-effect"]}],
@@ -509,12 +768,79 @@ def self_test():
             continue
         raise AssertionError(f"wrong or empty exit-zero output passed: {stdout!r}")
 
+    with tempfile.TemporaryDirectory(prefix="orbit-qa-platform-self-test-") as tmp:
+        repo = Path(tmp)
+        identity_paths = [
+            "scripts/check-ci-macos.sh", "scripts/qa-full-sweep-inventory.json",
+            "scripts/test-qa-full-sweep.py", ".github/workflows/ci-macos.yml",
+        ]
+        for relative in identity_paths:
+            path = repo / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(relative + "\n")
+        scenario = {
+            "command": ["./scripts/check-ci-macos.sh"],
+            "assertions": ["workflow-current", "matching-revision"],
+        }
+        hosted = {
+            "evidence_type": "orbit-macos-platform", "platform": "macos",
+            "source_revision": "a" * 40, "command": scenario["command"], "outcome": "PASS",
+            "assertions": scenario["assertions"],
+            "producer": {"system": "github-actions", "repository": "owner/orbit",
+                         "run_id": "123", "run_attempt": "1",
+                         "workflow_ref": "owner/orbit/.github/workflows/ci-macos.yml@refs/heads/main",
+                         "workflow_sha": "b" * 40},
+            "source_identity": {
+                path: hashlib.sha256((repo / path).read_bytes()).hexdigest()
+                for path in identity_paths
+            },
+        }
+        candidate = {"head": "a" * 40, "status": []}
+        validate_hosted_macos_evidence(hosted, scenario, candidate, repo)
+        mutations = [
+            {**hosted, "source_revision": "c" * 40},
+            {**hosted, "command": ["./wrong-command"]},
+            {**hosted, "outcome": "FAIL"},
+            {**hosted, "outcome": "NOT_RUN"},
+            {**hosted, "assertions": ["workflow-current"]},
+            {**hosted, "producer": {**hosted["producer"], "run_id": ""}},
+            {**hosted, "source_identity": {}},
+        ]
+        for mutation in mutations:
+            try:
+                validate_hosted_macos_evidence(mutation, scenario, candidate, repo)
+            except ValueError:
+                continue
+            raise AssertionError(f"invalid hosted macOS evidence passed: {mutation!r}")
+        try:
+            validate_hosted_macos_evidence(hosted, scenario,
+                                           {**candidate, "status": [" M scripts/file"]}, repo)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("hosted evidence passed for a dirty candidate")
 
-def import_platform_evidence(paths, inventory, candidate_id):
+
+def import_platform_evidence(paths, inventory, candidate, repo):
     imported = []
+    candidate_id = candidate["candidate_id"]
     scenarios = {item["id"]: item for item in inventory["scenarios"]}
     for path in paths:
         body = json.loads(path.read_text())
+        if body.get("schema_version") == 1:
+            scenario = scenarios.get("macos-platform")
+            if scenario is None:
+                raise ValueError(f"{path}: macos-platform is absent from the inventory")
+            validate_hosted_macos_evidence(body, scenario, candidate, repo)
+            imported.append({
+                "scenario": "macos-platform", "command": body["command"], "exit_code": 0,
+                "stdout": json.dumps({"producer": body["producer"],
+                                      "source_revision": body["source_revision"]}, sort_keys=True),
+                "stderr": "", "outcome": "PASS", "assertions": body["assertions"],
+                "candidate_id": candidate_id, "imported_from": str(path),
+                "evidence_sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            })
+            continue
         if body.get("schema_version") != 2 or body.get("candidate", {}).get("id") != candidate_id:
             raise ValueError(f"{path}: evidence is for a different or unsupported candidate")
         for result in body.get("results", []):
@@ -624,7 +950,7 @@ def main():
                                 "outcome":"NOT_RUN", "assertions":[], "candidate_id":candidate_id})
 
         try:
-            imported = import_platform_evidence(args.platform_evidence, inventory, candidate_id)
+            imported = import_platform_evidence(args.platform_evidence, inventory, candidate, repo)
             imported_scenarios = {result["scenario"] for result in imported}
             results = [result for result in results
                        if not (result["scenario"] in imported_scenarios and result["outcome"] == "NOT_RUN")]


### PR DESCRIPTION
## Task

[ORB-12062](https://orbit-cli.com/tasks/ORB-12062) — Close remaining full-QA CLI gaps and import verifiable hosted macOS evidence

### Description

## Problem
ORB-12047 merged at53c854dcf44d9fbfefc24178e83ff4906d953a21 honestly leaves required CLI config/host/log/logs/migrate capability gaps, so full pre-release sign-off cannot pass. Its macOS importer currently accepts only another full-harness schema-v2 report; existing hosted macOS CI produces no such report. The final candidate needs actual behavioral coverage and usable exact-candidate platform evidence.

## Scope
Extend the existing isolated harness and inventory to cover those five CLI surfaces using disposable HOME/registry/workspaces and known supported fixtures, exact readback, and refusal-without-mutation assertions. Do not weaken required coverage or merely remove gap declarations. Inspect current CLI contracts before choosing commands. Add a supported verifiable macOS evidence path: preferably emit a bounded machine-readable platform report/artifact from the existing hosted macOS check bound to checked-out commit, exact required command, result, and relevant source identity, then safely import it. Do not label Linux tests macOS evidence or synthesize hosted success. Preserve existing CI scope and hard gates.

## Constraints
No website deployment or npm publication. Browser and website source build remain actual separately enabled pre-release checks. No live host identity, config, logs, migration, or durable production records may be mutated by fixtures. No generic exit-zero or catalog-presence PASS. Root owns final exact-head hosted verification. This task implements coverage; final Opus sweep remains required.

### Acceptance Criteria

- Config scenario persists a valid supported setting then reads exact value; invalid writes refuse and preserve bytes.
- Host scenario verifies stable machine identity and supported rename/readback in an isolated registry; invalid or stale requests preserve identity and registry.
- Modern log and legacy logs scenarios use supported isolated fixtures, assert exact selected records/compatibility output and meaningful negative cases.
- Migration scenario exercises a known legacy disposable state: dry-run reports pending without mutation, confirmed migration applies, repeated run is idempotent, invalid/newer state refuses safely.
- Only after five scenarios execute real assertions are their required gaps removed; self-tests reject missing assertions, wrong state, and incomplete/failed scenarios.
- macOS CI emits or supplies authenticated exact-checkout/exact-command evidence usable by harness without requiring inaccessible manual Mac; stale, wrong-command, failed or unrun evidence is rejected. Actual post-merge hosted execution remains explicit operator verification.
- Run harness self-test/check, available complete behavioral trial, make ci-fast and ci-lint; attach honest report and document invocation. No unavailable check is called PASS.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added five required built-in QA scenarios for config, host identity, unified log selection, legacy logs compatibility, and migration lifecycle. Every scenario uses disposable HOME/root/workspaces and asserts exact positive behavior plus meaningful refusal/no-mutation behavior.
- Removed the five capability gaps only after registering the scenarios and their complete assertion sets; expanded fail-closed self-tests for missing/failed/stale/wrong-command/incomplete hosted evidence.
- Extended macOS CI to emit and upload a bounded GitHub Actions report after required macOS tests pass. The report binds the physical checkout HEAD, exact inventory command/assertions, run/workflow provenance, and hashes of the checker, workflow, inventory, and importer. Import requires a clean matching checkout and rejects stale, dirty, wrong-command, failed, unrun, incomplete-provenance, or source-mismatched evidence.
- Updated the runbook with hosted artifact import and explicit post-merge operator verification. No deployment or publication was performed.
- Attached qa/orb-12062-complete-report.json, an honest schema-v2 report for candidate c43f96781cb306884addb5d35315065df388816f626e870a18405b47a54ed506.

Acceptance criteria:
1. Config: PASS — valid workspace setting persisted/read back exactly; invalid enum value exited 1 and config.toml bytes were unchanged.
2. Host: PASS — initialized identity, rename/readback, stable machine_id, registry owner update, stale rename, and invalid path-like name were asserted; both refusals preserved host and registry bytes.
3. Logs: PASS — unified JSONL fixture selected exactly one requested record and excluded malformed/nonmatching records; a supported deterministic run produced exact legacy compatibility output/deprecation and rejected an unknown step.
4. Migration: PASS — a disposable custom-root v1 fixture reported 22 pending migrations without changing its marker, confirmed to current layout/schema, repeated idempotently, and refused v99 without changing marker or identity.
5. Gap/self-test gates: PASS — all five scenarios emitted their exact inventory assertion sets before gaps were removed; self-tests reject missing assertions, stale candidate, mixed/failed/NOT_RUN evidence, wrong state, missing persistence, wrong command, dirty checkout, bad provenance, and source mismatch.
6. macOS evidence path: PASS (implementation/static validation) — workflow emission/upload and strict import are implemented; actual macOS post-merge execution remains operator verification and was not represented as PASS on Linux.
7. Validation/reporting: PASS with explicitly incomplete platform/full-sweep legs — required checks ran and the complete report is attached without relabeling unavailable or failed checks.

Validation:
- PASS: python3 -m py_compile scripts/test-qa-full-sweep.py
- PASS: python3 scripts/test-qa-full-sweep.py --self-test
- PASS: python3 scripts/test-qa-full-sweep.py --check
- PASS: ./scripts/check-ci-macos.sh (65 orbit-core sandbox, 8 process identity, 18 owner, and 13 action tests discovered)
- PASS: local hosted-emission refusal check — --evidence-output rejected non-GitHub-Actions Linux and created no evidence file; this is not macOS PASS evidence.
- PASS: make ci-fast (compiler-cache namespace subcheck explicitly skipped because unprivileged mount namespaces are unavailable)
- PASS: make ci-lint
- PASS: git diff --check
- PASS for all five new scenario assertion sets: ./scripts/qa-full-sweep.sh --build-candidate --run-commands --output orb-12062-complete-report.json
- INCOMPLETE overall, recorded honestly in the attached report: api-process-boundary failed in existing parallel orbit-web fixture assertions; installer-update failed an existing routing assertion. dashboard-browser, website-build, and macos-platform were NOT_RUN because their capabilities were unavailable in this worker. All other enabled scenarios passed.

Assessment: The scoped coverage and hosted evidence contract are complete and fail closed. Remaining risk is the required post-merge hosted macOS run/import plus the separately enabled browser and website checks; the two unrelated local full-sweep failures remain visible in the attached report.

Deviations from original plan:
- The migration fixture uses a dedicated disposable custom root because migrate --dry-run does not honor the runtime-backed --workspace selector. This preserves isolation and exercises the supported dry-run/apply surface symmetrically. Friction F2026-09-117 records the discovered CLI asymmetry.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12062-6aa276e5`
- Behind base: 0
- Ahead of base: 1