### PR TITLE
orbit.task.show with a non-matching workspace filter leaves a stray bundle lock file

### DIFF
--- a/crates/orbit-store/src/repository/task/tests/v2_bundle.rs
+++ b/crates/orbit-store/src/repository/task/tests/v2_bundle.rs
@@ -123,6 +123,31 @@ fn bundle_store_lists_registered_bundles_from_registry() {
 }
 
 #[test]
+fn missing_bundle_read_does_not_create_lock_artifact() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = bundle_store(&temp);
+    store
+        .create_bundle(&sample_bundle("ORB-00000"))
+        .expect("create existing bundle");
+    let missing_bundle = store.bundle_path("ORB-00001").expect("missing bundle path");
+    let tasks_dir = missing_bundle.parent().expect("bundle parent");
+    let entries_before = lock_entries_for_task(tasks_dir, "ORB-00001");
+
+    assert!(matches!(
+        store.read_bundle("ORB-00001"),
+        Err(OrbitError::NotFound {
+            kind: NotFoundKind::Task,
+            ..
+        })
+    ));
+
+    assert_eq!(
+        lock_entries_for_task(tasks_dir, "ORB-00001"),
+        entries_before
+    );
+}
+
+#[test]
 fn delete_bundle_removes_canonical_bundle_and_registry_rows() {
     let temp = TempDir::new().expect("tempdir");
     let store = bundle_store(&temp);

--- a/crates/orbit-store/src/repository/task/v2_bundle.rs
+++ b/crates/orbit-store/src/repository/task/v2_bundle.rs
@@ -433,6 +433,12 @@ fn deletion_fault(_fault: DeletionFault) -> Result<(), OrbitError> {
 /// place atomically, so one file is always self-consistent, and the index
 /// validation that reads it on every listing pays nothing here.
 fn read_bundle_consistently(bundle_dir: &Path) -> Result<TaskBundleV2, OrbitError> {
+    // A missing bundle cannot be in a lifecycle transition. Avoid asking the
+    // shared-lock helper to create a stable lock target for a filtered miss.
+    if !bundle_dir.try_exists()? {
+        return read_bundle_at(bundle_dir);
+    }
+
     with_shared_file_lock(&bundle_lock_target(bundle_dir), "task artifact v2", || {
         read_bundle_at(bundle_dir)
     })
@@ -440,6 +446,10 @@ fn read_bundle_consistently(bundle_dir: &Path) -> Result<TaskBundleV2, OrbitErro
 
 /// Same lock as [`read_bundle_consistently`], without hashing artifact blobs.
 fn read_bundle_lightweight_consistently(bundle_dir: &Path) -> Result<TaskBundleV2, OrbitError> {
+    if !bundle_dir.try_exists()? {
+        return read_bundle_lightweight_at(bundle_dir);
+    }
+
     with_shared_file_lock(&bundle_lock_target(bundle_dir), "task artifact v2", || {
         read_bundle_lightweight_at(bundle_dir)
     })


### PR DESCRIPTION
## Task

[ORB-12104](https://orbit-cli.com/tasks/ORB-12104) — orbit.task.show with a non-matching workspace filter leaves a stray bundle lock file

### Description

Found during a full QA sweep of orbit 0.20.0 on the Mac mini (2026-09-10).


 `orbit.task.show` takes the task's bundle lock in the *filtered* workspace before checking
 that the task exists there, so a fail-closed workspace filter still creates a 0-byte
 `.<TASK_ID>.bundle.lock` in a workspace that has no such task. The file is never cleaned up.

 ## Repro
 ```
 orbit tool run orbit.task.show --input '{"id":"<task in ws A>","workspace":"<ws B>"}'
 # -> {"code":"task_not_found", ...}
 ls -a ~/.orbit/tasks/workspaces/<ws_B>/.<TASK_ID>.bundle.lock   # exists, 0 bytes
 ```
 Reproduced twice (`ws_dsearch`, `ws_kvdb`) on 0.20.0. Over time any workspace queried with a
 wrong filter accumulates dead lock files; `orbit doctor`'s stale-lock check scans them.

 ## Expected
 Resolve the task's existence in the selected workspace before acquiring its bundle lock, or
 remove the lock target when the lookup misses.

### Acceptance Criteria

- A `task.show` that returns `task_not_found` under a workspace filter leaves no new lock file behind
- Existing task reads keep their current locking guarantees
- Test asserts no lock artifact after a filtered miss

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a missing-bundle preflight to full and lightweight v2 bundle reads so a workspace-filtered task miss returns the existing not-found result without creating a sibling bundle lock file.
- Added a regression test that confirms a missing task read leaves the workspace task directory's lock entries unchanged.

Criteria:
- Filtered `task.show` misses leave no new lock artifact: met by the preflight and regression test.
- Existing task reads retain locking guarantees: met; existing bundle paths still execute through `with_shared_file_lock`.
- Test asserts no lock artifact after a filtered miss: met by `missing_bundle_read_does_not_create_lock_artifact`.

Validation:
- `cargo fmt --all -- --check`: passed.
- `cargo test -p orbit-store missing_bundle_read_does_not_create_lock_artifact`: passed.
- `cargo test -p orbit-store repository::task::tests::v2_bundle`: passed (12 tests).
- `make ci-fast`: passed; the compiler-cache namespace subcheck reported the documented environment limitation that bubblewrap cannot create a mount namespace, while its safe fallback checks passed.
- `make ci-lint`: passed.
- `git diff --check`: passed.
- `git status --short`: only the two scoped source/test files are modified.

Assessment: Small, scoped fix at the shared bundle-read boundary with coverage for the filtered-miss regression. Remaining risk is limited to the existing concurrent deletion race semantics around a bundle disappearing before the preflight check.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12104-6aa36d67`
- Behind base: 0
- Ahead of base: 1