### PR TITLE
Fence docs and semantic process fixtures against ancestor workspace capture

### DIFF
--- a/crates/orbit-cli/tests/docs.rs
+++ b/crates/orbit-cli/tests/docs.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Output;
 
 use assert_cmd::cargo::cargo_bin_cmd;
@@ -406,6 +406,132 @@ fn cli_semantic_index_all_keeps_task_rows_when_docs_fail() {
     );
 }
 
+/// ORB-12086 regression: a hostile ancestor directory carrying both a `.git`
+/// marker and a conflicting `.orbit/config.yaml` identity must not capture a
+/// child `workspace init`. Root discovery's legacy git-repo-root fallback
+/// walks ancestors for `.git`, so without the child's own boundary marker it
+/// would otherwise resolve the ancestor's `.orbit` as the workspace root —
+/// exactly how the original bug produced a shared `/tmp/.orbit` that later
+/// fixtures then refused as an identity conflict.
+#[test]
+fn workspace_init_ignores_hostile_ancestor_git_and_orbit_directories() {
+    let parent = tempdir().expect("hostile parent tempdir");
+    harden_dir(parent.path());
+    fs::create_dir_all(parent.path().join(".git")).expect("seed hostile parent git marker");
+    let parent_orbit = parent.path().join(".orbit");
+    fs::create_dir_all(&parent_orbit).expect("seed hostile parent .orbit");
+    fs::write(
+        parent_orbit.join("config.yaml"),
+        "schema_version: 1\nworkspace_id: ws_hostile-parent\n",
+    )
+    .expect("seed hostile parent config");
+    let home = parent.path().join("nested/home");
+    let work = parent.path().join("nested/work");
+    fs::create_dir_all(&home).expect("create nested home");
+    fs::create_dir_all(&work).expect("create nested work");
+    fs::create_dir_all(work.join(".git")).expect("seed child git boundary");
+
+    let parent_orbit_before = snapshot_tree(&parent_orbit);
+    let parent_top_level_before = top_level_entries(parent.path());
+
+    let output = run_orbit(
+        &work,
+        &home,
+        &["workspace", "init", "--name", "hostile-child"],
+    );
+    assert!(
+        output.status.success(),
+        "child workspace init failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let child_config_path = work.join(".orbit").join("config.yaml");
+    assert!(
+        child_config_path.exists(),
+        "child workspace must bind its own .orbit under work, not the hostile ancestor"
+    );
+    let child_config = fs::read_to_string(&child_config_path).expect("read child config");
+    assert!(
+        child_config.contains("ws_hostile-child"),
+        "child config should reflect the child's own workspace identity: {child_config}"
+    );
+
+    // Exercise roots=[] against the child's own config in this hostile-parent
+    // scenario: the empty override must be honored from the child's own
+    // .orbit/config.toml, never inherited or shadowed by ancestor state.
+    fs::write(
+        work.join(".orbit").join("config.toml"),
+        "[docs]\nroots = []\n",
+    )
+    .expect("seed child docs roots override");
+    fs::create_dir_all(work.join("docs")).expect("create child docs dir");
+    fs::write(
+        work.join("docs/cli.md"),
+        "---\ntype: design\nsummary: child doc\n---\n# Child Doc\n\nBody\n",
+    )
+    .expect("seed child doc");
+    let docs_output = run_orbit(&work, &home, &["docs", "list", "--json"]);
+    assert!(
+        docs_output.status.success(),
+        "child docs list failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&docs_output.stdout),
+        String::from_utf8_lossy(&docs_output.stderr)
+    );
+    let docs: Value = serde_json::from_slice(&docs_output.stdout).expect("docs list JSON");
+    assert_eq!(
+        docs,
+        json!([]),
+        "roots=[] must return no docs even with a hostile ancestor present: {docs}"
+    );
+
+    let parent_orbit_after = snapshot_tree(&parent_orbit);
+    assert_eq!(
+        parent_orbit_after, parent_orbit_before,
+        "hostile ancestor .orbit tree must remain byte-for-byte unchanged"
+    );
+    let parent_top_level_after = top_level_entries(parent.path());
+    assert_eq!(
+        parent_top_level_after, parent_top_level_before,
+        "hostile ancestor directory must gain no new top-level entries"
+    );
+}
+
+/// Recursively snapshots every file under `root` as `(relative path,
+/// contents)`, sorted for deterministic comparison.
+fn snapshot_tree(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+    let mut entries = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir).expect("read_dir") {
+            let entry = entry.expect("dir entry");
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else {
+                let relative = path
+                    .strip_prefix(root)
+                    .expect("relative path")
+                    .to_path_buf();
+                let contents = fs::read(&path).expect("read file");
+                entries.push((relative, contents));
+            }
+        }
+    }
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries
+}
+
+/// Sorted top-level entry names directly under `root`.
+fn top_level_entries(root: &Path) -> Vec<std::ffi::OsString> {
+    let mut names = fs::read_dir(root)
+        .expect("read_dir")
+        .map(|entry| entry.expect("dir entry").file_name())
+        .collect::<Vec<_>>();
+    names.sort();
+    names
+}
+
 struct TestWorkspace {
     _temp: TempDir,
     home: PathBuf,
@@ -422,6 +548,11 @@ impl TestWorkspace {
         let companion = temp.path().join("mock-companion");
         fs::create_dir_all(&home).expect("home");
         fs::create_dir_all(&work).expect("work");
+        // ORB-12086: seed a child `.git` marker so root discovery's
+        // walk-up boundary stops at `work` itself. Without it, an ambient
+        // `.git`/`.orbit` above the OS temp root can capture this fixture's
+        // `workspace init` into that ancestor instead of `work/.orbit`.
+        fs::create_dir_all(work.join(".git")).expect("seed child git boundary");
         let workspace = Self {
             _temp: temp,
             home,

--- a/crates/orbit-cli/tests/semantic_companion.rs
+++ b/crates/orbit-cli/tests/semantic_companion.rs
@@ -134,6 +134,123 @@ fn tool_run_hybrid_search_without_companion_returns_lexical_results() {
     );
 }
 
+/// ORB-12086 regression: a hostile ancestor directory carrying both a `.git`
+/// marker and a conflicting `.orbit/config.yaml` identity must not capture a
+/// child `workspace init`. Root discovery's legacy git-repo-root fallback
+/// walks ancestors for `.git`, so without the child's own boundary marker it
+/// would otherwise resolve the ancestor's `.orbit` as the workspace root —
+/// exactly how the original bug produced a shared `/tmp/.orbit` that later
+/// fixtures then refused as an identity conflict.
+#[test]
+fn workspace_init_ignores_hostile_ancestor_git_and_orbit_directories() {
+    let parent = tempdir().expect("hostile parent tempdir");
+    harden_dir(parent.path());
+    fs::create_dir_all(parent.path().join(".git")).expect("seed hostile parent git marker");
+    let parent_orbit = parent.path().join(".orbit");
+    fs::create_dir_all(&parent_orbit).expect("seed hostile parent .orbit");
+    fs::write(
+        parent_orbit.join("config.yaml"),
+        "schema_version: 1\nworkspace_id: ws_hostile-parent\n",
+    )
+    .expect("seed hostile parent config");
+    let home = parent.path().join("nested/home");
+    let work = parent.path().join("nested/work");
+    fs::create_dir_all(&home).expect("create nested home");
+    fs::create_dir_all(&work).expect("create nested work");
+    fs::create_dir_all(work.join(".git")).expect("seed child git boundary");
+
+    let parent_orbit_before = snapshot_tree(&parent_orbit);
+    let parent_top_level_before = top_level_entries(parent.path());
+
+    let output = run_orbit(
+        &work,
+        &home,
+        &["workspace", "init", "--name", "hostile-child"],
+        None,
+    );
+    assert_success("hostile-parent workspace init", &output);
+
+    let child_config_path = work.join(".orbit").join("config.yaml");
+    assert!(
+        child_config_path.exists(),
+        "child workspace must bind its own .orbit under work, not the hostile ancestor"
+    );
+    let child_config = fs::read_to_string(&child_config_path).expect("read child config");
+    assert!(
+        child_config.contains("ws_hostile-child"),
+        "child config should reflect the child's own workspace identity: {child_config}"
+    );
+
+    // Exercise roots=[] against the child's own config in this hostile-parent
+    // scenario: the empty override must be honored from the child's own
+    // .orbit/config.toml, never inherited or shadowed by ancestor state.
+    fs::write(
+        work.join(".orbit").join("config.toml"),
+        "[docs]\nroots = []\n",
+    )
+    .expect("seed child docs roots override");
+    fs::create_dir_all(work.join("docs")).expect("create child docs dir");
+    fs::write(
+        work.join("docs/cli.md"),
+        "---\ntype: design\nsummary: child doc\n---\n# Child Doc\n\nBody\n",
+    )
+    .expect("seed child doc");
+    let docs_output = run_orbit(&work, &home, &["docs", "list", "--json"], None);
+    assert_success("child docs list", &docs_output);
+    let docs: Value = serde_json::from_slice(&docs_output.stdout).expect("docs list JSON");
+    assert_eq!(
+        docs,
+        json!([]),
+        "roots=[] must return no docs even with a hostile ancestor present: {docs}"
+    );
+
+    let parent_orbit_after = snapshot_tree(&parent_orbit);
+    assert_eq!(
+        parent_orbit_after, parent_orbit_before,
+        "hostile ancestor .orbit tree must remain byte-for-byte unchanged"
+    );
+    let parent_top_level_after = top_level_entries(parent.path());
+    assert_eq!(
+        parent_top_level_after, parent_top_level_before,
+        "hostile ancestor directory must gain no new top-level entries"
+    );
+}
+
+/// Recursively snapshots every file under `root` as `(relative path,
+/// contents)`, sorted for deterministic comparison.
+fn snapshot_tree(root: &Path) -> Vec<(std::path::PathBuf, Vec<u8>)> {
+    let mut entries = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir).expect("read_dir") {
+            let entry = entry.expect("dir entry");
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else {
+                let relative = path
+                    .strip_prefix(root)
+                    .expect("relative path")
+                    .to_path_buf();
+                let contents = fs::read(&path).expect("read file");
+                entries.push((relative, contents));
+            }
+        }
+    }
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries
+}
+
+/// Sorted top-level entry names directly under `root`.
+fn top_level_entries(root: &Path) -> Vec<std::ffi::OsString> {
+    let mut names = fs::read_dir(root)
+        .expect("read_dir")
+        .map(|entry| entry.expect("dir entry").file_name())
+        .collect::<Vec<_>>();
+    names.sort();
+    names
+}
+
 struct TestWorkspace {
     _temp: TempDir,
     home: std::path::PathBuf,
@@ -152,6 +269,11 @@ impl TestWorkspace {
         let invocations = temp.path().join("companion-invocations");
         fs::create_dir_all(&home).expect("create home");
         fs::create_dir_all(&work).expect("create work");
+        // ORB-12086: seed a child `.git` marker so root discovery's
+        // walk-up boundary stops at `work` itself. Without it, an ambient
+        // `.git`/`.orbit` above the OS temp root can capture this fixture's
+        // `workspace init` into that ancestor instead of `work/.orbit`.
+        fs::create_dir_all(work.join(".git")).expect("seed child git boundary");
 
         let workspace = Self {
             _temp: temp,


### PR DESCRIPTION
## Task

[ORB-12086](https://orbit-cli.com/tasks/ORB-12086) — Fence docs and semantic process fixtures against ancestor workspace capture

### Description

Full-QA trial at 1530b388970d261e13a599f39ea8d4529dadf0cd exposed a shared fixture root-capture bug: docs roots=[] returned docs/cli.md and all four semantic tests refused an unexpected ws_docs-cli-test identity. Evidence: ORB-12077 artifact operator-evidence/fullqa-trial-1530.json; operator local /tmp/orbit-fullqa-trial-1530.json.
Read-only diagnosis: preexisting empty /tmp/.git marker (05:03) is supported by current root discovery. Docs fixture began 10:40:09, created /tmp/.orbit as ws_docs-cli-test at 10:40:10-12, and ignored its intended child work/.orbit/config.toml. Semantic then saw that parent identity. Both helpers create temp/work and scrub ambient Orbit authority but never establish a repo/workspace boundary before workspace init. Harness TMPDIR isolation alone cannot stop ancestor discovery.
Establish each fixture's intended child boundary before any Orbit CLI call, for example a child .git marker consistent with established test conventions, or explicit fixture root for intentional non-repo coverage. Preserve normal product ancestor discovery semantics. Do not delete/change /tmp/.git or /tmp/.orbit, move TMPDIR merely to hide the bug, or rerun unfenced mutating fixtures. Audit other full-QA process helpers for this exact pattern and report any further targets as findings.

### Acceptance Criteria

- Docs roots=[] returns no related documents and all four semantic companion process tests pass using only their own isolated workspace authority.
- Add hostile-parent regression coverage with a parent .git marker and conflicting parent .orbit config: child setup binds its own workspace and parent config/state remains unchanged.
- Retain ambient-authority scrubbing and legitimate product ancestor-root behavior; no production discovery weakening or live /tmp state cleanup.
- Run complete docs and semantic_companion integration targets and required ci-fast/ci-lint, recording isolated fixture paths and results.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed shared fixture root-capture bug in `crates/orbit-cli/tests/docs.rs` and `crates/orbit-cli/tests/semantic_companion.rs`.

Root cause: `TestWorkspace::new()` in both files created `home`/`work` under a fresh tempdir but never established a git boundary before the first `orbit workspace init` call. Core's bootstrap root resolution (`orbit-core/src/runtime/resolve.rs`) computes its walk-up boundary via `find_git_worktree_root(cwd)`, which walks ancestors for a `.git` marker. With no `.git` anywhere under the fixture's own tree, an ambient ancestor `.git`/`.orbit` (e.g. a stray `/tmp/.git`) becomes the discovered boundary/root instead, letting an unrelated ancestor `.orbit` capture the fixture's workspace identity — reproducing the observed "docs roots=[] returned docs/cli.md" and "semantic tests refused an unexpected ws_docs-cli-test identity" failures from the prior full-QA trial (ORB-12077 evidence).

Fix: seed a child `.git` marker directory (`fs::create_dir_all(work.join(".git"))`, the convention already used by orbit-core's own resolve.rs unit tests) in each `TestWorkspace::new()` before any Orbit CLI invocation. This pins root discovery's boundary — and the legacy git-repo-root fallback candidate — to the fixture's own `work` directory, so ancestor `.git`/`.orbit` state (real or hostile) can never be consulted. No change to production root-discovery code; no ambient `/tmp/.git`/`/tmp/.orbit` state touched, deleted, or moved.

Added regression coverage (one test per file, `workspace_init_ignores_hostile_ancestor_git_and_orbit_directories`), refined per operator comment at 10:59:15Z:
- Hostile parent seeds a `.git` marker plus a conflicting `.orbit/config.yaml` carrying a *different* `workspace_id` (`ws_hostile-parent`) — matching the real production config file/format and the actual observed identity-conflict shape, not a synthetic `config.toml`.
- After child `workspace init` (with its own `.git` boundary), asserts the child binds its own `work/.orbit/config.yaml` with its own identity (`ws_hostile-child`).
- Exercises roots=[] inside this same hostile-parent scenario: writes the child's own `.orbit/config.toml` with `[docs]\nroots = []`, seeds a doc under `work/docs/`, and asserts `docs list --json` returns `[]` — proving the empty override is read from the child's own config, never inherited/shadowed by ancestor state.
- Asserts the parent's entire `.orbit` tree is byte-for-byte unchanged (recursive snapshot of relative path -> contents, before vs. after) and that no new top-level entries appear under the hostile parent directory — not just a single file's content equality.
- Verified (manually, then reverted) that removing the child's `.git` boundary line reproduces the exact production symptom ("workspace identity ... conflicts with requested workspace ..."), confirming the test detects the original fault class.

Audited other full-QA process helper fixtures for the same pattern (grep across crates/orbit-cli/tests and orbit-core/src/runtime/tests/resolve.rs): task_publication.rs, workspace_source_remote.rs, workspace_selector.rs, and worktree_resolution.rs already construct real git repos/worktrees via `git init`/`git worktree` before any Orbit invocation, so they already carry their own boundary. No further affected fixtures found in scope; ORB-12087 separately owns the other seven process fixture families per operator comment.

Acceptance criteria:
- Docs roots=[] test (`cli_task_show_with_context_returns_empty_docs_when_roots_are_empty`) and all four semantic_companion.rs tests pass in isolation using only their own workspace authority: verified.
- Hostile-parent regression (parent `.git` + conflicting parent `.orbit/config.yaml` identity) added to both files; child binds its own workspace; parent config/state (whole `.orbit` tree + top-level directory listing) verified unchanged: done.
- Ambient-authority scrubbing (`test_env::clear_inherited_authority`) and legitimate git-worktree/ancestor discovery in orbit-core untouched; no production discovery code changed; no live /tmp state read, written, or cleaned: confirmed by diff scope (only the two test files changed).
- Full docs + semantic_companion integration targets and required ci-fast/ci-lint run and recorded below.

Validation commands run from repo root:
- `cargo test -p orbit-cli --test docs --test semantic_companion -- --test-threads=1` — passed, 13 + 5 = 18 tests ok (isolated fixture paths are per-test fresh `tempfile::tempdir()` roots, e.g. `/tmp/.tmpXXXXXX/{home,work}` and, for the new regression test, `/tmp/.tmpXXXXXX/{ .git, .orbit, nested/{home,work} }`).
- `make ci-fast` — passed (one guardrail, `test-compiler-cache-namespaces`, self-reported `skip:` due to sandbox lacking user-namespace permission; unrelated to this change).
- `make ci-lint` — passed, clean workspace-wide clippy with warnings denied.
- `git diff --check` — clean (no whitespace errors).
- `git status --short` — only `crates/orbit-cli/tests/docs.rs` and `crates/orbit-cli/tests/semantic_companion.rs` modified; no stray artifacts.

Left uncommitted per workflow ownership; no task/PR transition performed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12086-6aa28c62`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra