### PR TITLE
Keep read-only SQLite observations current when WAL commits arrive after open

### DIFF
--- a/crates/orbit-common/src/storage/sqlite.rs
+++ b/crates/orbit-common/src/storage/sqlite.rs
@@ -10,6 +10,7 @@
 
 use std::fs;
 use std::io;
+use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 
 use rusqlite::{Connection, OpenFlags};
@@ -25,6 +26,17 @@ pub const DEFAULT_BUSY_TIMEOUT_MS: u32 = 5_000;
 /// frames, so the main database file already holds every committed page.
 const WAL_HEADER_BYTES: u64 = 32;
 
+/// Leading bytes of every SQLite database file.
+const DATABASE_MAGIC: &[u8] = b"SQLite format 3\0";
+
+/// Bytes of the database header this module reads: through offsets 18 and 19,
+/// the write and read file-format versions.
+const DATABASE_HEADER_BYTES: u64 = 20;
+
+/// File-format version recorded at offsets 18 and 19 while a database is in
+/// WAL mode. Rollback-journal databases record `1`.
+const WAL_FILE_FORMAT: u8 = 2;
+
 /// A file-backed SQLite connection opened under Orbit's filesystem policy.
 pub struct OpenedConnection {
     /// The ready-to-use SQLite connection.
@@ -32,6 +44,9 @@ pub struct OpenedConnection {
     /// Whether the database was opened for observation only, without any
     /// ability to write.
     pub read_only: bool,
+    /// Whether this connection keeps up with commits made after it was opened.
+    /// Writable connections are always [`ObservationCurrency::Live`].
+    pub currency: ObservationCurrency,
 }
 
 /// Open an Orbit SQLite database without exposing its persisted state.
@@ -77,19 +92,25 @@ pub fn open_private(path: &Path) -> Result<OpenedConnection, OrbitError> {
     let pragmas = apply_default_pragmas(&connection)?;
     if pragmas.write_denied || filesystem_is_read_only(&path)? {
         drop(connection);
-        return Ok(OpenedConnection {
-            connection: open_observational(&path)?,
-            read_only: true,
-        });
+        return open_observational(&path, ObservationRequirement::PublishedMainFile);
     }
     harden_sqlite_files(&path)?;
 
     Ok(OpenedConnection {
         connection,
         read_only: false,
+        currency: ObservationCurrency::Live,
     })
 }
 
+/// Observe a database Orbit may not write.
+///
+/// Orbit's stores accept [`ObservationCurrency::MainFileOnly`] deliberately:
+/// state published as a static file set — a read-only mount of a directory
+/// whose last writer closed cleanly, and so left no wal-index behind — carries
+/// no sidecars at all, and refusing it would make such a deployment unreadable
+/// rather than stale. Every caller is handed the currency it got, and
+/// [`open_observational`] warns when the degraded read is in use.
 pub(super) fn open_private_read_only(
     path: &Path,
     filesystem_read_only: bool,
@@ -99,10 +120,7 @@ pub(super) fn open_private_read_only(
     if !filesystem_read_only {
         harden_read_only_sqlite_files(&path)?;
     }
-    Ok(OpenedConnection {
-        connection: open_observational(&path)?,
-        read_only: true,
-    })
+    open_observational(&path, ObservationRequirement::PublishedMainFile)
 }
 
 /// Resolve a SQLite file path through its existing parent and reject traversal
@@ -220,11 +238,9 @@ fn harden_read_only_sqlite_files(path: &Path) -> Result<(), OrbitError> {
 
 #[cfg(unix)]
 fn harden_existing_read_only_file(path: &Path) -> Result<(), OrbitError> {
-    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+    use std::os::unix::fs::PermissionsExt;
 
-    let mut options = fs::OpenOptions::new();
-    options.read(true).custom_flags(libc::O_NOFOLLOW);
-    let file = match options.open(path) {
+    let file = match open_read_no_follow(path) {
         Ok(file) => file,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(sqlite_path_error("inspect", path, error)),
@@ -243,6 +259,24 @@ fn harden_existing_read_only_file(path: &Path) -> Result<(), OrbitError> {
 #[cfg(not(unix))]
 fn harden_existing_read_only_file(_path: &Path) -> Result<(), OrbitError> {
     Ok(())
+}
+
+/// Open a database or sidecar file for reading without traversing a final
+/// symlink, so inspection stays inside the directory
+/// [`validated_sqlite_path`] resolved.
+#[cfg(unix)]
+fn open_read_no_follow(path: &Path) -> io::Result<fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn open_read_no_follow(path: &Path) -> io::Result<fs::File> {
+    fs::File::open(path)
 }
 
 fn sqlite_sidecar_paths(path: &Path) -> [PathBuf; 2] {
@@ -341,77 +375,174 @@ pub fn apply_default_pragmas(conn: &Connection) -> Result<PragmaOutcome, OrbitEr
     })
 }
 
-/// How an unwritable SQLite database can be observed without changing any of
-/// its files.
+/// What a caller needs from an observational open.
+///
+/// A database whose current state cannot be read without writing leaves only a
+/// degraded read, and which of the two answers is right — refuse, or read the
+/// main file alone — belongs to the caller, not to whichever sidecars happen
+/// to be on disk.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum ReadOnlyAccess {
-    /// `immutable=1`. The only mode that never needs WAL shared memory, and
-    /// correct only while the `-wal` sidecar cannot hide committed pages.
-    Immutable,
-    /// An ordinary read-only connection, reading the `-wal` through the `-shm`
-    /// wal-index already present on disk.
-    WalReadOnly,
+pub enum ObservationRequirement {
+    /// The connection must observe commits made after it is opened, or the
+    /// open must fail explaining what writable storage still owes it.
+    CurrentState,
+    /// The caller also accepts [`ObservationCurrency::MainFileOnly`], having
+    /// weighed that degraded read against not reading the database at all.
+    PublishedMainFile,
+}
+
+/// Whether a connection keeps up with commits another process makes after the
+/// connection was opened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObservationCurrency {
+    /// Ordinary access: every statement re-reads the database files, so a
+    /// commit that lands after this connection was opened becomes visible to
+    /// the next query.
+    Live,
+    /// `immutable=1`: the connection reads the main database file alone and is
+    /// free to cache it forever.
+    ///
+    /// It is not a guaranteed snapshot. It ignores every `-wal`, including one
+    /// a writer creates after the open, so later commits stay invisible; and
+    /// because `immutable=1` promises SQLite that the bytes never change, a
+    /// writer that later checkpoints into the main file can leave this
+    /// connection returning results that are not merely stale but internally
+    /// inconsistent. It is only sound for a database published as a static
+    /// file set, and only a caller that passes
+    /// [`ObservationRequirement::PublishedMainFile`] ever receives it.
+    /// Observing current state again means opening a new connection.
+    MainFileOnly,
 }
 
 /// Open an existing SQLite database for reads that must not write to it, and
 /// must not create a WAL/SHM sidecar.
 ///
-/// `immutable=1` is the mode a read-only mount reaches for, because SQLite's
-/// ordinary read-only mode may try to create WAL shared-memory state before the
-/// first SELECT. It is also the mode that makes SQLite ignore an existing
-/// `-wal`: a database whose newest commits were never checkpointed back reads
-/// as its older main-file state. A caller that treats that stale view as
-/// current then repairs a database it cannot write — how a read-only Orbit
-/// mount turned an observation into `attempt to write a readonly database`.
+/// Two SQLite behaviors bound what is possible here. An ordinary read-only
+/// connection stays current, but a WAL-mode database drives it through the
+/// `-shm` wal-index, which SQLite creates — a write — when it is absent; on a
+/// read-only mount that attempt fails outright. `immutable=1` needs no
+/// sidecars, but it buys that by reading the main file alone and trusting it
+/// never changes. Reporting either as current is how a read-only Orbit mount
+/// turned an observation into `attempt to write a readonly database`, and how
+/// a checkpointed database kept reporting its pre-open row count.
 ///
-/// So the sidecars pick the mode. See [`read_only_access`].
-pub fn open_observational(path: &Path) -> Result<Connection, OrbitError> {
-    let access = read_only_access(path)?;
-    let conn = open_read_only_connection(path, access)?;
+/// The database's own state decides which reads are possible, and
+/// `requirement` decides whether the degraded one is acceptable; see
+/// [`observation_currency`].
+pub fn open_observational(
+    path: &Path,
+    requirement: ObservationRequirement,
+) -> Result<OpenedConnection, OrbitError> {
+    let currency = observation_currency(path, requirement)?;
+    let connection = open_read_only_connection(path, currency)?;
 
-    if access == ReadOnlyAccess::WalReadOnly {
-        // Opening is lazy, so an unusable wal-index would otherwise surface as
-        // an opaque failure inside whichever query happened to run first.
-        conn.query_row("SELECT count(*) FROM sqlite_schema", [], |row| {
+    // Opening is lazy, so an unreadable database or an unusable wal-index would
+    // otherwise surface as an opaque failure inside whichever query happened to
+    // run first.
+    connection
+        .query_row("SELECT count(*) FROM sqlite_schema", [], |row| {
             row.get::<_, i64>(0)
         })
         .map_err(|error| {
-            observational_unavailable(path, &format!("its wal-index is unusable: {error}"))
+            observational_unavailable(path, &format!("its first read failed: {error}"))
         })?;
+
+    if currency == ObservationCurrency::MainFileOnly {
+        tracing::warn!(
+            target: "orbit.common.sqlite",
+            path = %path.display(),
+            "no wal-index is published alongside the database; reading its main file alone, which \
+             will not show commits made from writable storage after this open"
+        );
     }
 
-    Ok(conn)
+    Ok(OpenedConnection {
+        connection,
+        read_only: true,
+        currency,
+    })
 }
 
-/// Decide how `path` can be observed without writing, or explain why its
+/// Decide how `path` can be observed without writing to it, or explain why its
 /// current state cannot be read at all.
 ///
-/// A `-wal` holding frames may carry committed pages the main database file
-/// does not have, so those reads need a real read-only connection — which in
-/// turn needs the `-shm` wal-index to already exist, since creating one is a
-/// write. Without both, reporting the main file alone would be a silent,
-/// stale success, so this fails closed instead.
-pub(super) fn read_only_access(path: &Path) -> Result<ReadOnlyAccess, OrbitError> {
-    let [wal, shm] = sqlite_sidecar_paths(path);
+/// The database file's own header decides first: a rollback-journal database
+/// needs no shared memory, so an ordinary read-only connection reads it live
+/// and creates nothing. A WAL-mode database needs the wal-index, and a
+/// read-only connection may only use one that is already published, because
+/// SQLite creates both the `-wal` and the `-shm` when either is missing.
+///
+/// That leaves a WAL-mode database whose sidecars are incomplete. A `-wal`
+/// holding frames, or a `-shm` published without the `-wal` it indexes, may be
+/// hiding committed pages the main file does not have; reporting the main file
+/// alone would be a silent, stale success, so those always fail closed.
+///
+/// A WAL-mode database with no wal-index at all is the one case the caller
+/// decides. Nothing on disk proves it is quiescent — sidecar absence only says
+/// no writer holds it *right now* — so the degraded
+/// [`ObservationCurrency::MainFileOnly`] read is offered to
+/// [`ObservationRequirement::PublishedMainFile`] and refused to
+/// [`ObservationRequirement::CurrentState`].
+pub(super) fn observation_currency(
+    path: &Path,
+    requirement: ObservationRequirement,
+) -> Result<ObservationCurrency, OrbitError> {
+    let [wal_path, shm_path] = sqlite_sidecar_paths(path);
+    let wal = sidecar_metadata(&wal_path)?;
+    let shm = sidecar_metadata(&shm_path)?;
 
-    let wal_carries_frames =
-        sidecar_metadata(&wal)?.is_some_and(|metadata| metadata.len() > WAL_HEADER_BYTES);
-    if !wal_carries_frames {
-        return Ok(ReadOnlyAccess::Immutable);
+    if !database_uses_wal(path)? {
+        return Ok(ObservationCurrency::Live);
     }
-    if sidecar_metadata(&shm)?.is_none() {
-        return Err(observational_unavailable(
+
+    match (wal, shm) {
+        (Some(_), Some(_)) => Ok(ObservationCurrency::Live),
+        (None, Some(_)) => Err(observational_unavailable(
             path,
-            "its '-shm' wal-index is missing",
-        ));
+            "its '-shm' wal-index is published without the '-wal' sidecar it indexes",
+        )),
+        (Some(wal), None) if wal.len() > WAL_HEADER_BYTES => Err(observational_unavailable(
+            path,
+            "its '-wal' sidecar holds committed frames but its '-shm' wal-index is missing",
+        )),
+        (Some(_) | None, None) => match requirement {
+            ObservationRequirement::PublishedMainFile => Ok(ObservationCurrency::MainFileOnly),
+            ObservationRequirement::CurrentState => Err(observational_unavailable(
+                path,
+                "it is in WAL mode with no published '-shm' wal-index, so a reader that may not \
+                 create one can only read the main file alone",
+            )),
+        },
+    }
+}
+
+/// Whether the database file records WAL mode in its header.
+///
+/// A missing or truncated file, and any file that does not carry the SQLite
+/// magic, is reported as not WAL: there are no committed WAL frames to miss,
+/// and SQLite gives a better diagnosis of the file itself than this check
+/// could.
+fn database_uses_wal(path: &Path) -> Result<bool, OrbitError> {
+    let file = match open_read_no_follow(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(sqlite_path_error("inspect", path, error)),
+    };
+
+    let mut header = Vec::with_capacity(DATABASE_HEADER_BYTES as usize);
+    file.take(DATABASE_HEADER_BYTES)
+        .read_to_end(&mut header)
+        .map_err(|error| sqlite_path_error("read the header of", path, error))?;
+    if header.len() < DATABASE_HEADER_BYTES as usize || !header.starts_with(DATABASE_MAGIC) {
+        return Ok(false);
     }
 
-    Ok(ReadOnlyAccess::WalReadOnly)
+    Ok(header[18] == WAL_FILE_FORMAT || header[19] == WAL_FILE_FORMAT)
 }
 
 fn open_read_only_connection(
     path: &Path,
-    access: ReadOnlyAccess,
+    currency: ObservationCurrency,
 ) -> Result<Connection, OrbitError> {
     let mut uri = url::Url::from_file_path(path).map_err(|()| {
         OrbitError::Store(format!(
@@ -419,7 +550,7 @@ fn open_read_only_connection(
             path.display()
         ))
     })?;
-    if access == ReadOnlyAccess::Immutable {
+    if currency == ObservationCurrency::MainFileOnly {
         uri.query_pairs_mut().append_pair("immutable", "1");
     }
 
@@ -446,19 +577,18 @@ fn open_read_only_connection(
     Ok(conn)
 }
 
-/// The database holds committed WAL state this process may not read and may
-/// not write into place. Name the writable step an operator still owes rather
-/// than reporting the main file's older contents as current.
+/// The database's current state cannot be read from this process, and cannot
+/// be repaired without writable storage. Name the writable step an operator
+/// still owes rather than reporting the main file's older contents as current.
 ///
 /// Deliberately not phrased as a read-only/permission failure: callers that
 /// downgrade those to a warning and continue would turn this back into the
 /// silent stale read it exists to prevent.
 fn observational_unavailable(path: &Path, reason: &str) -> OrbitError {
     OrbitError::Store(format!(
-        "cannot observe current SQLite state '{}': its '-wal' sidecar holds committed frames but \
-         {reason}. Checkpoint the database from writable storage \
-         (`PRAGMA wal_checkpoint(TRUNCATE)`) or publish its '-shm' wal-index alongside it, then \
-         retry the observation",
+        "cannot observe current SQLite state '{}': {reason}. Checkpoint the database from \
+         writable storage (`PRAGMA wal_checkpoint(TRUNCATE)`) or publish its '-wal' and '-shm' \
+         sidecars alongside it, then retry the observation",
         path.display()
     ))
 }

--- a/crates/orbit-common/src/storage/tests/sqlite.rs
+++ b/crates/orbit-common/src/storage/tests/sqlite.rs
@@ -217,21 +217,32 @@ fn private_read_only_filesystem_path_has_no_side_effects() {
 }
 
 /// Read-only observation fixtures, all built around one shape: a database
-/// whose newest commit is still only in the WAL.
+/// another process may commit to while this process only observes it.
 #[cfg(unix)]
 mod read_only_observation {
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
+    use std::process::{Child, Command, Stdio};
+    use std::time::{Duration, Instant};
 
     use rusqlite::Connection;
 
     use crate::OrbitError;
     use crate::storage::sqlite::{
-        ReadOnlyAccess, open_private, open_private_read_only, read_only_access,
+        ObservationCurrency, ObservationRequirement, observation_currency, open_private,
+        open_private_read_only,
     };
 
     const SQLITE_FILE_SUFFIXES: [&str; 3] = ["", "-wal", "-shm"];
+
+    /// How long a fixture waits for its writer process to reach the next step.
+    const WRITER_TIMEOUT: Duration = Duration::from_secs(30);
+
+    /// Database the child writer opens, and the directory both halves use to
+    /// hand steps back and forth.
+    const WRITER_DATABASE_ENV: &str = "ORBIT_TEST_OBSERVATION_DATABASE";
+    const WRITER_CONTROL_ENV: &str = "ORBIT_TEST_OBSERVATION_CONTROL";
 
     fn sqlite_file(path: &Path, suffix: &str) -> PathBuf {
         PathBuf::from(format!("{}{suffix}", path.display()))
@@ -277,6 +288,18 @@ mod read_only_observation {
         }
     }
 
+    /// Make an existing file set read-only for this process, leaving the files
+    /// where they are so a writer that already opened them keeps its access.
+    fn publish_in_place_read_only(path: &Path) {
+        for suffix in SQLITE_FILE_SUFFIXES {
+            let file = sqlite_file(path, suffix);
+            if file.exists() {
+                fs::set_permissions(&file, fs::Permissions::from_mode(0o400))
+                    .unwrap_or_else(|error| panic!("make {} read-only: {error}", file.display()));
+            }
+        }
+    }
+
     fn published_bytes(path: &Path) -> Vec<(PathBuf, Vec<u8>)> {
         SQLITE_FILE_SUFFIXES
             .iter()
@@ -295,6 +318,151 @@ mod read_only_observation {
         let source = dir.path().join(format!("{name}-source.db"));
         let published = dir.path().join(format!("{name}.db"));
         (dir, source, published)
+    }
+
+    /// Write a WAL database holding one checkpointed row, so the main file is
+    /// complete and the `-wal` carries no frames. The writer closes, which
+    /// removes both sidecars.
+    fn write_checkpointed_database(path: &Path) {
+        let writer = Connection::open(path).expect("open fixture writer");
+        writer
+            .pragma_update(None, "journal_mode", "WAL")
+            .expect("enable WAL");
+        writer
+            .pragma_update(None, "wal_autocheckpoint", 0)
+            .expect("keep later frames in the WAL");
+        writer
+            .execute_batch(
+                "CREATE TABLE observed(value TEXT);
+                 INSERT INTO observed VALUES ('checkpointed');
+                 PRAGMA wal_checkpoint(TRUNCATE);",
+            )
+            .expect("commit and checkpoint the fixture row");
+    }
+
+    fn rows(connection: &Connection) -> Vec<String> {
+        let mut statement = connection
+            .prepare("SELECT value FROM observed ORDER BY rowid")
+            .expect("prepare observation query");
+        statement
+            .query_map([], |row| row.get::<_, String>(0))
+            .expect("run observation query")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect observed rows")
+    }
+
+    fn wait_for(marker: &Path, step: &str) {
+        let deadline = Instant::now() + WRITER_TIMEOUT;
+        while Instant::now() < deadline {
+            if marker.exists() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("the writer process never reached '{step}'");
+    }
+
+    /// A writer holding the database open in another process.
+    ///
+    /// It has to be another process: SQLite shares one wal-index mapping per
+    /// file within a process, so an in-process writer would let an observing
+    /// connection ride on the writer's writable mapping — exactly what a
+    /// separate read-only mount cannot do.
+    ///
+    /// The child opens the database read-write and then waits, so the fixture
+    /// can make the files read-only for this process while the child keeps
+    /// committing through the descriptors it already holds. That is the shape
+    /// of the reported failure: a reader behind a read-only view of a database
+    /// a writer still reaches from writable storage.
+    struct ExternalWriter {
+        child: Child,
+        control: PathBuf,
+        commits: usize,
+    }
+
+    impl ExternalWriter {
+        /// Re-runs this test binary as the writer. The filter below names
+        /// [`external_writer_process`] by its module path; renaming that test
+        /// without updating it makes the child run nothing, and every fixture
+        /// then fails waiting for 'ready'.
+        fn start(database: &Path, control: PathBuf) -> Self {
+            fs::create_dir_all(&control).expect("create writer control directory");
+            let child = Command::new(std::env::current_exe().expect("test binary path"))
+                .args([
+                    "--exact",
+                    "storage::tests::sqlite::read_only_observation::external_writer_process",
+                    "--ignored",
+                ])
+                .env(WRITER_DATABASE_ENV, database)
+                .env(WRITER_CONTROL_ENV, &control)
+                .stdout(Stdio::null())
+                .spawn()
+                .expect("spawn the writer process");
+
+            let writer = Self {
+                child,
+                control,
+                commits: 0,
+            };
+            wait_for(&writer.control.join("ready"), "ready");
+            writer
+        }
+
+        /// Commit one row and wait for the writer to confirm it.
+        fn commit(&mut self, value: &str) {
+            self.commits += 1;
+            let request = self.control.join(format!("commit-{}", self.commits));
+            let confirmation = self.control.join(format!("committed-{}", self.commits));
+            fs::write(&request, value).expect("request a commit");
+            wait_for(&confirmation, "commit");
+            let outcome = fs::read_to_string(&confirmation).expect("read commit outcome");
+            assert_eq!(outcome, "ok", "the writer process failed to commit");
+        }
+    }
+
+    impl Drop for ExternalWriter {
+        fn drop(&mut self) {
+            let _ = fs::write(self.control.join("stop"), b"");
+            let _ = self.child.wait();
+        }
+    }
+
+    /// The child half of [`ExternalWriter`]; never part of an ordinary run.
+    #[test]
+    #[ignore = "spawned by ExternalWriter as a separate writer process"]
+    fn external_writer_process() {
+        let Ok(database) = std::env::var(WRITER_DATABASE_ENV) else {
+            return;
+        };
+        let control = PathBuf::from(std::env::var(WRITER_CONTROL_ENV).expect("control directory"));
+
+        let connection = Connection::open(&database).expect("open the database for writing");
+        connection
+            .pragma_update(None, "wal_autocheckpoint", 0)
+            .expect("keep committed frames in the WAL");
+        // Force the wal-index into existence before the fixture publishes the
+        // file set, so the observing side sees a real `-shm`.
+        rows(&connection);
+        fs::write(control.join("ready"), b"").expect("announce readiness");
+
+        let stop = control.join("stop");
+        let deadline = Instant::now() + WRITER_TIMEOUT;
+        let mut commits = 0;
+        while Instant::now() < deadline && !stop.exists() {
+            let request = control.join(format!("commit-{}", commits + 1));
+            if !request.exists() {
+                std::thread::sleep(Duration::from_millis(10));
+                continue;
+            }
+            commits += 1;
+            let value = fs::read_to_string(&request).expect("read the requested value");
+            let outcome = match connection.execute("INSERT INTO observed VALUES (?1)", [&value]) {
+                Ok(_) => "ok".to_string(),
+                Err(error) => format!("failed: {error}"),
+            };
+            fs::write(control.join(format!("committed-{commits}")), outcome)
+                .expect("confirm the commit");
+        }
     }
 
     /// ORB-12090: `immutable=1` ignores the WAL, so a read-only open used to
@@ -331,40 +499,206 @@ mod read_only_observation {
         );
     }
 
-    /// The control for the branch above: once every frame is checkpointed back
-    /// into the main file, nothing can hide behind the WAL and the
-    /// sidecar-free mode stays in use.
+    /// ORB-12092: a checkpointed database with a published wal-index reads as
+    /// current, so a commit another process makes after the open is visible to
+    /// the next query. `immutable=1` used to be chosen here — the empty WAL
+    /// looked like proof that nothing could hide — and a read-only mount then
+    /// reported the pre-open state forever.
+    ///
+    /// The observing side never writes: it opens files this process cannot
+    /// write, and every byte of the file set is compared around each of its
+    /// reads.
     #[test]
-    fn checkpointed_database_stays_immutable() {
-        let (_dir, source, published) = fixture("checkpointed");
-        let writer = Connection::open(&source).expect("open fixture writer");
-        writer
-            .pragma_update(None, "journal_mode", "WAL")
-            .expect("enable WAL");
-        writer
-            .execute_batch(
-                "CREATE TABLE fresh(value TEXT);
-                 INSERT INTO fresh VALUES ('visible-only-in-wal');
-                 PRAGMA wal_checkpoint(TRUNCATE);",
-            )
-            .expect("commit and checkpoint fixture state");
-        publish_read_only(&source, &published, &SQLITE_FILE_SUFFIXES);
-        let before = published_bytes(&published);
+    fn checkpointed_wal_observes_a_commit_made_after_the_open() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("late-commit.db");
+        write_checkpointed_database(&path);
+
+        let mut writer = ExternalWriter::start(&path, dir.path().join("control"));
+        assert_eq!(
+            fs::metadata(sqlite_file(&path, "-wal"))
+                .expect("published WAL")
+                .len(),
+            0,
+            "the fixture WAL must be empty at open"
+        );
+        // Read-only for this process from here on; the writer keeps committing
+        // through the descriptors it opened above.
+        publish_in_place_read_only(&path);
+        let before_observation = published_bytes(&path);
+
+        let opened = open_private(&path).expect("observe the published database");
+
+        assert!(opened.read_only);
+        assert_eq!(
+            opened.currency,
+            ObservationCurrency::Live,
+            "a published wal-index must be read live, not frozen at open"
+        );
+        assert_eq!(rows(&opened.connection), ["checkpointed"]);
+        assert_eq!(
+            published_bytes(&path),
+            before_observation,
+            "opening and reading must not change the database, WAL, or SHM"
+        );
+
+        writer.commit("committed-after-the-open");
+        let after_commit = published_bytes(&path);
 
         assert_eq!(
-            read_only_access(&published).expect("classify a checkpointed database"),
-            ReadOnlyAccess::Immutable,
-            "an empty WAL cannot hide committed pages"
+            rows(&opened.connection),
+            ["checkpointed", "committed-after-the-open"],
+            "the observation must show the commit that landed after it was opened"
         );
-        let opened = open_private(&published).expect("open published database");
-        assert!(opened.read_only);
-        let value: String = opened
+
+        let denied = opened
             .connection
-            .query_row("SELECT value FROM fresh", [], |row| row.get(0))
-            .expect("read checkpointed state");
-        assert_eq!(value, "visible-only-in-wal");
+            .execute("INSERT INTO observed VALUES ('denied')", [])
+            .expect_err("observation must refuse writes");
+        assert!(
+            OrbitError::Store(denied.to_string()).is_readonly_or_access_failure(),
+            "{denied}"
+        );
 
         drop(opened);
+        assert_eq!(
+            published_bytes(&path),
+            after_commit,
+            "only the writer may change the file set"
+        );
+    }
+
+    /// A database published without its sidecars can only be read main-file
+    /// first: a reader that may not create a wal-index cannot see a WAL. The
+    /// open says so, and a caller that requires current state is refused
+    /// outright instead of being handed the degraded read.
+    #[test]
+    fn wal_created_after_the_open_is_invisible_to_a_main_file_read() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("unindexed.db");
+        write_checkpointed_database(&path);
+        for suffix in ["-wal", "-shm"] {
+            assert!(
+                !sqlite_file(&path, suffix).exists(),
+                "a closed writer leaves no {suffix} sidecar"
+            );
+        }
+        let before_observation = published_bytes(&path);
+
+        let refused = match observation_currency(&path, ObservationRequirement::CurrentState) {
+            Ok(currency) => panic!("current state is not readable here, but got {currency:?}"),
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            refused.contains("no published '-shm' wal-index"),
+            "{refused}"
+        );
+
+        // The files stay writable so a writer can still attach; this models the
+        // read-only-mount branch, where the mount is what denies the writes.
+        let opened =
+            open_private_read_only(&path, true).expect("observe a database without sidecars");
+
+        assert!(opened.read_only);
+        assert_eq!(
+            opened.currency,
+            ObservationCurrency::MainFileOnly,
+            "a store that accepts a published file set must still be told what it got"
+        );
+        assert_eq!(rows(&opened.connection), ["checkpointed"]);
+        assert_eq!(
+            published_bytes(&path),
+            before_observation,
+            "a main-file read must not create a WAL or wal-index"
+        );
+
+        let mut writer = ExternalWriter::start(&path, dir.path().join("control"));
+        writer.commit("committed-after-the-main-file-read");
+        assert!(
+            sqlite_file(&path, "-wal").exists(),
+            "the writer must have created a WAL after the observation opened"
+        );
+
+        assert_eq!(
+            rows(&opened.connection),
+            ["checkpointed"],
+            "a main-file read cannot see a WAL that appears after it opened"
+        );
+
+        let reopened = open_private_read_only(&path, true).expect("re-observe the database");
+        assert_eq!(
+            reopened.currency,
+            ObservationCurrency::Live,
+            "the wal-index the writer published makes live reads possible again"
+        );
+        assert_eq!(
+            rows(&reopened.connection),
+            ["checkpointed", "committed-after-the-main-file-read"],
+            "reopening is the documented way to leave a stale main-file read behind"
+        );
+    }
+
+    /// A rollback-journal database needs no wal-index at all, so it is read
+    /// live and creates nothing — the compatibility the sidecar-free mode used
+    /// to provide, without the frozen view it came with.
+    #[test]
+    fn rollback_journal_database_observes_a_commit_made_after_the_open() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("rollback.db");
+        let writer = Connection::open(&path).expect("open fixture writer");
+        writer
+            .execute_batch(
+                "CREATE TABLE observed(value TEXT); INSERT INTO observed VALUES ('journalled');",
+            )
+            .expect("commit the fixture row");
+        drop(writer);
+
+        assert_eq!(
+            observation_currency(&path, ObservationRequirement::CurrentState)
+                .expect("classify a rollback-journal database"),
+            ObservationCurrency::Live,
+        );
+        let opened = open_private_read_only(&path, true).expect("observe the database");
+        assert_eq!(rows(&opened.connection), ["journalled"]);
+
+        let mut external = ExternalWriter::start(&path, dir.path().join("control"));
+        external.commit("committed-after-the-open");
+
+        assert_eq!(
+            rows(&opened.connection),
+            ["journalled", "committed-after-the-open"],
+        );
+        for suffix in ["-wal", "-shm"] {
+            assert!(
+                !sqlite_file(&path, suffix).exists(),
+                "observing a rollback-journal database must not create a {suffix} sidecar"
+            );
+        }
+    }
+
+    /// A wal-index published without the WAL it indexes describes frames this
+    /// process cannot see. Fail closed rather than reporting the main file as
+    /// current — and without letting SQLite create the missing WAL.
+    #[test]
+    fn published_wal_index_without_its_wal_fails_closed() {
+        let (_dir, source, published) = fixture("orphan-index");
+        publish_uncheckpointed_wal_database(&source, &published, &["", "-shm"]);
+        let before = published_bytes(&published);
+
+        let error = match open_private(&published) {
+            Ok(_) => panic!("an orphaned wal-index must not read as current"),
+            Err(error) => error,
+        };
+
+        let message = error.to_string();
+        assert!(
+            message.contains("published without the '-wal' sidecar it indexes"),
+            "{message}"
+        );
+        assert!(
+            !sqlite_file(&published, "-wal").exists(),
+            "observation must not create a WAL"
+        );
         assert_eq!(published_bytes(&published), before);
     }
 

--- a/crates/orbit-store/src/driver/sqlite/connection.rs
+++ b/crates/orbit-store/src/driver/sqlite/connection.rs
@@ -104,8 +104,9 @@ impl Store {
                 orbit_common::tracing::warn!(
                     target: "orbit.store.sqlite",
                     path = %path.display(),
+                    currency = ?opened.currency,
                     error = %error,
-                    "skipped schema migration while opening a store for immutable reads"
+                    "skipped schema migration while opening a store for observational reads"
                 );
             } else {
                 return Err(error);


### PR DESCRIPTION
## Task

[ORB-12092](https://orbit-cli.com/tasks/ORB-12092) — Keep read-only SQLite observations current when WAL commits arrive after open

### Description

## Problem
ORB-12090 fixed existing WAL reads and readonly registry setup, but its final read_only_access still chooses immutable=1 whenever WAL is absent or <=32 bytes. A read-only bind mount does not freeze an external writer. A reproduced host case creates an initial row, checkpoints TRUNCATE (WAL0, SHM present), opens/queries a readonly reader, then commits another row outside the mount. The immutable connection permanently reports only the initial row; ordinary mode=ro observes both. This is confirmed behavior, not a hypothetical race.

## Evidence and scope
ORB-12090 holds reusable operator-evidence/orbit-readonly-late-wal-proof-12090.py and .json artifacts, plus existing-WAL controls. Root copies also exist at /tmp/orbit-readonly-late-wal-proof-12090.py/.json; use durable artifacts in worker namespace. Correct the observational selection/contract for live state, with existing usable SHM including empty WAL using actual readonly observation. Do not claim a one-time sidecar snapshot proves immutability. For absent read support, either provide fresh nonmutating reads safely or precise unavailable semantics; explicit immutable snapshots may remain only with a real caller contract. Preserve readonly no-sidecar-write/no-follow/private authority and existing static no-WAL compatibility where supportable. Scope to common SQLite opening and necessary callsites/tests; no broad storage redesign.

Root will replay actual bwrap cases when nested namespaces are unavailable. Worker must distinguish skipped bodies from PASS. This is the remaining correctness gap of12090, whose existing-WAL/prefix repair remains valuable.

### Acceptance Criteria

- A deterministic regression opens the actual observational helper with an empty/checkpointed WAL and existing SHM, then a separate writer commits; the same reader observes the new row without DB/WAL/SHM writes attributable to the reader.
- Cover WAL absent then created, and missing read-support cases; never return an apparently current silently stale immutable view. Document any explicit snapshot contract or precise unavailable behavior.
- Retain existing-WAL current-state tests, readonly registry behavior, no-follow and mutation-denial controls; actual host bwrap replay is an operator handoff if unavailable in worker.
- Run focused affected tests, cargo fmt, make ci-fast and make ci-lint; preserve meaningful no-WAL compatibility and report any deliberate behavior change.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Outcome

Read-only observation now picks its SQLite mode from the database's own state plus an explicit caller requirement, instead of falling back to `immutable=1` whenever the WAL is absent or <= 32 bytes.

`crates/orbit-common/src/storage/sqlite.rs`:
- `observation_currency(path, requirement)` (was `read_only_access`) decides: the main file's header (offsets 18/19) is read first — a rollback-journal database needs no wal-index, so it is read **live** and creates nothing. A WAL-mode database is read live when **both** `-wal` and `-shm` are published (this is the reported fix: an empty/checkpointed WAL with an existing SHM is now live, not immutable). `-wal` with frames and no `-shm`, or a `-shm` published without its `-wal`, fail closed with a precise unavailable error.
- The remaining case — WAL mode with no wal-index at all — is the caller's decision, not an inference from sidecar absence: `ObservationRequirement::CurrentState` is refused with a precise error; `ObservationRequirement::PublishedMainFile` receives `ObservationCurrency::MainFileOnly`, which `OpenedConnection.currency` reports to every caller and `open_observational` warns about. Its docs state the honest contract: it reads the main file alone, never sees a WAL created later, and — because `immutable=1` promises SQLite the bytes never change — can return internally inconsistent results if a writer checkpoints into the main file afterwards. No "frozen snapshot" guarantee is claimed.
- `open_observational(path, requirement)` returns `OpenedConnection` and now probes the first read on every path, so an unreadable database or unusable wal-index surfaces as the precise unavailable error at open rather than inside an arbitrary later query.
- `open_private` / `open_private_read_only` pass `PublishedMainFile` with the reason documented at the call site: state published as a static file set (a read-only mount whose last writer closed cleanly leaves no sidecars) would otherwise become unreadable rather than stale, which criterion 3 requires retaining.
- Header inspection uses a new `open_read_no_follow` helper (`O_NOFOLLOW` on unix), which also replaces the inline copy in `harden_existing_read_only_file`.

`crates/orbit-store/src/driver/sqlite/connection.rs` (added to context_files): `Store::open`'s read-only warning said "immutable reads", which is now wrong; it reports the actual `currency` instead.

## Evidence behind the design (probed in-worker, rusqlite 0.31 / bundled SQLite 3.45, Linux)

With a writer process holding the database open and the reader seeing `0400` files: ordinary `mode=ro` observed the late commit and left the database, `-wal` and `-shm` **byte-identical**; `immutable=1` in the identical fixture stayed permanently at the pre-open row — the reported failure. Also established: `mode=ro` **creates** `-wal`/`-shm` when the directory is writable, and creates a missing `-wal` when only a `-shm` is published (hence "both sidecars or not live"); with `0600` sidecars a reader does write read-marks into the `-shm`, with `0400` it does not; and on a non-writable directory a WAL database with no wal-index fails `mode=ro` outright, so `immutable=1` is the only read available there.

## Acceptance criteria

1. **Met.** `checkpointed_wal_observes_a_commit_made_after_the_open` builds a checkpointed WAL database (WAL 0 bytes, SHM present), hands it to a separate writer *process*, makes the files read-only for the test process, opens the real helper (`open_private`), reads, has the writer commit, and asserts the same reader sees the new row. Byte-for-byte comparison of database/`-wal`/`-shm` around both of the reader's queries proves no reader-attributable writes; mutation denial is asserted on the same connection. Verified to detect the original fault: with the ORB-12090 rule restored it fails (`SnapshotAtOpen` vs `Live`).
2. **Met.** `wal_created_after_the_open_is_invisible_to_a_main_file_read` covers WAL-absent-then-created: `CurrentState` is refused with the precise error, `PublishedMainFile` is told it got `MainFileOnly`, creates no sidecars, cannot see the WAL the writer creates afterwards, and a reopen reads live. `wal_without_read_support_fails_closed` and `published_wal_index_without_its_wal_fails_closed` cover the missing-read-support cases. No path returns an apparently current, silently stale immutable view: it is either live, a typed+warned `MainFileOnly` the caller asked for, or a precise error.
3. **Met.** `reads_committed_state_held_only_in_the_wal` (existing-WAL current state), `symlinked_sidecar_is_rejected` (no-follow), mutation-denial and the read-only registry/permission tests all retained and passing. `read_only_registry_files_keep_uncheckpointed_wal_reads_observational` (orbit-cli) passes. **Operator handoff:** `readonly_state_mount_keeps_cli_and_mcp_reads_observational` reports `ok` but its body was **skipped** — `bwrap --dev-bind / / ...` fails here with "No permissions to create new namespace", so the actual `--ro-bind` replay was not executed in this worker. Its in-worker equivalents (read-only directory + `0400` files) were probed for every branch; the one nuance not reproducible here is EROFS vs EACCES in SQLite's read-only `-shm` fallback.
4. **Met.** `cargo fmt --all`, `make ci-fast` (exit 0), `make ci-lint` (exit 0) after a first run caught `clippy::let_and_return`. Focused tests: `orbit-common` (274 passed), `orbit-store` driver::sqlite (222 passed), `orbit-search` vector (42 passed), the two orbit-cli read-only tests (2 passed, one body skipped as above).

## Deliberate behavior changes

- A WAL database whose `-shm` is published without its `-wal` now fails closed; it previously read the main file immutably (silently stale if frames were lost).
- A WAL database with published sidecars whose wal-index cannot be used read-only (e.g. it needs recovery) now returns the precise unavailable error, where an empty WAL previously produced a stale immutable success.
- No change to writable opens; `MainFileOnly` preserves the previous behavior for statically published, sidecar-free state.

## Residual risk

`open_private` chooses `PublishedMainFile` for all three stores. A long-lived reader of a sidecar-free WAL database on a read-only mount therefore still gets the degraded read (now typed and warned, not silent). Making `open_private` demand `CurrentState` would refuse it instead — that regresses the read-only-mount deployment covered by the bwrap test criterion 3 says to retain, so it is flagged for the operator rather than taken unilaterally. Changes left uncommitted; working tree contains only the three scoped files.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12092-6aa29ad0`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: sol