### PR TITLE
Fence remaining CLI process fixtures from ancestor workspace metadata

### DIFF
--- a/crates/orbit-cli/tests/ambient_authority_isolation.rs
+++ b/crates/orbit-cli/tests/ambient_authority_isolation.rs
@@ -33,6 +33,7 @@ use tempfile::{TempDir, tempdir};
 /// live managed authority a leaking fixture would otherwise reach.
 struct Sentinel {
     _temp: TempDir,
+    parent: PathBuf,
     home: PathBuf,
     work: PathBuf,
     workspace_id: String,
@@ -41,10 +42,15 @@ struct Sentinel {
 impl Sentinel {
     fn new() -> Self {
         let temp = tempdir().expect("sentinel tempdir");
-        let home = temp.path().join("home");
-        let work = temp.path().join("work");
+        let parent = temp.path().join("hostile-parent");
+        let home = parent.join("home");
+        let work = home.join("work");
+        std::fs::create_dir_all(parent.join(".git")).expect("create hostile parent repo");
+        std::fs::create_dir_all(parent.join(".orbit")).expect("create hostile parent state");
+        std::fs::write(parent.join(".orbit/sentinel"), "must remain unchanged\n")
+            .expect("write hostile parent sentinel");
         std::fs::create_dir_all(&home).expect("create sentinel home");
-        std::fs::create_dir_all(&work).expect("create sentinel work");
+        std::fs::create_dir_all(work.join(".git")).expect("create sentinel work repo");
 
         let mut command = isolated_orbit(&work, &home);
         run_ok(
@@ -64,6 +70,7 @@ impl Sentinel {
 
         Self {
             _temp: temp,
+            parent,
             home,
             work,
             workspace_id,
@@ -86,6 +93,12 @@ impl Sentinel {
         let mut files = BTreeMap::new();
         // Label each half: the registry and the task store both contain a
         // `.orbit/config.yaml`, and a colliding key would hide a change.
+        collect_files(
+            Path::new("hostile-parent"),
+            &self.parent.join(".orbit"),
+            &self.parent.join(".orbit"),
+            &mut files,
+        );
         collect_files(Path::new("registry"), &self.home, &self.home, &mut files);
         collect_files(Path::new("workspace"), &self.work, &self.work, &mut files);
         assert!(
@@ -138,9 +151,9 @@ impl Fixture {
     fn new(sentinel: &Sentinel) -> Self {
         let temp = tempdir().expect("fixture tempdir");
         let home = temp.path().join("home");
-        let work = temp.path().join("work");
+        let work = home.join("work");
         std::fs::create_dir_all(&home).expect("create fixture home");
-        std::fs::create_dir_all(&work).expect("create fixture work");
+        std::fs::create_dir_all(work.join(".git")).expect("create fixture work repo");
 
         let fixture = Self {
             _temp: temp,

--- a/crates/orbit-cli/tests/host_administration.rs
+++ b/crates/orbit-cli/tests/host_administration.rs
@@ -32,9 +32,9 @@ fn orbit_at_home(cwd: &std::path::Path, home: &std::path::Path) -> assert_cmd::C
 fn initialized_workspace() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
     let temp = tempdir().expect("tempdir");
     let home = temp.path().join("home");
-    let work = temp.path().join("work");
+    let work = home.join("work");
     std::fs::create_dir_all(&home).expect("create home");
-    std::fs::create_dir_all(&work).expect("create work");
+    std::fs::create_dir_all(work.join(".git")).expect("create work repo");
 
     orbit_at_home(&work, &home)
         .args([

--- a/crates/orbit-cli/tests/output_goldens.rs
+++ b/crates/orbit-cli/tests/output_goldens.rs
@@ -105,9 +105,9 @@ impl Fixture {
     fn new() -> Self {
         let temp = tempdir().expect("tempdir");
         let home = temp.path().join("home");
-        let work = temp.path().join("work");
+        let work = home.join("work");
         std::fs::create_dir_all(&home).expect("create home");
-        std::fs::create_dir_all(&work).expect("create work");
+        std::fs::create_dir_all(work.join(".git")).expect("create work repo");
         let fixture = Self {
             _temp: temp,
             home,

--- a/crates/orbit-cli/tests/table_rendering.rs
+++ b/crates/orbit-cli/tests/table_rendering.rs
@@ -188,9 +188,9 @@ impl TestWorkspace {
     fn new() -> Self {
         let temp = tempdir().expect("tempdir");
         let home = temp.path().join("home");
-        let work = temp.path().join("work");
+        let work = home.join("work");
         fs::create_dir_all(&home).expect("create home");
-        fs::create_dir_all(&work).expect("create work");
+        fs::create_dir_all(work.join(".git")).expect("create work repo");
 
         let workspace = Self {
             _temp: temp,

--- a/crates/orbit-cli/tests/task_tags.rs
+++ b/crates/orbit-cli/tests/task_tags.rs
@@ -153,9 +153,9 @@ impl TestWorkspace {
     fn new() -> Self {
         let temp = tempdir().expect("tempdir");
         let home = temp.path().join("home");
-        let work = temp.path().join("work");
+        let work = home.join("work");
         fs::create_dir_all(&home).expect("create home");
-        fs::create_dir_all(&work).expect("create work");
+        fs::create_dir_all(work.join(".git")).expect("create work repo");
 
         let workspace = Self {
             _temp: temp,

--- a/crates/orbit-cli/tests/task_trimmed_surface.rs
+++ b/crates/orbit-cli/tests/task_trimmed_surface.rs
@@ -422,9 +422,9 @@ impl TestWorkspace {
     fn new() -> Self {
         let temp = tempdir().expect("tempdir");
         let home = temp.path().join("home");
-        let work = temp.path().join("work");
+        let work = home.join("work");
         fs::create_dir_all(&home).expect("create home");
-        fs::create_dir_all(&work).expect("create work");
+        fs::create_dir_all(work.join(".git")).expect("create work repo");
 
         let workspace = Self {
             _temp: temp,

--- a/crates/orbit-cli/tests/workspace_sync.rs
+++ b/crates/orbit-cli/tests/workspace_sync.rs
@@ -45,9 +45,10 @@ fn read_optional(path: impl Into<PathBuf>) -> Option<Vec<u8>> {
 #[test]
 fn workspace_sync_creates_missing_defaults_preserves_operator_content_and_is_idempotent() {
     let home = tempdir().expect("home tempdir");
-    let repo = tempdir().expect("workspace tempdir");
+    let repo = home.path().join("workspace");
+    std::fs::create_dir_all(repo.join(".git")).expect("create workspace repo");
     write_host_identity(home.path());
-    orbit(repo.path(), home.path())
+    orbit(&repo, home.path())
         .args(["workspace", "init"])
         .assert()
         .success();
@@ -55,7 +56,7 @@ fn workspace_sync_creates_missing_defaults_preserves_operator_content_and_is_ide
     // `workspace sync` reports each action's path as the process resolves it,
     // so fixtures compared against those paths have to resolve the same way.
     // A macOS temp dir arrives as `/var/...` and resolves to `/private/var/...`.
-    let repo_root = std::fs::canonicalize(repo.path()).expect("canonical workspace root");
+    let repo_root = std::fs::canonicalize(&repo).expect("canonical workspace root");
     let workspace_root = repo_root.join(".orbit");
     let auto_tasks = workspace_root.join("auto_tasks");
     let missing = auto_tasks.join("code-review.yaml");
@@ -91,9 +92,9 @@ fn workspace_sync_creates_missing_defaults_preserves_operator_content_and_is_ide
     let identity = workspace_root.join("config.yaml");
     let registry_before = read(&registry);
     let identity_before = read(&identity);
-    let gitignore_before = read_optional(repo.path().join(".gitignore"));
+    let gitignore_before = read_optional(repo.join(".gitignore"));
 
-    let check = orbit(repo.path(), home.path())
+    let check = orbit(&repo, home.path())
         .args(["workspace", "sync", "--check", "--json"])
         .assert()
         .code(3)
@@ -121,12 +122,9 @@ fn workspace_sync_creates_missing_defaults_preserves_operator_content_and_is_ide
     );
     assert_eq!(read(&registry), registry_before);
     assert_eq!(read(&identity), identity_before);
-    assert_eq!(
-        read_optional(repo.path().join(".gitignore")),
-        gitignore_before
-    );
+    assert_eq!(read_optional(repo.join(".gitignore")), gitignore_before);
 
-    let applied = orbit(repo.path(), home.path())
+    let applied = orbit(&repo, home.path())
         .args(["workspace", "sync", "--json"])
         .assert()
         .success()
@@ -156,13 +154,10 @@ fn workspace_sync_creates_missing_defaults_preserves_operator_content_and_is_ide
     );
     assert_eq!(read(&registry), registry_before);
     assert_eq!(read(&identity), identity_before);
-    assert_eq!(
-        read_optional(repo.path().join(".gitignore")),
-        gitignore_before
-    );
+    assert_eq!(read_optional(repo.join(".gitignore")), gitignore_before);
 
     let managed_after = read(&missing);
-    orbit(repo.path(), home.path())
+    orbit(&repo, home.path())
         .args(["workspace", "sync", "--check", "--json"])
         .assert()
         .success();
@@ -175,20 +170,34 @@ fn workspace_sync_creates_missing_defaults_preserves_operator_content_and_is_ide
 
 #[test]
 fn workspace_sync_outside_registered_workspace_fails_before_writing() {
-    let home = tempdir().expect("home tempdir");
-    let repo = tempdir().expect("workspace tempdir");
-    write_host_identity(home.path());
-    let before: Vec<_> = std::fs::read_dir(repo.path())
-        .expect("read empty repo")
-        .collect();
-    orbit(repo.path(), home.path())
-        .args(["workspace", "sync"])
+    let parent = tempdir().expect("parent tempdir");
+    let home = parent.path().join("home");
+    let repo = home.join("outside-workspace");
+    let uninitialized_root = home.join("uninitialized-root");
+    std::fs::create_dir_all(parent.path().join(".git")).expect("create parent repo");
+    std::fs::create_dir_all(repo.join(".git")).expect("create outside repo");
+    std::fs::create_dir_all(&uninitialized_root).expect("create uninitialized root");
+    write_host_identity(&home);
+    orbit(parent.path(), &home)
+        .args(["workspace", "init", "--name", "initialized-parent"])
+        .assert()
+        .success();
+    let parent_state = read(parent.path().join(".orbit/config.yaml"));
+    let before: Vec<_> = std::fs::read_dir(&repo).expect("read empty repo").collect();
+    orbit(&repo, &home)
+        .args([
+            "workspace",
+            "sync",
+            "--root",
+            uninitialized_root.to_str().expect("utf8 root"),
+        ])
         .assert()
         .failure()
         .stderr(predicates::str::contains("orbit workspace init"));
-    let after: Vec<_> = std::fs::read_dir(repo.path())
+    let after: Vec<_> = std::fs::read_dir(&repo)
         .expect("reread empty repo")
         .collect();
     assert_eq!(after.len(), before.len());
-    assert!(!repo.path().join(".orbit").exists());
+    assert!(!repo.join(".orbit").exists());
+    assert_eq!(read(parent.path().join(".orbit/config.yaml")), parent_state);
 }


### PR DESCRIPTION
## Task

[ORB-12087](https://orbit-cli.com/tasks/ORB-12087) — Fence remaining CLI process fixtures from ancestor workspace metadata

### Description

Follow-up audit from ORB-12086 found the same unfenced temp/home + sibling temp/work pattern in seven additional CLI integration fixtures at bf00ce24af0043e370160ee246eff5743cc6ad81. These paths initialize a workspace before establishing a child repository/root boundary, so supported ancestor .git markers can redirect them into host parent .orbit state. Actual full-QA1530 wrote /tmp/.orbit from docs; see ORB-12077 artifact operator-evidence/fullqa-trial-1530.json. ORB-12086 owns docs+semantic only; this task owns the other seven files.
Put normal fixture workspaces beneath fixture HOME and establish a child .git boundary before implicit workspace init, retaining ambient-authority scrubbing. Audit facts: ambient Sentinel::new and Fixture::new are both affected; its explicit-root case is already fenced. host_administration initialization is affected despite later explicit host show roots. Four rendering/task helpers share the pattern. workspace_sync's negative unregistered cwd is special: RequireInitialized walks ancestor .orbit without git-root stopping, so a .git marker alone is insufficient. Keep that empty cwd under fixture HOME or pin an explicitly uninitialized disposable root.
Do not delete or alter host /tmp/.git or /tmp/.orbit, change product discovery semantics, weaken isolation/negative tests, or rerun unfenced mutating fixtures. Preserve the intentional ambient-authority leak reproducer only against its explicit disposable sentinel.

### Acceptance Criteria

- All seven fixture families establish their intended disposable boundary before any workspace mutation; normal commands resolve their own child workspace state.
- Hostile-parent regression coverage seeds conflicting parent .git/.orbit metadata and verifies parent sentinel contents remain unchanged, covering bootstrap and existing-root resolution.
- workspace_sync outside-unregistered-workspace still fails with init-required and creates no local state even with an initialized parent above fixture HOME; intentional ambient-authority and explicit-root assertions retain their original meaning.
- Run all seven affected integration targets plus ci-fast and ci-lint. Report any further affected fixtures with exact evidence instead of silently widening scope.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Fenced each of the seven CLI integration fixture families by locating its normal workspace beneath its fixture HOME and creating a child `.git` boundary before implicit workspace initialization.
- Extended the ambient-authority sentinel with hostile parent `.git` and `.orbit` state, and snapshot that state so bootstrap plus subsequent fixture operations prove it remains untouched.
- Made the workspace-sync negative case place its empty checkout below fixture HOME, initialize a conflicting parent workspace, and select an explicitly uninitialized disposable root; it still reports init-required and leaves both checkout and parent config unchanged.
Assessment: fixture authority is now local and explicit; the intentional unsanitized ambient-authority reproducer and explicit-root assertions were preserved.
Criteria evidence:
1. All seven listed integration fixtures now create work beneath HOME and seed work/.git before their first workspace mutation.
2. ambient_authority_isolation snapshots hostile parent `.orbit` sentinel state; workspace_sync additionally seeds a real initialized parent workspace and verifies its config is unchanged.
3. workspace_sync confirms init-required/no local state with a parent initialized above HOME; ambient and explicit-root tests pass unchanged.
4. Validation passed: cargo test -p orbit-cli --test ambient_authority_isolation --test host_administration --test output_goldens --test table_rendering --test task_tags --test task_trimmed_surface --test workspace_sync; make ci-fast; make ci-lint; cargo fmt --check; git diff --check.
Risks/deviations: No additional fixtures were changed; rg audit found no further affected constructor pattern within the scoped targets.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12087-6aa28dd1`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra