### PR TITLE
Read current SQLite WAL state without writes on read-only Orbit mounts

### DIFF
--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -4447,8 +4447,39 @@ fn readonly_state_mount_keeps_cli_and_mcp_reads_observational() {
         .expect("warm fixture search state");
     assert_command_succeeded("fixture search warmup", &warm_search);
 
-    let worktree = add_linked_worktree(&workspace.work);
+    // Leave a committed registry write behind in the WAL, the state the mount
+    // has to read through (ORB-12090). The holder pins the snapshot taken
+    // before the next task is created, so nothing checkpoints that task back
+    // into the main database file.
     let canonical_root = workspace.home.join(".orbit");
+    let registry = canonical_root.join("tasks").join("index.sqlite");
+    let registry_holder = hold_uncheckpointed_registry_snapshot(&registry);
+    let wal_only = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args([
+            "tool",
+            "run",
+            "orbit.task.add",
+            "--input",
+            &json!({
+                "title": "Committed into the registry WAL",
+                "description": "Only a WAL-aware read-only open reports this task",
+                "workspace": workspace.work,
+                "complexity": "low",
+                "model": "codex",
+            })
+            .to_string(),
+        ])
+        .output()
+        .expect("create the WAL-only fixture task");
+    assert_command_succeeded("WAL-only task add", &wal_only);
+    let wal_only: Value = serde_json::from_slice(&wal_only.stdout).expect("parse WAL-only task");
+    let wal_only_task_id = wal_only["id"].as_str().expect("WAL-only task id");
+    assert!(
+        !main_registry_file_has_task(&registry, wal_only_task_id),
+        "the fixture must keep {wal_only_task_id} out of the main registry file"
+    );
+
+    let worktree = add_linked_worktree(&workspace.work);
     let workspace_state_root = workspace.work.join(".orbit");
     let protected_state = snapshot_fixture_state(&[&canonical_root, &workspace_state_root]);
 
@@ -4467,6 +4498,10 @@ fn readonly_state_mount_keeps_cli_and_mcp_reads_observational() {
         (
             "orbit.task.show",
             json!({ "id": task_id, "model": "codex" }),
+        ),
+        (
+            "orbit.task.show",
+            json!({ "id": wal_only_task_id, "model": "codex" }),
         ),
         (
             "orbit.task.list",
@@ -4558,7 +4593,19 @@ fn readonly_state_mount_keeps_cli_and_mcp_reads_observational() {
         client.call_tool_ok("orbit_task_show", json!({ "id": task_id }))["id"],
         task_id
     );
-    assert!(client.call_tool_ok("orbit_task_list", json!({}))["items"].is_array());
+    assert_eq!(
+        client.call_tool_ok("orbit_task_show", json!({ "id": wal_only_task_id }))["id"],
+        wal_only_task_id
+    );
+    let listed = client.call_tool_ok("orbit_task_list", json!({}));
+    assert!(
+        listed["items"]
+            .as_array()
+            .expect("task list items")
+            .iter()
+            .any(|task| task["id"] == json!(wal_only_task_id)),
+        "the registry index must report its uncheckpointed WAL state: {listed}"
+    );
     assert_eq!(
         client.call_tool_ok(
             "orbit_search",
@@ -4582,6 +4629,161 @@ fn readonly_state_mount_keeps_cli_and_mcp_reads_observational() {
         protected_state,
         "read-only CLI and MCP calls must leave canonical and workspace state unchanged"
     );
+    drop(registry_holder);
+}
+
+/// The mount test above needs user and mount namespaces, which nested
+/// container runners deny. This carries the same WAL-aware read contract on
+/// every Unix runner by making the registry file set itself unwritable: the
+/// CLI reaches the identical read-only open, one process removed from its
+/// state, and must still report the task that only the WAL holds.
+///
+/// It does not replace the mount test — a `--ro-bind` also refuses the sidecar
+/// creation and directory writes that permission bits here still allow.
+#[cfg(unix)]
+#[test]
+fn read_only_registry_files_keep_uncheckpointed_wal_reads_observational() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let workspace = McpWorkspace::init();
+    let registry = workspace
+        .home
+        .join(".orbit")
+        .join("tasks")
+        .join("index.sqlite");
+    let created = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args([
+            "tool",
+            "run",
+            "orbit.task.add",
+            "--input",
+            &json!({
+                "title": "Warmed before the registry files turn read-only",
+                "description": "Every commit here is checkpointed into the main database file",
+                "workspace": workspace.work,
+                "complexity": "low",
+                "model": "codex",
+            })
+            .to_string(),
+        ])
+        .output()
+        .expect("create the warmup task");
+    assert_command_succeeded("warmup task add", &created);
+
+    let registry_holder = hold_uncheckpointed_registry_snapshot(&registry);
+    let wal_only = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args([
+            "tool",
+            "run",
+            "orbit.task.add",
+            "--input",
+            &json!({
+                "title": "Committed into the registry WAL",
+                "description": "Only a WAL-aware read-only open reports this task",
+                "workspace": workspace.work,
+                "complexity": "low",
+                "model": "codex",
+            })
+            .to_string(),
+        ])
+        .output()
+        .expect("create the WAL-only task");
+    assert_command_succeeded("WAL-only task add", &wal_only);
+    let wal_only: Value = serde_json::from_slice(&wal_only.stdout).expect("parse WAL-only task");
+    let wal_only_task_id = wal_only["id"].as_str().expect("WAL-only task id");
+    assert!(
+        !main_registry_file_has_task(&registry, wal_only_task_id),
+        "the fixture must keep {wal_only_task_id} out of the main registry file"
+    );
+
+    let registry_files: Vec<PathBuf> = ["", "-wal", "-shm"]
+        .iter()
+        .map(|suffix| PathBuf::from(format!("{}{suffix}", registry.display())))
+        .collect();
+    for file in &registry_files {
+        std::fs::set_permissions(file, std::fs::Permissions::from_mode(0o400))
+            .unwrap_or_else(|error| panic!("make {} read-only: {error}", file.display()));
+    }
+    let before: Vec<Vec<u8>> = registry_files
+        .iter()
+        .map(|file| std::fs::read(file).expect("snapshot registry file"))
+        .collect();
+
+    let shown = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args([
+            "tool",
+            "run",
+            "orbit.task.show",
+            "--input",
+            &json!({ "id": wal_only_task_id, "model": "codex" }).to_string(),
+        ])
+        .output()
+        .expect("show the WAL-only task through the read-only registry");
+    assert_command_succeeded("read-only orbit.task.show", &shown);
+    let shown: Value = serde_json::from_slice(&shown.stdout).expect("parse shown task");
+    assert_eq!(shown["id"], json!(wal_only_task_id));
+
+    let after: Vec<Vec<u8>> = registry_files
+        .iter()
+        .map(|file| std::fs::read(file).expect("re-read registry file"))
+        .collect();
+    assert_eq!(
+        after, before,
+        "observing must not change the registry database, WAL, or SHM"
+    );
+    drop(registry_holder);
+}
+
+/// Pin the registry's current snapshot so every write that follows stays in the
+/// WAL: SQLite checkpoints when the last connection closes, and otherwise
+/// copies frames back only as far as the oldest reader allows.
+#[cfg(unix)]
+fn hold_uncheckpointed_registry_snapshot(registry: &Path) -> Connection {
+    assert!(
+        registry.exists(),
+        "warmed fixture registry: {}",
+        registry.display()
+    );
+    let holder = Connection::open(registry).expect("open registry snapshot holder");
+    let journal_mode: String = holder
+        .pragma_query_value(None, "journal_mode", |row| row.get(0))
+        .expect("read registry journal mode");
+    assert_eq!(
+        journal_mode.to_lowercase(),
+        "wal",
+        "this fixture needs the registry's WAL"
+    );
+    holder
+        .pragma_update(None, "wal_autocheckpoint", 0)
+        .expect("keep new frames in the WAL");
+    holder
+        .execute_batch("BEGIN")
+        .expect("start the pinning read transaction");
+    holder
+        .query_row("SELECT count(*) FROM task_bundle_bindings", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .expect("pin the current registry snapshot");
+    holder
+}
+
+/// Whether the main registry file alone — the view `immutable=1` gives, which
+/// ignores the WAL entirely — knows about `task_id`.
+#[cfg(unix)]
+fn main_registry_file_has_task(registry: &Path, task_id: &str) -> bool {
+    let main_file_only = Connection::open_with_flags(
+        format!("file:{}?immutable=1", registry.display()),
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+    )
+    .expect("open the main registry file alone");
+    let bindings: i64 = main_file_only
+        .query_row(
+            "SELECT count(*) FROM task_bundle_bindings WHERE task_id = ?1",
+            [task_id],
+            |row| row.get(0),
+        )
+        .expect("count bindings in the main registry file");
+    bindings > 0
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/orbit-common/src/storage/sqlite.rs
+++ b/crates/orbit-common/src/storage/sqlite.rs
@@ -21,11 +21,16 @@ use crate::OrbitError;
 /// contending connection spins before surfacing `database is locked`.
 pub const DEFAULT_BUSY_TIMEOUT_MS: u32 = 5_000;
 
+/// Bytes in a WAL file header. A `-wal` of at most this size carries no
+/// frames, so the main database file already holds every committed page.
+const WAL_HEADER_BYTES: u64 = 32;
+
 /// A file-backed SQLite connection opened under Orbit's filesystem policy.
 pub struct OpenedConnection {
     /// The ready-to-use SQLite connection.
     pub connection: Connection,
-    /// Whether the database was opened in immutable read-only mode.
+    /// Whether the database was opened for observation only, without any
+    /// ability to write.
     pub read_only: bool,
 }
 
@@ -36,8 +41,9 @@ pub struct OpenedConnection {
 /// pre-existing sidecars are repaired as part of the same operation. Newly
 /// created parent directories are owner-only as well. An existing read-only
 /// database on writable storage has group/other permissions removed before it
-/// is opened immutable. A database on a read-only filesystem is opened
-/// immutable before any directory creation or permission change is attempted.
+/// is opened for observation. A database on a read-only filesystem is opened
+/// observationally before any directory creation or permission change is
+/// attempted; see [`open_observational`] for how such a database is read.
 pub fn open_private(path: &Path) -> Result<OpenedConnection, OrbitError> {
     let path = validated_sqlite_path(path)?;
 
@@ -72,7 +78,7 @@ pub fn open_private(path: &Path) -> Result<OpenedConnection, OrbitError> {
     if pragmas.write_denied || filesystem_is_read_only(&path)? {
         drop(connection);
         return Ok(OpenedConnection {
-            connection: open_immutable(&path)?,
+            connection: open_observational(&path)?,
             read_only: true,
         });
     }
@@ -94,7 +100,7 @@ pub(super) fn open_private_read_only(
         harden_read_only_sqlite_files(&path)?;
     }
     Ok(OpenedConnection {
-        connection: open_immutable(&path)?,
+        connection: open_observational(&path)?,
         read_only: true,
     })
 }
@@ -246,6 +252,23 @@ fn sqlite_sidecar_paths(path: &Path) -> [PathBuf; 2] {
     ]
 }
 
+/// Metadata for an existing sidecar, or `None` when it is absent.
+///
+/// A symlinked or otherwise irregular sidecar is rejected: read-only opens
+/// decide what to trust from these files, and SQLite would follow a link out
+/// of the state directory [`validated_sqlite_path`] just checked.
+fn sidecar_metadata(path: &Path) -> Result<Option<fs::Metadata>, OrbitError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_file() => Ok(Some(metadata)),
+        Ok(_) => Err(OrbitError::InvalidInput(format!(
+            "SQLite sidecar must be a regular file: {}",
+            path.display()
+        ))),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(sqlite_path_error("inspect", path, error)),
+    }
+}
+
 fn path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
     let mut value = path.as_os_str().to_os_string();
     value.push(suffix);
@@ -268,8 +291,8 @@ pub struct PragmaOutcome {
     /// such as `delete` when the filesystem refuses WAL sidecars).
     pub journal_mode: String,
     /// The connection refused a persistence pragma because its backing store
-    /// is read-only. Callers that need sidecar-free reads should reopen it as
-    /// an immutable SQLite URI.
+    /// is read-only. Callers that need sidecar-free reads should reopen it
+    /// with [`open_observational`].
     pub write_denied: bool,
 }
 
@@ -318,19 +341,88 @@ pub fn apply_default_pragmas(conn: &Connection) -> Result<PragmaOutcome, OrbitEr
     })
 }
 
-/// Open an existing SQLite database without creating WAL/SHM sidecars.
+/// How an unwritable SQLite database can be observed without changing any of
+/// its files.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ReadOnlyAccess {
+    /// `immutable=1`. The only mode that never needs WAL shared memory, and
+    /// correct only while the `-wal` sidecar cannot hide committed pages.
+    Immutable,
+    /// An ordinary read-only connection, reading the `-wal` through the `-shm`
+    /// wal-index already present on disk.
+    WalReadOnly,
+}
+
+/// Open an existing SQLite database for reads that must not write to it, and
+/// must not create a WAL/SHM sidecar.
 ///
-/// `immutable=1` is required for a database on a genuinely read-only mount:
-/// SQLite's ordinary read-only mode may still try to create WAL shared-memory
-/// state before the first SELECT.
-pub fn open_immutable(path: &Path) -> Result<Connection, OrbitError> {
+/// `immutable=1` is the mode a read-only mount reaches for, because SQLite's
+/// ordinary read-only mode may try to create WAL shared-memory state before the
+/// first SELECT. It is also the mode that makes SQLite ignore an existing
+/// `-wal`: a database whose newest commits were never checkpointed back reads
+/// as its older main-file state. A caller that treats that stale view as
+/// current then repairs a database it cannot write — how a read-only Orbit
+/// mount turned an observation into `attempt to write a readonly database`.
+///
+/// So the sidecars pick the mode. See [`read_only_access`].
+pub fn open_observational(path: &Path) -> Result<Connection, OrbitError> {
+    let access = read_only_access(path)?;
+    let conn = open_read_only_connection(path, access)?;
+
+    if access == ReadOnlyAccess::WalReadOnly {
+        // Opening is lazy, so an unusable wal-index would otherwise surface as
+        // an opaque failure inside whichever query happened to run first.
+        conn.query_row("SELECT count(*) FROM sqlite_schema", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .map_err(|error| {
+            observational_unavailable(path, &format!("its wal-index is unusable: {error}"))
+        })?;
+    }
+
+    Ok(conn)
+}
+
+/// Decide how `path` can be observed without writing, or explain why its
+/// current state cannot be read at all.
+///
+/// A `-wal` holding frames may carry committed pages the main database file
+/// does not have, so those reads need a real read-only connection — which in
+/// turn needs the `-shm` wal-index to already exist, since creating one is a
+/// write. Without both, reporting the main file alone would be a silent,
+/// stale success, so this fails closed instead.
+pub(super) fn read_only_access(path: &Path) -> Result<ReadOnlyAccess, OrbitError> {
+    let [wal, shm] = sqlite_sidecar_paths(path);
+
+    let wal_carries_frames =
+        sidecar_metadata(&wal)?.is_some_and(|metadata| metadata.len() > WAL_HEADER_BYTES);
+    if !wal_carries_frames {
+        return Ok(ReadOnlyAccess::Immutable);
+    }
+    if sidecar_metadata(&shm)?.is_none() {
+        return Err(observational_unavailable(
+            path,
+            "its '-shm' wal-index is missing",
+        ));
+    }
+
+    Ok(ReadOnlyAccess::WalReadOnly)
+}
+
+fn open_read_only_connection(
+    path: &Path,
+    access: ReadOnlyAccess,
+) -> Result<Connection, OrbitError> {
     let mut uri = url::Url::from_file_path(path).map_err(|()| {
         OrbitError::Store(format!(
             "cannot represent SQLite path '{}' as a file URI",
             path.display()
         ))
     })?;
-    uri.query_pairs_mut().append_pair("immutable", "1");
+    if access == ReadOnlyAccess::Immutable {
+        uri.query_pairs_mut().append_pair("immutable", "1");
+    }
+
     let conn = Connection::open_with_flags(
         uri.as_str(),
         OpenFlags::SQLITE_OPEN_READ_ONLY
@@ -340,10 +432,11 @@ pub fn open_immutable(path: &Path) -> Result<Connection, OrbitError> {
     )
     .map_err(|error| {
         OrbitError::Store(format!(
-            "cannot open SQLite database '{}' for immutable reads: {error}",
+            "cannot open SQLite database '{}' for observational reads: {error}",
             path.display()
         ))
     })?;
+
     conn.pragma_update(None, "query_only", "ON")
         .map_err(|error| OrbitError::Store(format!("failed to set query_only: {error}")))?;
     conn.pragma_update(None, "busy_timeout", DEFAULT_BUSY_TIMEOUT_MS)
@@ -351,6 +444,23 @@ pub fn open_immutable(path: &Path) -> Result<Connection, OrbitError> {
     conn.pragma_update(None, "foreign_keys", "ON")
         .map_err(|error| OrbitError::Store(format!("failed to enable foreign keys: {error}")))?;
     Ok(conn)
+}
+
+/// The database holds committed WAL state this process may not read and may
+/// not write into place. Name the writable step an operator still owes rather
+/// than reporting the main file's older contents as current.
+///
+/// Deliberately not phrased as a read-only/permission failure: callers that
+/// downgrade those to a warning and continue would turn this back into the
+/// silent stale read it exists to prevent.
+fn observational_unavailable(path: &Path, reason: &str) -> OrbitError {
+    OrbitError::Store(format!(
+        "cannot observe current SQLite state '{}': its '-wal' sidecar holds committed frames but \
+         {reason}. Checkpoint the database from writable storage \
+         (`PRAGMA wal_checkpoint(TRUNCATE)`) or publish its '-shm' wal-index alongside it, then \
+         retry the observation",
+        path.display()
+    ))
 }
 
 /// Whether `path` resides on a filesystem mounted read-only.

--- a/crates/orbit-common/src/storage/tests/sqlite.rs
+++ b/crates/orbit-common/src/storage/tests/sqlite.rs
@@ -215,3 +215,204 @@ fn private_read_only_filesystem_path_has_no_side_effects() {
     assert!(!std::path::PathBuf::from(format!("{}-wal", path.display())).exists());
     assert!(!std::path::PathBuf::from(format!("{}-shm", path.display())).exists());
 }
+
+/// Read-only observation fixtures, all built around one shape: a database
+/// whose newest commit is still only in the WAL.
+#[cfg(unix)]
+mod read_only_observation {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+
+    use rusqlite::Connection;
+
+    use crate::OrbitError;
+    use crate::storage::sqlite::{
+        ReadOnlyAccess, open_private, open_private_read_only, read_only_access,
+    };
+
+    const SQLITE_FILE_SUFFIXES: [&str; 3] = ["", "-wal", "-shm"];
+
+    fn sqlite_file(path: &Path, suffix: &str) -> PathBuf {
+        PathBuf::from(format!("{}{suffix}", path.display()))
+    }
+
+    /// Write a database where `main_only` is checkpointed back into the main
+    /// file and `fresh` is not, then publish the requested files read-only.
+    ///
+    /// Autocheckpoint is off so the split stays put, and the observed database
+    /// is a copy rather than the writer's own files: SQLite shares one
+    /// wal-index mapping per file across a process, so a live local writer
+    /// would let an observing connection write through it — exactly what a
+    /// separate read-only mount cannot do.
+    fn publish_uncheckpointed_wal_database(source: &Path, published: &Path, suffixes: &[&str]) {
+        let writer = Connection::open(source).expect("open fixture writer");
+        writer
+            .pragma_update(None, "journal_mode", "WAL")
+            .expect("enable WAL");
+        writer
+            .pragma_update(None, "wal_autocheckpoint", 0)
+            .expect("keep new frames in the WAL");
+        writer
+            .execute_batch(
+                "CREATE TABLE main_only(value TEXT);
+                 INSERT INTO main_only VALUES ('checkpointed');
+                 PRAGMA wal_checkpoint(TRUNCATE);
+                 CREATE TABLE fresh(value TEXT);
+                 INSERT INTO fresh VALUES ('visible-only-in-wal');",
+            )
+            .expect("commit fixture state into the WAL");
+
+        publish_read_only(source, published, suffixes);
+    }
+
+    fn publish_read_only(source: &Path, published: &Path, suffixes: &[&str]) {
+        for suffix in suffixes {
+            let from = sqlite_file(source, suffix);
+            let to = sqlite_file(published, suffix);
+            fs::copy(&from, &to)
+                .unwrap_or_else(|error| panic!("publish {}: {error}", from.display()));
+            fs::set_permissions(&to, fs::Permissions::from_mode(0o400))
+                .unwrap_or_else(|error| panic!("make {} read-only: {error}", to.display()));
+        }
+    }
+
+    fn published_bytes(path: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+        SQLITE_FILE_SUFFIXES
+            .iter()
+            .map(|suffix| sqlite_file(path, suffix))
+            .filter(|file| file.exists())
+            .map(|file| {
+                let bytes = fs::read(&file)
+                    .unwrap_or_else(|error| panic!("read {}: {error}", file.display()));
+                (file, bytes)
+            })
+            .collect()
+    }
+
+    fn fixture(name: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source = dir.path().join(format!("{name}-source.db"));
+        let published = dir.path().join(format!("{name}.db"));
+        (dir, source, published)
+    }
+
+    /// ORB-12090: `immutable=1` ignores the WAL, so a read-only open used to
+    /// report the older main-file state as if it were current.
+    #[test]
+    fn reads_committed_state_held_only_in_the_wal() {
+        let (_dir, source, published) = fixture("wal");
+        publish_uncheckpointed_wal_database(&source, &published, &SQLITE_FILE_SUFFIXES);
+        let before = published_bytes(&published);
+
+        let opened = open_private(&published).expect("open published database");
+
+        assert!(opened.read_only);
+        let value: String = opened
+            .connection
+            .query_row("SELECT value FROM fresh", [], |row| row.get(0))
+            .expect("read state only the WAL holds");
+        assert_eq!(value, "visible-only-in-wal");
+
+        let denied = opened
+            .connection
+            .execute("INSERT INTO fresh VALUES ('denied')", [])
+            .expect_err("observation must refuse writes");
+        assert!(
+            OrbitError::Store(denied.to_string()).is_readonly_or_access_failure(),
+            "{denied}"
+        );
+
+        drop(opened);
+        assert_eq!(
+            published_bytes(&published),
+            before,
+            "observing must not change the database, WAL, or SHM"
+        );
+    }
+
+    /// The control for the branch above: once every frame is checkpointed back
+    /// into the main file, nothing can hide behind the WAL and the
+    /// sidecar-free mode stays in use.
+    #[test]
+    fn checkpointed_database_stays_immutable() {
+        let (_dir, source, published) = fixture("checkpointed");
+        let writer = Connection::open(&source).expect("open fixture writer");
+        writer
+            .pragma_update(None, "journal_mode", "WAL")
+            .expect("enable WAL");
+        writer
+            .execute_batch(
+                "CREATE TABLE fresh(value TEXT);
+                 INSERT INTO fresh VALUES ('visible-only-in-wal');
+                 PRAGMA wal_checkpoint(TRUNCATE);",
+            )
+            .expect("commit and checkpoint fixture state");
+        publish_read_only(&source, &published, &SQLITE_FILE_SUFFIXES);
+        let before = published_bytes(&published);
+
+        assert_eq!(
+            read_only_access(&published).expect("classify a checkpointed database"),
+            ReadOnlyAccess::Immutable,
+            "an empty WAL cannot hide committed pages"
+        );
+        let opened = open_private(&published).expect("open published database");
+        assert!(opened.read_only);
+        let value: String = opened
+            .connection
+            .query_row("SELECT value FROM fresh", [], |row| row.get(0))
+            .expect("read checkpointed state");
+        assert_eq!(value, "visible-only-in-wal");
+
+        drop(opened);
+        assert_eq!(published_bytes(&published), before);
+    }
+
+    /// A WAL with frames but no published wal-index cannot be read without
+    /// creating one. Fail closed: the main file alone would be a silent, stale
+    /// success.
+    #[test]
+    fn wal_without_read_support_fails_closed() {
+        let (_dir, source, published) = fixture("no-shm");
+        publish_uncheckpointed_wal_database(&source, &published, &["", "-wal"]);
+        let before = published_bytes(&published);
+
+        let error = match open_private(&published) {
+            Ok(_) => panic!("a WAL without read support must not read as current"),
+            Err(error) => error,
+        };
+
+        let message = error.to_string();
+        assert!(message.contains("'-shm' wal-index is missing"), "{message}");
+        assert!(message.contains("wal_checkpoint(TRUNCATE)"), "{message}");
+        assert!(
+            !error.is_readonly_or_access_failure(),
+            "a stale-read refusal must not be tolerated as a write denial: {message}"
+        );
+        assert!(
+            !sqlite_file(&published, "-shm").exists(),
+            "observation must not publish a wal-index"
+        );
+        assert_eq!(published_bytes(&published), before);
+    }
+
+    #[test]
+    fn symlinked_sidecar_is_rejected() {
+        let (dir, source, published) = fixture("linked");
+        publish_uncheckpointed_wal_database(&source, &published, &SQLITE_FILE_SUFFIXES);
+        let wal = sqlite_file(&published, "-wal");
+        let elsewhere = dir.path().join("elsewhere-wal");
+        fs::rename(&wal, &elsewhere).expect("move the WAL out of the published file set");
+        std::os::unix::fs::symlink(&elsewhere, &wal).expect("link the WAL back");
+
+        let error = match open_private_read_only(&published, true) {
+            Ok(_) => panic!("a symlinked sidecar must not be trusted"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error.to_string().contains("sidecar must be a regular file"),
+            "{error}"
+        );
+    }
+}

--- a/crates/orbit-store/src/driver/sqlite/task_registry/schema.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/schema.rs
@@ -145,18 +145,53 @@ pub(super) fn apply_schema(conn: &Connection) -> Result<(), OrbitError> {
     Ok(())
 }
 
-// Required additive storage is checked even when user_version is current.
-// A complete registry needs no write transaction, including on read-only media.
+/// Whether the stored schema is already exactly the shape this build reads.
+///
+/// Required additive storage is checked even when user_version is current: a
+/// complete registry then needs no write transaction, including on read-only
+/// media.
+fn schema_is_current(conn: &Connection) -> Result<bool, OrbitError> {
+    Ok(registry_user_version(conn)? == REGISTRY_SCHEMA_VERSION
+        && table_has_column(conn, "task_action_keys", "action_key")?)
+}
+
+/// Confirm a registry opened for observation is already readable as-is.
+///
+/// Setup, migration and v6 recovery all need a write transaction, so on
+/// read-only storage there is nothing to attempt: naming the writable step the
+/// registry still owes beats an opaque SQLite write error raised from a
+/// transaction that could only fail.
+pub(super) fn assert_readable_schema(conn: &Connection, path: &Path) -> Result<(), OrbitError> {
+    if schema_is_current(conn)? {
+        return Ok(());
+    }
+
+    let version = registry_user_version(conn)?;
+    if version > 6 {
+        return Err(unsupported_schema(version, path));
+    }
+    let action_keys = if table_has_column(conn, "task_action_keys", "action_key")? {
+        ""
+    } else {
+        " without task action keys"
+    };
+    Err(OrbitError::Store(format!(
+        "task registry '{}' requires writable additive setup/recovery: the database is read-only, \
+         and observing it found schema version {version}{action_keys} instead of version \
+         {REGISTRY_SCHEMA_VERSION} with task action keys. Open the registry once from writable \
+         storage, then retry the observation",
+        path.display()
+    )))
+}
+
 pub(super) fn ensure_compatible_schema(
     conn: &mut Connection,
     path: &Path,
 ) -> Result<(), OrbitError> {
-    let version = registry_user_version(conn)?;
-    if version == REGISTRY_SCHEMA_VERSION
-        && table_has_column(conn, "task_action_keys", "action_key")?
-    {
+    if schema_is_current(conn)? {
         return Ok(());
     }
+    let version = registry_user_version(conn)?;
     if version > 6 {
         return Err(unsupported_schema(version, path));
     }

--- a/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
@@ -17,7 +17,8 @@ use super::queries::{
     workspace_checkout_by_paths, write_task_index_rows,
 };
 use super::schema::{
-    apply_schema, assert_registry_user_version, ensure_compatible_schema, registry_user_version,
+    apply_schema, assert_readable_schema, assert_registry_user_version, ensure_compatible_schema,
+    registry_user_version,
 };
 use super::util::{now_string, parse_relation_type_name, path_to_string, relation_type_name};
 use super::workspace_id::{next_workspace_id_candidate, sanitize_slug, validate_workspace_id};
@@ -68,11 +69,19 @@ impl TaskRegistryStore {
                 return Err(mapped);
             }
         }
-        if registry_user_version(&conn)? < super::REGISTRY_SCHEMA_VERSION {
-            apply_schema(&conn)?;
+        // Setup, migration and recovery all need a write transaction, so a
+        // registry opened for observation is either already readable as-is or
+        // reported as needing writable storage. Attempting them here is how a
+        // read-only mount produced `attempt to write a readonly database`.
+        if read_only {
+            assert_readable_schema(&conn, path)?;
+        } else {
+            if registry_user_version(&conn)? < super::REGISTRY_SCHEMA_VERSION {
+                apply_schema(&conn)?;
+            }
+            ensure_compatible_schema(&mut conn, path)?;
+            assert_registry_user_version(&conn)?;
         }
-        ensure_compatible_schema(&mut conn, path)?;
-        assert_registry_user_version(&conn)?;
 
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
@@ -441,6 +450,28 @@ impl TaskRegistryStore {
                 "task prefix '{task_prefix}' must be 2-5 uppercase ASCII letters and must not use a reserved artifact namespace"
             )));
         }
+        // Runtime construction reasserts the same prefix on every command. That
+        // no-op is an observation, so answer it without a write transaction:
+        // BEGIN IMMEDIATE here is what made every read fail on a read-only
+        // registry. Reading outside the lock is safe because a bound prefix is
+        // immutable — only a pristine `ORB` row can still adopt one.
+        {
+            let conn = self
+                .conn
+                .lock()
+                .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+            let current: String = conn
+                .query_row(
+                    "SELECT task_prefix FROM allocator_state WHERE authority = 'local'",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(|e| OrbitError::Store(e.to_string()))?;
+            if current == task_prefix {
+                return Ok(());
+            }
+        }
+
         let mut conn = self
             .conn
             .lock()

--- a/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
@@ -153,6 +153,35 @@ fn allocator_uses_host_prefix_and_expands_past_five_digits() {
     );
 }
 
+/// Runtime construction reasserts the configured prefix on every command, so
+/// the matching case has to stay observational: a registry on read-only
+/// storage must answer it instead of failing on a write it never needed.
+#[cfg(unix)]
+#[test]
+fn reasserting_the_bound_task_prefix_needs_no_write() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = TempDir::new().expect("tempdir");
+    let path = registry_path(&temp);
+    let store = TaskRegistryStore::open(&path).expect("open registry");
+    store.set_task_prefix("DE").expect("bind the host prefix");
+    drop(store);
+    let before = fs::read(&path).expect("snapshot the bound registry");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o400)).expect("make read-only");
+
+    let registry = TaskRegistryStore::open(&path).expect("observe the bound registry");
+    registry
+        .set_task_prefix("DE")
+        .expect("reasserting the bound prefix is an observation");
+
+    let error = registry
+        .set_task_prefix("XY")
+        .expect_err("a real prefix change still needs writable storage");
+    assert!(error.is_readonly_or_access_failure(), "{error}");
+    drop(registry);
+    assert_eq!(fs::read(&path).expect("re-read the registry"), before);
+}
+
 #[test]
 fn open_creates_registry_parent_and_workspaces_dir() {
     let temp = TempDir::new().expect("tempdir");

--- a/crates/orbit-store/src/driver/sqlite/task_registry/tests/schema.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/tests/schema.rs
@@ -1,7 +1,7 @@
 //! Upgrade coverage uses the schema shipped before action-key admission existed.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Barrier};
 use std::thread;
 
@@ -251,6 +251,12 @@ fn readonly_prior_v5_requires_upgrade_and_current_registry_remains_readable() {
         Err(error) => error,
     };
     assert!(error.is_readonly_or_access_failure(), "{error}");
+    assert!(
+        error
+            .to_string()
+            .contains("requires writable additive setup/recovery"),
+        "read-only setup must name the writable step it owes: {error}"
+    );
     assert_eq!(fs::read(&path).expect("read failed upgrade"), before);
     assert!(!path.parent().expect("parent").join("workspaces").exists());
 
@@ -560,4 +566,111 @@ fn readonly_known_v6_waits_for_writable_recovery() {
             .expect("read task")
             .is_some()
     );
+}
+
+/// Copy a database and its live sidecars to `published`, read-only.
+///
+/// SQLite shares one wal-index mapping per file across a process, so a local
+/// writer would let an observing connection write through it. Observing a copy
+/// keeps the fixture honest about what a separate read-only mount can do.
+#[cfg(unix)]
+fn publish_read_only(source: &Path, published: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::create_dir_all(published.parent().expect("published parent")).expect("create parent");
+    for suffix in ["", "-wal", "-shm"] {
+        let from = PathBuf::from(format!("{}{suffix}", source.display()));
+        let to = PathBuf::from(format!("{}{suffix}", published.display()));
+        assert!(from.exists(), "live fixture file: {}", from.display());
+        fs::copy(&from, &to).expect("publish registry file");
+        fs::set_permissions(&to, fs::Permissions::from_mode(0o400)).expect("publish read-only");
+    }
+}
+
+#[cfg(unix)]
+fn published_bytes(path: &Path) -> Vec<Vec<u8>> {
+    ["", "-wal", "-shm"]
+        .iter()
+        .map(|suffix| {
+            fs::read(PathBuf::from(format!("{}{suffix}", path.display())))
+                .expect("read published registry file")
+        })
+        .collect()
+}
+
+/// ORB-12090: an upgrade that is committed but not yet checkpointed lives only
+/// in the WAL. Reading the main file alone reports the pre-upgrade schema, and
+/// the opener then tried to apply that upgrade to storage it cannot write.
+#[cfg(unix)]
+#[test]
+fn readonly_registry_reads_an_upgrade_that_only_the_wal_holds() {
+    let temp = TempDir::new().expect("tempdir");
+    let path = prior_v5(&temp);
+
+    // Hold the pre-upgrade snapshot open: the upgrade's frames then cannot be
+    // checkpointed back into the main database file.
+    let holder = Connection::open(&path).expect("open snapshot holder");
+    holder
+        .pragma_update(None, "journal_mode", "WAL")
+        .expect("enable WAL");
+    holder
+        .pragma_update(None, "wal_autocheckpoint", 0)
+        .expect("keep new frames in the WAL");
+    holder
+        .execute_batch("BEGIN")
+        .expect("start the pinning read transaction");
+    holder
+        .query_row("SELECT count(*) FROM allocator_state", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .expect("pin the pre-upgrade snapshot");
+
+    drop(TaskRegistryStore::open(&path).expect("upgrade the registry"));
+
+    let main_file_only = Connection::open_with_flags(
+        format!("file:{}?immutable=1", path.display()),
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+    )
+    .expect("open the main database file alone");
+    assert!(
+        table_columns(&main_file_only, "task_action_keys").is_empty(),
+        "the fixture must keep the upgrade out of the main database file"
+    );
+    drop(main_file_only);
+
+    let published = temp.path().join("published").join("index.sqlite");
+    publish_read_only(&path, &published);
+    let before = published_bytes(&published);
+
+    let registry = TaskRegistryStore::open(&published).expect("observe the upgraded registry");
+
+    assert_eq!(
+        registry.allocator_next_number().expect("read allocator"),
+        100005
+    );
+    assert!(
+        registry
+            .find_task_binding("DE-100004")
+            .expect("read retained task")
+            .is_some()
+    );
+    let error = registry
+        .reserve_task_action(WORKSPACE, "new", "digest")
+        .expect_err("observation cannot admit");
+    assert!(error.is_readonly_or_access_failure(), "{error}");
+
+    drop(registry);
+    assert_eq!(
+        published_bytes(&published),
+        before,
+        "observing must not change the database, WAL, or SHM"
+    );
+    assert!(
+        !published
+            .parent()
+            .expect("parent")
+            .join("workspaces")
+            .exists()
+    );
+    drop(holder);
 }


### PR DESCRIPTION
## Task

[ORB-12090](https://orbit-cli.com/tasks/ORB-12090) — Read current SQLite WAL state without writes on read-only Orbit mounts

### Description

Operator host validation of ORB-12085 (PR1896/c715a58c, workercommit bc1abdaacdbfba6e92b2c71c34214e011335364d) executes the real bwrap body and fails read-only orbit.tool.list with store_error: attempt to write a readonly database. Exact command: cargo test -p orbit-cli --test mcp_roundtrip readonly_state_mount_keeps_cli_and_mcp_reads_observational -- --exact --nocapture. Evidence is ORB-12085 artifact operator-evidence/readonly-host-replay.json. This body skipped inside the managed worker; operator host supports it. Task85 already fixed wrong authority routing; preserve that fix.
Namespace-aware disposable probe /tmp/orbit-readonly-wal-probe-12085 confirmed cause: with a writer holding committed table/data only in fixture.db-wal and existing -shm, SQLite immutable=1 reports no such table while mode=ro reads the committed row through an actual bwrap read-only bind. Current open_private selects open_immutable on a read-only filesystem (crates/orbit-store/src/driver/sqlite.rs); immutable ignores committed WAL state. TaskRegistry then sees old main-DB schema and calls apply_schema if below current version (driver/sqlite/task_registry/store.rs), causing the readonly write error. Prior ORB-10963/11049 are done, not current owners; preserve their observational and private-file guarantees.
Implement WAL-aware read-only observation with no incidental writes or stale-state success. Use an actually read-only/query-only connection when valid existing WAL/SHM supports current reads. Retain an appropriate checkpointed/no-WAL immutable path. If current state cannot be read without mutation, return an actionable observational-unavailable diagnosis rather than silently ignoring WAL. Registry schema handling must never attempt migrations on a read-only connection and must distinguish compatibility from genuine migration requirements.
Preserve filesystem descriptor, no-follow, owner/private-permission, authorization and mutation-denial safeguards. Do not work around the bug by checkpointing/prewarming away the WAL in the regression, ignoring the mount test, making state writable, or weakening query correctness. No production database edits during testing. Operator will replay unsupported kernel tests on the host before sign-off.

### Acceptance Criteria

- A real read-only bwrap mount with deliberately uncheckpointed committed WAL data returns current tool/task/MCP observations without changing database, WAL, SHM, schema, or other protected fixture state; task mutations still fail attributable to the read-only boundary.
- Registry bootstrap/current-schema compatibility does not attempt schema writes on a read-only connection. Incompatible schema or unavailable WAL read support yields precise fail-closed diagnostics rather than stale or partial success.
- Add deterministic no-WAL/checkpointed and WAL-without-usable-read-support controls; preserve existing permission/descriptor/no-follow security tests.
- Run focused SQLite/registry tests, mcp_roundtrip target, ci-fast and ci-lint. Retain exact results and any nested-namespace limitation; provide operator replay recipe so host executes the real mount body before full-QA release sign-off.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Outcome

Read-only Orbit state now reports current SQLite content without writing, and the registry no longer attempts setup on storage it cannot write. Two independent defects were involved; the second was found only by reproducing the operator's exact error.

## Changes

1. **`crates/orbit-common/src/storage/sqlite.rs`** — `open_immutable` is replaced by `open_observational`, which picks the read mode from the sidecars instead of always using `immutable=1`:
   - `-wal` absent or at most a 32-byte header (no frames) -> `immutable=1`, unchanged behavior, no sidecar needed.
   - `-wal` carries frames and the `-shm` wal-index is already on disk -> an ordinary read-only connection (`query_only=ON`), which reads the WAL. A probe query runs at open so an unusable wal-index is diagnosed there, not inside an unrelated later query.
   - `-wal` carries frames with no `-shm` -> fail closed with an actionable diagnosis naming `PRAGMA wal_checkpoint(TRUNCATE)` or publishing the `-shm`. Deliberately not worded as a read-only/permission failure, so callers that downgrade those to a warning cannot turn it back into a silent stale read.
   - New `sidecar_metadata` rejects symlinked/irregular `-wal`/`-shm`, extending the existing no-follow policy to the files the mode decision trusts. No sidecar is ever created: `mode=ro` without an existing `-shm` creates one on writable storage, which is why presence is required rather than attempted.

2. **`task_registry/schema.rs` + `store.rs`** — a registry opened for observation now goes through `assert_readable_schema` instead of `apply_schema`/`ensure_compatible_schema`/`assert_registry_user_version`. Setup, migration and v6 recovery all need a write transaction, so on read-only storage there is nothing to attempt; the error names the writable step still owed and the schema state actually observed. `schema_is_current` is the single shared predicate. Incompatible newer versions still route to `unsupported_schema`.

3. **`task_registry/store.rs`, `set_task_prefix`** — added the observational fast path. This is the defect behind the operator's exact report. Runtime construction reasserts the configured prefix on every command (`orbit-cmd/src/registry_runtime.rs`), and the method opened `BEGIN IMMEDIATE` even when the stored prefix already matched, so **every** read failed on a read-only registry, with or without a WAL. `bind_workspace` already carried this shape and comment; `set_task_prefix` now matches it. Reading outside the transaction is safe because a bound prefix is immutable — only a pristine `ORB` row can adopt one.

## Criteria

1. **Real mount with uncheckpointed WAL** — `readonly_state_mount_keeps_cli_and_mcp_reads_observational` now builds the WAL condition: a pinned reader holds the registry snapshot while a second task is created, an `immutable=1` connection asserts that task is absent from the main registry file, and CLI + MCP reads through the mount must report it. Its closing byte snapshot covers DB, WAL and SHM. `orbit.task.update` still fails naming `.task.yaml.lock`. **Its body did not execute here** — this worker denies user namespaces (`bwrap: No permissions to create new namespace`), so the test returns early. Host replay required; recipe attached (see below).
2. **No schema writes on a read-only connection; fail-closed diagnostics** — `assert_readable_schema`; covered by `readonly_registry_reads_an_upgrade_that_only_the_wal_holds` (upgrade committed only to the WAL, published read-only, read successfully and byte-identical afterwards) and by the strengthened `readonly_prior_v5_requires_upgrade_and_current_registry_remains_readable`. Both existing read-only registry tests (`prior_v5`, `known_v6`) still require writable recovery and still pass.
3. **Controls** — new `read_only_observation` module in `crates/orbit-common/src/storage/tests/sqlite.rs`: WAL-only read, checkpointed/no-frames control asserting `ReadOnlyAccess::Immutable`, WAL-without-usable-read-support fail-closed control, symlinked-sidecar rejection. All existing permission/descriptor/no-follow tests are unchanged and passing. Fixtures observe a published copy of the file set, because SQLite shares one wal-index mapping per file per process and a live local writer would let an observing connection write through it — an artifact that would have made the byte-stability assertion meaningless.
4. **Validation** — below.

## Validation

Passed:
- `cargo test -p orbit-common --features sqlite,test-util` — 271 passed, 1 ignored.
- `cargo test -p orbit-store -p orbit-search` — 511 + 93 + 2 passed, 7 ignored.
- `cargo test -p orbit-cli --test mcp_roundtrip` — 51 passed (see limitation).
- `cargo test -p orbit-core -p orbit-cmd` — 1379 + 131 + 55 passed.
- `make ci-fast` — exit 0.
- `make ci-lint` — exit 0. `cargo fmt --all --check` clean.

Regression detection verified by reintroducing each fault: forcing `ReadOnlyAccess::Immutable` fails `reads_committed_state_held_only_in_the_wal`, `wal_without_read_support_fails_closed`, `symlinked_sidecar_is_rejected` and `readonly_registry_reads_an_upgrade_that_only_the_wal_holds`; disabling the prefix fast path fails `reasserting_the_bound_task_prefix_needs_no_write`.

Not run here — `readonly_state_mount_keeps_cli_and_mcp_reads_observational`'s body. `bwrap --die-with-parent --ro-bind / / -- /bin/true` fails with `No permissions to create new namespace`, so the test early-returns and its `ok` result proves nothing about the mount. `make ci-fast` skips `test-compiler-cache-namespaces` for the same reason.

Compensating evidence run here in full, with the mount's assertions approximated by permission bits:
- New `read_only_registry_files_keep_uncheckpointed_wal_reads_observational` (in `mcp_roundtrip.rs`, `#[cfg(unix)]`, runs on every Unix runner): registry file set made unwritable with a WAL-only task, `orbit.task.show` through the real CLI reports it, DB/WAL/SHM bytes unchanged.
- Manual disposable-HOME probe with `env -i`, routing verified by `orbit workspace show --format json` before any mutation: with **every** file and directory under both state roots stripped of write bits, `orbit tool list`, `orbit.task.show`, `orbit.task.list` and `orbit.search` all exit 0 (audit/JSONL writes degrade to warnings, as before), while `orbit.task.update` fails with `is not writable: Permission denied`.

## Limits and risk

- Permission bits are not a mount: EACCES rather than EROFS, and a `--ro-bind` also refuses directory writes and sidecar creation that these fixtures still allow. The mount test remains the authority and needs the host replay before QA sign-off. Artifact `operator-evidence/readonly-mount-replay-recipe.json` carries the exact commands, expected results and failure triage.
- Conservative fail-closed edge: a WAL whose frames were all checkpointed by a PASSIVE checkpoint (file not truncated) is indistinguishable from a WAL carrying unmerged frames without reading the wal-index, so if its `-shm` is also missing the open fails closed rather than silently reading the main file. The diagnosis names the remedy. Normal Orbit state has no `-wal` at rest — the last connection close checkpoints and removes both sidecars — so ordinary read-only mounts keep the previous `immutable=1` path.
- `open_observational` is a public rename of the previously public, externally unused `open_immutable`; no caller outside the module referenced either.
- `crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs` was not in `context_files`; it was appended, and holds the one test for the `set_task_prefix` fast path, placed with its sibling allocator/prefix tests.

Friction `F2026-09-120` filed: the reported root cause reproduced but was not the cause of the reported failure.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12090-6aa29202`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra