### PR TITLE
Preserve explicit browser capability and retained evidence in the full-QA harness

### DIFF
--- a/docs/runbooks/qa-full-sweep.md
+++ b/docs/runbooks/qa-full-sweep.md
@@ -48,13 +48,25 @@ installed binary without that build attestation intentionally makes provenance
 FAIL, even when `--version` exits zero. The harness constructs a clean child
 environment and disposable Orbit root and Git repositories for mutations.
 
-For the browser leg, pass the absolute Playwright module installed in the
-worker's own disposable namespace:
+For the browser leg, pass all three prepared capability inputs from the
+worker's own disposable namespace. The harness forwards only these browser
+paths to the dashboard process; it does not inherit the worker's Orbit or
+general host environment. The report records the launched Chromium version and
+retains screenshots plus `result.json` in the output-side evidence directory.
 
 ```bash
 ./scripts/qa-full-sweep.sh --build-candidate --run-commands \
-  --playwright-module /tmp/orbit-browser-check/node_modules/playwright/index.mjs
+  --playwright-module /tmp/orbit-browser-check/node_modules/playwright/index.mjs \
+  --playwright-browsers-path /tmp/orbit-browser-check/browsers \
+  --browser-ld-library-path /tmp/orbit-browser-check/sysroot/usr/lib/x86_64-linux-gnu \
+  --browser-evidence-dir /tmp/orbit-qa-evidence/browser
 ```
+
+Attach both the JSON report and its retained evidence directory (or its file
+hash manifest in `results[].retained_evidence`) to the task. If any prepared
+path is absent or Chromium cannot launch, the browser scenario remains
+`NOT_RUN` rather than passing; retain its capability probe in the report for
+operator-owned post-merge verification.
 
 Add `--website-build` only after preparing the website dependencies through
 the isolated procedure in [website validation](website-validation.md). It

--- a/scripts/qa-full-sweep.sh
+++ b/scripts/qa-full-sweep.sh
@@ -5,6 +5,9 @@ repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
 output="$repo_root/qa-full-sweep-report.json"
 run_commands=0
 playwright_module=""
+playwright_browsers_path=""
+browser_ld_library_path=""
+browser_evidence_dir=""
 website_build=0
 build_candidate=0
 platform_evidence=()
@@ -16,6 +19,9 @@ while [[ $# -gt 0 ]]; do
     --orbit-bin) orbit_bin="$2"; shift 2 ;;
     --run-commands) run_commands=1; shift ;;
     --playwright-module) playwright_module="$2"; shift 2 ;;
+    --playwright-browsers-path) playwright_browsers_path="$2"; shift 2 ;;
+    --browser-ld-library-path) browser_ld_library_path="$2"; shift 2 ;;
+    --browser-evidence-dir) browser_evidence_dir="$2"; shift 2 ;;
     --website-build) website_build=1; shift ;;
     --build-candidate) build_candidate=1; shift ;;
     --platform-evidence) platform_evidence+=("$2"); shift 2 ;;
@@ -34,6 +40,15 @@ if [[ "$run_commands" == 1 ]]; then
 fi
 if [[ -n "$playwright_module" ]]; then
   extra_args+=(--playwright-module "$playwright_module")
+fi
+if [[ -n "$playwright_browsers_path" ]]; then
+  extra_args+=(--playwright-browsers-path "$playwright_browsers_path")
+fi
+if [[ -n "$browser_ld_library_path" ]]; then
+  extra_args+=(--browser-ld-library-path "$browser_ld_library_path")
+fi
+if [[ -n "$browser_evidence_dir" ]]; then
+  extra_args+=(--browser-evidence-dir "$browser_evidence_dir")
 fi
 if [[ "$website_build" == 1 ]]; then
   extra_args+=(--website-build)

--- a/scripts/test-qa-full-sweep.py
+++ b/scripts/test-qa-full-sweep.py
@@ -125,9 +125,14 @@ def candidate_source(repo: Path, excluded_paths=()):
     head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
     diff = subprocess.check_output(["git", "diff", "--binary", "HEAD"], cwd=repo)
     status = subprocess.check_output(["git", "status", "--porcelain=v1"], cwd=repo, text=True)
-    excluded = {str(path) for path in excluded_paths}
+    excluded = tuple(str(path) for path in excluded_paths)
+
+    def is_excluded(path):
+        return any(path == excluded_path or path.startswith(f"{excluded_path}/")
+                   for excluded_path in excluded)
+
     status_lines = [line for line in status.splitlines()
-                    if (line[3:].split(" -> ")[-1] if len(line) > 3 else line) not in excluded]
+                    if not is_excluded(line[3:].split(" -> ")[-1] if len(line) > 3 else line)]
     untracked_output = subprocess.check_output(
         ["git", "ls-files", "--others", "--exclude-standard", "-z"], cwd=repo)
     untracked = []
@@ -136,7 +141,7 @@ def candidate_source(repo: Path, excluded_paths=()):
             continue
         path = raw_path.decode()
         candidate = repo / path
-        if path not in excluded and candidate.is_file():
+        if not is_excluded(path) and candidate.is_file():
             untracked.append((path, hashlib.sha256(candidate.read_bytes()).hexdigest()))
     material = json.dumps({"head": head, "diff": hashlib.sha256(diff).hexdigest(),
                            "untracked": untracked}, sort_keys=True).encode()
@@ -187,17 +192,42 @@ def scenario_decision(inventory, results, candidate_id):
     return not failures, failures
 
 
-def isolated_environment(temp: Path):
+def isolated_environment(temp: Path, host_env=None):
     keep = ["PATH", "USER", "LOGNAME", "LANG", "LC_ALL", "RUSTUP_TOOLCHAIN"]
-    env = {key: os.environ[key] for key in keep if key in os.environ}
+    host_env = os.environ if host_env is None else host_env
+    env = {key: host_env[key] for key in keep if key in host_env}
     user_home = Path.home()
     env.update({"HOME": str(temp / "home"), "USERPROFILE": str(temp / "home"),
                 "XDG_CONFIG_HOME": str(temp / "xdg"), "TMPDIR": str(temp / "tmp"),
-                "CARGO_HOME": os.environ.get("CARGO_HOME", str(user_home / ".cargo")),
-                "RUSTUP_HOME": os.environ.get("RUSTUP_HOME", str(user_home / ".rustup"))})
+                "CARGO_HOME": host_env.get("CARGO_HOME", str(user_home / ".cargo")),
+                "RUSTUP_HOME": host_env.get("RUSTUP_HOME", str(user_home / ".rustup"))})
     for path in (temp / "home", temp / "xdg", temp / "tmp"):
         path.mkdir(parents=True, exist_ok=True)
     return env
+
+
+def browser_environment(base: dict, playwright_browsers_path: Path | None,
+                        browser_ld_library_path: Path | None):
+    """Add only declared browser capability paths to the disposable child env."""
+    env = dict(base)
+    if playwright_browsers_path:
+        env["PLAYWRIGHT_BROWSERS_PATH"] = str(playwright_browsers_path)
+    if browser_ld_library_path:
+        env["LD_LIBRARY_PATH"] = str(browser_ld_library_path)
+    return env
+
+
+def inspect_browser_capability(playwright_module: Path, env: dict, repo: Path):
+    probe = run([
+        "node", "--input-type=module", "-e",
+        "import { pathToFileURL } from 'node:url'; "
+        "const { chromium } = await import(pathToFileURL(process.argv[1]).href); "
+        "const browser = await chromium.launch({ headless: true }); "
+        "console.log(browser.version()); await browser.close();",
+        str(playwright_module),
+    ], cwd=repo, env=env, timeout=180)
+    version = probe["stdout"].strip() if probe["exit_code"] == 0 else None
+    return probe, version
 
 
 def add_result(results, scenario, evidence):
@@ -768,6 +798,37 @@ def self_test():
             continue
         raise AssertionError(f"wrong or empty exit-zero output passed: {stdout!r}")
 
