### PR TITLE
[code-review] README and ARCHITECTURE still document the .orbit/tasks checkout projection ORB-11994 removed

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -89,8 +89,8 @@ feature.
   `fs` owns narrowly named lock, path-safety, and YAML mechanics; private
   `driver/file` and `driver/sqlite` modules implement exactly one persistence
   technology each. `repository` owns live invariants that join drivers (task
-  bundles + registry indexes + checkout projections, and friction SQLite +
-  file taxonomy). `workflow` owns explicit import/export/reindex/repair,
+  bundles + registry allocation/index rows, and friction SQLite + file
+  taxonomy). `workflow` owns explicit import/export/reindex/repair,
   owner-only task-publication transport, read-only task-publication
   inspection, and layout-upgrade operations.
   `compose` constructs concrete implementations and
@@ -148,13 +148,12 @@ flowchart BT
 
 The file and SQLite drivers are private and never import one another. Shared
 atomic-write, advisory-lock, path-safety, and YAML mechanics belong to `fs`,
-not to a backend-shaped utility module. Checkout projection and workspace
+not to a backend-shaped utility module. Canonical task bundles and workspace
 binding YAML are file behavior even though registry rows are SQLite-backed.
 
-Live task writes are committed by the composite task repository: canonical
-bundle durability is the file-driver operation, allocation/binding/index rows
-are the registry-driver operation, and `.orbit/tasks` symlinks are disposable
-checkout projections. The drivers do not call each other. Task archive
+Live task writes are committed by the composite task repository: a canonical
+bundle write plus registry allocation/binding/index rows. The drivers do not
+call each other. Task archive
 import/export/reindex, owner-only task-publication transport and its read-only
 inspection, friction Markdown import/SQLite export, legacy audit and job-run
 import, and workspace layout upgrades are explicit `workflow` modules.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ The companion is released for macOS arm64 and Linux x86_64/aarch64 (glibc >= 2.3
 ├── config.yaml                  # workspace_id only
 ├── auto_tasks/                  # recurring task definitions
 ├── routines/                    # routine definitions
-├── tasks/                       # projection of ~/.orbit/tasks/workspaces/<id>/
 ├── resources/                   # activities, jobs, executors, policies (customizable)
 └── state/                       # worktrees, logs, job-runs, audit spool, scoreboard, semantic.db
 


### PR DESCRIPTION
## Task

[ORB-12078](https://orbit-cli.com/tasks/ORB-12078) — [code-review] README and ARCHITECTURE still document the .orbit/tasks checkout projection ORB-11994 removed

### Description

ORB-11994 (`4f29985af`, PR #1882) removed workspace `.orbit/tasks` symlink
projections: it deleted `crates/orbit-store/src/repository/checkout_projection.rs`,
dropped `tasks_dir` from `ensure_workspace_dirs`
(`crates/orbit-core/src/bootstrap/init.rs:471-474`), and added layout migration
v3 (`crates/orbit-store/src/workflow/layout/mod.rs:91-96`, `:167-224`) which
unlinks the shipped projection links and removes the directory when it empties.

The change updated `crates/orbit-store/CLAUDE.md`, `docs/design/task-artifacts/**`,
`docs/design/task-migration/1_overview.md`, `docs/runbooks/state-and-backup.md`,
`docs/runbooks/upgrades.md`, and `docs/design/policy-sandbox/2_design.md` — but
left the two top-level current docs describing the removed mechanism as live.

## Stale sites (verified at `c6ac75d84`)

**`README.md:141`** — the "Workspace Layout" tree still lists a directory that
Orbit no longer creates and actively deletes:

```
├── tasks/                       # projection of ~/.orbit/tasks/workspaces/<id>/
```

This is the layout section a new reader hits first, and the entry sits between
`routines/` and `resources/`, which do still exist.
`crates/orbit-cli/tests/ambient_authority_isolation.rs:421-424` and `:450` now
assert `!work.join(".orbit/tasks").exists()` after task mutations, and
`crates/orbit-cli/src/command/workspace/tests/init.rs:1605-1608` asserts the same
for a freshly initialized nested workspace — so the README contradicts the
shipped regression tests.

**`ARCHITECTURE.md:92`** — the `orbit-store` crate description still names
checkout projections as one of the live invariants `repository` joins:

> `repository` owns live invariants that join drivers (task bundles + registry
> indexes + checkout projections, and friction SQLite + file taxonomy).

**`ARCHITECTURE.md:151`** — still assigns ownership for a module that no longer
exists:

> Checkout projection and workspace binding YAML are file behavior even though
> registry rows are SQLite-backed.

**`ARCHITECTURE.md:155-157`** — still describes a task commit as a three-part
join:

> canonical bundle durability is the file-driver operation,
> allocation/binding/index rows are the registry-driver operation, and
> `.orbit/tasks` symlinks are disposable checkout projections.

The equivalent sentence in `crates/orbit-store/CLAUDE.md:35-37` was corrected in
the same commit to "a canonical bundle write plus registry allocation/index rows",
so the crate guide and the repository architecture doc now disagree with each
other.

## Why this matters

`CLAUDE.md` names `ARCHITECTURE.md` as the authority to read "before adding a new
crate, a new dependency edge, or a new persisted artifact", and its Design Docs
rule states that stale descriptions of live behavior are a review blocker. An
agent or contributor following `ARCHITECTURE.md` today would look for a
checkout-projection owner in `driver/file` and find nothing, or would model a new
persisted artifact on a three-part join that is now two parts.

## Suggested repair

Delete the projection row from the `README.md` layout tree and correct the three
`ARCHITECTURE.md` statements to match `crates/orbit-store/CLAUDE.md`. Grep for
remaining live-doc references before finishing; `docs/design/_archive/task-sync/**`
is archived and should be left alone.

### Acceptance Criteria

- README.md's current workspace-layout tree no longer lists a live tasks projection directory, and the named current top-level descriptions match canonical task storage.
- ARCHITECTURE.md describes task persistence as canonical bundles plus registry allocation/index rows and no longer assigns ownership to removed checkout-projection plumbing; it agrees with the current store guide.
- Search remaining non-archived documentation for statements that portray checkout projections as live and correct any directly related stale descriptions. Preserve accurate upgrade/removal guidance and historical evidence that intentionally mention the old layout; do not blindly remove every .orbit/tasks string.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Removed the obsolete `.orbit/tasks` checkout-projection entry from README.md's current workspace layout.
- Updated ARCHITECTURE.md so orbit-store repository ownership and live task writes describe canonical task bundles plus registry allocation/binding/index rows, matching crates/orbit-store/CLAUDE.md; removed checkout-projection ownership language.
- Audited remaining non-archived Markdown references. Preserved the upgrade runbook's legacy-removal guidance, the explicitly superseded project-learnings decision, and canonical task-store documentation; no other live checkout-projection description required correction.
Assessment: Documentation now reflects the shipped v3 layout migration and the current two-part task persistence join without disturbing historical or migration evidence.
Validation:
- `make ci-fast` — passed; its compiler-cache namespace subcheck reported the environment's known bubblewrap permission skip.
- `make ci-lint` — passed (`cargo clippy --workspace --all-targets -- -D warnings`).
- `git diff --check` — passed.
- Final `git status --short` — only the authorized README.md and ARCHITECTURE.md edits remain.
- Non-archived Markdown stale-reference scan — reviewed remaining matches and confirmed each is canonical, historical/superseded, or upgrade/removal guidance.
Risks/deviations: No code or runtime behavior changed; validation did not exercise the removed projection behavior beyond documentation and existing repository guardrails.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12078-6aa28574`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra