### PR TITLE
[code-review] Avoid credential redaction inside ordinary hyphenated identifiers

### DIFF
--- a/crates/orbit-common/src/security/redaction.rs
+++ b/crates/orbit-common/src/security/redaction.rs
@@ -714,8 +714,12 @@ impl PatternRedactor {
                 "[REDACTED_SSH_FINGERPRINT]",
             ),
             (
-                Regex::new(r"sk-[A-Za-z0-9_\-]{20,}").expect("valid regex"),
-                "[REDACTED_SECRET]",
+                // Keep provider-key matching at a token boundary. Without the
+                // prefix capture, `task-checkout-projections` is misread from
+                // its trailing `sk-` as a provider key.
+                Regex::new(r"(^|[^\p{L}\p{N}_-])sk-[A-Za-z0-9_\-]{20,}")
+                    .expect("valid regex"),
+                "${1}[REDACTED_SECRET]",
             ),
             (
                 Regex::new(r"AIza[0-9A-Za-z_\-]{35}").expect("valid regex"),
@@ -773,8 +777,8 @@ impl PatternRedactor {
     pub fn with_argv_secrets() -> Self {
         let mut me = Self::http_default();
         me.patterns.push((
-            Regex::new(r"sk-[A-Za-z0-9_\-]+").expect("valid regex"),
-            "[REDACTED_API_KEY]",
+            Regex::new(r"(^|[^\p{L}\p{N}_-])sk-[A-Za-z0-9_\-]+").expect("valid regex"),
+            "${1}[REDACTED_API_KEY]",
         ));
         me
     }

--- a/crates/orbit-common/src/security/tests/redaction.rs
+++ b/crates/orbit-common/src/security/tests/redaction.rs
@@ -1,8 +1,9 @@
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use super::super::redaction::{
-    credential_safe_location, is_high_confidence_single_token_credential, is_redactable_value,
-    is_sensitive_env_name, redact_all, redact_home_dir, redact_sensitive_env_text,
+    PatternRedactor, credential_safe_location, is_high_confidence_single_token_credential,
+    is_redactable_value, is_sensitive_env_name, redact_all, redact_home_dir,
+    redact_sensitive_env_text,
 };
 
 #[test]
@@ -122,6 +123,60 @@ fn redact_all_preserves_knowledge_record_identifiers_and_paths() {
     );
 
     assert_eq!(redact_all(legitimate), legitimate);
+}
+
+#[test]
+fn provider_key_redaction_respects_identifier_boundaries() {
+    let migration = "remove-task-checkout-projections";
+    let compounds = [
+        "disk-sk-checkout-projections",
+        "risk-sk-checkout-projections",
+        "task-sk-checkout-projections",
+        "é-sk-checkout-projections",
+    ];
+    let default = PatternRedactor::default();
+    let argv = PatternRedactor::with_argv_secrets();
+
+    assert_eq!(redact_all(migration), migration);
+    assert_eq!(default.apply_str(migration), migration);
+    assert_eq!(argv.apply_str(migration), migration);
+
+    for compound in compounds {
+        assert_eq!(redact_all(compound), compound, "default: {compound}");
+        assert_eq!(argv.apply_str(compound), compound, "argv: {compound}");
+    }
+}
+
+#[test]
+fn provider_key_redaction_keeps_standalone_and_argv_forms() {
+    let key = "sk-abcdefghijklmnopqrstuvwxyz";
+    let default = PatternRedactor::default();
+
+    for input in [
+        key.to_string(),
+        format!("before {key} after"),
+        format!("'{key}'"),
+        format!("({key}),"),
+        format!("X-Api-Key: {key}"),
+        format!(r#"{{"api_key":"{key}"}}"#),
+    ] {
+        let redacted = default.apply_str(&input);
+        assert!(!redacted.contains(key), "{input}");
+        assert!(
+            redacted.contains("[REDACTED_SECRET]") || redacted.contains("[REDACTED_AUTH]"),
+            "{redacted}"
+        );
+    }
+
+    let argv = PatternRedactor::with_argv_secrets();
+    for (input, marker) in [
+        (key, "[REDACTED_SECRET]"),
+        ("--api-key=sk-short", "[REDACTED_API_KEY]"),
+    ] {
+        let redacted = argv.apply_str(input);
+        assert!(!redacted.contains("sk-"), "{redacted}");
+        assert!(redacted.contains(marker), "{redacted}");
+    }
 }
 
 #[test]

--- a/crates/orbit-core/src/adapter/tool_host/artifact_redaction.rs
+++ b/crates/orbit-core/src/adapter/tool_host/artifact_redaction.rs
@@ -1008,6 +1008,79 @@ mod tests {
     }
 
     #[test]
+    fn dispatch_round_trips_identifiers_and_reports_synthetic_provider_key_redaction() {
+        let (_root, runtime, _repo_root) = test_runtime();
+        let identifier = "remove-task-checkout-projections";
+        let key = "sk-abcdefghijklmnopqrstuvwxyz";
+
+        let task = runtime
+            .execute_tool_command(
+                "orbit.task.add",
+                json!({
+                    "title": identifier,
+                    "description": format!("migration {identifier}; credential {key}"),
+                    "complexity": "low",
+                    "workspace": ".",
+                }),
+                Some("codex".to_string()),
+                Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+            )
+            .expect("task add succeeds");
+
+        assert_eq!(task["redactions_applied"], true);
+        assert_eq!(task["title"], identifier);
+        assert_eq!(
+            task["description"],
+            format!("migration {identifier}; credential [REDACTED_SECRET]")
+        );
+        assert_eq!(task["redactions"][0]["field_path"], "description");
+        assert_eq!(task["redactions"][0]["redaction_kinds"], json!(["pattern"]));
+        assert_eq!(
+            task["redactions"][0]["redaction_classes"],
+            json!(["credential"])
+        );
+        let task_id = task["id"].as_str().expect("task id");
+        assert_eq!(
+            runtime.get_task(task_id).expect("task persisted").title,
+            identifier
+        );
+
+        let friction = runtime
+            .execute_tool_command(
+                "orbit.friction.add",
+                json!({
+                    "body": format!("migration {identifier}; credential {key}"),
+                    "tags": ["tooling"],
+                }),
+                Some("codex".to_string()),
+                Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+            )
+            .expect("friction add succeeds");
+
+        assert_eq!(friction["redactions_applied"], true);
+        assert_eq!(
+            friction["body"],
+            format!("migration {identifier}; credential [REDACTED_SECRET]")
+        );
+        assert_eq!(friction["redactions"][0]["field_path"], "body");
+        assert_eq!(
+            friction["redactions"][0]["redaction_kinds"],
+            json!(["pattern"])
+        );
+        assert_eq!(
+            friction["redactions"][0]["redaction_classes"],
+            json!(["credential"])
+        );
+        let shown = runtime
+            .run_tool("orbit.friction.show", json!({ "id": friction["id"] }))
+            .expect("friction show succeeds");
+        assert_eq!(
+            shown["body"],
+            format!("migration {identifier}; credential [REDACTED_SECRET]")
+        );
+    }
+
+    #[test]
     fn friction_body_update_is_sanitized_but_tags_are_verbatim() {
         let token = "orbit-friction-secret-value";
         let _env = env_var("GITHUB_TOKEN", token);


### PR DESCRIPTION
## Task

[ORB-12084](https://orbit-cli.com/tasks/ORB-12084) — [code-review] Avoid credential redaction inside ordinary hyphenated identifiers

### Description

F2026-09-119, discovered during Opus review12072, records a reproducible task/friction write corruption. A normal migration identifier assembled as ["remove", "task", "checkout", "projections"].join("-") is truncated mid-word by the secret redactor. Both task.add and friction.add returned redactions_applied=true with credential/pattern metadata; the task description had to be rewritten to preserve its meaning. The historical10867 repair concerns environment-value heuristics and does not cover this substring-pattern defect.

Current crates/orbit-common/src/security/redaction.rs contains an unanchored bare provider-key regex at approximately717, and with_argv_patterns adds an even shorter unanchored variant near776. They can begin inside an ordinary identifier whose preceding word ends in s followed by k. Fix token-boundary handling consistently without weakening true credential redaction or turning off durable-write redaction. Preserve existing HTTP/header/JSON/env-value protections and short-key argv behavior where those are intentional. Do not require a guessed mixed-character/entropy shape that would exempt otherwise supported real key forms. Keep the existing redaction metadata truthful.

Reproduce through deterministic ordinary identifiers and synthetic key-shaped controls; no actual credentials are required or permitted in fixtures. Include a disposable task/friction write round-trip that proves the ordinary migration text persists byte-for-byte while a synthetic standalone key is redacted. This is a focused false-positive repair, not a redesign of credential policy or a broad exception list.

### Acceptance Criteria

- Normal long hyphenated identifiers containing the triggering letters inside a word survive default and argv redaction unchanged; regressions include the reconstructed migration identifier plus disk/risk/task compounds and punctuation/Unicode boundaries as appropriate.
- Supported standalone synthetic credential forms remain redacted at start of input and in whitespace/quoted/punctuation/header/JSON/argv contexts; existing env-value and credential tests continue to pass, with no real credentials used.
- Disposable task and friction writes round-trip benign identifier text exactly and still redact synthetic credential controls with correct redaction metadata. No bypass of durable redaction or broad host-environment logging is introduced.
- Focused redaction/write-boundary tests, make ci-fast, and make ci-lint pass. The execution summary maps the corrected behavior to F2026-09-119 and records any intentionally unchanged ambiguity.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- F2026-09-119: constrained default and argv provider-key matching to a Unicode-aware token boundary that treats hyphenated identifier segments as part of the identifier, preserving the preceding delimiter when redacting.
- Added default/argv regressions for remove-ta[REDACTED_SECRET], disk/risk/task compounds, Unicode adjacency, standalone whitespace/quote/punctuation/header/JSON forms, and short argv keys.
- Added disposable task and friction dispatch coverage proving the identifier survives persistence while a synthetic provider-key control is redacted and reports pattern/credential metadata.
Criteria evidence:
1. Default and argv tests preserve the reconstructed migration identifier plus disk/risk/task and Unicode-boundary compounds.
2. Focused tests retain standalone synthetic credential redaction across requested text contexts; existing redaction tests passed.
3. Dispatch test reads task and friction records back, verifies durable masking and exact pattern/credential metadata, with no host-environment logging change.
4. Validation passed: cargo test -p orbit-common security::tests::redaction; cargo test -p orbit-core adapter::tool_host::artifact_redaction::tests::dispatch_round_trips_identifiers_and_reports_synthetic_provider_key_redaction; make ci-fast; make ci-lint; git diff --check.
Assessment: focused boundary repair with durable-write coverage.
Intentionally unchanged ambiguity: provider keys directly prefixed by a hyphen are treated as part of a hyphenated identifier; normal standalone keys remain redacted after start, whitespace, quotes, punctuation, headers, JSON, and argv assignment delimiters.
Risks: no real credentials or broad host-environment logging were used; synthetic fixtures only.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12084-6aa286a5`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra