### PR TITLE
Fix unused LinuxRuntimeWriteAuthority import in v2 host sandbox

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
@@ -9,8 +9,10 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::path::PathBuf;
 
+#[cfg(target_os = "linux")]
+use orbit_engine::LinuxRuntimeWriteAuthority;
 use orbit_engine::RuntimeHost;
-use orbit_engine::{DispatchError, LinuxRuntimeWriteAuthority, ResolvedSandbox};
+use orbit_engine::{DispatchError, ResolvedSandbox};
 use orbit_types::policy::{ResolvedFsProfile, UNRESTRICTED_FS_PROFILE};
 use orbit_types::workflow::ExecutorSandboxKind;
 


### PR DESCRIPTION
## Task

[ORB-12095](https://orbit-cli.com/tasks/ORB-12095) — Fix unused LinuxRuntimeWriteAuthority import in v2 host sandbox

### Description

User reports Rust unused_imports warning at crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs:13:35 for `use orbit_engine::{DispatchError, LinuxRuntimeWriteAuthority, ResolvedSandbox};`.

Inspect the current import and its uses, including target/feature cfg gates. Remove it if obsolete or gate it consistently with its consumers if needed only on certain targets. The reporting target and feature flags were not supplied; do not assume a Linux-only check reproduces a potential non-Linux warning. Preserve sandbox runtime-write authority behavior and avoid blanket warning suppression. Keep this a narrowly scoped warning fix.

### Acceptance Criteria

- The reported LinuxRuntimeWriteAuthority unused-import warning is absent from an orbit-core check on the affected target/configuration; record the target, features, and command used.
- Linux consumers of LinuxRuntimeWriteAuthority still compile; any target-specific import uses cfg conditions consistent with its consumers.
- The change does not add allow(unused_imports) or weaken sandbox behavior; formatting and applicable repository lint checks pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a target_os = "linux" cfg gate to the LinuxRuntimeWriteAuthority import in crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs.
- Kept DispatchError, ResolvedSandbox, and RuntimeHost unconditional; all LinuxRuntimeWriteAuthority consumers remain in Linux-cfg functions, preserving runtime-write authority behavior.
- No allow(unused_imports) or sandbox-policy weakening was added.

Acceptance criteria:
- The warning is absent under RUSTFLAGS='-D warnings' cargo check -p orbit-core --all-targets --target x86_64-unknown-linux-gnu --no-default-features; target: x86_64-unknown-linux-gnu, features: no default features.
- Linux consumers compile in that same all-targets orbit-core check, and the import cfg matches every consumer's target cfg.
- cargo fmt --all -- --check, make ci-fast, make ci-lint, and git diff --check passed. The ci-fast compiler-cache namespace subcheck reported an environment skip because unprivileged bubblewrap namespaces are unavailable; the gate itself exited successfully.

Validation:
- Passed: cargo check -p orbit-core --all-targets --target x86_64-unknown-linux-gnu.
- Passed: RUSTFLAGS='-D warnings' cargo check -p orbit-core --all-targets --target x86_64-unknown-linux-gnu --no-default-features.
- Passed: cargo fmt --all -- --check.
- Passed: make ci-fast (with the documented namespace subcheck skip).
- Passed: make ci-lint.
- Passed: git diff --check.
- Passed: rg -n "allow\\([^)]*unused_imports" crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs found no suppression.
- Not run: a non-Linux cross-target check; rustup target list --installed exposed only x86_64-unknown-linux-gnu in this environment. Source inspection confirms the import and all uses share the Linux cfg.

Assessment: Narrow, formatted, warning-focused change with no runtime behavior change or unrelated file modifications.

Remaining risk: Non-Linux compilation was not executable in this checkout because no non-Linux Rust target is installed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12095-6aa35b88`
- Behind base: 0
- Ahead of base: 1