### PR TITLE
Allow observational startup when optional semantic index is absent on read-only storage

### DIFF
--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -4734,6 +4734,104 @@ fn read_only_registry_files_keep_uncheckpointed_wal_reads_observational() {
     drop(registry_holder);
 }
 
+/// The mount test's other read-only surface, carried on every Unix runner: the
+/// canonical state directory refuses writes while the optional semantic index
+/// it never carried is absent. The CLI reaches the identical creation denial
+/// one process removed from a `--ro-bind`, and must still start and answer the
+/// reads — such as tool listing — that never needed that index.
+///
+/// It does not replace the mount test: permission bits still allow directory
+/// and sidecar writes a `--ro-bind` refuses outright.
+#[cfg(unix)]
+#[test]
+fn absent_global_semantic_index_keeps_read_only_cli_reads_observational() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let workspace = McpWorkspace::init();
+    let created = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args([
+            "tool",
+            "run",
+            "orbit.task.add",
+            "--input",
+            &json!({
+                "title": "Readable without a global semantic index",
+                "description": "The canonical root never built one",
+                "workspace": workspace.work,
+                "complexity": "low",
+                "model": "codex",
+            })
+            .to_string(),
+        ])
+        .output()
+        .expect("create the fixture task");
+    assert_command_succeeded("fixture task add", &created);
+    let created: Value = serde_json::from_slice(&created.stdout).expect("parse fixture task");
+    let task_id = created["id"].as_str().expect("fixture task id");
+
+    // The canonical root is not the checkout: nothing has run `orbit semantic
+    // index` against it, so its optional index is absent.
+    let canonical_root = workspace.home.join(".orbit");
+    let state_dir = canonical_root.join("state");
+    std::fs::create_dir_all(&state_dir).expect("canonical state directory");
+    let semantic_db = state_dir.join("semantic.db");
+    for suffix in ["", "-wal", "-shm"] {
+        let sidecar = PathBuf::from(format!("{}{suffix}", semantic_db.display()));
+        if sidecar.exists() {
+            std::fs::remove_file(&sidecar).expect("clear the unbuilt semantic index");
+        }
+    }
+
+    let worktree = add_linked_worktree(&workspace.work);
+    let original = std::fs::metadata(&state_dir)
+        .expect("canonical state metadata")
+        .permissions();
+    std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o500))
+        .expect("make the canonical state directory read-only");
+    if std::fs::File::create(state_dir.join("probe")).is_ok() {
+        // A user that ignores the mode bits (typically root) cannot reproduce
+        // the creation denial this fixture is about.
+        std::fs::set_permissions(&state_dir, original).expect("restore state permissions");
+        return;
+    }
+
+    let listed = McpWorkspace::orbit_command(&worktree, &workspace.home)
+        .env("ORBIT_ROOT", &canonical_root)
+        .args(["tool", "list", "--json"])
+        .output()
+        .expect("list tools with an unavailable semantic index");
+    let shown = McpWorkspace::orbit_command(&worktree, &workspace.home)
+        .env("ORBIT_ROOT", &canonical_root)
+        .args([
+            "tool",
+            "run",
+            "orbit.task.show",
+            "--root",
+            canonical_root.to_str().expect("utf8 Orbit root"),
+            "--input",
+            &json!({ "id": task_id, "model": "codex" }).to_string(),
+        ])
+        .output()
+        .expect("show a task with an unavailable semantic index");
+    std::fs::set_permissions(&state_dir, original).expect("restore state permissions");
+
+    assert_command_succeeded("read-only orbit.tool.list", &listed);
+    let listed: Value = serde_json::from_slice(&listed.stdout).expect("parse listed tools");
+    assert!(
+        listed
+            .as_array()
+            .is_some_and(|tools| tools.iter().any(|tool| tool["name"] == "orbit.task.show")),
+        "tool listing needs no semantic index and must still answer: {listed}"
+    );
+    assert_command_succeeded("read-only orbit.task.show", &shown);
+    let shown: Value = serde_json::from_slice(&shown.stdout).expect("parse shown task");
+    assert_eq!(shown["id"], json!(task_id));
+    assert!(
+        !semantic_db.exists(),
+        "an unavailable index must not be created by a read"
+    );
+}
+
 /// Pin the registry's current snapshot so every write that follows stays in the
 /// WAL: SQLite checkpoints when the last connection closes, and otherwise
 /// copies frames back only as far as the oldest reader allows.

--- a/crates/orbit-core/src/application/docs/mod.rs
+++ b/crates/orbit-core/src/application/docs/mod.rs
@@ -142,7 +142,7 @@ impl OrbitRuntime {
     pub fn index_docs(&self, params: DocIndexParams) -> Result<DocIndexResult, OrbitError> {
         let roots = self.docs_roots()?;
         let sources = doc_embedding_sources(&self.paths().repo_root, &roots)?;
-        orbit_search::doc_index(&self.stores().semantic_vector, &sources, params)
+        orbit_search::doc_index(self.stores().semantic_index().store()?, &sources, params)
     }
 
     pub fn migrate_docs(&self, dry_run: bool) -> Result<DocMigrationReport, OrbitError> {

--- a/crates/orbit-core/src/application/search/federated.rs
+++ b/crates/orbit-core/src/application/search/federated.rs
@@ -255,7 +255,13 @@ pub(super) fn apply_workspace_cap(targets: &mut Vec<FederatedWorkspaceTarget>) -
 /// name instead of emitting a plausible-looking ranking the caller cannot
 /// tell apart from a fused one.
 fn model_mismatch_note(runtime: &OrbitRuntime, query_model: &str) -> Option<String> {
-    let indexed = runtime.stores().semantic_vector.model_ids().ok()?;
+    let indexed = runtime
+        .stores()
+        .semantic_index()
+        .store()
+        .ok()?
+        .model_ids()
+        .ok()?;
     describe_model_mismatch(&indexed, query_model)
 }
 

--- a/crates/orbit-core/src/application/search/mod.rs
+++ b/crates/orbit-core/src/application/search/mod.rs
@@ -559,7 +559,7 @@ impl OrbitRuntime {
         }
 
         Ok(orbit_search::doc_semantic_search(
-            &self.stores().semantic_vector,
+            self.stores().semantic_index().store()?,
             DocSemanticSearchParams {
                 query: query.to_string(),
                 limit,

--- a/crates/orbit-core/src/application/semantic.rs
+++ b/crates/orbit-core/src/application/semantic.rs
@@ -52,7 +52,7 @@ impl OrbitRuntime {
         params: SemanticIndexParams,
     ) -> Result<TaskIndexResult, OrbitError> {
         let tasks = self.stores().tasks().list_tasks()?;
-        orbit_search::semantic_index(&self.stores().semantic_vector, &tasks, params)
+        orbit_search::semantic_index(self.stores().semantic_index().store()?, &tasks, params)
     }
 
     fn semantic_index_docs(
@@ -73,14 +73,14 @@ impl OrbitRuntime {
             .into_iter()
             .map(|task| task.id)
             .collect();
-        orbit_search::semantic_stats(&self.stores().semantic_vector, &task_ids)
+        orbit_search::semantic_stats(self.stores().semantic_index().store()?, &task_ids)
     }
 
     pub fn semantic_search(
         &self,
         params: SemanticSearchParams,
     ) -> Result<SemanticSearchResult, OrbitError> {
-        orbit_search::semantic_search(&self.stores().semantic_vector, params)
+        orbit_search::semantic_search(self.stores().semantic_index().store()?, params)
     }
 
     pub fn semantic_related(
@@ -88,6 +88,6 @@ impl OrbitRuntime {
         params: SemanticRelatedParams,
     ) -> Result<SemanticRelatedResult, OrbitError> {
         let tasks = self.stores().tasks().list_tasks()?;
-        orbit_search::semantic_related(&self.stores().semantic_vector, &tasks, params)
+        orbit_search::semantic_related(self.stores().semantic_index().store()?, &tasks, params)
     }
 }

--- a/crates/orbit-core/src/application/task/records.rs
+++ b/crates/orbit-core/src/application/task/records.rs
@@ -1,7 +1,7 @@
 //! Coordinated task document, history, artifact, and search-index writes.
 
 use orbit_common::{NotFoundKind, OrbitError};
-use orbit_search::{EmbedWorker, VectorStore};
+use orbit_search::{EmbedWorker, SemanticIndex};
 use orbit_store::contracts::{
     TaskArtifactStoreBackend, TaskArtifactUpdateParams, TaskCreateParams, TaskDocumentStoreBackend,
     TaskDocumentUpdateParams, TaskHistoryStoreBackend, TaskHistoryUpdateParams, TaskStoreBackend,
@@ -18,7 +18,7 @@ impl OrbitStores {
             document: self.task_documents(),
             history: self.task_history(),
             artifact: self.task_artifacts(),
-            semantic_vector: self.semantic_vector(),
+            semantic_index: self.semantic_index(),
             semantic_worker: self.semantic_worker(),
         }
     }
@@ -32,7 +32,7 @@ pub(crate) struct TaskRecordService<'a> {
     document: &'a dyn TaskDocumentStoreBackend,
     history: &'a dyn TaskHistoryStoreBackend,
     artifact: &'a dyn TaskArtifactStoreBackend,
-    semantic_vector: &'a VectorStore,
+    semantic_index: &'a SemanticIndex,
     semantic_worker: &'a EmbedWorker,
 }
 
@@ -132,7 +132,15 @@ impl TaskRecordService<'_> {
 
     pub(crate) fn delete(&self, id: &str) -> Result<bool, OrbitError> {
         let deleted = self.store.delete_task(id)?;
-        if deleted && let Err(error) = self.semantic_vector.delete_source("task", id) {
+        // A workspace with no index has nothing to retract, so an unavailable
+        // index reports here exactly like a failed cascade: the task is gone
+        // either way, and the index reconciles on its next reindex.
+        if deleted
+            && let Err(error) = self
+                .semantic_index
+                .store()
+                .and_then(|vector| vector.delete_source("task", id))
+        {
             orbit_common::tracing::debug!(
                 target: "orbit.search.indexer",
                 task_id = id,

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use orbit_engine::PrConfig;
 use orbit_policy::PolicyEngine;
-use orbit_search::{EmbedWorker, VectorStore};
+use orbit_search::{EmbedWorker, SemanticIndex};
 use orbit_store::Store;
 use orbit_store::contracts::{
     AuditEventStoreBackend, AutomationStoreBackend, ExecutorDefStoreBackend,
@@ -115,7 +115,7 @@ pub(crate) struct OrbitStores {
     pub(crate) task_document: Arc<dyn TaskDocumentStoreBackend>,
     pub(crate) task_history: Arc<dyn TaskHistoryStoreBackend>,
     pub(crate) task_artifact: Arc<dyn TaskArtifactStoreBackend>,
-    pub(crate) semantic_vector: Arc<VectorStore>,
+    pub(crate) semantic_index: SemanticIndex,
     pub(crate) semantic_worker: Arc<EmbedWorker>,
     pub(crate) task_reservation: Arc<dyn TaskReservationStoreBackend>,
     pub(crate) job_run: Arc<dyn JobRunStoreBackend>,
@@ -133,7 +133,7 @@ impl OrbitStores {
         task_document: Arc<dyn TaskDocumentStoreBackend>,
         task_history: Arc<dyn TaskHistoryStoreBackend>,
         task_artifact: Arc<dyn TaskArtifactStoreBackend>,
-        semantic_vector: Arc<VectorStore>,
+        semantic_index: SemanticIndex,
         semantic_worker: Arc<EmbedWorker>,
         task_reservation: Arc<dyn TaskReservationStoreBackend>,
         job_run: Arc<dyn JobRunStoreBackend>,
@@ -148,7 +148,7 @@ impl OrbitStores {
             task_document,
             task_history,
             task_artifact,
-            semantic_vector,
+            semantic_index,
             semantic_worker,
             task_reservation,
             job_run,
@@ -176,8 +176,10 @@ impl OrbitStores {
         self.task_artifact.as_ref()
     }
 
-    pub(crate) fn semantic_vector(&self) -> &VectorStore {
-        self.semantic_vector.as_ref()
+    /// The optional semantic index. Callers reach its store through
+    /// [`SemanticIndex::store`], which names the absence when there is none.
+    pub(crate) fn semantic_index(&self) -> &SemanticIndex {
+        &self.semantic_index
     }
 
     pub(crate) fn semantic_worker(&self) -> &EmbedWorker {

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use orbit_policy::PolicyEngine;
-use orbit_search::{EmbedWorker, VectorStore};
+use orbit_search::{EmbedWorker, SemanticIndex};
 use orbit_store::Store;
 use orbit_store::compose::{
     WorkspaceTaskBackends, audit_event_store_sqlite, automation_store, coordination_task_backends,
@@ -113,10 +113,13 @@ pub(crate) fn build_context_from_roots(
             "skipped malformed legacy state records during SQLite import",
         );
     }
-    let semantic_vector_store = Arc::new(VectorStore::open(&persistence.semantic_db)?);
-    let semantic_worker = match host_lifetime {
-        HostLifetime::LongLived => Arc::new(EmbedWorker::start((*semantic_vector_store).clone())),
-        HostLifetime::ShortLived => Arc::new(EmbedWorker::disabled()),
+    let semantic_index = SemanticIndex::open(&persistence.semantic_db)?;
+    // The worker writes embeddings. Without an index to write into there is
+    // nothing for it to drain, so it stays disabled alongside the short-lived
+    // hosts that refresh through `orbit semantic index` instead.
+    let semantic_worker = match (host_lifetime, semantic_index.store()) {
+        (HostLifetime::LongLived, Ok(vector)) => Arc::new(EmbedWorker::start(vector.clone())),
+        _ => Arc::new(EmbedWorker::disabled()),
     };
     let job_run_store = workspace_job_run_store(store.clone(), workspace_id);
 
@@ -189,7 +192,7 @@ pub(crate) fn build_context_from_roots(
             task_backends.document,
             task_backends.history,
             task_backends.artifact,
-            semantic_vector_store,
+            semantic_index,
             semantic_worker,
             task_reservation_store,
             job_run_store,

--- a/crates/orbit-core/src/runtime/tests/builder.rs
+++ b/crates/orbit-core/src/runtime/tests/builder.rs
@@ -309,3 +309,135 @@ fn explicit_data_dir_runtime_does_not_bind_parent_as_a_checkout() {
         "executor-list-style data-dir open must not insert a checkout for parent(data-dir); got {candidates:?}"
     );
 }
+
+/// A read-only state mount carries no writable state directory, so an optional
+/// semantic index that was never built there cannot be created at startup.
+/// Opening the runtime and every read that does not need that index must still
+/// work; semantic ranking must name the unavailable index instead of answering
+/// as a complete but empty corpus.
+#[cfg(unix)]
+#[test]
+fn absent_semantic_index_on_unwritable_state_keeps_the_runtime_observational() {
+    use std::os::unix::fs::PermissionsExt;
+
+    use orbit_search::SemanticSearchParams;
+
+    use crate::application::search::{
+        GlobalSearchKind, GlobalSearchMode, GlobalSearchParams, GlobalSearchResponse,
+    };
+
+    let (_root, global_root, workspace_root, runtime) = v2_runtime();
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Observational needle".to_string(),
+            description: "Readable through a state directory that refuses writes".to_string(),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("create task on writable state");
+    drop(runtime);
+
+    let state_dir = workspace_root.join("state");
+    let semantic_db = state_dir.join("semantic.db");
+    assert!(
+        semantic_db.exists(),
+        "writable initialization must create the semantic index"
+    );
+    for suffix in ["", "-wal", "-shm"] {
+        let sidecar = PathBuf::from(format!("{}{suffix}", semantic_db.display()));
+        if sidecar.exists() {
+            std::fs::remove_file(&sidecar).expect("remove the index this workspace never built");
+        }
+    }
+    let original = std::fs::metadata(&state_dir)
+        .expect("state metadata")
+        .permissions();
+    std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o500))
+        .expect("make the state directory read-only");
+    if std::fs::File::create(state_dir.join("probe")).is_ok() {
+        // A user that ignores the mode bits (typically root) cannot reproduce
+        // the denial this fixture is about.
+        std::fs::set_permissions(&state_dir, original).expect("restore state permissions");
+        return;
+    }
+
+    let observed = observe_unwritable_state(&global_root, &workspace_root, &task.id);
+    std::fs::set_permissions(&state_dir, original).expect("restore state permissions");
+    assert!(
+        !semantic_db.exists(),
+        "observing an unavailable index must not create it"
+    );
+
+    let (listed, semantic, hybrid) = observed;
+    assert_eq!(
+        listed,
+        vec![task.id.clone()],
+        "task reads must still answer"
+    );
+
+    let message = semantic.to_string();
+    assert!(
+        message.contains("semantic index") && message.contains("is unavailable"),
+        "semantic search must name the unavailable index: {message}"
+    );
+    assert_eq!(
+        hybrid.mode,
+        GlobalSearchMode::Lexical,
+        "hybrid search must degrade rather than report an empty semantic corpus"
+    );
+    assert!(
+        hybrid
+            .notes
+            .iter()
+            .any(|note| note.contains("falling back to lexical task search")
+                && note.contains("is unavailable")),
+        "the fallback must disclose why semantic ranking was skipped: {:?}",
+        hybrid.notes
+    );
+    assert_eq!(
+        hybrid.results.first().and_then(|hit| hit.id.as_deref()),
+        Some(task.id.as_str()),
+        "lexical ranking must still find the task"
+    );
+
+    /// Opens a second runtime while the state directory refuses writes and
+    /// collects everything the assertions need, so the fixture can restore the
+    /// directory's mode before any of them can unwind.
+    fn observe_unwritable_state(
+        global_root: &std::path::Path,
+        workspace_root: &std::path::Path,
+        task_id: &str,
+    ) -> (Vec<String>, OrbitError, GlobalSearchResponse) {
+        let runtime = OrbitRuntime::from_roots(global_root, workspace_root)
+            .expect("an absent optional semantic index must not refuse the runtime");
+        let listed = runtime
+            .list_tasks()
+            .expect("list tasks through the unwritable state directory")
+            .into_iter()
+            .map(|task| task.id)
+            .collect();
+        let semantic = runtime
+            .semantic_search(SemanticSearchParams {
+                query: "observational needle".to_string(),
+                limit: 3,
+                field: None,
+                kind: None,
+                model: None,
+            })
+            .expect_err("semantic search must refuse an unavailable index");
+        let hybrid = runtime
+            .global_search(GlobalSearchParams {
+                query: Some("observational needle".to_string()),
+                hybrid: true,
+                kind: GlobalSearchKind::Task,
+                limit: 3,
+                ..Default::default()
+            })
+            .expect("hybrid search must fall back instead of failing");
+        assert_eq!(
+            runtime.get_task(task_id).expect("read the task").title,
+            "Observational needle"
+        );
+        (listed, semantic, hybrid)
+    }
+}

--- a/crates/orbit-search/src/lib.rs
+++ b/crates/orbit-search/src/lib.rs
@@ -62,6 +62,6 @@ pub use rpc::{
 };
 pub use subprocess::SubprocessEmbedder;
 pub use vector::{
-    DocEmbeddingSource, EmbedWorker, SOURCE_KIND_DOC, SOURCE_KIND_TASK, SemanticStats,
-    UpsertReport, VectorStore,
+    DocEmbeddingSource, EmbedWorker, SOURCE_KIND_DOC, SOURCE_KIND_TASK, SemanticIndex,
+    SemanticStats, UpsertReport, VectorStore,
 };

--- a/crates/orbit-search/src/vector/index.rs
+++ b/crates/orbit-search/src/vector/index.rs
@@ -1,0 +1,72 @@
+//! The optional semantic index handle: an open [`VectorStore`], or the
+//! explained reason there is none.
+//!
+//! Unlike the task registry and the audit database, the semantic index is not
+//! authoritative state. A workspace that never ran `orbit semantic index` has
+//! no database at all, and Orbit must still open — including on a read-only
+//! mount, where creating one is impossible. Storage that refuses the index is
+//! therefore a startup outcome rather than a startup failure.
+//!
+//! It is not an empty corpus, though. A caller that asked for semantic ranking
+//! gets the unavailability by name from [`SemanticIndex::store`], never a
+//! complete-looking empty result it cannot tell apart from a genuinely
+//! unindexed workspace.
+
+use std::path::Path;
+
+use orbit_common::OrbitError;
+
+use super::store::VectorStore;
+
+/// An opened semantic index, or the explanation for its absence.
+#[derive(Clone)]
+pub enum SemanticIndex {
+    /// The index is open and can answer semantic reads and writes.
+    Ready(VectorStore),
+    /// This storage would not yield a usable index. Carries the
+    /// operator-facing explanation reported to every semantic caller.
+    Unavailable(String),
+}
+
+impl SemanticIndex {
+    /// Open the index at `path`, or report it unavailable when the storage
+    /// refuses to open or create one.
+    ///
+    /// Only a readonly/access refusal degrades this way — a read-only mount, a
+    /// state directory this caller cannot write, an index whose schema cannot
+    /// be built here. Everything else is state that exists and failed: a
+    /// malformed file, an unusable WAL, an incompatible layout. Those keep
+    /// propagating, so a broken index is never mistaken for an absent one.
+    pub fn open(path: &Path) -> Result<Self, OrbitError> {
+        match VectorStore::open(path) {
+            Ok(store) => Ok(Self::Ready(store)),
+            Err(error) if error.is_readonly_or_access_failure() => {
+                orbit_common::tracing::warn!(
+                    target: "orbit.search.vector",
+                    path = %path.display(),
+                    error = %error,
+                    "storage refused the optional semantic index; continuing without it"
+                );
+                Ok(Self::Unavailable(unavailable_reason(path, &error)))
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    /// The open store, or the error every semantic operation reports when
+    /// there is no index to consult.
+    pub fn store(&self) -> Result<&VectorStore, OrbitError> {
+        match self {
+            Self::Ready(store) => Ok(store),
+            Self::Unavailable(reason) => Err(OrbitError::Store(reason.clone())),
+        }
+    }
+}
+
+fn unavailable_reason(path: &Path, error: &OrbitError) -> String {
+    format!(
+        "semantic index '{}' is unavailable: this storage will not open or create it ({error}); \
+         run `orbit semantic index` where the state directory is writable",
+        path.display()
+    )
+}

--- a/crates/orbit-search/src/vector/mod.rs
+++ b/crates/orbit-search/src/vector/mod.rs
@@ -3,6 +3,8 @@
 //! Module layout:
 //!
 //! - [`store`] — [`VectorStore`], the SQLite-backed index. Entry point.
+//! - [`index`] — [`SemanticIndex`], the optional handle a runtime holds: an
+//!   open store, or the explained absence semantic callers are told about.
 //! - [`chunker`] — paragraph-boundary chunker for fields exceeding the
 //!   model's context window.
 //! - [`worker`] — optional background indexer for long-lived hosts. Short-lived
@@ -21,12 +23,14 @@
 
 pub(crate) mod chunker;
 pub(crate) mod doc_fields;
+pub(crate) mod index;
 pub(crate) mod query;
 pub(crate) mod store;
 pub(crate) mod task_fields;
 pub(crate) mod worker;
 
 pub use doc_fields::DocEmbeddingSource;
+pub use index::SemanticIndex;
 pub use store::{SOURCE_KIND_DOC, SOURCE_KIND_TASK, VectorStore};
 pub use worker::EmbedWorker;
 

--- a/crates/orbit-search/src/vector/store/mod.rs
+++ b/crates/orbit-search/src/vector/store/mod.rs
@@ -45,16 +45,23 @@ impl VectorStore {
     pub fn open(path: &Path) -> Result<Self, OrbitError> {
         let conn = orbit_common::storage::sqlite::open_private(path)?.connection;
         if let Err(error) = schema::ensure_vector_schema(&conn) {
-            if error.is_readonly_or_access_failure() {
-                tracing::warn!(
-                    target: "orbit.search.vector",
-                    path = %path.display(),
-                    error = %error,
-                    "skipped incidental semantic-index schema persistence"
-                );
-            } else {
+            if !error.is_readonly_or_access_failure() {
                 return Err(error);
             }
+            // An index that already exists stays readable: the schema call only
+            // wanted to re-apply or migrate DDL this process cannot write. One
+            // that carries no index at all has nothing to read and nothing a
+            // writer could ever land in, so the refusal is the whole answer
+            // rather than an incidental one.
+            if !schema::vector_schema_present(&conn)? {
+                return Err(error);
+            }
+            tracing::warn!(
+                target: "orbit.search.vector",
+                path = %path.display(),
+                error = %error,
+                "skipped incidental semantic-index schema persistence"
+            );
         }
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),

--- a/crates/orbit-search/src/vector/store/schema.rs
+++ b/crates/orbit-search/src/vector/store/schema.rs
@@ -99,6 +99,19 @@ pub fn ensure_vector_schema(conn: &Connection) -> Result<(), OrbitError> {
     }
 }
 
+/// Whether this database carries a vector index at all — the current layout or
+/// the pre-[ORB-11695] inline one.
+///
+/// A database with neither has nothing to read: every query would fail on a
+/// missing table. It is the difference between a schema call that could not
+/// re-apply DDL to an index that already exists and one that could not build
+/// the index in the first place.
+pub(super) fn vector_schema_present(conn: &Connection) -> Result<bool, OrbitError> {
+    Ok(table_exists(conn, "embeddings")?
+        || table_exists(conn, "corpus_fts")?
+        || table_exists(conn, legacy_task_fts_table())?)
+}
+
 fn is_current_layout(conn: &Connection) -> Result<bool, OrbitError> {
     Ok(table_exists(conn, "embeddings")?
         && table_exists(conn, "chunks")?

--- a/crates/orbit-search/src/vector/tests/index.rs
+++ b/crates/orbit-search/src/vector/tests/index.rs
@@ -1,0 +1,263 @@
+//! Unit tests for `index` — sibling layout under vector/tests/.
+//!
+//! The contract under test is what an Orbit host may do with an optional index
+//! it could not open: continue when the storage refused it, keep failing when
+//! the index exists and is broken, and never report either as an empty corpus.
+
+use crate::vector::index::SemanticIndex;
+
+const UNAVAILABLE_MARKER: &str = "is unavailable";
+
+/// An ordinary writable state directory still yields a functional index.
+#[test]
+fn writable_state_opens_a_usable_index() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let path = root.path().join("state/semantic.db");
+
+    let index = SemanticIndex::open(&path).expect("open writable index");
+
+    let store = index.store().expect("writable index must be ready");
+    assert!(
+        store.model_ids().expect("query a ready index").is_empty(),
+        "a freshly created index carries no embedding rows yet"
+    );
+    assert!(
+        path.exists(),
+        "opening writable state must create the index"
+    );
+}
+
+/// A database that exists but cannot be read is real state that failed, not an
+/// index that was never built. It must keep propagating.
+#[test]
+fn existing_malformed_database_still_fails_closed() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let path = root.path().join("semantic.db");
+    std::fs::write(&path, b"this is not a SQLite database").expect("write malformed index");
+
+    let Err(error) = SemanticIndex::open(&path) else {
+        panic!("a malformed index must not be tolerated");
+    };
+
+    assert!(
+        !error.to_string().contains(UNAVAILABLE_MARKER),
+        "a broken index must not be reported as an absent one: {error}"
+    );
+    assert!(
+        error.to_string().contains("not a database"),
+        "the SQLite diagnostic must survive: {error}"
+    );
+}
+
+/// The startup path behind the read-only mount: the optional index is absent
+/// and the state directory refuses to create it. The host must still open, and
+/// every semantic caller must be told why there is nothing to consult.
+///
+/// See [`read_only_store_without_a_vector_schema_is_unavailable_not_ready`] for
+/// the same refusal reached one step later, on a database that does exist.
+#[cfg(unix)]
+#[test]
+fn absent_index_on_unwritable_state_reports_unavailable_instead_of_failing() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = tempfile::tempdir().expect("tempdir");
+    let state = root.path().join("state");
+    std::fs::create_dir_all(&state).expect("create state directory");
+    let path = state.join("semantic.db");
+    let _guard = ReadOnlyDir::hold(&state);
+    if std::fs::File::create(state.join("probe")).is_ok() {
+        // Running as a user that ignores the mode bits (typically root) makes
+        // this fixture unable to reproduce the denial it is about.
+        return;
+    }
+
+    let index = SemanticIndex::open(&path).expect("an absent optional index must not fail startup");
+
+    let Err(error) = index.store() else {
+        panic!("an unavailable index must not answer as an empty corpus");
+    };
+    let message = error.to_string();
+    assert!(
+        message.contains(UNAVAILABLE_MARKER) && message.contains("semantic.db"),
+        "the unavailability must name the index: {message}"
+    );
+    assert!(
+        message.contains("orbit semantic index"),
+        "the unavailability must carry its remediation: {message}"
+    );
+    assert!(
+        !path.exists(),
+        "reporting unavailability must not create the index"
+    );
+    assert_eq!(
+        std::fs::metadata(&state)
+            .expect("state metadata")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o500,
+        "opening must leave the protected state directory unchanged"
+    );
+}
+
+/// An index that exists behind a directory this caller cannot enter is also a
+/// refusal, and must be described as one. Classifying it by asking whether the
+/// path exists would be wrong twice over: the inspection itself is denied, and
+/// the answer would call real state absent.
+#[cfg(unix)]
+#[test]
+fn inaccessible_existing_index_is_reported_as_refused_not_absent() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let state = root.path().join("state");
+    std::fs::create_dir_all(&state).expect("create state directory");
+    let path = state.join("semantic.db");
+    SemanticIndex::open(&path).expect("build the index while the directory is reachable");
+    let _guard = ReadOnlyDir::hold_with_mode(&state, 0o000);
+    if std::fs::metadata(&path).is_ok() {
+        // A user that ignores the mode bits (typically root) can still enter
+        // the directory, so the denial this fixture is about cannot happen.
+        return;
+    }
+
+    let index = SemanticIndex::open(&path).expect("a denied optional index must not fail startup");
+
+    let Err(error) = index.store() else {
+        panic!("an index this process cannot reach must not be handed out as ready");
+    };
+    let message = error.to_string();
+    assert!(
+        message.contains(UNAVAILABLE_MARKER),
+        "the denial must be reported as unavailability: {message}"
+    );
+    assert!(
+        !message.contains("does not exist"),
+        "a denied inspection must not claim the index is absent: {message}"
+    );
+}
+
+/// A read-only database carrying no vector index at all is not a usable store.
+/// Opening its connection succeeded, but every query would fail on a missing
+/// table and no writer could land a row, so it must be reported unavailable
+/// rather than handed out as ready — a `Ready` store is what a long-lived host
+/// starts its embed worker against.
+#[cfg(unix)]
+#[test]
+fn read_only_store_without_a_vector_schema_is_unavailable_not_ready() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let path = root.path().join("semantic.db");
+    rusqlite::Connection::open(&path)
+        .expect("create an empty SQLite database")
+        .execute_batch("CREATE TABLE unrelated(id INTEGER PRIMARY KEY)")
+        .expect("seed a database that carries no vector index");
+    if !deny_writes(&path) {
+        return;
+    }
+
+    let index =
+        SemanticIndex::open(&path).expect("an unusable optional index must not fail startup");
+
+    let Err(error) = index.store() else {
+        panic!("a database with no vector index must not be handed out as ready");
+    };
+    assert!(
+        error.to_string().contains(UNAVAILABLE_MARKER),
+        "the refusal must be reported as unavailability: {error}"
+    );
+}
+
+/// The other side of that rule, and the [ORB-12090] read-only mount case: an
+/// index that already exists stays readable when its schema call cannot write.
+/// Here the pre-[ORB-11695] inline layout cannot be migrated in place, and the
+/// store must still open rather than degrade a readable index to unavailable.
+#[cfg(unix)]
+#[test]
+fn read_only_store_with_an_unmigratable_index_stays_ready() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let path = root.path().join("semantic.db");
+    rusqlite::Connection::open(&path)
+        .expect("create the legacy index")
+        .execute_batch(
+            r#"
+                CREATE VIRTUAL TABLE corpus_fts USING fts5(
+                    source_kind UNINDEXED,
+                    source_id UNINDEXED,
+                    field UNINDEXED,
+                    content,
+                    tokenize = 'porter unicode61 remove_diacritics 2'
+                );
+                INSERT INTO corpus_fts(source_kind, source_id, field, content)
+                VALUES ('task', 'T1', 'purpose', 'alpha neutrino');
+            "#,
+        )
+        .expect("seed the pre-migration inline layout");
+    if !deny_writes(&path) {
+        return;
+    }
+
+    let index = SemanticIndex::open(&path).expect("open the read-only legacy index");
+
+    let store = index
+        .store()
+        .expect("an existing index must stay readable when its migration cannot run");
+    let connection = store.connection();
+    let conn = connection.lock().expect("lock the vector connection");
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM corpus_fts WHERE corpus_fts MATCH 'neutrino'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("read the legacy corpus"),
+        1,
+        "the unmigrated rows must still be readable"
+    );
+}
+
+/// Make `path` refuse writes through its permission bits, reporting whether the
+/// running user is actually bound by them.
+#[cfg(unix)]
+fn deny_writes(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o400))
+        .expect("make the database read-only");
+    // A user that ignores the mode bits (typically root) cannot reproduce the
+    // write denial these fixtures are about.
+    std::fs::OpenOptions::new().write(true).open(path).is_err()
+}
+
+/// Restricts a directory's mode and restores it, so the temporary directory can
+/// be removed even when an assertion unwinds out of the test.
+#[cfg(unix)]
+struct ReadOnlyDir {
+    path: std::path::PathBuf,
+    original: std::fs::Permissions,
+}
+
+#[cfg(unix)]
+impl ReadOnlyDir {
+    fn hold(path: &std::path::Path) -> Self {
+        Self::hold_with_mode(path, 0o500)
+    }
+
+    fn hold_with_mode(path: &std::path::Path, mode: u32) -> Self {
+        use std::os::unix::fs::PermissionsExt;
+
+        let original = std::fs::metadata(path)
+            .expect("read directory permissions")
+            .permissions();
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+            .expect("restrict the state directory");
+        Self {
+            path: path.to_path_buf(),
+            original,
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for ReadOnlyDir {
+    fn drop(&mut self) {
+        let _ = std::fs::set_permissions(&self.path, self.original.clone());
+    }
+}

--- a/crates/orbit-search/src/vector/tests/mod.rs
+++ b/crates/orbit-search/src/vector/tests/mod.rs
@@ -1,5 +1,6 @@
 mod chunker;
 mod doc_fields;
+mod index;
 mod task_fields;
 mod worker;
 

--- a/docs/design/orbit-search/2_design.md
+++ b/docs/design/orbit-search/2_design.md
@@ -176,6 +176,18 @@ This makes "reindex everything" idempotent and cheap when nothing has changed. R
 
 **Same-source concurrency.** The first complete write (`upsert_embeddings` or `delete_source`) that commits after a snapshot wins. An in-flight upsert whose snapshot no longer matches does not write: it cannot mix field revisions, overwrite a later accepted source, or resurrect a deleted source. A hash recheck of only the fields this call prepared is not the commit gate. Unrelated sources and readers are not blocked during inference (mutex released; WAL).
 
+### 3.4 A refused index is a startup outcome, not a startup failure
+
+The semantic index is optional state: a workspace that never ran `orbit semantic index` has no `semantic.db` at all. A runtime therefore opens it as a `SemanticIndex`, which is either the open `VectorStore` or an explained refusal, and `orbit-core` holds that handle rather than a store it assumed exists.
+
+Unavailability is exactly one thing: the storage refused to give this process a usable index. A read-only mount with no `semantic.db`, a state directory the caller cannot write, a database whose schema cannot be built here, a directory this process cannot enter. Startup continues and the embed worker stays disabled, because there is nothing for it to write into.
+
+Everything else still propagates. A database that exists and fails to open is state that failed — a malformed file, an unusable WAL, an incompatible layout as in [§5.1](#51-fts5-virtual-table) — so a broken index is never mistaken for a refused one. The refusal is also not classified by asking whether the file exists: on a directory that denies inspection, that question is itself denied and its answer would call real state absent.
+
+The distinction runs one level down, in `VectorStore::open`. A schema call that cannot write is incidental when the database already carries an index — the pre-[ORB-11695] inline layout on a read-only mount is readable through its own reader and stays `Ready`. It is the whole answer when the database carries no index at all: every query would fail on a missing table and no writer could land a row, so that store is refused rather than handed out as ready for a long-lived host to start an embed worker against.
+
+An unavailable index is not an empty corpus. Every semantic operation reports it by name rather than returning a complete-looking empty result. That is what lets hybrid search degrade honestly: it falls back to lexical ranking and says why in the response's `notes` ([§6.3](#63-result-shape)). Authoritative stores — the task registry, the audit database — keep failing closed; only this optional index degrades.
+
 ---
 
 ## 4. What to Embed for Tasks


### PR DESCRIPTION
## Task

[ORB-12093](https://orbit-cli.com/tasks/ORB-12093) — Allow observational startup when optional semantic index is absent on read-only storage

### Description

## Confirmed failure
Root ran cargo test -p orbit-cli --test mcp_roundtrip readonly_state_mount_keeps_cli_and_mcp_reads_observational -- --exact --nocapture on final ORB-12090 worker source d9e47f5b821ddfce2cdf28a253acf206050fbe4c (merged PR1900 agent-main611c74cc). Actual host bwrap body executes, then read-only orbit.tool.list fails with store_error: failed to create SQLite state '/tmp/<fixture>/home/.orbit/state/semantic.db': Read-only file system (os error30). 0pass1fail0ignored, exit101. Earlier registry prefix error is fixed.

## Diagnosis and scope
runtime/builder.rs unconditionally calls VectorStore::open(&persistence.semantic_db). Missing DB -> open_private -> creation -> EROFS before observational fallback. Tool listing does not require semantic search. Fixture warms workspace.work semantic DB but no-workspace tool list resolves global HOME/.orbit semantic DB, which is absent. Simply warming that file would mask the actual startup defect. Allow observational runtime startup when this optional index is absent and cannot be created due readonly/access; semantic operations should report their capability unavailability honestly, not silently return an apparently complete empty corpus. Preserve existing malformed/incompatible DB errors and writable index creation. Keep task/registry authoritative data strict. Keep embed worker disabled for unavailable semantic store. Use current architecture to choose a bounded representation, not broad refactoring.

Preserve the actual mount test with global index absent, and run through later CLI/MCP assertions. If another unrelated failure appears, report exact evidence promptly. Root handles actual host bwrap replay if nested namespace denied; worker permission bits are supplemental only. Independent92 handles late-WAL selection in common SQLite; avoid editing its files if possible.

### Acceptance Criteria

- Actual readonly fixture with absent optional global semantic.db can list tools and perform supported task reads without creating any file; existing readonly mount test passes on host with unchanged protected state.
- Semantic index/search operations requiring an unavailable store return clear capability/error semantics, not a misleading successful empty result; existing malformed/incompatible database errors are preserved.
- Writable normal initialization still creates functional semantic state; unavailable semantic state does not start a writing embed worker; authoritative stores remain fail-closed.
- Add focused runtime/search tests for missing readonly index, existing malformed/incompatible store and ordinary writable state; run affected tests, make ci-fast, make ci-lint and formatting. Root replays real bwrap body when worker cannot.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Outcome

Runtime startup no longer dies when storage refuses the optional semantic index. `orbit-search` gains `SemanticIndex` (`crates/orbit-search/src/vector/index.rs`): `Ready(VectorStore)` or `Unavailable(reason)`. `SemanticIndex::open` degrades on a readonly/access refusal from `VectorStore::open` and propagates everything else. `orbit-core` `OrbitStores` holds that handle instead of `Arc<VectorStore>`, and every semantic call site reaches the store through `semantic_index().store()?`.

Confirmed reproduction of the reported fault before the fix (same failure class, EACCES vs the mount's EROFS):
`store_error: failed to create SQLite state '/tmp/.tmpT5ZHi1/home/.orbit/state/semantic.db': Permission denied (os error 13)` from a read-only `orbit tool list`.

Unavailability is deliberately *not* classified by asking whether the file exists: on a directory that denies inspection that question is itself denied, and its answer would label real state absent (root spotcheck 12:13). One level down, `VectorStore::open` now distinguishes an incidental schema-write refusal (the database already carries an index — e.g. a read-only pre-ORB-11695 inline layout, readable through its own reader) from a decisive one (no vector tables at all: every query would fail on a missing table and no writer could land a row). Only the former stays `Ready`; the latter returns its error, becomes `Unavailable`, and gets no embed worker.

## Criteria → results

1. **Readonly fixture with absent global semantic.db lists tools and performs task reads without creating a file; existing readonly mount test still passes.** Met. New `absent_global_semantic_index_keeps_read_only_cli_reads_observational` (crates/orbit-cli/tests/mcp_roundtrip.rs) drives the real `orbit` binary from a linked worktree with `ORBIT_ROOT` at the canonical root whose `state/` is mode 0500 and whose `semantic.db` is absent: `tool list --json` and `tool run orbit.task.show` both succeed and the index is still absent afterwards. Reverting the fix makes it fail with the exact reported diagnostic. `readonly_state_mount_keeps_cli_and_mcp_reads_observational` compiles and passes but **early-returns on this worker** — bwrap reports "No permissions to create new namespace"; root must replay the real bwrap body on the host. The permission-bits test is supplemental: it does not exercise the `--ro-bind` sidecar/directory refusal.
2. **Unavailable store returns capability/error semantics, not a misleading empty result; malformed/incompatible errors preserved.** Met. `SemanticIndex::store()` returns `OrbitError::Store("semantic index '<path>' is unavailable: this storage will not open or create it (<cause>); run `orbit semantic index` where the state directory is writable")`. `semantic_search`/`semantic_related`/`semantic_stats`/`semantic_index`/`doc_index`/`doc_semantic_search` all surface it; hybrid search degrades to lexical through the existing `fallback_reason` path with a note naming the unavailability; `orbit doctor` already renders it as a `semantic-index` warning. Malformed DB keeps the raw SQLite "not a database" diagnostic (asserted); the forward-only FTS5 layout diagnostic is untouched (query-time, not open-time).
3. **Writable init still functional; unavailable state starts no writing embed worker; authoritative stores fail closed.** Met. `writable_state_opens_a_usable_index` asserts creation + queryability. The builder matches `(host_lifetime, semantic_index.store())`, so `EmbedWorker::start` runs only for a long-lived host with a ready index; otherwise `EmbedWorker::disabled()`. The schema-presence guard closes the path where a schema-less read-only database could have posed as ready and received a worker. Task registry and audit database open paths are unchanged, and the mount test's `assert_readonly_mutation_failed` / `assert_readonly_diagnostic` assertions still hold in the full suite run.
4. **Focused tests + validation commands.** Met (with the bwrap limitation above). `crates/orbit-search/src/vector/tests/index.rs` covers six cases: ordinary writable state, absent index on an unwritable state directory, existing malformed database, existing inaccessible index (must not be labelled absent), read-only store with no vector schema (unavailable, not ready), read-only store with an unmigratable inline index (stays ready). `absent_semantic_index_on_unwritable_state_keeps_the_runtime_observational` in `crates/orbit-core/src/runtime/tests/builder.rs` opens a real runtime over an unwritable state dir: task reads answer, `semantic_search` errors by name, hybrid falls back to lexical with a disclosing note. Every fault-detecting test was verified to FAIL when its guard is mutated (degraded branch disabled; schema guard dropped; schema guard forced).

## Validation

- `cargo test -p orbit-search` — passed (99 lib + 2 parity).
- `cargo test -p orbit-core` — passed (1380 lib + all integration targets).
- `cargo test -p orbit-cli --test mcp_roundtrip` — passed (52; the bwrap mount test early-returns here).
- `cargo test -p orbit-cmd` — passed (131).
- `cargo build --workspace --all-targets` — passed.
- `make ci-fast` — passed (its own `test-compiler-cache-namespaces` step skips for the same bwrap denial).
- `make ci-lint` — passed (after fixing one `clippy::err_expect` and one unused import in the new tests).
- `cargo fmt --all --check` — clean. `git diff --check` clean; no stray artifacts.
- Not run: full `make ci` (workspace policy defers it to the PR gate); the bwrap mount-test body.

## Scope notes

Unlisted files changed, appended to `context_files`: `crates/orbit-search/src/vector/index.rs` and `crates/orbit-search/src/vector/tests/index.rs` (new owner of the behavior and its sibling tests), `crates/orbit-search/src/vector/mod.rs` + `crates/orbit-search/src/lib.rs` (module declaration and re-export needed to expose it to `orbit-core`), `crates/orbit-search/src/vector/store/schema.rs` (new `vector_schema_present` predicate behind the incidental-vs-decisive schema-failure split), and `docs/design/orbit-search/2_design.md` (new §3.4 documents the contract; the doc previously implied `VectorStore::open` always yields a store). No new cross-crate dependency edge — `orbit-core → orbit-search` already exists, so `ARCHITECTURE.md` is unchanged. `crates/orbit-common/src/storage/sqlite.rs` was deliberately not touched, leaving ORB-12092's late-WAL selection work uncontended. Listed selectors `vector/store/tests/schema.rs` and `search/tests/hybrid.rs` needed no change: the existing schema-migration tests and the override-driven hybrid fallback tests remain correct.

## Risks

- The read-only mount contract remains proven only by the host replay; this worker's permission-bits fixtures cannot refuse the directory and sidecar writes a `--ro-bind` refuses.
- All permission-bits fixtures self-skip (restoring the mode first) when the running user ignores mode bits, so they contribute no signal under a root test runner.
- `crates/orbit-cli/tests/mcp_roundtrip.rs` grows to ~5,000 lines. The new test was placed with its existing read-only sibling rather than split out; that file is already well past the size guidance and is a standing candidate for a split.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12093-6aa29b4c`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: sol