### PR TITLE
Global --workspace is ignored by orbit tool run

### DIFF
--- a/crates/orbit-cli/src/command/tool/run.rs
+++ b/crates/orbit-cli/src/command/tool/run.rs
@@ -152,6 +152,7 @@ pub(super) fn local_tool_session_context(
 ) -> Result<ToolSessionContext, OrbitError> {
     let (machine_id, host_id) = local_machine_identity(&runtime.global_root())?;
     Ok(ToolSessionContext {
+        workspace: Some(runtime.paths().repo_root.to_string_lossy().into_owned()),
         workspace_id: owner
             .map(|owner| owner.id.clone())
             .or_else(|| runtime.workspace_id().ok()),

--- a/crates/orbit-cli/tests/workspace_selector.rs
+++ b/crates/orbit-cli/tests/workspace_selector.rs
@@ -228,6 +228,144 @@ fn global_workspace_flag_fails_closed_on_unknown_selector() {
     );
 }
 
+#[test]
+fn tool_run_workspace_selection_uses_global_flag_and_input_precedence() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let orbit_repo = temp.path().join("orbit");
+    let other_repo = temp.path().join("other");
+    let elsewhere = temp.path().join("elsewhere");
+    fs::create_dir_all(&home).expect("home");
+    fs::create_dir_all(&elsewhere).expect("elsewhere");
+
+    init_git_repo(&orbit_repo);
+    init_git_repo(&other_repo);
+
+    run_orbit(
+        &orbit_repo,
+        &home,
+        &[
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "selector-host",
+            "--task-prefix",
+            "SEL",
+        ],
+    )
+    .success();
+    run_orbit(
+        &orbit_repo,
+        &home,
+        &["workspace", "init", "--name", "orbit"],
+    )
+    .success();
+    run_orbit(
+        &other_repo,
+        &home,
+        &["workspace", "init", "--name", "other"],
+    )
+    .success();
+
+    let shown = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "--workspace",
+            "orbit",
+            "--format",
+            "json",
+            "workspace",
+            "show",
+        ],
+    );
+    assert_eq!(
+        Path::new(shown["checkout"]["repo_root"].as_str().expect("repo root")),
+        fs::canonicalize(&orbit_repo).expect("canonical orbit repo")
+    );
+    assert_eq!(
+        Path::new(shown["checkout"]["orbit_dir"].as_str().expect("orbit dir")),
+        fs::canonicalize(orbit_repo.join(".orbit")).expect("canonical orbit dir")
+    );
+
+    let flag_only = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "--workspace",
+            "orbit",
+            "tool",
+            "run",
+            "orbit.task.add",
+            "--input",
+            r#"{"title":"Selected by global flag","description":"Global selector","complexity":"low","model":"codex"}"#,
+        ],
+    );
+    assert_eq!(flag_only["title"], "Selected by global flag");
+
+    let input_only = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "tool",
+            "run",
+            "orbit.task.add",
+            "--input",
+            r#"{"title":"Selected by input","description":"Input selector","workspace":"other","complexity":"low","model":"codex"}"#,
+        ],
+    );
+    assert_eq!(input_only["title"], "Selected by input");
+
+    let both_supplied = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "--workspace",
+            "other",
+            "tool",
+            "run",
+            "orbit.task.add",
+            "--input",
+            r#"{"title":"Input wins","description":"Explicit input selector","workspace":"orbit","complexity":"low","model":"codex"}"#,
+        ],
+    );
+    assert_eq!(both_supplied["title"], "Input wins");
+
+    let orbit_tasks = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "--workspace",
+            "orbit",
+            "tool",
+            "run",
+            "orbit.task.list",
+            "--input",
+            r#"{"limit":10,"model":"codex"}"#,
+        ],
+    );
+    let orbit_titles = task_titles(&orbit_tasks);
+    assert!(orbit_titles.contains(&"Selected by global flag".to_string()));
+    assert!(orbit_titles.contains(&"Input wins".to_string()));
+    assert!(!orbit_titles.contains(&"Selected by input".to_string()));
+
+    let other_tasks = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "tool",
+            "run",
+            "orbit.task.list",
+            "--input",
+            r#"{"workspace":"other","limit":10,"model":"codex"}"#,
+        ],
+    );
+    let other_titles = task_titles(&other_tasks);
+    assert!(other_titles.contains(&"Selected by input".to_string()));
+    assert!(!other_titles.contains(&"Selected by global flag".to_string()));
+    assert!(!other_titles.contains(&"Input wins".to_string()));
+}
+
 /// A workspace whose ID equals another workspace's name must still be reachable
 /// from its checkout and by absolute path. The colliding token stays fail-closed
 /// only when the operator types it as an id-or-name selector [ORB-11805].
@@ -732,6 +870,22 @@ fn task_ids(value: &Value) -> Vec<String> {
         .iter()
         .filter_map(|task| {
             task.get("id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+        .collect()
+}
+
+fn task_titles(value: &Value) -> Vec<String> {
+    let items = value
+        .as_array()
+        .cloned()
+        .or_else(|| value.get("tasks").and_then(Value::as_array).cloned())
+        .unwrap_or_default();
+    items
+        .iter()
+        .filter_map(|task| {
+            task.get("title")
                 .and_then(Value::as_str)
                 .map(ToOwned::to_owned)
         })


### PR DESCRIPTION
## Task

[ORB-12106](https://orbit-cli.com/tasks/ORB-12106) — Global --workspace is ignored by orbit tool run

### Description

Found during a full QA sweep of orbit 0.20.0 on the Mac mini (2026-09-10).


 Every other subcommand honours the global `--workspace <SELECTOR>` flag, but the tool surface
 only reads `workspace` from the JSON input:

 ```
 orbit --workspace qa-sweep tool run orbit.task.add --input '{"title":"x","description":"y","complexity":"low"}'
 # -> invalid input: missing `workspace`; pass a registered workspace name, ...
 ```

 while the identical call with `"workspace":"qa-sweep"` inside the JSON succeeds. The error
 text does not mention that the global flag exists and will not be used, so the natural fix
 (adding the flag) fails silently in the same way.

 ## Expected
 `orbit tool run` should accept the global `--workspace` as the selector when the input omits
 one (input still wins if both are present), or the error should say the flag is not consulted
 on this surface.

### Acceptance Criteria

- `orbit --workspace <ws> tool run <tool>` resolves the workspace for tools that require one
- An explicit `workspace` in the JSON input still takes precedence
- MCP-session-provided workspace resolution is unchanged
- Test covers flag-only, input-only, and both-supplied cases

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added the resolved local runtime checkout path to the CLI tool session context so workspace-required tools can use global --workspace when JSON input omits workspace.
- Added integration coverage for global-flag-only routing, input-only routing, explicit input precedence when both selectors are supplied, and routing verification against the selected checkout.

Assessment: The local CLI adapter now supplies the same resolved checkout selector used by workspace-required tools; explicit JSON input remains authoritative, and MCP session handling is unchanged.

Acceptance criteria:
- Global --workspace resolves workspace-required tools: passed by tool_run_workspace_selection_uses_global_flag_and_input_precedence.
- Explicit JSON workspace takes precedence: passed; global other plus input orbit writes to orbit.
- MCP-session-provided workspace resolution unchanged: passed by managed_mcp_config_updates_a_task_without_a_workspace_argument; MCP source was not changed.
- Flag-only, input-only, and both-supplied cases covered: passed by the new integration test.

Validation:
- cargo test -p orbit-cli --test workspace_selector tool_run_workspace_selection_uses_global_flag_and_input_precedence -- --exact: passed.
- cargo test -p orbit-cli --test workspace_selector: passed (7 tests).
- cargo test -p orbit-cli --test mcp_roundtrip managed_mcp_config_updates_a_task_without_a_workspace_argument -- --exact: passed.
- cargo fmt --all -- --check: passed.
- make ci-fast: passed; compiler-cache namespace check was skipped by the environment because bubblewrap cannot create an unprivileged mount namespace.
- make ci-lint: passed.
- git diff --check: passed.
- git status --short: two intended tracked modifications only.

Risks/deviations:
- No known behavioral risks beyond the existing platform limitation noted for the skipped namespace check. Changes remain uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12106-6aa36d6b`
- Behind base: 0
- Ahead of base: 1