### PR TITLE
Align read-only MCP mutation diagnostics with the layout-v3 canonical data partition

### DIFF
--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -4536,6 +4536,10 @@ fn readonly_state_mount_keeps_cli_and_mcp_reads_observational() {
         assert_command_succeeded(name, &output);
     }
 
+    // `TaskUpdateParams` has no workspace selector, so `--root canonical_root`
+    // is the only routing this mutation gets: it always lands in the unbound
+    // canonical partition (`UNBOUND_DATA_DIR_WORKSPACE_ID`), not the checkout's
+    // bound workspace. The denial below must therefore name that partition.
     let mutation = readonly_orbit_command(
         &worktree,
         &workspace.home,
@@ -4558,7 +4562,7 @@ fn readonly_state_mount_keeps_cli_and_mcp_reads_observational() {
     ])
     .output()
     .expect("attempt task mutation through the read-only mount");
-    assert_readonly_mutation_failed("CLI", &mutation);
+    assert_readonly_mutation_failed("CLI", &canonical_root, &mutation);
 
     let mut child = readonly_orbit_command(
         &worktree,
@@ -4613,6 +4617,9 @@ fn readonly_state_mount_keeps_cli_and_mcp_reads_observational() {
         )["mode"],
         "lexical"
     );
+    // Same unbound-partition routing as the CLI mutation above: the server was
+    // started with `--root canonical_root` and `orbit_task_update` has no
+    // workspace selector to route it elsewhere.
     let mutation = client.call_tool_err(
         "orbit_task_update",
         json!({
@@ -4621,7 +4628,11 @@ fn readonly_state_mount_keeps_cli_and_mcp_reads_observational() {
             "model": "codex"
         }),
     );
-    assert_readonly_diagnostic("MCP", mutation["message"].as_str().unwrap_or_default());
+    assert_readonly_diagnostic(
+        "MCP",
+        &canonical_root,
+        mutation["message"].as_str().unwrap_or_default(),
+    );
     drop(client);
 
     assert_eq!(
@@ -4981,19 +4992,36 @@ fn assert_command_succeeded(label: &str, output: &std::process::Output) {
 }
 
 #[cfg(target_os = "linux")]
-fn assert_readonly_mutation_failed(label: &str, output: &std::process::Output) {
+fn assert_readonly_mutation_failed(
+    label: &str,
+    canonical_root: &Path,
+    output: &std::process::Output,
+) {
     assert!(
         !output.status.success(),
         "{label} mutation unexpectedly succeeded"
     );
-    assert_readonly_diagnostic(label, &String::from_utf8_lossy(&output.stderr));
+    assert_readonly_diagnostic(
+        label,
+        canonical_root,
+        &String::from_utf8_lossy(&output.stderr),
+    );
 }
 
+/// Both CLI and MCP mutations above route through `--root canonical_root`
+/// with no workspace selector, so the denial must name the unbound canonical
+/// partition (`UNBOUND_DATA_DIR_WORKSPACE_ID` in `orbit-core`'s runtime
+/// builder) that write actually targeted, not a stale pre-layout-v3 lock path.
 #[cfg(target_os = "linux")]
-fn assert_readonly_diagnostic(label: &str, diagnostic: &str) {
+fn assert_readonly_diagnostic(label: &str, canonical_root: &Path, diagnostic: &str) {
+    let unbound_partition = canonical_root
+        .join("tasks")
+        .join("workspaces")
+        .join("ws_unbound-data-dir");
+    let unbound_partition = unbound_partition.to_str().expect("utf8 partition path");
     assert!(
-        diagnostic.contains(".task.yaml.lock"),
-        "{label} diagnostic must attribute the task path: {diagnostic}"
+        diagnostic.contains(unbound_partition),
+        "{label} diagnostic must attribute the unbound canonical partition {unbound_partition}: {diagnostic}"
     );
     let normalized = diagnostic.to_ascii_lowercase();
     assert!(


### PR DESCRIPTION
## Task

[ORB-12094](https://orbit-cli.com/tasks/ORB-12094) — Align read-only MCP mutation diagnostics with the layout-v3 canonical data partition

### Description

## Confirmed validation defect
Actualhost test on3398870e082a5112b3bea4870c90d175d1cf1f98 nowpasses readonlyCLItool-list/taskreads after90/92/93, but readonly_state_mount_keeps_cli_and_mcp_reads_observational fails at mcp_roundtrip.rs4994: assert_readonly_diagnostic demands .task.yaml.lock. Actualmutationerror is io_error, canonical HOME/.orbit/tasks/workspaces/ws_unbound-data-dir notwritable EROFS. Bothmutation invocations deliberatelyuse --root canonical_root (lines4549/4573), noselectedcheckout. Runtimebuilder explicitlyassigns UNBOUND_DATA_DIR_WORKSPACE_ID=ws_unbound-data-dir for thiscase; TaskUpdateParams hasnoworkspaceselector. This is the correct protectedcanonicalpartition denial, notwrongproductrouting. The oldv2lockpath assertion isstale.

## Bounded fix
Changeonlythe MCP integrationfixture: pass canonical_root into diagnosticassertions and require its exact tasks/workspaces/ws_unbound-data-dir path plusEROFS/EACCES/not-writable. Commentwhy --root exercisesunboundcanonicalpartition. PreservebothCLIandMCPmutationdenials, allreadonlyreads includingWAL-onlytask, andcompletebefore/afterprotectedstatebytescheck. Do notweaken togenericerror or countincidental loggingwarningsas mutationdenial. No productcodechange; no host/tmp workaround. Rootwillreplayrealbwrapbody asnestedworker namespacescanbeunavailable.

### Acceptance Criteria

- Diagnostic checks attribute both denied mutations to exactfixture canonicalroot/tasks/workspaces/ws_unbound-data-dir and retain readonly/access errorclassification.
- All existing CLI/MCP read assertions, WAL-only taskvisibility, mutation-denial andfinalprotectedfilebytes assertions remainintact. Actualhost replaypassesfullbody (rootoperatorhandoffifnestednamespaces unavailable).
- Run focused MCP integrationtarget, formatting, make ci-fast andmake ci-lint; distinguishworkerbody skipsfromactualhostPASS. Changeonlymcp_roundtrip.rs unlessconcrete evidence provesanotherfixturetargetrequired.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success (implementation and worker-available validation complete; privileged bwrap-mount replay remains a root-operator handoff)

Note: a prior run's execution_summary on this task described this same fix, but the worktree and git history showed no such change had ever landed or persisted (clean tree, no commit touching mcp_roundtrip.rs). This run re-implemented the fix from scratch in a fresh worktree.

Changes (only `crates/orbit-cli/tests/mcp_roundtrip.rs`):
- `assert_readonly_diagnostic` now takes `canonical_root: &Path` and asserts the diagnostic contains the exact `<canonical_root>/tasks/workspaces/ws_unbound-data-dir` path (verified against `UNBOUND_DATA_DIR_WORKSPACE_ID` in `crates/orbit-core/src/runtime/builder.rs` and the write-error formatting in `OrbitError::from_write_io` / `write_access_error_message`, which embeds the full target path being written), replacing the stale `.task.yaml.lock` expectation. The EROFS/EACCES/not-writable classification check is unchanged.
- `assert_readonly_mutation_failed` now threads `canonical_root` through to `assert_readonly_diagnostic`.
- Both call sites (CLI mutation and MCP `orbit_task_update` mutation) now pass `canonical_root`, with a comment on each explaining that `--root canonical_root` is the only routing available because `TaskUpdateParams` has no workspace selector, so both mutations always land in the unbound canonical partition.

Criteria evidence:
1. Met: both CLI and MCP diagnostic assertions route through `assert_readonly_diagnostic`, which now requires the exact `canonical_root/tasks/workspaces/ws_unbound-data-dir` substring and still requires the read-only/permission/not-writable classification.
2. Met: all pre-existing assertions are intact — read-only CLI/MCP reads (tool list, task show x2, task list, search), WAL-only task visibility (`main_registry_file_has_task` check plus the MCP `orbit_task_list` assertion), both mutation-denial checks, and the final `snapshot_fixture_state` before/after equality check on canonical and workspace state. Actual full-body replay under the bwrap read-only mount was not available in this managed worker: `bwrap --die-with-parent --ro-bind / / -- /bin/true` fails with "No permissions to create new namespace" (exit 1), so `readonly_state_mount_keeps_cli_and_mcp_reads_observational` takes its documented early-return guard rather than exercising the new assertions end-to-end. This is an environment limitation, not evidence against correctness; the assertion logic was verified by direct inspection of the runtime write-error path (see Changes). Actual privileged-host replay remains a root-operator handoff.
3. Met for available validation: `cargo fmt --all -- --check` passed; `cargo test -p orbit-cli --test mcp_roundtrip --no-run` compiles cleanly; `make ci-fast` passed (its own namespace-specific cache test reported the same expected environment skip: "cannot create a mount namespace"); `make ci-lint` passed with no warnings; the focused command `cargo test -p orbit-cli --test mcp_roundtrip readonly_state_mount_keeps_cli_and_mcp_reads_observational -- --nocapture` passed at the worker boundary (1 passed) with the body-skip noted above. `git diff --check` passed and `git status --short` shows only the intended tracked file modified.

Validation:
- passed: `cargo fmt --all -- --check`
- passed: `cargo test -p orbit-cli --test mcp_roundtrip --no-run` (compile check)
- passed: `make ci-fast`
- passed: `make ci-lint`
- passed (worker harness; mount-test body skipped by design): `cargo test -p orbit-cli --test mcp_roundtrip readonly_state_mount_keeps_cli_and_mcp_reads_observational -- --nocapture`
- passed: `git diff --check`
- not run: privileged actual-host bwrap-mount full-body replay; requires root operator handoff because unprivileged user/mount namespaces are denied in this worker (`bwrap: No permissions to create new namespace`).

Risks / deviations:
- No product code or other fixture changed; only `mcp_roundtrip.rs`.
- The new path assertion is inferred from tracing the actual write-error code path (`orbit-store/src/fs/yaml.rs` → `OrbitError::from_write_io` → `orbit-common/src/fs/io.rs::write_access_error_message`) rather than from a captured live diagnostic string, because the mount-test body cannot run in this worker. The privileged replay is the remaining piece of direct evidence.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12094-6aa35a96`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: sol