### PR TITLE
Prove and model the remaining validated descriptor-read CodeQL flows

### DIFF
--- a/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yaml
+++ b/.github/codeql/extensions/orbit-rust-path-validation/path-validation.yaml
@@ -11,13 +11,19 @@ extensions:
         ]
       - [
           "orbit_core::runtime::validated_existing_config_root",
-          "ReturnValue.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]",
+          "ReturnValue",
+          "path-injection",
+          "manual",
+        ]
+      - [
+          "orbit_core::runtime::validated_runtime_config_path",
+          "ReturnValue",
           "path-injection",
           "manual",
         ]
       - [
           "orbit_registry::host_identity::validated_existing_global_root",
-          "ReturnValue.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]",
+          "ReturnValue",
           "path-injection",
           "manual",
         ]
@@ -59,7 +65,7 @@ extensions:
         ]
       - [
           "orbit_common::fs::io::validated_private_file_path",
-          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "ReturnValue",
           "path-injection",
           "manual",
         ]
@@ -72,6 +78,12 @@ extensions:
       - [
           "orbit_core::adapter::engine_host::v2_host::sandbox::validated_linux_runtime_root",
           "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "path-injection",
+          "manual",
+        ]
+      - [
+          "orbit_core::adapter::engine_host::v2_host::sandbox::validated_linux_runtime_descendant",
+          "ReturnValue",
           "path-injection",
           "manual",
         ]
@@ -131,19 +143,19 @@ extensions:
         ]
       - [
           "orbit_store::driver::file::auto_task::validated_cursor_state_dir",
-          "ReturnValue.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]",
+          "ReturnValue",
           "path-injection",
           "manual",
         ]
       - [
           "orbit_store::driver::file::auto_task::validated_cursor_state_file_name",
-          "ReturnValue.Field[core::result::Result::Ok(0)]",
+          "ReturnValue",
           "path-injection",
           "manual",
         ]
       - [
           "orbit_common::fs::file_lock::validated_lock_holder_parent",
-          "ReturnValue.Field[core::option::Option::Some(0)]",
+          "ReturnValue",
           "path-injection",
           "manual",
         ]

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -385,15 +385,7 @@ impl OrbitRuntime {
     /// changing precedence. This pathname records selection only; readers must
     /// still open the file through a race-safe boundary.
     pub fn config_path(&self) -> Result<PathBuf, OrbitError> {
-        let shared_root = self.shared_root();
-        let global_root = self.global_root();
-        if shared_root != global_root
-            && let Some(workspace_config) = existing_workspace_config_path(&shared_root)?
-        {
-            return Ok(workspace_config);
-        }
-
-        Ok(global_root.join(CONFIG_TOML_FILE))
+        validated_runtime_config_path(self)
     }
 
     pub fn persistence_config_json(&self) -> Value {
@@ -696,6 +688,23 @@ impl OrbitRuntime {
     ) -> Result<(), OrbitError> {
         self.stores().policies().upsert_policy_def(def)
     }
+}
+
+/// Select the fixed config leaf from roots owned by an initialized runtime.
+///
+/// Keeping this as a free-function boundary gives static analysis a precise
+/// callable whose return is authoritative. It does not authorize an arbitrary
+/// caller-supplied root: both roots come from the runtime's resolved context.
+fn validated_runtime_config_path(runtime: &OrbitRuntime) -> Result<PathBuf, OrbitError> {
+    let shared_root = runtime.shared_root();
+    let global_root = runtime.global_root();
+    if shared_root != global_root
+        && let Some(workspace_config) = existing_workspace_config_path(&shared_root)?
+    {
+        return Ok(workspace_config);
+    }
+
+    Ok(global_root.join(CONFIG_TOML_FILE))
 }
 
 const CONFIG_TOML_FILE: &str = "config.toml";


### PR DESCRIPTION
## Task

[ORB-12051](https://orbit-cli.com/tasks/ORB-12051) — Prove and model the remaining validated descriptor-read CodeQL flows

### Description

## Problem
ORB-12048 merged as 7436c401898a5620999e7a3b3adb4e0c3b38a686, adding an effective pipeline guard and fixing local CodeQL discovery. The remaining known read and runtime findings need complete authority proofs and narrowly scoped models. No GHCR publication or remote pack pin is needed.

## Findings to investigate
The last complete scan at 53c854 reported: #411 runtime/mod.rs:737; #424 application/docs/config.rs:212; #419 orbit-registry/src/host_identity.rs:216; #421 orbit-store/src/driver/file/auto_task/mod.rs:165; #423 orbit-common/src/fs/file_lock.rs:242; #425 adapter/engine_host/v2_host/sandbox.rs:423; and #426 orbit-common/src/fs/io.rs:581. Paths are relative to their owning crate. #416 is the pipeline case owned by ORB-12048; root verifies its hosted closure. Lines can move: inspect current source and current scan disposition. Earlier #418, #420 and #422 closed when ORB-12054 consolidated the reader.

## Required method
Establish the complete caller authority and path/descriptor boundary for each surviving flow. Absolute syntax and O_NOFOLLOW alone do not establish authorization. Check canonical roots, permitted descendants, descriptor identity, nonblocking regular-file reads, aliases, missing paths and platform limitations. The docs-config helper explicitly leaves parent trust to its callers.

Use CodeQL 2.27.0 controlled without/with-model evidence. Model only verified callable-return or boolean-validation boundaries that actually affect dataflow. Keep an intentionally unsafe control reported. Never add a generic OpenOptions, canonicalize, symlink_metadata or open_read_only_no_follow sanitizer. Do not dismiss alerts or disable queries. File any real residual vulnerability for a bounded source repair instead of modeling it away.

## Available tools and evidence
Root copied the verified CLI outside the workers' private /tmp: ~/.cache/orbit-operator-tools/codeql-2.27.0/codeql. Use temporary writable caches and fixtures; do not modify the shared tool directory. Download public query libraries into temporary storage if necessary.

ORB-12048 artifacts codeql-2.27.0-controlled-evidence.json and operator-evidence/local-discovery.tar.gz prove the pipeline guard's 2-to-1 result and the .yaml versus .yml discovery behavior. The source model is now .github/codeql/extensions/orbit-rust-path-validation/path-validation.yaml. Its manifest must remain compatible with the generated extensions/**/*.yaml glob.

ORB-12054 added NONBLOCK; ORB-12065 made its FIFO regression stage-aware and leak-free. ORB-12042 and ORB-12063 passed the actual Linux descriptor-replacement test. Root also ran a real agent_loop on candidate 865b5ccd: actual --bind-fd grants for the DB/WAL/SHM, a persisted nested task update, EROFS on a recovery-authority write, an unchanged host sentinel, and WAL growth from 0 to 1,013,552 bytes. Evidence is on ORB-12039 under candidate-runtime. These are bounded observations, not blanket caller-trust proofs.

## Delivery and constraints
Preserve four language suites, default queries, build mode, action pins, permissions and paths-ignore. No publication or credential changes. Validated task-scoped delivery is authorized; root performs the fresh hosted verification after merge. Do not block local delivery merely because hosted checks require the merged candidate. Leave uncertain cases unmodeled and report them explicitly. Final Opus QA and review remain required.

### Acceptance Criteria

- Document complete caller, path and descriptor authority evidence for every surviving target, including platform limits; file actual defects instead of modeling them away.
- Show CodeQL 2.27.0 without/with results proving each narrow model affects only verified boundaries while unsafe controls remain findings.
- Keep local .yaml discovery compatible with the generated extension glob and preserve all four language suites and existing workflow settings.
- Relevant behavioral regressions, model/schema/discovery checks, make ci-fast and make ci-lint pass without broadening filesystem authority.
- Persist exact commands, versions, source/model hashes and controlled results. Root verifies same-head hosted participation and finding closures after merge; unavailable checks are never called PASS.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented the remaining descriptor-read CodeQL boundaries. Source review established caller, path, descriptor, missing-path, alias, and platform authority for runtime config selection/docs reads, host identity, auto-task cursor reads, lock-holder reads, private-file opens, and Linux runtime sidecar grants. The review exposed an in-scope model defect: CodeQL 2.27.0 instantiated none of the projected Result/Option return selectors, and the inherent config_path method canonicalized as <orbit_core::runtime::OrbitRuntime>::config_path, which the extension schema intentionally rejects. Corrected the six existing scoped return models to ReturnValue, added the Linux descendant model, and extracted config selection into validated_runtime_config_path(OrbitRuntime) so its free-function return is both schema-compatible and still rooted exclusively in initialized runtime authority. No generic OpenOptions, canonicalize, symlink_metadata, or open_read_only_no_follow sanitizer was added; no residual source vulnerability was found that required a separate repair task.

Acceptance evidence: (1) Complete per-boundary authority evidence, including Unix/Windows/other-platform limits and mutable-ancestor exclusions, is persisted in artifact orb12051-codeql-evidence.json. (2) A fresh CodeQL 2.27.0 traced cargo-check database and controlled query reported 16 findings without the model (13 calls across all eight verified boundaries plus three intentionally unsafe open_read_only_no_follow controls) and 3 with the model (all three unsafe controls; zero verified-boundary calls). Exact versions, source/model/query hashes, commands, counts and SARIF hashes are in the artifact. (3) .github/workflows/codeql.yml, .github/codeql/codeql-config.yml and codeql-pack.yml are unchanged; all four language suites, build-mode none, default-query behavior, pins, permissions, paths-ignore, and path-validation.yaml discovery compatibility remain. (4) Focused descriptor/config/sandbox regressions, schema checks, pack creation, make ci-fast, and make ci-lint passed without broadening filesystem authority. (5) Exact local evidence is persisted. Same-head hosted participation and alert closure require the merged candidate and were not run or called PASS; root retains that verification.

Validation passed: python3 scripts/test-codeql-extension-schema.py; python3 scripts/check-codeql-extension-schema.py; cargo fmt --all -- --check; CodeQL 2.27.0 pack create; traced CodeQL database create with cargo check --workspace; controlled CodeQL without-model analysis (16 findings); controlled CodeQL with-model analysis (3 unsafe-control findings); cargo test -p orbit-registry host_identity (23 passed); cargo test -p orbit-store cursor_state (8 passed); cargo test -p orbit-common 'fs::tests::io' (25 passed, one fixture-child test intentionally ignored in the parent harness and exercised by its owning test); cargo test -p orbit-core config_path (4 passed); cargo test -p orbit-core config_reader (11 passed); cargo test -p orbit-core runtime_store_grants (12 passed); make ci-fast; make ci-lint; git diff --check; workflow/config/manifest unchanged diff check. make ci-fast reported its existing mount-namespace subcheck as skipped because unprivileged namespaces are unavailable, while the required command exited successfully.

Final state: only .github/codeql/extensions/orbit-rust-path-validation/path-validation.yaml and crates/orbit-core/src/runtime/mod.rs are modified. Remaining risk is the explicitly deferred post-merge hosted CodeQL same-head verification; local CodeQL's ordinary rust/path-injection query produced no findings in this local extraction, so it is not represented as passing or as closure evidence.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12051-6aa27f4f`
- Behind base: 0
- Ahead of base: 1