### PR TITLE
mcp-callers.toml cannot deny a single caller while the file default is agent

### DIFF
--- a/crates/orbit-cli/src/command/mcp/callers.rs
+++ b/crates/orbit-cli/src/command/mcp/callers.rs
@@ -181,6 +181,14 @@ fn check(path: &Path, machine_id: &str) -> CommandOut {
         }
     );
     println!("granted: [{}]", capability_list(&grant.granted));
+    println!(
+        "decision: {}",
+        if grant.granted.is_empty() {
+            "denied"
+        } else {
+            "granted"
+        }
+    );
     match &grant.pinned_fingerprint {
         Some(fingerprint) => println!(
             "identity pin: {fingerprint}, enforced where this machine can observe the \

--- a/crates/orbit-mcp/src/remote/callers.rs
+++ b/crates/orbit-mcp/src/remote/callers.rs
@@ -85,8 +85,9 @@ pub struct CallerRow {
     /// The calling machine's stable `hm_…` identity.
     pub machine_id: String,
     /// The ceiling this destination serves that caller. `agent` and
-    /// `operator` only; `runner` is stamped in-process by a managed run and
-    /// can never arrive over a transport.
+    /// `operator` grant capabilities; `deny` or an empty list grants none.
+    /// `runner` is stamped in-process by a managed run and can never arrive
+    /// over a transport.
     pub capabilities: Vec<String>,
     /// Operator-facing display name. Never an identity input.
     #[serde(default)]
@@ -275,18 +276,24 @@ fn validate_workspace_scope(
 }
 
 /// The row's capabilities, as the grantable subset of the capability
-/// vocabulary.
+/// vocabulary. `deny` and an empty list are the explicit empty-grant forms.
 ///
 /// `runner` parses as a capability everywhere else in Orbit, which is exactly
 /// why it is rejected by name here rather than left to fall through an unknown
 /// value: a run's own sanction must not be reachable over a transport.
 fn parse_capabilities(row: &CallerRow, path: &Path) -> Result<BTreeSet<McpCapability>, OrbitError> {
     if row.capabilities.is_empty() {
+        return Ok(BTreeSet::new());
+    }
+    if row.capabilities.iter().any(|value| value == "deny") {
+        if row.capabilities.len() == 1 {
+            return Ok(BTreeSet::new());
+        }
         return Err(invalid(
             path,
             format!(
-                "caller '{}' has an empty `capabilities` list; use `default = \"deny\"` or remove \
-                 the row",
+                "caller '{}' combines `deny` with grant capabilities; use `deny` alone or an \
+                 empty `capabilities` list",
                 row.machine_id
             ),
         ));
@@ -299,8 +306,8 @@ fn parse_capabilities(row: &CallerRow, path: &Path) -> Result<BTreeSet<McpCapabi
             other => Err(invalid(
                 path,
                 format!(
-                    "caller '{}' declares capability '{other}'; only `agent` and `operator` may \
-                     be granted to a caller",
+                    "caller '{}' declares capability '{other}'; use `agent`, `operator`, or \
+                     `deny` for a caller capability",
                     row.machine_id
                 ),
             )),
@@ -799,7 +806,8 @@ pub fn render_callers_seed(callers: &[SeedCaller]) -> String {
          # Raising a row to operator is a deliberate hand edit.\n\
          \n\
          # Capabilities served to a caller that matches no row below.\n\
-         # Permitted values: \"agent\" or \"deny\".\n\
+         # File default values: \"agent\" or \"deny\". Operator is never a default.\n\
+         # Per-caller values: \"agent\", \"operator\", or \"deny\"; \"deny\" and [] grant none.\n\
          default = \"agent\"\n",
     );
     for caller in callers {

--- a/crates/orbit-mcp/src/remote/tests/callers.rs
+++ b/crates/orbit-mcp/src/remote/tests/callers.rs
@@ -99,12 +99,51 @@ capabilities = ["agent", "runner"]
 }
 
 #[test]
+fn a_caller_can_be_denied_with_an_explicit_or_empty_capability_list() {
+    for capabilities in [r#"["deny"]"#, "[]"] {
+        let (_dir, path) = write(&format!(
+            r#"
+default = "agent"
+
+[[callers]]
+machine_id = "hm_denied"
+capabilities = {capabilities}
+"#
+        ));
+        let file = load_callers(&path).expect("a denied row must parse");
+        let grant = file.resolve(&caller("hm_denied"));
+
+        assert!(grant.matched);
+        assert!(grant.granted.is_empty());
+        assert!(
+            SessionCapabilityPolicy::from_grant(McpSessionAuthority::Operator, grant)
+                .effective_for(None)
+                .is_empty(),
+            "a denied row must override the agent default"
+        );
+    }
+}
+
+#[test]
+fn deny_cannot_be_combined_with_a_grant_capability() {
+    let (_dir, path) = write(
+        r#"
+[[callers]]
+machine_id = "hm_denied"
+capabilities = ["deny", "agent"]
+"#,
+    );
+
+    let error = load_callers(&path).expect_err("mixed deny and grant must be rejected");
+
+    assert!(error.to_string().contains("deny"), "{error}");
+}
+
+#[test]
 fn a_malformed_file_is_never_served_as_if_absent() {
     for contents in [
         // Unknown key.
         "[[callers]]\nmachine_id = \"hm_alpha\"\ncapabilities = [\"agent\"]\nallow = true\n",
-        // Empty capabilities.
-        "[[callers]]\nmachine_id = \"hm_alpha\"\ncapabilities = []\n",
         // Unknown default.
         "default = \"operator\"\n",
         // Malformed machine_id.
@@ -514,7 +553,7 @@ fn the_seeder_never_writes_an_operator_grant() {
         },
     ]);
 
-    assert!(!seeded.contains("\"operator\""));
+    assert!(!seeded.contains("capabilities = [\"operator\"]"));
     assert!(seeded.contains("machine_id   = \"hm_alpha\""));
     assert!(seeded.contains("label        = \"daniels-mac-mini\""));
     assert!(seeded.contains("capabilities = [\"agent\"]"));

--- a/docs/design/federated-mcp/specs/caller-authorization.md
+++ b/docs/design/federated-mcp/specs/caller-authorization.md
@@ -46,7 +46,8 @@ Destination-side authorization is declared in the machine-global operator file `
 
 ```toml
 # Capabilities served to a caller that matches no row below.
-# Permitted values: "agent" or "deny". Operator is never a default.
+# File default values: "agent" or "deny". Operator is never a default.
+# Per-caller values: "agent", "operator", or "deny"; "deny" and [] grant none.
 default = "agent"
 
 [[callers]]
@@ -71,6 +72,10 @@ agent_invoke_mode = "cooperative"
 [[callers]]
 machine_id   = "hm_gamma"
 capabilities = ["agent"]
+
+[[callers]]
+machine_id   = "hm_denied"
+capabilities = ["deny"]
 ```
 
 Row keys:
@@ -78,7 +83,7 @@ Row keys:
 | Key | Required | Meaning |
 |---|---|---|
 | `machine_id` | yes | The calling machine's stable `hm_…` identity. Matched against the caller identity resolved below. |
-| `capabilities` | yes | The ceiling this destination will serve that caller. Values are `agent` and `operator` only. |
+| `capabilities` | yes | The ceiling this destination will serve that caller. Values are `agent` and `operator`; `deny` or an empty list grants no capabilities. `deny` must be used alone. |
 | `label` | no | Operator-facing display name. Never an identity input. |
 | `workspaces` | no | Narrows the grant to these logical `ws_*` IDs. Omitted means every workspace on this destination. |
 | `ssh_key_fingerprint` | no | Binds the row to a key sshd authenticated, in the `SHA256:…` form `ssh-keygen -l` prints. See Tier 2. |
@@ -90,7 +95,7 @@ File-level invariants:
 
 1. A missing file is valid and means `default = "agent"` with no rows.
 2. A duplicate `machine_id` makes the entire file invalid with `ambiguous_caller` at load, before any session is served — the same fail-closed shape `ambiguous_destination` has in the destinations file.
-3. An unknown key, an unknown capability value, an empty `capabilities`, a `default` other than `agent` or `deny`, a malformed `machine_id`, or an `ssh_key_fingerprint` that is not a well-formed `SHA256:` digest invalidates the file at load. A malformed file is never served as if absent. The fingerprint format is checked here rather than at comparison time because a fingerprint in the wrong shape — an `MD5:` one, most plausibly — would otherwise never match and would present as a key mismatch on every session.
+3. An unknown key, an unknown capability value, `deny` combined with a grant capability, a `default` other than `agent` or `deny`, a malformed `machine_id`, or an `ssh_key_fingerprint` that is not a well-formed `SHA256:` digest invalidates the file at load. A malformed file is never served as if absent. A row with `capabilities = ["deny"]` or `capabilities = []` is an explicit per-caller denial and overrides the file default. The fingerprint format is checked here rather than at comparison time because a fingerprint in the wrong shape — an `MD5:` one, most plausibly — would otherwise never match and would present as a key mismatch on every session.
 4. `runner` is not a grantable value. It is stamped in-process by a managed run and can never arrive over a transport.
 5. Load happens once per server process, at startup, alongside identity resolution. A session's ceiling does not change under it mid-session.
 6. `agent_invoke = true` additionally requires `operator` and an explicit workspace scope: `agent_invoke_workspaces`, or legacy `workspaces` when the new key is omitted. Both scopes reject empty or non-`ws_*` lists. Its default/key-bound mode also requires `ssh_key_fingerprint`. `agent_invoke_mode = "cooperative"` is the only mode that may omit the fingerprint; an unknown mode or invocation-only option without the operation grant invalidates the file.


### PR DESCRIPTION
## Task

[ORB-12105](https://orbit-cli.com/tasks/ORB-12105) — mcp-callers.toml cannot deny a single caller while the file default is agent

### Description

Found during a full QA sweep of orbit 0.20.0 on the Mac mini (2026-09-10).


 There is no way to express "serve everyone the default, but deny this one machine".

 - `capabilities = ["deny"]` → parse error: *caller '<id>' declares capability 'deny'; only
   `agent` and `operator` may be granted to a caller*.
 - `capabilities = []` → parse error: *has an empty `capabilities` list; use
   `default = "deny"` or remove the row*.

 The file's own seeded comment reads `# Permitted values: "agent" or "deny".` directly above
 `default = "agent"`, which reasonably reads as the per-row vocabulary too, and
 `docs/design/federated-mcp/specs/caller-authorization.md` discusses `default = "deny"`
 without saying a row cannot deny.

 The failure mode is severe: the whole file fails to load, so `orbit doctor` reports an ERROR
 and **every remote-originated MCP session on the host is refused** until someone hand-edits
 the file. This is the current state of the Mac mini (`hm_9ca6004473492f06` / dk-server-1 row).

 ## Expected
 Pick one and make it coherent: either accept a per-row deny (`capabilities = ["deny"]` or
 `[]` meaning "no capabilities"), or keep the restriction and fix the seeded comment plus the
 error text so it names the only supported shapes ("remove the row, or set `default = \"deny\"`
 and allow-list the rest").

### Acceptance Criteria

- A single caller can be denied without flipping the whole file to `default = "deny"`, or the docs/comment/error text make the intended pattern unambiguous
- `orbit mcp callers check <machine_id>` reports the denial for that caller
- The seeded `mcp-callers.toml` comment matches the accepted vocabulary
- Parser test covers the denied-row and empty-list shapes

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Accepted per-caller `capabilities = ["deny"]` and `capabilities = []` as explicit empty grants while rejecting ambiguous mixed deny/grant lists.
- Updated `orbit mcp callers check` to print an explicit `decision: denied` for empty grants.
- Updated seeded comments and the caller-authorization specification with the distinct file-default and per-caller vocabularies.
- Added parser/resolution coverage for both denied-row shapes and retained the seeder's no-operator-grant assertion.

Acceptance criteria:
1. A caller can be denied while `default = "agent"`: passed; both row forms override the agent default and resolve to no capabilities.
2. `orbit mcp callers check <machine_id>` reports denial: passed; isolated binary check reported `matched: a row`, `granted: [none]`, `decision: denied`, and no effective capabilities for either authority request.
3. Seeded `mcp-callers.toml` comment matches the vocabulary: passed; generated comments distinguish file defaults (`agent`/`deny`) from per-caller values (`agent`/`operator`/`deny`) and empty lists.
4. Parser test covers denied-row and empty-list shapes: passed; `a_caller_can_be_denied_with_an_explicit_or_empty_capability_list` exercises both.

Validation:
- `cargo fmt --all -- --check`: passed.
- `cargo test -p orbit-mcp remote::tests::callers`: passed, 27 tests.
- `cargo test -p orbit-cli callers`: passed, 8 CLI unit tests and 2 matching MCP roundtrip tests.
- `make ci-fast`: passed; compiler-cache namespace probe reported the expected environment limitation (bwrap cannot create an unprivileged mount namespace), while the suite completed successfully.
- `make ci-lint`: passed; workspace clippy with warnings denied.
- `git diff --check`: passed.
- `git status --short`: only the four intended tracked files are modified.

Assessment: The parser, resolution, CLI diagnosis, tests, and current specification now share one coherent per-caller denial model. No known remaining task-scoped risks.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12105-6aa36d68`
- Behind base: 0
- Ahead of base: 1