+    with tempfile.TemporaryDirectory(prefix="orbit-qa-browser-self-test-") as tmp:
+        temp = Path(tmp)
+        browser_cache = temp / "browsers"
+        browser_libs = temp / "sysroot"
+        browser_cache.mkdir()
+        browser_libs.mkdir()
+        isolated = isolated_environment(temp, {
+            "PATH": os.environ.get("PATH", ""), "ORBIT_ROOT": "must-not-leak",
+            "PLAYWRIGHT_BROWSERS_PATH": "/host/browser-cache",
+            "LD_LIBRARY_PATH": "/host/browser-libraries",
+        })
+        browser = browser_environment(isolated, browser_cache, browser_libs)
+        if browser.get("PLAYWRIGHT_BROWSERS_PATH") != str(browser_cache):
+            raise AssertionError("declared Playwright browser cache was dropped")
+        if browser.get("LD_LIBRARY_PATH") != str(browser_libs):
+            raise AssertionError("declared browser library path was dropped")
+        if "ORBIT_ROOT" in isolated:
+            raise AssertionError("isolated environment inherited host Orbit configuration")
+        observed = run(["python3", "-c", "import json, os; print(json.dumps({key: os.getenv(key) for key in ['PLAYWRIGHT_BROWSERS_PATH', 'LD_LIBRARY_PATH', 'ORBIT_ROOT']}))"],
+                       cwd=temp, env=browser)
+        child = parse_json(observed, "browser environment regression")
+        if child != {"PLAYWRIGHT_BROWSERS_PATH": str(browser_cache),
+                     "LD_LIBRARY_PATH": str(browser_libs), "ORBIT_ROOT": None}:
+            raise AssertionError(f"browser child environment is not bounded: {child!r}")
+        evidence = temp / "retained-evidence"
+        evidence.mkdir()
+        (evidence / "failure.png").write_bytes(b"failure evidence")
+        excluded = [str(evidence.relative_to(temp))]
+        if not any(str(evidence.relative_to(temp)).startswith(path) for path in excluded):
+            raise AssertionError("retained browser evidence is not excluded from candidate inputs")
+
     with tempfile.TemporaryDirectory(prefix="orbit-qa-platform-self-test-") as tmp:
         repo = Path(tmp)
         identity_paths = [
@@ -866,6 +927,9 @@ def main():
     parser.add_argument("--run-commands", action="store_true")
     parser.add_argument("--check", action="store_true")
     parser.add_argument("--playwright-module", type=Path)
+    parser.add_argument("--playwright-browsers-path", type=Path)
+    parser.add_argument("--browser-ld-library-path", type=Path)
+    parser.add_argument("--browser-evidence-dir", type=Path)
     parser.add_argument("--website-build", action="store_true")
     parser.add_argument("--build-candidate", action="store_true")
     parser.add_argument("--platform-evidence", action="append", type=Path, default=[])
@@ -887,9 +951,15 @@ def main():
         print("qa-full-sweep inventory: ok")
         return
     output = (args.output or repo / "qa-full-sweep-report.json").resolve()
+    browser_evidence_dir = (args.browser_evidence_dir or
+                            output.parent / f"{output.stem}.browser-evidence").resolve()
     excluded_paths = []
     try:
         excluded_paths.append(output.relative_to(repo))
+    except ValueError:
+        pass
+    try:
+        excluded_paths.append(browser_evidence_dir.relative_to(repo))
     except ValueError:
         pass
     candidate = candidate_source(repo, excluded_paths)
@@ -901,15 +971,37 @@ def main():
                 "candidate_id":candidate_id}]
 
     binary = None if args.build_candidate else (Path(args.orbit_bin).resolve() if args.orbit_bin else None)
+    browser_inputs_valid = bool(args.playwright_module and args.playwright_module.is_file()
+                                and args.playwright_browsers_path and args.playwright_browsers_path.is_dir()
+                                and args.browser_ld_library_path and args.browser_ld_library_path.is_dir())
     capabilities = {"local": bool(binary) or args.build_candidate,
-                    "browser": bool(args.playwright_module and args.playwright_module.is_file()),
+                    "browser": browser_inputs_valid,
                     "website-build": args.website_build,
                     "macos": platform.system() == "Darwin"}
     binary_record = {"path":str(binary) if binary else None, "version":None,
                      "sha256":hashlib.sha256(binary.read_bytes()).hexdigest() if binary else None}
+    browser_record = {
+        "playwright_module": str(args.playwright_module) if args.playwright_module else None,
+        "playwright_module_sha256": (hashlib.sha256(args.playwright_module.read_bytes()).hexdigest()
+                                      if args.playwright_module and args.playwright_module.is_file() else None),
+        "playwright_browsers_path": str(args.playwright_browsers_path) if args.playwright_browsers_path else None,
+        "browser_ld_library_path": str(args.browser_ld_library_path) if args.browser_ld_library_path else None,
+        "version": None,
+        "capability_probe": None,
+    }
     with tempfile.TemporaryDirectory(prefix="orbit-qa-full-") as tmp:
         temp = Path(tmp)
         env = isolated_environment(temp)
+        browser_env = browser_environment(env, args.playwright_browsers_path,
+                                          args.browser_ld_library_path)
+        if browser_inputs_valid:
+            probe, browser_record["version"] = inspect_browser_capability(
+                args.playwright_module, browser_env, repo)
+            browser_record["capability_probe"] = {
+                "command": probe["command"], "exit_code": probe["exit_code"],
+                "stdout": probe["stdout"], "stderr": probe["stderr"],
+            }
+            capabilities["browser"] = probe["exit_code"] == 0
         provenance = None
         if args.build_candidate and not errors:
             build = run(["cargo", "build", "--locked", "-p", "orbit-cli", "--bin", "orbit",
@@ -937,13 +1029,30 @@ def main():
                 continue
             if args.run_commands and capabilities.get(scenario["capability"], False):
                 command = [part.replace("{playwright_module}", str(args.playwright_module))
-                           .replace("{evidence_dir}", str(temp / "browser-evidence"))
+                           .replace("{evidence_dir}", str(browser_evidence_dir))
                            for part in scenario["command"]]
-                evidence = run(command, cwd=repo, env=env, timeout=1800)
+                scenario_env = browser_env if scenario["capability"] == "browser" else env
+                evidence = run(command, cwd=repo, env=scenario_env, timeout=1800)
+                if scenario["capability"] == "browser":
+                    browser_evidence_dir.mkdir(parents=True, exist_ok=True)
+                    (browser_evidence_dir / "harness-result.json").write_text(
+                        json.dumps({"command": command, "exit_code": evidence["exit_code"],
+                                    "stdout": evidence["stdout"], "stderr": evidence["stderr"],
+                                    "browser_version": browser_record["version"]}, indent=2) + "\n")
                 unchanged = candidate_source(repo, excluded_paths)["candidate_id"] == candidate_id
                 failure = None if unchanged else "source candidate changed while the scenario ran"
-                results.append({"scenario":scenario["id"],
-                    **finalize_result(evidence, scenario["assertions"], candidate_id, failure)})
+                result = {"scenario":scenario["id"],
+                          **finalize_result(evidence, scenario["assertions"], candidate_id, failure)}
+                if scenario["capability"] == "browser":
+                    artifacts = []
+                    if browser_evidence_dir.is_dir():
+                        for path in sorted(browser_evidence_dir.rglob("*")):
+                            if path.is_file():
+                                artifacts.append({"path": str(path.relative_to(browser_evidence_dir)),
+                                                  "sha256": hashlib.sha256(path.read_bytes()).hexdigest()})
+                    result["retained_evidence"] = {"directory": str(browser_evidence_dir),
+                                                   "files": artifacts}
+                results.append(result)
             else:
                 results.append({"scenario":scenario["id"], "command":scenario.get("command", []),
                                 "exit_code":None, "stdout":"", "stderr":f"capability or execution not enabled: {scenario['capability']}",
@@ -978,7 +1087,7 @@ def main():
         "candidate": {"id":candidate_id, "source_revision":candidate["head"]},
         "source_state": {"status": candidate["status"], "diff_sha256": candidate["diff_sha256"],
                          "changed_file_sha256": changed_hashes},
-        "binary": binary_record,
+        "binary": binary_record, "browser": browser_record,
         "managed_assets": {str(path.relative_to(repo)):hashlib.sha256(path.read_bytes()).hexdigest()
                            for path in repo.glob(".orbit/**/.orbit-managed-assets.json")},
         "environment": {"os":platform.system(), "release":platform.release(), "architecture":platform.machine(),


### PR DESCRIPTION
## Task

[ORB-12077](https://orbit-cli.com/tasks/ORB-12077) — Preserve explicit browser capability and retained evidence in the full-QA harness

### Description

The full-QA browser leg is not executable with the documented prepared browser capability. On clean c6ac75d84fdb7fc377920ae8958fa2656d2802d4, Chromium153.0.8010.12 launches successfully using /tmp/orbit-browser-check/node_modules/playwright/index.mjs with PLAYWRIGHT_BROWSERS_PATH=/tmp/orbit-browser-check/browsers and LD_LIBRARY_PATH=/tmp/orbit-browser-check/sysroot/usr/lib/x86_64-linux-gnu. Calling the harness's isolated_environment and run for the actual dashboard_loading_browser.mjs drops both explicitly supplied variables. The child then fails because it searches its fresh disposable HOME/.cache/ms-playwright instead. The operator's exact probe is attached as evidence; no full sweep can pass this leg as documented.

Support explicit, bounded browser capability inputs through the browser scenario without inheriting the whole host environment or leaking host Orbit configuration into disposable CLI scenarios. Keep unavailable/mismatched capability fail-closed. The harness currently writes browser screenshots into TemporaryDirectory/browser-evidence, which is removed before the report returns; preserve referenced browser evidence in an intentional output-side artifact directory with enough provenance to attach/review after completion. Keep generated assets outside tracked sources and clean up only owned disposable state. Update the runbook invocation accordingly.

This task repairs only the harness/capability/evidence lifecycle. Do not weaken behavioral browser checks, waive the required browser leg, fabricate PASS, mutate production Orbit state, deploy the website, or publish npm. Reuse the documented disposable browser setup inside a worker namespace if host /tmp is not visible; operator can rerun real Chromium validation after merge.

### Acceptance Criteria

- A deterministic integration regression reproduces the original loss of explicitly supplied browser paths and proves the corrected browser launch receives its declared capability while unrelated host/Orbit environment remains excluded.
- The real dashboard browser scenario runs using a prepared Playwright/Chromium capability and reports its actual result; missing capability remains NOT_RUN/BLOCKED/FAIL rather than PASS. Record exact source, command, browser version, and any worker limitation; operator-owned real launch can complete post-merge verification.
- Browser evidence referenced in the report remains readable after harness temporary-state cleanup, with output-side paths/hashes or a manifest suitable for canonical task artifact attachment; failure evidence is retained too. No screenshots or transient absolute-path markers enter the source PR.
- Harness self-tests/inventory check and required fast/lint checks pass; runbook documents the supported browser input and retained-evidence collection. No broad environment inheritance or release/publication mutation.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added bounded browser capability inputs for the Playwright module, browser cache, and browser library directory; only those paths are added to the disposable child environment.
- Added a deterministic self-test that proves declared browser paths survive into a child while injected host Orbit and host browser-path values are excluded, plus fail-closed capability probing with Chromium version capture.
- Retained browser screenshots/result output and a harness failure manifest in an output-side evidence directory; reports include file hashes for attachment/review.
- Documented the supported invocation and retained-evidence workflow.

Criteria evidence:
1. PASS — `python3 scripts/test-qa-full-sweep.py --self-test` exercises the bounded child-environment regression.
2. PASS with worker limitation — `/tmp/orb-12077-qa-report.json` recorded `dashboard-browser` as NOT_RUN (not PASS): this worker has no prepared Playwright module/browser-cache/sysroot capability; the exact inventory command is recorded and browser version is null. Post-merge operator launch remains required.
3. PASS — browser results now retain `harness-result.json`, screenshots/result files, and SHA-256 manifest under the selected output-side evidence directory.
4. PASS — inventory/self-tests, `make ci-fast`, `make ci-lint`, shell syntax, and `git diff --check` passed; runbook updated.

Validation:
- PASSED: `python3 scripts/test-qa-full-sweep.py --self-test`
- PASSED: `python3 scripts/test-qa-full-sweep.py --check`
- PASSED: `bash -n scripts/qa-full-sweep.sh`
- PASSED: `make ci-fast`
- PASSED: `make ci-lint`
- PASSED: `git diff --check`
- COMPLETED AS EXPECTED: `python3 scripts/test-qa-full-sweep.py --orbit-bin ~/.orbit/bin/orbit --output /tmp/orb-12077-qa-report.json` produced INCOMPLETE because required browser capability, website build, and macOS evidence were unavailable; browser is explicitly NOT_RUN.

Risk: no real Chromium launch was possible in this worker because the documented `/tmp/orbit-browser-check` capability was absent. No generated report or evidence was added to the source patch.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12077-6aa2838f`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra