### PR TITLE
[ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### DIFF
--- a/crates/orbit-cli/tests/task_trimmed_surface.rs
+++ b/crates/orbit-cli/tests/task_trimmed_surface.rs
@@ -385,7 +385,7 @@ fn migrate_bare_invocation_inspects_and_confirm_applies() {
     workspace.run(&["migrate", "--confirm"], "confirmed migration");
     assert_eq!(
         fs::read_to_string(&marker).expect("read applied marker"),
-        "2\n",
+        "3\n",
         "confirmed migrate must advance the layout"
     );
 }

--- a/crates/orbit-core/src/runtime/resolve.rs
+++ b/crates/orbit-core/src/runtime/resolve.rs
@@ -412,7 +412,10 @@ fn is_initialized_orbit_root(path: &Path) -> bool {
         return true;
     }
 
-    path.join("resources").is_dir() && path.join("tasks").is_dir() && path.join("state").is_dir()
+    // Task bundles are canonical in the global registry. The checkout-local
+    // `.orbit/tasks` projection was removed in layout version 3, so it cannot
+    // be part of the initialized-root probe anymore.
+    path.join("resources").is_dir() && path.join("state").is_dir()
 }
 
 fn resolve_root_path_value(raw: &str, base_dir: &Path) -> Result<PathBuf, OrbitError> {

--- a/crates/orbit-core/src/runtime/tests/builder.rs
+++ b/crates/orbit-core/src/runtime/tests/builder.rs
@@ -120,7 +120,7 @@ fn registry_neutral_binding_rejects_a_conflicting_workspace_config() {
 
 #[test]
 fn v2_task_backend_wires_through_runtime_add_show_list_and_update() {
-    let (_root, _global_root, workspace_root, runtime) = v2_runtime();
+    let (_root, global_root, _workspace_root, runtime) = v2_runtime();
 
     let task = runtime
         .add_task(TaskAddParams {
@@ -132,8 +132,11 @@ fn v2_task_backend_wires_through_runtime_add_show_list_and_update() {
         })
         .expect("create task");
     assert_eq!(task.id, "ORB-00000");
-    assert!(!workspace_root.join("tasks/backlog").exists());
-    assert!(workspace_root.join("tasks/ORB-00000").exists());
+    let bundle_path = global_root
+        .join("tasks/workspaces")
+        .join(runtime.workspace_id().expect("workspace identity"))
+        .join(&task.id);
+    assert!(bundle_path.exists());
 
     let started = runtime
         .start_task(&task.id, Some("start".to_string()), None)

--- a/crates/orbit-web/src/api/tests/task_listing.rs
+++ b/crates/orbit-web/src/api/tests/task_listing.rs
@@ -80,7 +80,7 @@ async fn aggregate_selects_global_newest_rows_before_reading_off_page_workspace_
     let (alpha_orbit, alpha_repo) = seed_workspace(&global, temp.path(), "alpha");
     let alpha = OrbitRuntime::from_roots(&global, &alpha_orbit).unwrap();
     let corrupt = seed_task_with_artifact(&alpha);
-    let artifact = find_artifact_blob(&alpha.data_root(), "file.json").unwrap();
+    let artifact = find_artifact_blob(&alpha.global_root(), "file.json").unwrap();
     std::fs::write(artifact, "invalid artifact content").unwrap();
     assert!(alpha.get_task(&corrupt.id).is_err());
     let (beta_orbit, beta_repo) = seed_workspace(&global, temp.path(), "beta");
@@ -141,7 +141,7 @@ async fn task_list_detail_and_aggregate_leave_async_requests_runnable_during_blo
     for endpoint in ["list", "detail", "aggregate"] {
         let runtime = Arc::new(OrbitRuntime::in_memory().unwrap());
         let task = seed_task_with_artifact(&runtime);
-        let artifact = find_artifact_blob(&runtime.data_root(), "file.json").unwrap();
+        let artifact = find_artifact_blob(&runtime.global_root(), "file.json").unwrap();
         let description = artifact
             .ancestors()
             .find(|path| {

--- a/crates/orbit-web/src/api/tests/tasks.rs
+++ b/crates/orbit-web/src/api/tests/tasks.rs
@@ -557,7 +557,7 @@ fn swap_artifact_blob_for_symlink(
     runtime: &OrbitRuntime,
     target: &std::path::Path,
 ) -> std::path::PathBuf {
-    let blob_path = find_artifact_blob(&runtime.data_root(), "file.json")
+    let blob_path = find_artifact_blob(&runtime.global_root(), "file.json")
         .expect("artifact blob exists on disk");
     assert!(
         blob_path.components().any(|c| c.as_os_str() == "artifacts"),


### PR DESCRIPTION
## Task

[ORB-12068](https://orbit-cli.com/tasks/ORB-12068) — [ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `CI`
- Failing job: `Check / Clippy / Test`
- Failing step: `Run CI guardrails`
- Commit the runner actually checked out: `942c1a3a1b50c49881fee3d89b43c33748a48c19`
- Normalized error signature (the dedupe identity, not a quote): `fail [ <n>.<n>s] (<n>/<n>) orbit-web api::tests::task_listing::aggregate_selects_global_newest_rows_before_reading_off_page_workspace_bodies`
- Repository: `constellation-works/orbit`
- Release branch as GitHub reports it: `agent-main`
- Evidence collected at: 2026-09-10T09:42:47.845727999+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/constellation-works/orbit/actions/runs/34460283059 run `34460283059` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `942c1a3a1b50c49881fee3d89b43c33748a48c19`
  - current head of that ref: `7436c401898a5620999e7a3b3adb4e0c3b38a686`
  - commit actually checked out: `942c1a3a1b50c49881fee3d89b43c33748a48c19`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/usr/bin/git checkout --progress --force -B agent-main refs/remotes/origin/agent-main`
  - checkout evidence: `/usr/bin/git log -1 --format=%H`
  - failed job `Check / Clippy / Test` (id `102816225943`): https://github.com/constellation-works/orbit/actions/runs/34460283059/job/102816225943
  - failing step(s): `Run CI guardrails`

## Failed-step log excerpt

_Failure regions from a completely scanned command; the full command was not retained. 1160159 of 1191102 source bytes omitted, including 0 assertion payload bytes. All 44 recognized failure anchors and bounded context are retained (64 KiB selection limit)._

```
2026-09-10T09:23:58.1716993Z ##[group]Run ./scripts/ci-guardrails.sh
[... 683285 command bytes omitted ...]
2026-09-10T09:29:05.5220737Z [31;1m        FAIL[0m [   0.559s] (3119/5334) [35;1morbit-web[0m [36mapi::tests::task_listing[0m[36m::[0m[34;1maggregate_selects_global_newest_rows_before_reading_off_page_workspace_bodies[0m
2026-09-10T09:29:05.5224148Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-10T09:29:05.5224816Z 
2026-09-10T09:29:05.5225295Z     running 1 test
2026-09-10T09:29:05.5226927Z     test api::tests::task_listing::aggregate_selects_global_newest_rows_before_reading_off_page_workspace_bodies ... FAILED
2026-09-10T09:29:05.5227875Z 
2026-09-10T09:29:05.5228203Z     failures:
2026-09-10T09:29:05.5228587Z 
2026-09-10T09:29:05.5228902Z     failures:
2026-09-10T09:29:05.5230034Z         api::tests::task_listing::aggregate_selects_global_newest_rows_before_reading_off_page_workspace_bodies
2026-09-10T09:29:05.5230922Z 
2026-09-10T09:29:05.5231547Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 379 filtered out; finished in 0.55s
2026-09-10T09:29:05.5232542Z     [0m
2026-09-10T09:29:05.5233259Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-10T09:29:05.5233778Z 
2026-09-10T09:29:05.5235311Z     [0m[31;1mthread 'api::tests::task_listing::aggregate_selects_global_newest_rows_before_reading_off_page_workspace_bodies' (74280) panicked at crates/orbit-web/src/api/tests/task_listing.rs:83:72:[0m
2026-09-10T09:29:05.5237996Z     [31;1mcalled `Option::unwrap()` on a `None` value[0m
2026-09-10T09:29:05.5239107Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-10T09:29:05.5239828Z 
2026-09-10T09:29:05.6701754Z [32;1m        PASS[0m [   0.580s] (3120/5334) [35;1morbit-web[0m [36mapi::tests::task_listing[0m[36m::[0m[34;1mcold_workspace_resolution_leaves_unrelated_requests_runnable[0m
2026-09-10T09:29:05.9319067Z [32;1m        PASS[0m [   0.407s] (3121/5334) [35;1morbit-web[0m [36mapi::tests::task_listing[0m[36m::[0m[34;1mlist_and_detail_reuse_bundle_sidecars_with_response_parity[0m
2026-09-10T09:29:06.1019254Z [31;1m        FAIL[0m [   0.431s] (3122/5334) [35;1morbit-web[0m [36mapi::tests::task_listing[0m[36m::[0m[34;1mtask_list_detail_and_aggregate_leave_async_requests_runnable_during_blocked_io[0m
2026-09-10T09:29:06.1037418Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-10T09:29:06.1066898Z 
2026-09-10T09:29:06.1079022Z     running 1 test
2026-09-10T09:29:06.1121848Z     test api::tests::task_listing::task_list_detail_and_aggregate_leave_async_requests_runnable_during_blocked_io ... FAILED
2026-09-10T09:29:06.1122953Z 
2026-09-10T09:29:06.1123358Z     failures:
2026-09-10T09:29:06.1123747Z 
2026-09-10T09:29:06.1124054Z     failures:
2026-09-10T09:29:06.1124954Z         api::tests::task_listing::task_list_detail_and_aggregate_leave_async_requests_runnable_during_blocked_io
2026-09-10T09:29:06.1125801Z 
2026-09-10T09:29:06.1126606Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 379 filtered out; finished in 0.42s
2026-09-10T09:29:06.1127691Z     [0m
2026-09-10T09:29:06.1128321Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-10T09:29:06.1128842Z 
2026-09-10T09:29:06.1130531Z     [0m[31;1mthread 'api::tests::task_listing::task_list_detail_and_aggregate_leave_async_requests_runnable_during_blocked_io' (74710) panicked at crates/orbit-web/src/api/tests/task_listing.rs:144:78:[0m
2026-09-10T09:29:06.1132306Z     [31;1mcalled `Option::unwrap()` on a `None` value[0m
2026-09-10T09:29:06.1133391Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-10T09:29:06.1134117Z 
2026-09-10T09:29:06.3374533Z [32;1m        PASS[0m [   0.408s] (3123/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mcreate_task_only_accepts_creation_legal_statuses_and_ignores_comment[0m
2026-09-10T09:29:06.5259467Z [32;1m        PASS[0m [   0.425s] (3124/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mcreate_task_persists_relations_from_body[0m
2026-09-10T09:29:06.6393842Z [32;1m        PASS[0m [   0.301s] (3125/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mcreate_task_rejects_an_undeclared_body_field[0m
2026-09-10T09:29:06.9199751Z [32;1m        PASS[0m [   0.394s] (3126/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mcreate_task_rejects_invalid_relation_target[0m
2026-09-10T09:29:06.9428502Z [32;1m        PASS[0m [   0.303s] (3127/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mcreate_task_rejects_stray_workspace_body_key[0m
2026-09-10T09:29:07.2245047Z [32;1m        PASS[0m [   0.304s] (3128/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mcreate_task_requires_assessed_complexity[0m
2026-09-10T09:29:07.3550656Z [32;1m        PASS[0m [   0.412s] (3129/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mget_task_artifact_downloads_html_instead_of_serving_inline[0m
2026-09-10T09:29:07.6279059Z [32;1m        PASS[0m [   0.401s] (3130/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mget_task_artifact_downloads_script_media_types[0m
[... 194 command bytes omitted ...]
2026-09-10T09:29:08.0271952Z [31;1m        FAIL[0m [   0.399s] (3132/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mget_task_artifact_fails_closed_on_symlink_with_foreign_content[0m
2026-09-10T09:29:08.0297252Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-10T09:29:08.0326800Z 
2026-09-10T09:29:08.0356968Z     running 1 test
2026-09-10T09:29:08.0387355Z     test api::tests::tasks::get_task_artifact_fails_closed_on_symlink_with_foreign_content ... FAILED
2026-09-10T09:29:08.0416882Z 
2026-09-10T09:29:08.0446936Z     failures:
2026-09-10T09:29:08.0476712Z 
2026-09-10T09:29:08.0506953Z     failures:
2026-09-10T09:29:08.0537536Z         api::tests::tasks::get_task_artifact_fails_closed_on_symlink_with_foreign_content
2026-09-10T09:29:08.0566742Z 
2026-09-10T09:29:08.0597339Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 379 filtered out; finished in 0.39s
2026-09-10T09:29:08.0617082Z     [0m
2026-09-10T09:29:08.0657206Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-10T09:29:08.0686752Z 
2026-09-10T09:29:08.0718087Z     [0m[31;1mthread 'api::tests::tasks::get_task_artifact_fails_closed_on_symlink_with_foreign_content' (75923) panicked at crates/orbit-web/src/api/tests/tasks.rs:561:10:[0m
2026-09-10T09:29:08.0727202Z     [31;1martifact blob exists on disk[0m
2026-09-10T09:29:08.0747403Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-10T09:29:08.0747995Z 
2026-09-10T09:29:08.1995593Z [32;1m        PASS[0m [   0.415s] (3133/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mget_task_artifact_normalizes_text_plain_and_keeps_it_inline[0m
2026-09-10T09:29:08.4376343Z [31;1m        FAIL[0m [   0.412s] (3134/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mget_task_artifact_refuses_symlink_escaping_artifact_root[0m
2026-09-10T09:29:08.4398502Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-10T09:29:08.4426984Z 
2026-09-10T09:29:08.4457104Z     running 1 test
2026-09-10T09:29:08.4458004Z     test api::tests::tasks::get_task_artifact_refuses_symlink_escaping_artifact_root ... FAILED
2026-09-10T09:29:08.4477339Z 
2026-09-10T09:29:08.4478385Z     failures:
2026-09-10T09:29:08.4487993Z 
2026-09-10T09:29:08.4488414Z     failures:
2026-09-10T09:29:08.4489189Z         api::tests::tasks::get_task_artifact_refuses_symlink_escaping_artifact_root
2026-09-10T09:29:08.4489900Z 
2026-09-10T09:29:08.4490554Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 379 filtered out; finished in 0.40s
2026-09-10T09:29:08.4491615Z     [0m
2026-09-10T09:29:08.4492233Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-10T09:29:08.4492747Z 
2026-09-10T09:29:08.4494047Z     [0m[31;1mthread 'api::tests::tasks::get_task_artifact_refuses_symlink_escaping_artifact_root' (76163) panicked at crates/orbit-web/src/api/tests/tasks.rs:561:10:[0m
2026-09-10T09:29:08.4495411Z     [31;1martifact blob exists on disk[0m
2026-09-10T09:29:08.4496372Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-10T09:29:08.4497236Z 
2026-09-10T09:29:08.6134800Z [32;1m        PASS[0m [   0.414s] (3135/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mget_task_artifact_rejects_adversarial_paths[0m
2026-09-10T09:29:08.8617471Z [32;1m        PASS[0m [   0.424s] (3136/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mget_task_artifact_rejects_traversal_path[0m
2026-09-10T09:29:09.0074939Z [32;1m        PASS[0m [   0.393s] (3137/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mget_task_artifact_returns_not_found_for_missing_artifact[0m
2026-09-10T09:29:09.2709879Z [32;1m        PASS[0m [   0.407s] (3138/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mget_task_artifact_serves_subdirectory_bytes_and_media_type[0m
2026-09-10T09:29:09.4092637Z [32;1m        PASS[0m [   0.401s] (3139/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mget_task_projects_artifact_manifest_without_content[0m
2026-09-10T09:29:09.6727276Z [32;1m        PASS[0m [   0.403s] (3140/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mhistorical_review_record_renders_as_an_opaque_task_comment[0m
2026-09-10T09:29:09.8242430Z [32;1m        PASS[0m [  10.145s] (3141/5334) [35;1morbit-web[0m [36mapi::tests::runs[0m[36m::[0m[34;1mlist_run_events_returns_payload_too_large_when_scan_budget_exceeded[0m
2026-09-10T09:29:10.0944325Z [32;1m        PASS[0m [   0.421s] (3142/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mlist_tasks_honors_status_type_and_limit_filters[0m
[... 43407 command bytes omitted ...]
2026-09-10T09:30:35.7277743Z [31;1m        FAIL[0m [   0.237s] (3363/5334) [35;1morbit-cli::task_trimmed_surface[0m [34;1mmigrate_bare_invocation_inspects_and_confirm_applies[0m
2026-09-10T09:30:35.7279271Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-10T09:30:35.7279599Z 
2026-09-10T09:30:35.7279734Z     running 1 test
2026-09-10T09:30:35.7280517Z     test migrate_bare_invocation_inspects_and_confirm_applies ... FAILED
2026-09-10T09:30:35.7280990Z 
2026-09-10T09:30:35.7281128Z     failures:
2026-09-10T09:30:35.7281305Z 
2026-09-10T09:30:35.7281434Z     failures:
2026-09-10T09:30:35.7281835Z         migrate_bare_invocation_inspects_and_confirm_applies
2026-09-10T09:30:35.7282212Z 
2026-09-10T09:30:35.7282638Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.23s
2026-09-10T09:30:35.7283407Z     [0m
2026-09-10T09:30:35.7283813Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-10T09:30:35.7284117Z 
2026-09-10T09:30:35.7285016Z     [0m[31;1mthread 'migrate_bare_invocation_inspects_and_confirm_applies' (99610) panicked at crates/orbit-cli/tests/task_trimmed_surface.rs:379:5:[0m
2026-09-10T09:30:35.7286768Z     [31;1merror: workspace error: no initialized orbit workspace found from the current directory; run `orbit init` first[0m
2026-09-10T09:30:35.7287511Z 
2026-09-10T09:30:35.7287855Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-10T09:30:35.7288175Z 
2026-09-10T09:30:36.2018945Z [32;1m        PASS[0m [   0.474s] (3364/5334) [35;1morbit-cli::task_trimmed_surface[0m [34;1mrun_cancel_confirmation_precedes_run_lookup[0m
2026-09-10T09:30:37.5831221Z [32;1m        PASS[0m [   1.381s] (3365/5334) [35;1morbit-cli::task_trimmed_surface[0m [34;1mtask_add_attributes_from_model_flag_and_managed_identity_env[0m
2026-09-10T09:30:38.2501332Z [32;1m        PASS[0m [   0.667s] (3366/5334) [35;1morbit-cli::task_trimmed_surface[0m [34;1mtask_update_complexity_roundtrips_through_a_real_task_record[0m
2026-09-10T09:30:39.4893758Z [32;1m        PASS[0m [   1.239s] (3367/5334) [35;1morbit-cli::task_trimmed_surface[0m [34;1mtask_update_repeats_dependencies_and_clears_context[0m
2026-09-10T09:30:40.3410592Z [32;1m        PASS[0m [   0.852s] (3368/5334) [35;1morbit-cli::task_trimmed_surface[0m [34;1mupdate_status_performs_approve_and_reject_transitions[0m
2026-09-10T09:30:41.5081878Z [32;1m        PASS[0m [   1.167s] (3369/5334) [35;1morbit-cli::task_trimmed_surface[0m [34;1mupdate_status_reopens_done_directly_and_accepts_accompanying_edits[0m
2026-09-10T09:30:42.2933602Z [32;1m        PASS[0m [   0.785s] (3370/5334) [35;1morbit-cli::task_trimmed_surface[0m [34;1mupdate_status_restores_archived_task_directly_to_any_status[0m
2026-09-10T09:30:43.1630974Z [32;1m        PASS[0m [   0.870s] (3371/5334) [35;1morbit-cli::task_trimmed_surface[0m [34;1mworkspace_remove_is_recoverable_by_reinitializing_the_checkout[0m
[... 2475 command bytes omitted ...]
2026-09-10T09:30:47.1503070Z [31;1m        FAIL[0m [   0.500s] (3386/5334) [35;1morbit-cli::update[0m [34;1mupdate_without_a_root_override_retains_default_workspace_routing[0m
2026-09-10T09:30:47.1503818Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-10T09:30:47.1504033Z 
2026-09-10T09:30:47.1504131Z     running 1 test
2026-09-10T09:30:47.1504494Z     test update_without_a_root_override_retains_default_workspace_routing ... FAILED
2026-09-10T09:30:47.1504824Z 
2026-09-10T09:30:47.1504910Z     failures:
2026-09-10T09:30:47.1505034Z 
2026-09-10T09:30:47.1505118Z     failures:
2026-09-10T09:30:47.1505412Z         update_without_a_root_override_retains_default_workspace_routing
2026-09-10T09:30:47.1505722Z 
2026-09-10T09:30:47.1506002Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.50s
2026-09-10T09:30:47.1506741Z     [0m
2026-09-10T09:30:47.1507025Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-10T09:30:47.1507224Z 
2026-09-10T09:30:47.1507788Z     [0m[31;1mthread 'update_without_a_root_override_retains_default_workspace_routing' (100046) panicked at crates/orbit-cli/tests/update.rs:271:5:[0m
2026-09-10T09:30:47.1508495Z     [31;1massertion `left == right` failed[0m
2026-09-10T09:30:47.1508790Z       left: Null
2026-09-10T09:30:47.1509024Z      right: "/tmp/.tmpSgG9to/repo/.orbit"
2026-09-10T09:30:47.1509506Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-10T09:30:47.1509823Z 
2026-09-10T09:30:47.9317909Z [32;1m        PASS[0m [   0.781s] (3387/5334) [35;1morbit-cli::web_serve_root[0m [34;1mweb_serve_honors_an_explicit_root_over_the_global_registry[0m
2026-09-10T09:30:48.3471082Z [32;1m        PASS[0m [   0.415s] (3388/5334) [35;1morbit-cli::web_serve_root[0m [34;1mweb_serve_without_an_explicit_root_still_serves_the_global_registry[0m
2026-09-10T09:30:48.4764698Z [32;1m        PASS[0m [   0.129s] (3389/5334) [35;1morbit-cli::web_serve_shutdown[0m [34;1mdashboard_exits_promptly_on_sigterm_with_open_connections[0m
2026-09-10T09:31:01.5240452Z [32;1m        PASS[0m [  13.048s] (3390/5334) [35;1morbit-cli::web_serve_shutdown[0m [34;1mdashboard_outlives_shutdown_grace_period_when_no_signal_is_sent[0m
2026-09-10T09:31:02.6861385Z [32;1m        PASS[0m [   1.162s] (3391/5334) [35;1morbit-cli::workspace_selector[0m [34;1mcheckout_path_and_cwd_resolve_an_id_that_collides_with_another_workspace_name[0m
2026-09-10T09:31:03.0943864Z [32;1m        PASS[0m [   0.408s] (3392/5334) [35;1morbit-cli::workspace_selector[0m [34;1mglobal_workspace_flag_fails_closed_on_unknown_selector[0m
2026-09-10T09:31:04.8021804Z [32;1m        PASS[0m [   1.708s] (3393/5334) [35;1morbit-cli::workspace_selector[0m [34;1mglobal_workspace_flag_selects_by_name_and_id_from_a_foreign_checkout[0m
[... 1204 command bytes omitted ...]
2026-09-10T09:31:11.0934599Z [31;1m        FAIL[0m [   0.242s] (3400/5334) [35;1morbit-cli::workspace_sync[0m [34;1mworkspace_sync_creates_missing_defaults_preserves_operator_content_and_is_idempotent[0m
2026-09-10T09:31:11.0935853Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-10T09:31:11.0936186Z 
2026-09-10T09:31:11.0936323Z     running 1 test
2026-09-10T09:31:11.0937230Z     test workspace_sync_creates_missing_defaults_preserves_operator_content_and_is_idempotent ... FAILED
2026-09-10T09:31:11.0937876Z 
2026-09-10T09:31:11.0937997Z     failures:
2026-09-10T09:31:11.0938175Z 
2026-09-10T09:31:11.0938304Z     failures:
2026-09-10T09:31:11.0938869Z         workspace_sync_creates_missing_defaults_preserves_operator_content_and_is_idempotent
2026-09-10T09:31:11.0939445Z 
2026-09-10T09:31:11.0939746Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.24s
2026-09-10T09:31:11.0940230Z     [0m
2026-09-10T09:31:11.0940505Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-10T09:31:11.0940702Z 
2026-09-10T09:31:11.0941550Z     [0m[31;1mthread 'workspace_sync_creates_missing_defaults_preserves_operator_content_and_is_idempotent' (100618) panicked at /rustc/48a229ceaefd4985c50990b14116b6d856af0985/library/core/src/ops/function.rs:250:5:[0m
2026-09-10T09:31:11.0942474Z     [31;1mUnexpected return code, failed var == 3[0m
2026-09-10T09:31:11.0942808Z     └── var: 1
2026-09-10T09:31:11.0942931Z 
2026-09-10T09:31:11.0944995Z     command=`cd "/tmp/.tmpDwGSIe" && env -u ORBIT_ACTIVE_TASK_ID -u ORBIT_ACTIVITY_DIR -u ORBIT_ACTIVITY_FS_PROFILE -u ORBIT_ACTIVITY_ID -u ORBIT_ACTIVITY_TOOLS -u ORBIT_AGENT_MODEL -u ORBIT_AGENT_NAME -u ORBIT_BIN -u ORBIT_HOME -u ORBIT_JOB_DIR -u ORBIT_MANAGED_RUN_CONTEXT -u ORBIT_OPERATOR -u ORBIT_PROC_ALLOWED_PROGRAMS -u ORBIT_REGISTRY_ROOT -u ORBIT_ROOT -u ORBIT_RUN_ID -u ORBIT_SESSION_ID -u ORBIT_STEP_INDEX -u ORBIT_TASK_ACTOR_KIND -u ORBIT_TASK_ID -u ORBIT_WORKSPACE -u ORBIT_WORKSPACE_CLAIM_TOKEN -u ORBIT_WORKTREE_ROOT HOME="/tmp/.tmp7g0O41" USERPROFILE="/tmp/.tmp7g0O41" "/home/runner/work/orbit/orbit/target/debug/orbit" "workspace" "sync" "--check" "--json"`
2026-09-10T09:31:11.0947477Z     code=1
2026-09-10T09:31:11.0947674Z     stdout=""
2026-09-10T09:31:11.0947880Z     stderr=```
2026-09-10T09:31:11.0948075Z     {
2026-09-10T09:31:11.0948287Z       \"code\": \"workspace_error\",
2026-09-10T09:31:11.0948866Z       \"error\": \"workspace error: current directory is not an initialized and registered Orbit workspace; run `orbit workspace init` first\"
2026-09-10T09:31:11.0949417Z     }
[... 837 command bytes omitted ...]
2026-09-10T09:32:04.4763982Z [31;1m        FAIL[0m [   0.534s] (3404/5334) [35;1morbit-cli::worktree_resolution[0m [34;1mconfig_show_reports_shared_and_local_roots_for_git_worktrees_and_overrides[0m
2026-09-10T09:32:04.4764813Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-10T09:32:04.4766757Z 
2026-09-10T09:32:04.4766899Z     running 1 test
2026-09-10T09:32:04.4767449Z     test config_show_reports_shared_and_local_roots_for_git_worktrees_and_overrides ... FAILED
2026-09-10T09:32:04.4767968Z 
2026-09-10T09:32:04.4768096Z     failures:
2026-09-10T09:32:04.4768263Z 
2026-09-10T09:32:04.4768378Z     failures:
2026-09-10T09:32:04.4768851Z         config_show_reports_shared_and_local_roots_for_git_worktrees_and_overrides
2026-09-10T09:32:04.4769264Z 
2026-09-10T09:32:04.4769622Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.53s
2026-09-10T09:32:04.4770306Z     [0m
2026-09-10T09:32:04.4770716Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-10T09:32:04.4771008Z 
2026-09-10T09:32:04.4772170Z     [0m[31;1mthread 'config_show_reports_shared_and_local_roots_for_git_worktrees_and_overrides' (100827) panicked at /rustc/48a229ceaefd4985c50990b14116b6d856af0985/library/core/src/ops/function.rs:250:5:[0m
2026-09-10T09:32:04.4773568Z     [31;1mUnexpected failure.[0m
2026-09-10T09:32:04.4773984Z     code=1
2026-09-10T09:32:04.4774290Z     stderr=``````
2026-09-10T09:32:04.4774615Z     {
2026-09-10T09:32:04.4774926Z       \"code\": \"invalid_input\",
2026-09-10T09:32:04.4775896Z       \"error\": \"invalid input: /tmp/.tmpdZ35Hm/repo/.orbit is not an Orbit workspace; run `orbit workspace init` first or pass `--root <path/to/.orbit>`\"
2026-09-10T09:32:04.4776904Z     }
2026-09-10T09:32:04.4777160Z     ```
2026-09-10T09:32:04.4777346Z     ```
2026-09-10T09:32:04.4780615Z     command=`cd "/tmp/.tmpdZ35Hm/repo-worktree" && env -u LLVM_PROFILE_FILE -u ORBIT_ACTIVE_TASK_ID -u ORBIT_ACTIVITY_DIR -u ORBIT_ACTIVITY_FS_PROFILE -u ORBIT_ACTIVITY_ID -u ORBIT_ACTIVITY_TOOLS -u ORBIT_AGENT_MODEL -u ORBIT_AGENT_NAME -u ORBIT_BIN -u ORBIT_JOB_DIR -u ORBIT_MANAGED_RUN_CONTEXT -u ORBIT_OPERATOR -u ORBIT_PROC_ALLOWED_PROGRAMS -u ORBIT_REGISTRY_ROOT -u ORBIT_ROOT -u ORBIT_RUN_ID -u ORBIT_SESSION_ID -u ORBIT_STEP_INDEX -u ORBIT_TASK_ACTOR_KIND -u ORBIT_TASK_ID -u ORBIT_WORKSPACE -u ORBIT_WORKSPACE_CLAIM_TOKEN -u ORBIT_WORKTREE_ROOT HOME="/tmp/.tmpdZ35Hm/home" PATH="/tmp/.tmpdZ35Hm/home/stub-bin:/snap/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin" USERPROFILE="/tmp/.tmpdZ35Hm/home" "/home/runner/work/orbit/orbit/target/debug/orbit" "--root" "/tmp/.tmpdZ35Hm/repo/.orbit" "config" "show" "--json"`
2026-09-10T09:32:04.4784053Z     code=1
[... 84040 command bytes omitted ...]
2026-09-10T09:32:28.9558316Z [31;1m        FAIL[0m [   0.624s] (3792/5334) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_in_independent_nested_git_repo_preserves_parent_binding[0m
2026-09-10T09:32:28.9559666Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-10T09:32:28.9559926Z 
2026-09-10T09:32:28.9560057Z     running 1 test
2026-09-10T09:32:28.9560850Z     test command::workspace::tests::init::workspace_init_in_independent_nested_git_repo_preserves_parent_binding ... FAILED
2026-09-10T09:32:28.9561589Z 
2026-09-10T09:32:28.9561728Z     failures:
2026-09-10T09:32:28.9561902Z 
2026-09-10T09:32:28.9562030Z     failures:
2026-09-10T09:32:28.9562764Z         command::workspace::tests::init::workspace_init_in_independent_nested_git_repo_preserves_parent_binding
2026-09-10T09:32:28.9563474Z 
2026-09-10T09:32:28.9563895Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 492 filtered out; finished in 0.61s
2026-09-10T09:32:28.9564670Z     [0m
2026-09-10T09:32:28.9565071Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-10T09:32:28.9565373Z 
2026-09-10T09:32:28.9566853Z     [0m[31;1mthread 'command::workspace::tests::init::workspace_init_in_independent_nested_git_repo_preserves_parent_binding' (101915) panicked at crates/orbit-cli/src/command/workspace/tests/init.rs:1601:9:[0m
2026-09-10T09:32:28.9568293Z     [31;1mchild workspace must own its tasks state[0m
2026-09-10T09:32:28.9569104Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-10T09:32:28.9569580Z 
2026-09-10T09:32:29.1664221Z [32;1m        PASS[0m [   0.211s] (3793/5334) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_preserves_existing_orbitignore[0m
2026-09-10T09:32:29.3825363Z [32;1m        PASS[0m [   0.216s] (3794/5334) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_rejects_existing_checkout_path_with_different_id_without_force[0m
2026-09-10T09:32:29.6038792Z [32;1m        PASS[0m [   0.221s] (3795/5334) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_rejects_existing_durable_id_without_force[0m
2026-09-10T09:32:30.0060021Z [32;1m        PASS[0m [   0.402s] (3796/5334) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_replaces_legacy_bare_orbit_gitignore_line_with_managed_block[0m
2026-09-10T09:32:30.4077451Z [32;1m        PASS[0m [   0.402s] (3797/5334) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_retires_adr_store_gitignore_lines[0m
2026-09-10T09:32:30.6195580Z [32;1m        PASS[0m [   0.212s] (3798/5334) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_seeds_auto_detected_mcp_configs[0m
2026-09-10T09:32:31.0306821Z [32;1m        PASS[0m [   0.411s] (3799/5334) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_seeds_disabled_routines_and_reinit_preserves_authored_files[0m
2026-09-10T09:32:31.2455115Z [32;1m        PASS[0m [   0.215s] (3800/5334) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_skips_mcp_by_default[0m
[... 318861 command bytes omitted ...]
2026-09-10T09:37:48.1694787Z [31;1m        FAIL[0m [   0.268s] (5197/5334) [35;1morbit-core[0m [36mruntime::tests::builder[0m[36m::[0m[34;1mv2_task_backend_wires_through_runtime_add_show_list_and_update[0m
2026-09-10T09:37:48.1696071Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-10T09:37:48.1696556Z 
2026-09-10T09:37:48.1696689Z     running 1 test
2026-09-10T09:37:48.1697409Z     test runtime::tests::builder::v2_task_backend_wires_through_runtime_add_show_list_and_update ... FAILED
2026-09-10T09:37:48.1698030Z 
2026-09-10T09:37:48.1698160Z     failures:
2026-09-10T09:37:48.1698339Z 
2026-09-10T09:37:48.1698455Z     failures:
2026-09-10T09:37:48.1698932Z         runtime::tests::builder::v2_task_backend_wires_through_runtime_add_show_list_and_update
2026-09-10T09:37:48.1699287Z 
2026-09-10T09:37:48.1699571Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1379 filtered out; finished in 0.26s
2026-09-10T09:37:48.1700062Z     [0m
2026-09-10T09:37:48.1700344Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-10T09:37:48.1700552Z 
2026-09-10T09:37:48.1701284Z     [0m[31;1mthread 'runtime::tests::builder::v2_task_backend_wires_through_runtime_add_show_list_and_update' (112229) panicked at crates/orbit-core/src/runtime/tests/builder.rs:136:5:[0m
2026-09-10T09:37:48.1702173Z     [31;1massertion failed: workspace_root.join("tasks/ORB-00000").exists()[0m
2026-09-10T09:37:48.1702802Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-10T09:37:48.1703134Z 
2026-09-10T09:37:48.1812572Z [32;1m        PASS[0m [   0.012s] (5198/5334) [35;1morbit-core[0m [36mruntime::tests::resolve[0m[36m::[0m[34;1mbootstrap_ignores_home_global_orbit_when_repo_has_no_workspace_orbit[0m
2026-09-10T09:37:48.1921562Z [32;1m        PASS[0m [   0.011s] (5199/5334) [35;1morbit-core[0m [36mruntime::tests::resolve[0m[36m::[0m[34;1mbootstrap_rejects_home_when_cwd_is_home_with_global_orbit_and_no_git[0m
2026-09-10T09:37:48.2031149Z [32;1m        PASS[0m [   0.011s] (5200/5334) [35;1morbit-core[0m [36mruntime::tests::resolve[0m[36m::[0m[34;1mbootstrap_rejects_home_when_home_itself_is_a_git_repo[0m
2026-09-10T09:37:48.2106772Z [32;1m        PASS[0m [   0.008s] (5201/5334) [35;1morbit-core[0m [36mruntime::tests::resolve[0m[36m::[0m[34;1mbootstrap_root_allows_uninitialized_path_without_creating_it[0m
2026-09-10T09:37:48.2200432Z [32;1m        PASS[0m [   0.009s] (5202/5334) [35;1morbit-core[0m [36mruntime::tests::resolve[0m[36m::[0m[34;1mcaller_supplied_workspace_hint_keeps_registry_out_of_core_resolution[0m
2026-09-10T09:37:48.2287616Z [32;1m        PASS[0m [   0.009s] (5203/5334) [35;1morbit-core[0m [36mruntime::tests::resolve[0m[36m::[0m[34;1menv_root_precedes_worktree_resolution[0m
2026-09-10T09:37:48.2374627Z [32;1m        PASS[0m [   0.009s] (5204/5334) [35;1morbit-core[0m [36mruntime::tests::resolve[0m[36m::[0m[34;1mexplicit_root_precedes_env_and_worktree_resolution[0m
2026-09-10T09:37:48.2451815Z [32;1m        PASS[0m [   0.008s] (5205/5334) [35;1morbit-core[0m [36mruntime::tests::resolve[0m[36m::[0m[34;1mexplicit_root_prefers_initialized_child_orbit_over_polluted_repo_root[0m
2026-09-10T09:37:48.2529088Z [32;1m        PASS[0m [   0.008s] (5206/5334) [35;1morbit-core[0m [36mruntime::tests::resolve[0m[36m::[0m[34;1mexplicit_root_with_initialized_child_orbit_resolves_to_child[0m
[... 25856 command bytes omitted ...]
2026-09-10T09:38:34.4042868Z [31;1m     Summary[0m [ 687.183s] [1m5334[0m tests run: [1m5324[0m [32;1mpassed[0m ([1m1[0m [33;1mslow[0m), [1m10[0m [31;1mfailed[0m, [1m18[0m [33;1mskipped[0m
2026-09-10T09:38:34.4044661Z [31;1m        FAIL[0m [   0.559s] (3119/5334) [35;1morbit-web[0m [36mapi::tests::task_listing[0m[36m::[0m[34;1maggregate_selects_global_newest_rows_before_reading_off_page_workspace_bodies[0m
2026-09-10T09:38:34.4046708Z [31;1m        FAIL[0m [   0.431s] (3122/5334) [35;1morbit-web[0m [36mapi::tests::task_listing[0m[36m::[0m[34;1mtask_list_detail_and_aggregate_leave_async_requests_runnable_during_blocked_io[0m
2026-09-10T09:38:34.4048398Z [31;1m        FAIL[0m [   0.399s] (3132/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mget_task_artifact_fails_closed_on_symlink_with_foreign_content[0m
2026-09-10T09:38:34.4049975Z [31;1m        FAIL[0m [   0.412s] (3134/5334) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mget_task_artifact_refuses_symlink_escaping_artifact_root[0m
2026-09-10T09:38:34.4051485Z [31;1m        FAIL[0m [   0.237s] (3363/5334) [35;1morbit-cli::task_trimmed_surface[0m [34;1mmigrate_bare_invocation_inspects_and_confirm_applies[0m
2026-09-10T09:38:34.4052900Z [31;1m        FAIL[0m [   0.500s] (3386/5334) [35;1morbit-cli::update[0m [34;1mupdate_without_a_root_override_retains_default_workspace_routing[0m
2026-09-10T09:38:34.4054705Z [31;1m        FAIL[0m [   0.242s] (3400/5334) [35;1morbit-cli::workspace_sync[0m [34;1mworkspace_sync_creates_missing_defaults_preserves_operator_content_and_is_idempotent[0m
2026-09-10T09:38:34.4056396Z [31;1m        FAIL[0m [   0.534s] (3404/5334) [35;1morbit-cli::worktree_resolution[0m [34;1mconfig_show_reports_shared_and_local_roots_for_git_worktrees_and_overrides[0m
2026-09-10T09:38:34.4058424Z [31;1m        FAIL[0m [   0.624s] (3792/5334) [35;1morbit-cli::bin/orbit[0m [36mcommand::workspace::tests::init[0m[36m::[0m[34;1mworkspace_init_in_independent_nested_git_repo_preserves_parent_binding[0m
2026-09-10T09:38:34.4060285Z [31;1m        FAIL[0m [   0.268s] (5197/5334) [35;1morbit-core[0m [36mruntime::tests::builder[0m[36m::[0m[34;1mv2_task_backend_wires_through_runtime_add_show_list_and_update[0m
2026-09-10T09:38:34.4081906Z [31;1merror[0m: test run failed
2026-09-10T09:38:34.4115053Z ##[error]Process completed with exit code 100.

```

_The collection display was truncated. Selected evidence is used for diagnosis; its retention limits are independent of that display._

_The run-scoped failed-step log came back empty, so this excerpt is the evidence from job `Check / Clippy / Test` (id `102816225943`), read from the job log API._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `CI` run https://github.com/constellation-works/orbit/actions/runs/34459020416 — superseded_by_newer_workflow_run: newer relevant run 34460283059 at 2026-09-10T09:22:32Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34457516104 — superseded_by_newer_workflow_run: newer relevant run 34460283059 at 2026-09-10T09:22:32Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34455994171 — superseded_by_newer_workflow_run: newer relevant run 34456839406 at 2026-09-10T08:44:56Z is completed with conclusion success
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34455898672 — superseded_by_newer_workflow_run: newer relevant run 34456839406 at 2026-09-10T08:44:56Z is completed with conclusion success
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34455568390 — superseded_by_newer_workflow_run: newer relevant run 34456839406 at 2026-09-10T08:44:56Z is completed with conclusion success
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34455540812 — superseded_by_newer_workflow_run: newer relevant run 34456839406 at 2026-09-10T08:44:56Z is completed with conclusion success

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 2,
  "current_failures_discovered": 4,
  "current_failures_investigated": 4,
  "current_failures_investigation_attempted": 6,
  "inconclusive": 0,
  "investigation_cursor": 496953,
  "job_log_reads": 4,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_job_log_reads": 6,
  "max_pull_requests": 10,
  "max_retired_ref_probes": 20,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely",
    "6 of 12 current or mixed-state runs were listed but not investigated (max_investigated_runs=6); their run URLs are still present, and the rotating slot reaches a different overflow candidate on the next sweep"
  ],
  "pull_requests_scanned": 1,
  "refs_scanned": 2,
  "retired_refs": [
    "orbit/ORB-11994-6aa26c01",
    "orbit/ORB-12023-6aa261a9",
    "orbit/ORB-12042-6aa264bd",
    "orbit/ORB-12044-6aa26407",
    "orbit/ORB-12045-6aa263ad",
    "orbit/ORB-12049-6aa264fa",
    "orbit/ORB-12050-6aa26537",
    "orbit/ORB-12053-6aa269b9",
    "orbit/ORB-12054-6aa26a34",
    "orbit/ORB-12055-6aa26a54",
    "orbit/ORB-12064-6aa275f3"
  ],
  "runs_listed": 100,
  "unverified_refs": []
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `CI` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated initialized-root detection to recognize layout version 3, where task bundles are canonical in the global registry and checkout-local .orbit/tasks projections no longer exist.
- Updated affected regression fixtures to locate artifact/task bundles under the global registry, changed the migration marker expectation to layout version 3, and asserted the canonical runtime bundle path.
- The workspace sync, update routing, and worktree configuration failures are covered by the shared resolver correction. No workflow, assertion strength, or lint level was weakened.

Assessment: The runner failure was repository-owned and reproduced locally. The common cause was stale initialized-root detection plus fixtures assuming retired task projections.

Acceptance criteria:
- Root cause fixed without disabling or weakening CI: passed; production root discovery and affected fixtures now match the shipped projection-free layout.
- Runner failure reproduced and fixed: passed; the exact narrow command cargo test -p orbit-web --lib 'api::tests::task_listing::aggregate_selects_global_newest_rows_before_reading_off_page_workspace_bodies' -- --exact --nocapture failed before the change with an artifact-path unwrap and passed after it.
- Documented pre-handoff gate: passed; make ci-fast and make ci-lint both exited 0. ci-fast reported one environment-limited optional compiler-cache namespace check skipped because bubblewrap could not create a user namespace; all other guardrails passed.
- Infrastructure assessment: not applicable; the failure reproduced locally and was fixed in repository code.

Validation:
- Full orbit-web library suite via cargo test -p orbit-web --lib --no-fail-fast: passed, 379 passed, 0 failed, 1 ignored.
- Full orbit-cli test suite via cargo nextest run -p orbit-cli --no-fail-fast --tests: passed, 647/647.
- Full orbit-core library suite via cargo nextest run -p orbit-core --no-fail-fast --lib: passed, 1378/1378, 2 skipped.
- Focused task-listing tests: passed, 4/4.
- Focused artifact tests: passed, 10/10.
- Focused migration, update routing, workspace sync, worktree-resolution, nested-workspace initialization, runtime builder, and runtime resolution tests: passed.
- git diff --check: passed.
- git status --short: only the five task-scoped files are modified.

Remaining risks or deviations: Full make ci was not run per repository guidance; the CI full workspace test/doc gate remains for the task PR. The ci-fast namespace-dependent compiler-cache check was skipped by the environment and is not claimed as passed. Friction F2026-09-118 records the layout/fixture gotcha.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12068-6aa27cd7`
- Behind base: 0
- Ahead of base: 1