### PR TITLE
Make MCP process fixtures deterministic for provider selection and read-only canonical storage

### DIFF
--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -1341,7 +1341,11 @@ ssh_key_fingerprint = "{CALLER_KEY_FINGERPRINT}"
 #[test]
 fn a_key_bound_remote_operator_invokes_an_agent_only_in_the_granted_workspace() {
     let workspace = McpWorkspace::init();
+    // `model` attributes the caller; the workspace's frozen default crew picks
+    // the provider. Stub both possible selected providers, because an inherited
+    // host `claude` binary makes `opus` the default crew during fixture init.
     plant_agent_response_stub(&McpWorkspace::stub_bin_dir(&workspace.home), "codex");
+    plant_agent_response_stub(&McpWorkspace::stub_bin_dir(&workspace.home), "claude");
     let registry: Value = serde_json::from_str(
         &std::fs::read_to_string(workspace.home.join(".orbit/workspaces.json"))
             .expect("read workspace registry"),
@@ -4444,12 +4448,19 @@ fn readonly_state_mount_keeps_cli_and_mcp_reads_observational() {
     assert_command_succeeded("fixture search warmup", &warm_search);
 
     let worktree = add_linked_worktree(&workspace.work);
-    let state_root = workspace.work.join(".orbit");
+    let canonical_root = workspace.home.join(".orbit");
+    let workspace_state_root = workspace.work.join(".orbit");
+    let protected_state = snapshot_fixture_state(&[&canonical_root, &workspace_state_root]);
 
-    let tool_list = readonly_orbit_command(&worktree, &workspace.home, &state_root)
-        .args(["tool", "list", "--json"])
-        .output()
-        .expect("list tools through the read-only mount");
+    let tool_list = readonly_orbit_command(
+        &worktree,
+        &workspace.home,
+        &canonical_root,
+        &workspace_state_root,
+    )
+    .args(["tool", "list", "--json"])
+    .output()
+    .expect("list tools through the read-only mount");
     assert_command_succeeded("read-only orbit.tool.list", &tool_list);
 
     for (name, input) in [
@@ -4470,47 +4481,62 @@ fn readonly_state_mount_keeps_cli_and_mcp_reads_observational() {
             }),
         ),
     ] {
-        let output = readonly_orbit_command(&worktree, &workspace.home, &state_root)
-            .args([
-                "tool",
-                "run",
-                name,
-                "--root",
-                state_root.to_str().expect("utf8 Orbit root"),
-                "--input",
-                &input.to_string(),
-            ])
-            .output()
-            .unwrap_or_else(|error| panic!("run {name} through the read-only mount: {error}"));
-        assert_command_succeeded(name, &output);
-    }
-
-    let mutation = readonly_orbit_command(&worktree, &workspace.home, &state_root)
+        let output = readonly_orbit_command(
+            &worktree,
+            &workspace.home,
+            &canonical_root,
+            &workspace_state_root,
+        )
         .args([
             "tool",
             "run",
-            "orbit.task.update",
+            name,
             "--root",
-            state_root.to_str().expect("utf8 Orbit root"),
+            canonical_root.to_str().expect("utf8 Orbit root"),
             "--input",
-            &json!({
-                "id": task_id,
-                "execution_summary": "must not persist",
-                "model": "codex"
-            })
-            .to_string(),
+            &input.to_string(),
         ])
         .output()
-        .expect("attempt task mutation through the read-only mount");
+        .unwrap_or_else(|error| panic!("run {name} through the read-only mount: {error}"));
+        assert_command_succeeded(name, &output);
+    }
+
+    let mutation = readonly_orbit_command(
+        &worktree,
+        &workspace.home,
+        &canonical_root,
+        &workspace_state_root,
+    )
+    .args([
+        "tool",
+        "run",
+        "orbit.task.update",
+        "--root",
+        canonical_root.to_str().expect("utf8 Orbit root"),
+        "--input",
+        &json!({
+            "id": task_id,
+            "execution_summary": "must not persist",
+            "model": "codex"
+        })
+        .to_string(),
+    ])
+    .output()
+    .expect("attempt task mutation through the read-only mount");
     assert_readonly_mutation_failed("CLI", &mutation);
 
-    let mut child = readonly_orbit_command(&worktree, &workspace.home, &state_root);
+    let mut child = readonly_orbit_command(
+        &worktree,
+        &workspace.home,
+        &canonical_root,
+        &workspace_state_root,
+    );
     child
         .args([
             "mcp",
             "serve",
             "--root",
-            state_root.to_str().expect("utf8 Orbit root"),
+            canonical_root.to_str().expect("utf8 Orbit root"),
         ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -4549,6 +4575,13 @@ fn readonly_state_mount_keeps_cli_and_mcp_reads_observational() {
         }),
     );
     assert_readonly_diagnostic("MCP", mutation["message"].as_str().unwrap_or_default());
+    drop(client);
+
+    assert_eq!(
+        snapshot_fixture_state(&[&canonical_root, &workspace_state_root]),
+        protected_state,
+        "read-only CLI and MCP calls must leave canonical and workspace state unchanged"
+    );
 }
 
 #[cfg(target_os = "linux")]
@@ -4569,16 +4602,21 @@ fn bubblewrap_mount_namespaces_available() -> bool {
 }
 
 #[cfg(target_os = "linux")]
-fn readonly_orbit_command(worktree: &Path, home: &Path, state_root: &Path) -> Command {
+fn readonly_orbit_command(
+    worktree: &Path,
+    home: &Path,
+    canonical_root: &Path,
+    workspace_state_root: &Path,
+) -> Command {
     let mut command = Command::new("bwrap");
     command
         .args(["--die-with-parent", "--bind", "/", "/"])
         .arg("--ro-bind")
-        .arg(state_root)
-        .arg(state_root)
+        .arg(canonical_root)
+        .arg(canonical_root)
         .arg("--ro-bind")
-        .arg(home.join(".orbit"))
-        .arg(home.join(".orbit"))
+        .arg(workspace_state_root)
+        .arg(workspace_state_root)
         .arg("--chdir")
         .arg(worktree)
         .arg("--setenv")
@@ -4592,10 +4630,41 @@ fn readonly_orbit_command(worktree: &Path, home: &Path, state_root: &Path) -> Co
         .arg(stub_first_path(&McpWorkspace::stub_bin_dir(home)))
         .arg("--setenv")
         .arg("ORBIT_ROOT")
-        .arg(state_root)
+        .arg(canonical_root)
         .arg("--")
         .arg(env!("CARGO_BIN_EXE_orbit"));
     command
+}
+
+#[cfg(target_os = "linux")]
+fn snapshot_fixture_state(roots: &[&Path]) -> BTreeSet<(PathBuf, Vec<u8>)> {
+    let mut state = BTreeSet::new();
+
+    for root in roots {
+        snapshot_fixture_state_at(root, &mut state);
+    }
+
+    state
+}
+
+#[cfg(target_os = "linux")]
+fn snapshot_fixture_state_at(root: &Path, state: &mut BTreeSet<(PathBuf, Vec<u8>)>) {
+    for entry in std::fs::read_dir(root).expect("read protected fixture state directory") {
+        let entry = entry.expect("read protected fixture state entry");
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .expect("read protected fixture state type");
+
+        if file_type.is_dir() {
+            snapshot_fixture_state_at(&path, state);
+        } else if file_type.is_file() {
+            state.insert((
+                path.clone(),
+                std::fs::read(&path).expect("read protected fixture state"),
+            ));
+        }
+    }
 }
 
 // Not Linux-specific: this only asserts on exit status, and 14 call sites


### PR DESCRIPTION
## Task

[ORB-12085](https://orbit-cli.com/tasks/ORB-12085) — Make MCP process fixtures deterministic for provider selection and read-only canonical storage

### Description

Full-QA trial at 1530b388970d261e13a599f39ea8d4529dadf0cd failed 2 of 50 MCP process tests. Evidence is ORB-12077 artifact operator-evidence/fullqa-trial-1530.json (operator copy /tmp/orbit-fullqa-trial-1530.json). Fix test setup without weakening authorization or storage authority.
The key-bound remote operator test plants only a codex stub while retaining inherited PATH. Attribution model=codex does not select a crew; host discovery selected opus/claude and invoked the real provider. Make the selected fixture provider deterministic and fully fake/offline.
readonly_state_mount_keeps_cli_and_mcp_reads_observational initializes the canonical database under fixture HOME/.orbit but its bwrap helper sets ORBIT_ROOT to work/.orbit, a different uninitialized read-only root; it fails creating work/.orbit/orbit.db. Route reads to the initialized canonical authority and retain read-only mounts on both authority and workspace state. Do not add fallbacks, ignore failures, or write real host state.

### Acceptance Criteria

- The key-bound remote invoke succeeds with a deterministic stub provider even when another provider exists on inherited PATH; wrong-workspace and denied-grant assertions still pass without external provider invocation.
- The read-only CLI/MCP test operates on the initialized canonical database, proves reads leave protected fixture state unchanged, and preserves mutation-refusal assertions under real supported bwrap.
- Run the complete mcp_roundtrip integration target and required ci-fast/ci-lint; report any nested sandbox capability limit explicitly for operator replay.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Made the key-bound remote-invoke fixture install offline response stubs for both codex and Claude, so frozen crew selection cannot reach an inherited host provider.
- Routed read-only CLI/MCP commands to the initialized HOME/.orbit canonical root while remounting both canonical and workspace .orbit state read-only; added a byte-for-byte protected-state snapshot assertion after client shutdown.
Assessment: scoped test-fixture correction; authorization denials and mutation-refusal assertions remain intact.
Criteria:
1. Full mcp_roundtrip passes, including the granted remote invoke and its wrong-workspace/revoked-grant denials.
2. The read-only fixture now names canonical and workspace state distinctly and asserts neither changes; nested bwrap was unavailable here, so its Linux body skipped (bwrap exit 1: kernel denies unprivileged user namespaces).
3. Passed cargo test -p orbit-cli --test mcp_roundtrip (50 tests), make ci-fast, and make ci-lint.
Validation:
- cargo fmt --check -- crates/orbit-cli/tests/mcp_roundtrip.rs: passed.
- cargo test -p orbit-cli --test mcp_roundtrip: passed (50 passed).
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.
Risk: operator replay on a Linux host with supported bwrap remains required to execute the nested mount namespace body; this runner reports no permission to create a new namespace.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12085-6aa28c62`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra