### PR TITLE
[code-review] orbit config show reports a phantom task-store path after the projection removal

### DIFF
--- a/crates/orbit-cli/src/command/config/show.rs
+++ b/crates/orbit-cli/src/command/config/show.rs
@@ -80,7 +80,7 @@ pub(super) fn effective_json(runtime: &OrbitRuntime, values: &[EffectiveConfigVa
     })
 }
 
-fn effective_text(runtime: &OrbitRuntime, values: &[EffectiveConfigValue]) -> String {
+pub(super) fn effective_text(runtime: &OrbitRuntime, values: &[EffectiveConfigValue]) -> String {
     use std::fmt::Write as _;
     let mut out = String::new();
     let _ = writeln!(out, "source: effective layered configuration");
@@ -150,7 +150,7 @@ fn effective_text(runtime: &OrbitRuntime, values: &[EffectiveConfigValue]) -> St
     out
 }
 
-fn scoped_json(
+pub(super) fn scoped_json(
     runtime: &OrbitRuntime,
     store: &orbit_config::ConfigStore,
     snapshot: &orbit_config::ConfigSnapshot,
@@ -185,7 +185,7 @@ fn scoped_json(
     })
 }
 
-fn scoped_text(
+pub(super) fn scoped_text(
     runtime: &OrbitRuntime,
     store: &orbit_config::ConfigStore,
     snapshot: &orbit_config::ConfigSnapshot,

--- a/crates/orbit-cli/src/command/config/tests/show.rs
+++ b/crates/orbit-cli/src/command/config/tests/show.rs
@@ -2,7 +2,8 @@ use std::fs;
 
 use orbit_config::{ConfigRoots, load_effective_config};
 
-use super::super::show::effective_json;
+use super::super::show::{effective_json, effective_text, scoped_json, scoped_text};
+use super::super::support::{ConfigScopeArg, open_store_for_scope};
 use super::test_runtime;
 
 #[test]
@@ -88,5 +89,40 @@ provider = "claude"
         json["settings"].get("crews.opus.effort").is_none(),
         "omitted effort must not appear in settings: {}",
         json["settings"]
+    );
+}
+
+#[test]
+fn config_show_omits_the_retired_workspace_task_projection() {
+    let (_root, runtime, global_root, workspace_root) = test_runtime();
+    let effective = load_effective_config(&ConfigRoots::new(&global_root, &workspace_root))
+        .expect("load effective layered config");
+
+    let json = effective_json(&runtime, effective.values());
+    let text = effective_text(&runtime, effective.values());
+    let scoped_store =
+        open_store_for_scope(&runtime, ConfigScopeArg::Global).expect("open global scoped config");
+    let scoped_snapshot = scoped_store.snapshot().expect("read scoped config");
+    let scoped_settings = scoped_snapshot.all_values();
+    let scoped_json = scoped_json(&runtime, &scoped_store, &scoped_snapshot, &scoped_settings);
+    let scoped_text = scoped_text(&runtime, &scoped_store, &scoped_snapshot, &scoped_settings);
+
+    assert!(
+        json["persistence"].get("task").is_none(),
+        "configuration must not advertise the removed workspace task projection: {}",
+        json["persistence"]
+    );
+    assert!(
+        !text.contains("\"task\""),
+        "text configuration output must not advertise the removed task store: {text}"
+    );
+    assert!(
+        scoped_json["persistence"].get("task").is_none(),
+        "scoped JSON must not advertise the removed task store: {}",
+        scoped_json["persistence"]
+    );
+    assert!(
+        !scoped_text.contains("\"task\""),
+        "scoped text must not advertise the removed task store: {scoped_text}"
     );
 }

--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -733,25 +733,23 @@ pub(crate) fn disk_space_check(path: &Path) -> WorkspaceDoctorResult {
     check("disk-space", status, message)
 }
 
-/// Lock files in the directories the file-backed stores lock in:
-/// `state/` and `tasks/` (v2 bundle locks).
-/// Non-recursive on purpose — the lock layouts are flat.
+/// Lock files in the workspace-local state directory.
+///
+/// Task bundle locks live in the registry-owned global bundle store, which is
+/// not a workspace-local diagnostic target.
 pub(crate) fn collect_lock_files(paths: &WorkspacePaths) -> Vec<PathBuf> {
-    let dirs = [paths.state_dir.clone(), paths.tasks_dir.clone()];
     let mut lock_files = Vec::new();
-    for dir in dirs {
-        let Ok(entries) = std::fs::read_dir(&dir) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let is_lock = path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name.ends_with(".lock"));
-            if is_lock && path.is_file() {
-                lock_files.push(path);
-            }
+    let Ok(entries) = std::fs::read_dir(&paths.state_dir) else {
+        return lock_files;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let is_lock = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.ends_with(".lock"));
+        if is_lock && path.is_file() {
+            lock_files.push(path);
         }
     }
     lock_files

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -380,11 +380,10 @@ fn interrupted_layout_upgrade_is_reported_stale() {
 
 #[cfg(unix)]
 #[test]
-fn stale_task_lock_files_are_removed() {
+fn stale_workspace_state_lock_files_are_removed() {
     let temp = tempfile::tempdir().expect("tempdir");
     let runtime = workspace_runtime(&temp);
-    let paths = runtime.paths();
-    let stale_locks = [paths.tasks_dir.join(".ORB-00001.lock")];
+    let stale_locks = [runtime.paths().state_dir.join(".crashed-op.lock")];
 
     let dead_pid = reaped_child_pid();
     for path in &stale_locks {
@@ -412,7 +411,7 @@ fn stale_task_lock_files_are_removed() {
 fn cleanup_preserves_a_lock_held_by_a_live_process() {
     let temp = tempfile::tempdir().expect("tempdir");
     let runtime = workspace_runtime(&temp);
-    let lock_path = runtime.paths().tasks_dir.join(".ORB-00001.lock");
+    let lock_path = runtime.paths().state_dir.join(".held-op.lock");
     write_holder_lock(&lock_path, reaped_child_pid(), "stale metadata");
 
     let file = fs::OpenOptions::new()
@@ -620,10 +619,7 @@ fn collect_lock_files_scans_the_store_lock_locations() {
     let runtime = workspace_runtime(&temp);
     let paths = runtime.paths().clone();
 
-    let expected = [
-        paths.state_dir.join(".id_alloc.lock"),
-        paths.tasks_dir.join(".ORB-00001.lock"),
-    ];
+    let expected = [paths.state_dir.join(".id_alloc.lock")];
     for path in &expected {
         fs::create_dir_all(path.parent().expect("parent")).expect("create dir");
         fs::write(path, b"{}").expect("write lock file");

--- a/crates/orbit-config/src/persistence.rs
+++ b/crates/orbit-config/src/persistence.rs
@@ -8,14 +8,11 @@ use serde_json::{Value, json};
 /// These are derived from the two roots, never from the config document, so a
 /// `config.toml` cannot relocate a store.
 ///
-/// - Tasks: workspace only
 /// - Skills: workspace override directory layered over global defaults
 /// - Activities/Jobs/Executors/Policies: global only
 /// - Audit: global only (single SQLite database)
 #[derive(Debug, Clone)]
 pub struct PersistenceConfig {
-    /// Workspace task documents.
-    pub task_dir: PathBuf,
     /// Global activity definitions.
     pub activity_dir: PathBuf,
     /// Global job definitions.
@@ -58,7 +55,6 @@ impl PersistenceConfig {
         let global_resources_dir = paths.global_dir.join("resources");
 
         Self {
-            task_dir: paths.tasks_dir.clone(),
             activity_dir: global_resources_dir.join("activities"),
             job_dir: global_resources_dir.join("jobs"),
             skill_dir: paths.skills_dir.clone(),
@@ -73,7 +69,6 @@ impl PersistenceConfig {
     /// runtime diagnostics.
     pub fn as_json_value(&self) -> Value {
         json!({
-            "task": { "path": self.task_dir.to_string_lossy() },
             "activity": { "path": self.activity_dir.to_string_lossy() },
             "job": { "path": self.job_dir.to_string_lossy() },
             "skill": { "path": self.skill_dir.to_string_lossy() },

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -319,12 +319,7 @@ fn build_v2_task_backends(
         }
     }
 
-    Ok(workspace_task_backends(
-        registry,
-        binding.workspace_id,
-        Some(binding.workspace_path.to_string_lossy().into_owned()),
-        Some(binding.repo_root.to_string_lossy().into_owned()),
-    ))
+    Ok(workspace_task_backends(registry, binding.workspace_id))
 }
 
 fn rebind_candidate_workspace_id(

--- a/crates/orbit-store/src/compose/mod.rs
+++ b/crates/orbit-store/src/compose/mod.rs
@@ -31,15 +31,8 @@ pub struct WorkspaceTaskBackends {
 pub fn workspace_task_backends(
     registry: TaskRegistryStore,
     workspace_id: String,
-    workspace_path: Option<String>,
-    repo_root: Option<String>,
 ) -> WorkspaceTaskBackends {
-    let store = Arc::new(TaskV2Store::new(
-        registry,
-        workspace_id,
-        workspace_path,
-        repo_root,
-    ));
+    let store = Arc::new(TaskV2Store::new(registry, workspace_id));
     WorkspaceTaskBackends {
         task: store.clone(),
         document: store.clone(),
@@ -50,12 +43,12 @@ pub fn workspace_task_backends(
 
 /// Constructs coordination-only task backends for a logical workspace that
 /// has no checkout on this machine. Canonical bundles and registry indexes
-/// remain available; checkout-local projections are intentionally omitted.
+/// remain available without a distinct checkout-local store.
 pub fn coordination_task_backends(
     registry: TaskRegistryStore,
     workspace_id: String,
 ) -> WorkspaceTaskBackends {
-    let store = Arc::new(TaskV2Store::new_checkoutless(registry, workspace_id));
+    let store = Arc::new(TaskV2Store::new(registry, workspace_id));
     WorkspaceTaskBackends {
         task: store.clone(),
         document: store.clone(),

--- a/crates/orbit-store/src/compose/tests/factory.rs
+++ b/crates/orbit-store/src/compose/tests/factory.rs
@@ -59,12 +59,7 @@ fn workspace_task_backends_exposes_create_get_and_list_trait_surface() {
             repo_fingerprint: None,
         })
         .expect("bind workspace");
-    let backends = workspace_task_backends(
-        registry,
-        binding.workspace_id,
-        Some(repo_dir.to_string_lossy().into_owned()),
-        Some(repo_dir.to_string_lossy().into_owned()),
-    );
+    let backends = workspace_task_backends(registry, binding.workspace_id);
 
     let created = backends
         .task

--- a/crates/orbit-store/src/driver/sqlite/task_registry/tests/schema.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/tests/schema.rs
@@ -167,7 +167,7 @@ fn upgraded_registry_replays_admission_after_reservation_and_bundle_creation() {
     drop(registry);
 
     let registry = TaskRegistryStore::open(&path).expect("reopen for admission");
-    let tasks = TaskV2Store::new_checkoutless(registry.clone(), WORKSPACE.into());
+    let tasks = TaskV2Store::new(registry.clone(), WORKSPACE.into());
     let created = tasks
         .create_task_with_key(params.clone(), Some(key))
         .expect("recover reserved action");
@@ -179,7 +179,7 @@ fn upgraded_registry_replays_admission_after_reservation_and_bundle_creation() {
     // repeatedly without allocating another ID or rewriting creation evidence.
     for _ in 0..2 {
         let registry = TaskRegistryStore::open(&path).expect("reopen after admission");
-        let tasks = TaskV2Store::new_checkoutless(registry.clone(), WORKSPACE.into());
+        let tasks = TaskV2Store::new(registry.clone(), WORKSPACE.into());
         let replay = tasks
             .create_task_with_key(params.clone(), Some(key))
             .expect("replay action");
@@ -349,7 +349,7 @@ fn known_v6_recovers_preserving_reservations_and_bundle_replay() {
             .expect("replay"),
         "DE-100005"
     );
-    let tasks = TaskV2Store::new_checkoutless(registry.clone(), WORKSPACE.into());
+    let tasks = TaskV2Store::new(registry.clone(), WORKSPACE.into());
     let created = tasks
         .create_task_with_key(params.clone(), Some("retained"))
         .expect("recover bundle");
@@ -358,7 +358,7 @@ fn known_v6_recovers_preserving_reservations_and_bundle_replay() {
     drop(registry);
 
     let registry = TaskRegistryStore::open(&path).expect("repeat recovery");
-    let tasks = TaskV2Store::new_checkoutless(registry.clone(), WORKSPACE.into());
+    let tasks = TaskV2Store::new(registry.clone(), WORKSPACE.into());
     assert_eq!(
         tasks
             .create_task_with_key(params, Some("retained"))

--- a/crates/orbit-store/src/repository/task/v2/mod.rs
+++ b/crates/orbit-store/src/repository/task/v2/mod.rs
@@ -65,21 +65,7 @@ pub(crate) struct TaskV2Store {
 }
 
 impl TaskV2Store {
-    pub(crate) fn new(
-        registry: TaskRegistryStore,
-        workspace_id: String,
-        _workspace_path: Option<String>,
-        _repo_root: Option<String>,
-    ) -> Self {
-        Self {
-            bundle_store: TaskBundleStoreV2::new(registry.clone(), workspace_id.clone()),
-            registry,
-            workspace_id,
-            envelope_cache: EnvelopeCache::default(),
-        }
-    }
-
-    pub(crate) fn new_checkoutless(registry: TaskRegistryStore, workspace_id: String) -> Self {
+    pub(crate) fn new(registry: TaskRegistryStore, workspace_id: String) -> Self {
         Self {
             bundle_store: TaskBundleStoreV2::new(registry.clone(), workspace_id.clone()),
             registry,

--- a/crates/orbit-store/src/repository/task/v2/tests/listing.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/listing.rs
@@ -22,7 +22,7 @@ pub(super) fn reads(store: &TaskV2Store) -> (usize, usize) {
 
 pub(super) fn corpus(temp: &TempDir, count: usize) -> TaskV2Store {
     let bound = store(temp);
-    let store = TaskV2Store::new_checkoutless(bound.registry.clone(), bound.workspace_id.clone());
+    let store = TaskV2Store::new(bound.registry.clone(), bound.workspace_id.clone());
     for index in 0..count {
         let mut params = create_params(&format!("Task {index}"), TaskStatus::Backlog);
         params.description =

--- a/crates/orbit-store/src/repository/task/v2/tests/listing_bench.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/listing_bench.rs
@@ -87,7 +87,7 @@ pub(super) fn seed(global: &Path, workspace: &str, count: usize) -> TaskV2Store 
             repo_fingerprint: None,
         })
         .unwrap();
-    let store = TaskV2Store::new_checkoutless(registry, workspace.to_string());
+    let store = TaskV2Store::new(registry, workspace.to_string());
     for index in 0..1 {
         let mut params = create_params(&format!("Task {index}"), TaskStatus::Backlog);
         params.description =

--- a/crates/orbit-store/src/repository/task/v2/tests/mod.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/mod.rs
@@ -30,12 +30,7 @@ pub(super) fn store(temp: &TempDir) -> TaskV2Store {
             repo_fingerprint: None,
         })
         .expect("bind workspace");
-    TaskV2Store::new(
-        registry,
-        binding.workspace_id,
-        Some(repo_dir.to_string_lossy().into_owned()),
-        Some(repo_dir.to_string_lossy().into_owned()),
-    )
+    TaskV2Store::new(registry, binding.workspace_id)
 }
 
 pub(super) fn create_params(title: &str, status: TaskStatus) -> TaskCreateParams {

--- a/crates/orbit-types/src/workspace/registry.rs
+++ b/crates/orbit-types/src/workspace/registry.rs
@@ -173,7 +173,6 @@ pub struct WorkspacePaths {
     pub global_dir: PathBuf,
     pub resources_dir: PathBuf,
     pub state_dir: PathBuf,
-    pub tasks_dir: PathBuf,
     pub knowledge_dir: PathBuf,
     pub activities_dir: PathBuf,
     pub jobs_dir: PathBuf,
@@ -204,7 +203,6 @@ impl WorkspacePaths {
         Self {
             resources_dir: resources_dir.clone(),
             state_dir: state_dir.clone(),
-            tasks_dir: orbit_dir.join("tasks"),
             knowledge_dir: orbit_dir.join("knowledge"),
             activities_dir: resources_dir.join("activities"),
             jobs_dir: resources_dir.join("jobs"),


### PR DESCRIPTION
## Task

[ORB-12079](https://orbit-cli.com/tasks/ORB-12079) — [code-review] orbit config show reports a phantom task-store path after the projection removal

### Description

ORB-11994 (`4f29985af`, PR #1882) removed the workspace `.orbit/tasks`
projection but left the checkout-bound task plumbing that fed it in place. The
operator-visible consequence is that `orbit config show` now advertises a
directory Orbit neither creates nor uses.

## The phantom path

`WorkspacePaths::new_with_local` still derives `tasks_dir: orbit_dir.join("tasks")`
(`crates/orbit-types/src/workspace/registry.rs:176`, `:207`), and
`PersistenceConfig::from_workspace_paths` still publishes it as the task store
location (`crates/orbit-config/src/persistence.rs:61`), rendered as
`"task": {"path": ...}` by `as_json_value` (`:76`).

That value reaches operators through `orbit config show` in every mode —
`effective_json` (`crates/orbit-cli/src/command/config/show.rs:79`),
`effective_text` (`:148`), `scoped_json` (`:184`), and `scoped_text` (`:244`)
all embed `runtime.persistence_config_json()`.

Before ORB-11994 `<workspace>/.orbit/tasks/` existed and held one symlink per
task, so naming it the task path was defensible. Now:

- `ensure_workspace_dirs` no longer creates it
  (`crates/orbit-core/src/bootstrap/init.rs:471-474` — `&paths.tasks_dir` was
  deleted from the create list), and
- layout migration v3 unlinks the legacy links and calls `fs::remove_dir` on the
  directory (`crates/orbit-store/src/workflow/layout/mod.rs:214-224`).

So on any workspace opened by a current binary, `orbit config show` prints a path
that does not exist. The canonical bundles live at
`<global>/tasks/workspaces/<workspace-id>/`
(`registry.canonical_task_bundle_path`), which is what the field should name or
the field should be dropped.

`crates/orbit-cli/src/command/workspace/tests/init.rs:1605-1608` and
`crates/orbit-cli/tests/ambient_authority_isolation.rs:421-424` both assert the
directory is absent, so the code and the diagnostic now contradict each other in
the same test run.

## Related dead plumbing from the same removal

Worth cleaning in the same change, since it is the same vestigial path:

1. **`TaskV2Store::new` and `TaskV2Store::new_checkoutless` are now identical.**
   `crates/orbit-store/src/repository/task/v2/mod.rs:66-88` — both build the same
   `Self` with `TaskBundleStoreV2::new(registry.clone(), workspace_id.clone())`.
   `new` differs only by three parameters it ignores: `workspace_orbit_dir` was
   deleted by ORB-11994, and `_workspace_path` / `_repo_root` were already
   unused. There is no longer a checkout-bound task store to distinguish.

2. **Two dead arguments are threaded through three layers to reach them.**
   `build_v2_task_backends` (`crates/orbit-core/src/runtime/builder.rs:319-328`)
   stringifies `binding.workspace_path` and `binding.repo_root` and passes them
   to `compose::workspace_task_backends`
   (`crates/orbit-store/src/compose/mod.rs:31-48`), which forwards them to
   `TaskV2Store::new`, which drops them.

3. **`orbit doctor`'s stale-lock sweep scans `paths.tasks_dir`**
   (`crates/orbit-cmd/src/doctor.rs:738-740`, comment: "`tasks/` (v2 bundle
   locks)"). This scan was already dead before this window — v2 bundle locks are
   created as `.<task-id>.bundle.lock` beside the canonical bundle
   (`crates/orbit-store/src/driver/file/task_bundle/lock.rs:7-9` plus
   `lock_path_for` at `crates/orbit-common/src/fs/io.rs:552-559`), never in
   `.orbit/tasks/` — and its tests fabricate the directory
   (`crates/orbit-cmd/src/tests/doctor.rs:387`, `:415`, `:625`), so they pass
   without exercising a real layout. Removing `tasks_dir` makes the dead branch
   unambiguous; decide whether the sweep should point at the canonical bundle
   directory instead or drop that entry.

## Scope note

This is diagnostic and dead-code cleanup, not a data-path defect: task reads and
writes already go through the registry's canonical paths and are unaffected.

### Acceptance Criteria

- `orbit config show` (JSON and text, effective and scoped) no longer reports a task-store path that Orbit does not create — the field either names the canonical `<global>/tasks/workspaces/<workspace-id>/` location or is removed, with a test asserting the reported path exists after `workspace init`.
- `TaskV2Store` exposes one constructor: the duplicate `new`/`new_checkoutless` pair is collapsed and the unused `workspace_path`/`repo_root` arguments are removed from `TaskV2Store`, `compose::workspace_task_backends`, and `build_v2_task_backends`.
- `WorkspacePaths::tasks_dir` is either removed or repointed at a directory Orbit actually owns, with `orbit doctor`'s stale-lock sweep updated to scan where v2 bundle locks are really written (or that entry dropped) and its tests no longer fabricating a directory the product never creates.
- `make ci-fast` and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Removed the retired workspace `.orbit/tasks` projection from `WorkspacePaths` and the `PersistenceConfig` diagnostic JSON, so effective and scoped `orbit config show` output no longer advertises a path Orbit does not own.
- Collapsed `TaskV2Store` to its sole registry-backed constructor and removed obsolete checkout-path/repo-root plumbing from store composition and runtime construction.
- Limited `orbit doctor` stale-lock cleanup to workspace-local state locks; canonical task-bundle locks are registry-global and are no longer falsely modeled as workspace-local task locks.
- Added config-show coverage for effective/scoped JSON and text projections; updated store and doctor tests to use actual owned paths.

Criteria:
1. Passed: effective and scoped config JSON/text test confirms no `task` persistence path is reported.
2. Passed: one `TaskV2Store::new(registry, workspace_id)` constructor remains; callers no longer thread checkout paths.
3. Passed: `WorkspacePaths::tasks_dir` is removed, doctor scans only state locks, and tests no longer fabricate `.orbit/tasks`.
4. Passed: `make ci-fast` and `make ci-lint`.

Validation:
- Passed: `cargo test -p orbit-cli config_show_omits_the_retired_workspace_task_projection`.
- Passed: `cargo test -p orbit-store workspace_task_backends_exposes_create_get_and_list_trait_surface`.
- Passed: `cargo test -p orbit-cmd stale_workspace_state_lock_files_are_removed`.
- Passed: `cargo test -p orbit-cmd cleanup_preserves_a_lock_held_by_a_live_process`.
- Passed: `make ci-fast` (the compiler-cache namespace subcheck was skipped because this runner cannot create a bubblewrap mount namespace; the CI gate completed successfully).
- Passed: `make ci-lint`.
- Passed: `git diff --check`.

Assessment: task-bundle data paths remain registry-owned; diagnostics now avoid claiming ownership of removed checkout projections. No friction record filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12079-6aa28574`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra