### PR TITLE
orbit sweep --workspace is accepted but ignored

### DIFF
--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -50,20 +50,32 @@ pub enum RuntimeNeed {
 pub struct DispatchContext<'a> {
     runtime: Option<&'a OrbitRuntime>,
     root_override: Option<&'a Path>,
+    /// The global `--workspace` selector, for the runtime-forbidden commands
+    /// that resolve their own workspaces instead of being handed one runtime.
+    workspace_selector: Option<&'a str>,
 }
 
 impl<'a> DispatchContext<'a> {
-    pub fn with_runtime(runtime: &'a OrbitRuntime, root_override: Option<&'a Path>) -> Self {
+    pub fn with_runtime(
+        runtime: &'a OrbitRuntime,
+        root_override: Option<&'a Path>,
+        workspace_selector: Option<&'a str>,
+    ) -> Self {
         Self {
             runtime: Some(runtime),
             root_override,
+            workspace_selector,
         }
     }
 
-    pub fn without_runtime(root_override: Option<&'a Path>) -> Self {
+    pub fn without_runtime(
+        root_override: Option<&'a Path>,
+        workspace_selector: Option<&'a str>,
+    ) -> Self {
         Self {
             runtime: None,
             root_override,
+            workspace_selector,
         }
     }
 
@@ -1045,7 +1057,9 @@ fn dispatch_run(command: Commands, context: DispatchContext<'_>) -> CommandOut {
 
 fn dispatch_sweep(command: Commands, context: DispatchContext<'_>) -> CommandOut {
     match command {
-        Commands::Sweep(command) => command.execute_without_runtime(context.root_override),
+        Commands::Sweep(command) => {
+            command.execute_without_runtime(context.root_override, context.workspace_selector)
+        }
         _ => dispatch_mismatch("Sweep"),
     }
 }

--- a/crates/orbit-cli/src/command/sweep.rs
+++ b/crates/orbit-cli/src/command/sweep.rs
@@ -29,6 +29,8 @@ use serde_json::json;
                   By default only noteworthy rows (fires, retries, baselines, errors)\n\
                   print — the per-minute clock must not grow its log with `not_due`\n\
                   churn. Use --verbose for every routine's row.\n\n\
+                  Pass the global `--workspace <selector>` to evaluate and fire only that\n\
+                  registered workspace's routines.\n\n\
                   Inspect routines with `orbit routine list`; dispatched fires appear in\n\
                   `orbit run history`."
 )]
@@ -78,13 +80,21 @@ pub(crate) fn format_report_line(report: &RoutineSweepReport) -> String {
 impl SweepCommand {
     /// Runs without a pre-initialized runtime: the sweep resolves every
     /// workspace from the global registry (per-workspace runtimes are built
-    /// inside orbit-core).
-    pub fn execute_without_runtime(self, root_override: Option<&Path>) -> CommandOut {
+    /// inside orbit-core). The global `--workspace` selector, when present,
+    /// narrows that set to one registered workspace.
+    pub fn execute_without_runtime(
+        self,
+        root_override: Option<&Path>,
+        workspace_selector: Option<&str>,
+    ) -> CommandOut {
         let options = SweepOptions {
             dry_run: self.dry_run,
             ..SweepOptions::default()
         };
-        let outcome = run_sweep_for_selected_root(root_override, options)?;
+        let workspace_selector = workspace_selector
+            .map(str::trim)
+            .filter(|selector| !selector.is_empty());
+        let outcome = run_sweep_for_selected_root(root_override, workspace_selector, options)?;
 
         let doc = outcome_json(&outcome, self.dry_run);
 
@@ -159,16 +169,17 @@ impl SweepCommand {
 
 fn run_sweep_for_selected_root(
     root_override: Option<&Path>,
+    workspace_selector: Option<&str>,
     options: SweepOptions,
 ) -> Result<SweepOutcome, OrbitError> {
     let has_env_override = std::env::var("ORBIT_ROOT").is_ok_and(|root| !root.trim().is_empty());
     if root_override.is_none() && !has_env_override {
-        return run_sweep(options);
+        return run_sweep(options, workspace_selector);
     }
 
     let cwd = std::env::current_dir().map_err(|error| OrbitError::Io(error.to_string()))?;
     let roots = OrbitRuntime::resolve_roots_for_cwd(&cwd, root_override)?;
-    run_sweep_at(&roots.global_root, options)
+    run_sweep_at(&roots.global_root, options, workspace_selector)
 }
 
 pub(crate) fn outcome_json(outcome: &SweepOutcome, dry_run: bool) -> serde_json::Value {

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -241,7 +241,10 @@ fn main() {
             );
             let result = dispatch(
                 cli.command,
-                DispatchContext::without_runtime(root_override.as_deref()),
+                DispatchContext::without_runtime(
+                    root_override.as_deref(),
+                    workspace_selector.as_deref(),
+                ),
             );
             finish_command(result, &sink, suppress_errors, json_error_preference);
             return;
@@ -273,7 +276,11 @@ fn main() {
     }
     .with_actor(actor);
 
-    let context = DispatchContext::with_runtime(&runtime, root_override.as_deref());
+    let context = DispatchContext::with_runtime(
+        &runtime,
+        root_override.as_deref(),
+        workspace_selector.as_deref(),
+    );
     // ORB-10453: the CLI's single authorization chokepoint. Every command
     // traverses it before dispatch, so a governed operation cannot be reached
     // by adding a subcommand that forgets its own guard.

--- a/crates/orbit-cli/tests/sweep_workspace.rs
+++ b/crates/orbit-cli/tests/sweep_workspace.rs
@@ -1,0 +1,264 @@
+#![allow(missing_docs)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+//! `orbit sweep --workspace <selector>` must restrict a pass to one registered
+//! workspace [ORB-12108]. The flag used to be accepted and ignored, so an
+//! operator asking for one workspace's due routines got the whole host.
+//!
+//! Each fixture host owns two registered workspaces with their own `.orbit/`
+//! directories, both routine sources, each with one enabled routine. Routines
+//! report their source workspace, so a pass that visited the unselected
+//! workspace is directly observable — and, in the live case, so is the
+//! scheduler state it would have written.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command as StdCommand;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
+use serde_json::Value;
+use tempfile::{TempDir, tempdir};
+
+/// Registered names of the two fixture workspaces.
+const SELECTED: &str = "sweep-selected";
+const OTHER: &str = "sweep-other";
+
+/// The seeded routine each fixture workspace enables. Seeding renders one
+/// definition per workspace with a workspace-unique name, all of them disabled;
+/// enabling exactly one per workspace gives each side a routine that reaches
+/// the scheduler.
+const ENABLED_ROUTINE: &str = "worktree_gc.yaml";
+
+struct Fixture {
+    _temp: TempDir,
+    home: PathBuf,
+    selected_repo: PathBuf,
+}
+
+impl Fixture {
+    /// Both workspaces are registered against the same HOME-resolved root, so
+    /// each keeps its own repo-local `.orbit/` and its own routine set.
+    fn initialized() -> Self {
+        let temp = tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        fs::create_dir_all(&home).expect("create home");
+
+        let selected_repo = temp.path().join("selected");
+        let other_repo = temp.path().join("other");
+        init_git_repo(&selected_repo);
+        init_git_repo(&other_repo);
+
+        run_success(
+            &selected_repo,
+            &home,
+            &[
+                "init",
+                "--non-interactive",
+                "--host-name",
+                "sweep-workspace-host",
+                "--task-prefix",
+                "SW",
+            ],
+        );
+        for (repo, name) in [(&selected_repo, SELECTED), (&other_repo, OTHER)] {
+            run_success(repo, &home, &["workspace", "init", "--name", name]);
+            enable_routine_source(repo);
+            enable_seeded_routine(repo);
+        }
+
+        Self {
+            _temp: temp,
+            home,
+            selected_repo,
+        }
+    }
+
+    fn sweep(&self, args: &[&str]) -> Value {
+        run_json(&self.selected_repo, &self.home, args)
+    }
+}
+
+#[test]
+fn dry_run_sweep_evaluates_only_the_selected_workspace() {
+    let fixture = Fixture::initialized();
+
+    // The unfiltered pass still visits every registered workspace.
+    let every_workspace = fixture.sweep(&["sweep", "--dry-run", "--format", "json"]);
+    assert_eq!(
+        report_sources(&every_workspace),
+        BTreeSet::from([OTHER.to_string(), SELECTED.to_string()]),
+        "unfiltered dry-run must report both workspaces: {every_workspace}"
+    );
+
+    let selected_only = fixture.sweep(&[
+        "--workspace",
+        SELECTED,
+        "sweep",
+        "--dry-run",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(
+        report_sources(&selected_only),
+        BTreeSet::from([SELECTED.to_string()]),
+        "filtered dry-run must report only the selected workspace: {selected_only}"
+    );
+    assert!(
+        report_actions(&selected_only).contains("would_baseline"),
+        "the selected workspace's enabled routine must still be evaluated: {selected_only}"
+    );
+}
+
+#[test]
+fn live_sweep_fires_only_the_selected_workspace() {
+    let fixture = Fixture::initialized();
+
+    let selected_only = fixture.sweep(&["--workspace", SELECTED, "sweep", "--format", "json"]);
+    assert_eq!(
+        report_sources(&selected_only),
+        BTreeSet::from([SELECTED.to_string()]),
+        "filtered live pass must report only the selected workspace: {selected_only}"
+    );
+    assert!(
+        report_actions(&selected_only).contains("baselined"),
+        "the selected workspace's enabled routine must reach the scheduler: {selected_only}"
+    );
+
+    // The unselected workspace must also be untouched in the store: its
+    // enabled routine takes its first-observation baseline now, on the first
+    // pass that actually visits it, while the already-baselined selected one
+    // does not repeat.
+    let every_workspace = fixture.sweep(&["sweep", "--format", "json"]);
+    assert_eq!(
+        baselined_sources(&every_workspace),
+        BTreeSet::from([OTHER.to_string()]),
+        "the filtered pass must not have recorded scheduler state for {OTHER}: {every_workspace}"
+    );
+}
+
+#[test]
+fn unknown_workspace_selector_fails_instead_of_sweeping_the_host() {
+    let fixture = Fixture::initialized();
+
+    command(&fixture.selected_repo, &fixture.home)
+        .args(["--workspace", "not-registered", "sweep", "--dry-run"])
+        .assert()
+        .failure();
+}
+
+/// Source workspace of every reported routine.
+fn report_sources(outcome: &Value) -> BTreeSet<String> {
+    reports(outcome)
+        .iter()
+        .map(|report| report["source"].as_str().unwrap_or_default().to_string())
+        .collect()
+}
+
+/// Every reported action, regardless of routine.
+fn report_actions(outcome: &Value) -> BTreeSet<String> {
+    reports(outcome)
+        .iter()
+        .map(|report| report["action"].as_str().unwrap_or_default().to_string())
+        .collect()
+}
+
+/// Source workspaces whose routines recorded a first-observation baseline.
+fn baselined_sources(outcome: &Value) -> BTreeSet<String> {
+    reports(outcome)
+        .iter()
+        .filter(|report| report["action"] == "baselined")
+        .map(|report| report["source"].as_str().unwrap_or_default().to_string())
+        .collect()
+}
+
+fn reports(outcome: &Value) -> &Vec<Value> {
+    outcome["reports"]
+        .as_array()
+        .unwrap_or_else(|| panic!("sweep outcome must carry reports: {outcome}"))
+}
+
+fn run_success(cwd: &Path, home: &Path, args: &[&str]) {
+    command(cwd, home).args(args).assert().success();
+}
+
+fn run_json(cwd: &Path, home: &Path, args: &[&str]) -> Value {
+    let output = command(cwd, home)
+        .args(args)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    serde_json::from_slice(&output).unwrap_or_else(|error| {
+        panic!(
+            "parse JSON from `orbit {}`: {error}\nstdout:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output)
+        )
+    })
+}
+
+/// Every command runs against the disposable HOME, with no inherited managed
+/// authority that could outrank it.
+fn command(cwd: &Path, home: &Path) -> assert_cmd::Command {
+    let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("USERPROFILE", home);
+    command
+}
+
+fn enable_routine_source(repo: &Path) {
+    fs::write(
+        repo.join(".orbit").join("config.toml"),
+        "[routines]\nrole = \"source\"\n",
+    )
+    .expect("declare routine source");
+}
+
+fn enable_seeded_routine(repo: &Path) {
+    let path = repo.join(".orbit").join("routines").join(ENABLED_ROUTINE);
+    let definition = fs::read_to_string(&path).expect("read seeded routine");
+    let enabled = definition.replace("\nenabled: false\n", "\nenabled: true\n");
+    assert_ne!(
+        definition,
+        enabled,
+        "seeded routine {} must ship disabled",
+        path.display()
+    );
+    fs::write(&path, enabled).expect("enable seeded routine");
+}
+
+fn init_git_repo(repo: &Path) {
+    fs::create_dir_all(repo).expect("create repo");
+    run_git(repo, &["init", "--quiet"]);
+    run_git(repo, &["config", "user.name", "Orbit Test"]);
+    run_git(repo, &["config", "user.email", "orbit-test@example.com"]);
+    run_git(repo, &["config", "commit.gpgsign", "false"]);
+    fs::write(repo.join("README.md"), "# sweep workspace test\n").expect("write readme");
+    run_git(repo, &["add", "README.md"]);
+    run_git(repo, &["commit", "--quiet", "-m", "initial"]);
+}
+
+fn run_git(cwd: &Path, args: &[&str]) {
+    let output = StdCommand::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git -C {} {} failed\nstdout:\n{}\nstderr:\n{}",
+        cwd.display(),
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/orbit-cmd/src/registry_routines.rs
+++ b/crates/orbit-cmd/src/registry_routines.rs
@@ -21,13 +21,26 @@ use crate::registry_runtime::RegisteredRuntimeFactory;
 struct RegistryRoutineEnvironment {
     global_root: std::path::PathBuf,
     identity: HostIdentity,
+    /// Registered workspace this pass is restricted to, resolved from the
+    /// caller's `--workspace` selector. `None` visits every local workspace.
+    workspace_filter: Option<String>,
 }
 
 impl RegistryRoutineEnvironment {
-    fn load(global_root: &Path) -> Result<Self, OrbitError> {
+    /// An unknown, unregistered, or inactive selector fails closed here,
+    /// before the sweep touches any scheduler state: an operator asking for
+    /// one workspace must never silently get the whole host.
+    fn load(global_root: &Path, workspace_selector: Option<&str>) -> Result<Self, OrbitError> {
+        let workspace_filter = workspace_selector
+            .map(|selector| {
+                RegisteredRuntimeFactory::resolve_workspace_selector(global_root, selector)
+                    .map(|selected| selected.workspace.id)
+            })
+            .transpose()?;
         Ok(Self {
             global_root: global_root.to_path_buf(),
             identity: load_host_identity(global_root)?,
+            workspace_filter,
         })
     }
 
@@ -66,15 +79,17 @@ pub(crate) fn load_routine_placement_at(
 
 impl RoutineWorkspaceProvider for RegistryRoutineEnvironment {
     fn discover_workspaces(&self, global_root: &Path) -> Result<DiscoveredWorkspaces, OrbitError> {
-        discover_registered_workspaces(global_root)
+        discover_registered_workspaces(global_root, self.workspace_filter.as_deref())
     }
 }
 
-/// Discover runnable registered checkouts for routine execution.
+/// Discover runnable registered checkouts for routine execution, optionally
+/// restricted to one registered workspace id.
 /// The provider delegates here so this production path can be exercised with
 /// an explicit global root.
 pub(crate) fn discover_registered_workspaces(
     global_root: &Path,
+    workspace_filter: Option<&str>,
 ) -> Result<DiscoveredWorkspaces, OrbitError> {
     let registry_path = workspace_registry::registry_path_for(global_root);
     let mut registry = workspace_registry::load_registry_from(&registry_path)?;
@@ -84,6 +99,9 @@ pub(crate) fn discover_registered_workspaces(
     let mut discovered = DiscoveredWorkspaces::default();
     for (workspace, checkout) in workspace_registry::local_workspaces(&registry) {
         if workspace.status != WorkspaceStatus::Active || !checkout.orbit_dir.exists() {
+            continue;
+        }
+        if workspace_filter.is_some_and(|selected| selected != workspace.id) {
             continue;
         }
         match RegisteredRuntimeFactory::open_registered_checkout(global_root, workspace, checkout) {
@@ -99,7 +117,7 @@ pub(crate) fn discover_registered_workspaces(
 }
 
 pub fn routine_statuses(global_root: &Path) -> Result<RoutineStatusReport, OrbitError> {
-    let environment = RegistryRoutineEnvironment::load(global_root)?;
+    let environment = RegistryRoutineEnvironment::load(global_root, None)?;
     orbit_core::application::routines::routine_statuses_with_providers(
         global_root,
         &environment,
@@ -108,9 +126,14 @@ pub fn routine_statuses(global_root: &Path) -> Result<RoutineStatusReport, Orbit
     )
 }
 
-pub fn run_sweep(options: SweepOptions) -> Result<SweepOutcome, OrbitError> {
+/// Run one sweep pass over this host's registered workspaces, or only the one
+/// named by `workspace_selector`.
+pub fn run_sweep(
+    options: SweepOptions,
+    workspace_selector: Option<&str>,
+) -> Result<SweepOutcome, OrbitError> {
     let global_root = workspace_registry::global_orbit_dir()?;
-    let environment = RegistryRoutineEnvironment::load(&global_root)?;
+    let environment = RegistryRoutineEnvironment::load(&global_root, workspace_selector)?;
     orbit_core::application::routines::run_sweep_with_providers(
         options,
         environment.local_host(),
@@ -119,8 +142,13 @@ pub fn run_sweep(options: SweepOptions) -> Result<SweepOutcome, OrbitError> {
     )
 }
 
-pub fn run_sweep_at(global_root: &Path, options: SweepOptions) -> Result<SweepOutcome, OrbitError> {
-    let environment = RegistryRoutineEnvironment::load(global_root)?;
+/// As [`run_sweep`], against an explicit global root.
+pub fn run_sweep_at(
+    global_root: &Path,
+    options: SweepOptions,
+    workspace_selector: Option<&str>,
+) -> Result<SweepOutcome, OrbitError> {
+    let environment = RegistryRoutineEnvironment::load(global_root, workspace_selector)?;
     orbit_core::application::routines::run_sweep_at_with_providers(
         global_root,
         options,

--- a/crates/orbit-cmd/src/tests/registry_routines.rs
+++ b/crates/orbit-cmd/src/tests/registry_routines.rs
@@ -122,7 +122,7 @@ fn workspace_discovery_builds_bound_runtimes() {
     )
     .expect("registry");
 
-    let discovered = discover_registered_workspaces(&global).expect("discovery");
+    let discovered = discover_registered_workspaces(&global, None).expect("discovery");
     assert!(discovered.errors.is_empty());
     assert_eq!(discovered.entries.len(), 1);
     let binding = discovered.entries[0]

--- a/crates/orbit-core/assets/skills/orbit/references/setup/automation.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/automation.md
@@ -134,7 +134,12 @@ orbit routine list                 # every routine: enabled / pinned / paused, n
 orbit routine show <name>          # definition, effective state, recent fires
 orbit sweep --dry-run              # what would fire; records and dispatches nothing
 orbit sweep --dry-run --verbose    # include not-due rows
+orbit --workspace <name> sweep --dry-run   # restrict the pass to one workspace
 ```
+
+The global `--workspace` selector narrows a sweep — dry-run or live — to one
+registered workspace's routines; without it the pass covers every routine-source
+workspace on the host.
 
 ## Observe and control
 

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -317,6 +317,15 @@ Per pass:
    routine provenance cannot silently resolve to a different store.
 10. Record outcomes and exit.
 
+The global `--workspace <selector>` narrows one pass to a single registered
+workspace: discovery visits only that workspace, so nothing outside it is
+evaluated, fired, or recorded, in dry-run and live passes alike. The selector is
+resolved against the local registry before the pass touches scheduler state, and
+an unknown, unregistered, or inactive selector fails the invocation rather than
+silently sweeping the host [ORB-12108]. Placement validation still reads the
+whole-host registry projection, because a routine's host pin is a host-level
+fact.
+
 `orbit routine list`, `orbit routine show`, and `orbit sweep` expose the local registry
 source (`local_workspace_registry`) plus stable diagnostic codes and severity in human and
 JSON output. Compatibility fields for cache age and staleness remain empty/false. Moving a

--- a/plugin/skills/orbit/references/setup/automation.md
+++ b/plugin/skills/orbit/references/setup/automation.md
@@ -134,7 +134,12 @@ orbit routine list                 # every routine: enabled / pinned / paused, n
 orbit routine show <name>          # definition, effective state, recent fires
 orbit sweep --dry-run              # what would fire; records and dispatches nothing
 orbit sweep --dry-run --verbose    # include not-due rows
+orbit --workspace <name> sweep --dry-run   # restrict the pass to one workspace
 ```
+
+The global `--workspace` selector narrows a sweep — dry-run or live — to one
+registered workspace's routines; without it the pass covers every routine-source
+workspace on the host.
 
 ## Observe and control
 

--- a/website/src/content/docs/how-to/recurring-work.md
+++ b/website/src/content/docs/how-to/recurring-work.md
@@ -50,7 +50,13 @@ You can always run the pass by hand, which is the right way to try a change:
 orbit sweep --dry-run            # report what would fire; record and dispatch nothing
 orbit sweep --verbose            # a row per routine, including not-due ones
 orbit sweep --json
+orbit --workspace <name> sweep   # only that workspace's routines
 ```
+
+A pass visits every registered routine-source workspace on the host. The global
+`--workspace` selector narrows it to one — in both dry-run and live passes,
+nothing outside the selected workspace is evaluated, fired, or recorded. An
+unregistered selector fails instead of falling back to the whole host.
 
 By default `orbit sweep` prints only noteworthy rows — fires, retries,
 baselines, errors — so a per-minute clock does not fill the log with `not_due`

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -110,7 +110,7 @@ See [Delivery Workflows](../../getting-started/workflows/).
 
 | Command | Purpose |
 |---|---|
-| `orbit sweep` | The scheduler pass: fire due routines on this host. `--dry-run`, `--verbose`, `--json`. |
+| `orbit sweep` | The scheduler pass: fire due routines on this host. `--dry-run`, `--verbose`, `--json`. The global `--workspace <SELECTOR>` restricts the pass to one registered workspace's routines. |
 | `orbit routine list` \| `show` \| `pause` \| `resume` | Inspect routines and pause them host-locally. |
 | `orbit routine clock status` \| `pause` \| `enable` \| `set` | Control the host OS sweep clock. |
 | `orbit routine init [--install-clock]` | Read host identity and optionally install the OS clock unit. |


### PR DESCRIPTION
## Task

[ORB-12108](https://orbit-cli.com/tasks/ORB-12108) — orbit sweep --workspace is accepted but ignored

### Description

Found during a full QA sweep of orbit 0.20.0 on the Mac mini (2026-09-10).


 `orbit sweep --dry-run --workspace qa-sweep` evaluates and reports routines for *every*
 registered workspace, identically to the unfiltered invocation. The flag is advertised in
 `orbit sweep --help` and silently has no effect, which is the worst shape for a scheduler
 command: an operator asking to fire one workspace's due routines gets the whole host.

 (Only `--dry-run` was exercised during QA; the non-dry path should be checked too — if it
 also ignores the filter it is dispatching unintended runs.)

 ## Expected
 Restrict evaluation and firing to the selected workspace, or reject the flag.

### Acceptance Criteria

- `orbit sweep --workspace <ws>` evaluates and fires only that workspace's routines, in both dry-run and live modes
- The unfiltered invocation is unchanged
- Test covers the filtered dry-run and filtered live pass

## Execution Summary

<details>
<summary>Click to expand</summary>

`orbit sweep --workspace <selector>` now restricts the pass to one registered workspace instead of accepting the flag and sweeping the host.

Root cause: `sweep` is a `RuntimeNeed::Forbidden` command, so `main.rs` never handed it the global `--workspace` selector — `DispatchContext` carried only `root_override`, and the sweep resolved every registered workspace itself.

Change:
- `DispatchContext` now carries `workspace_selector` (both constructors; `main.rs` passes `cli.workspace`), and `dispatch_sweep` forwards it to `SweepCommand::execute_without_runtime`, which trims/empties it and threads it through `run_sweep` / `run_sweep_at` (crates/orbit-cli/src/command/{operation.rs,sweep.rs}, src/main.rs).
- `orbit-cmd::registry_routines`: `RegistryRoutineEnvironment::load` resolves the selector to a registered workspace id via `RegisteredRuntimeFactory::resolve_workspace_selector` before any scheduler state is touched, and `discover_registered_workspaces` skips every other workspace. Because discovery feeds both routine collection and dispatch, the filter applies identically to dry-run and live passes. An unknown/unregistered/inactive selector fails closed (exit 1, `invalid_input`) rather than falling back to the whole host. `routine_statuses` is unchanged (passes `None`).
- Docs updated in the same change: `orbit sweep --help` after-help, `docs/design/routines/2_design.md` §3, `website/.../how-to/recurring-work.md`, `website/.../reference/cli.md`, and both copies of the shipped skill reference `references/setup/automation.md` (canonical asset + plugin mirror, verified in sync by the ci-fast guardrail).
- Scope addition: `file:website/src/content/docs/reference/cli.md` (the CLI reference row for `orbit sweep` described the flags and would have been stale) and the new test file `file:crates/orbit-cli/tests/sweep_workspace.rs`.

Acceptance criteria:
1. "evaluates and fires only that workspace's routines, in both dry-run and live modes" — met. Filtered dry-run reports only the selected workspace's routines; the filtered live pass reports only that workspace and records its first-observation baseline, and a later unfiltered live pass shows the unselected workspace baselining for the first time, proving the filtered pass wrote no scheduler state for it.
2. "The unfiltered invocation is unchanged" — met. No selector means no filter; the sweep's JSON/human output shape is untouched, `sweep_root.rs` still passes, and the new test asserts the unfiltered dry-run still reports both workspaces.
3. "Test covers the filtered dry-run and filtered live pass" — met by `crates/orbit-cli/tests/sweep_workspace.rs` (3 tests: filtered dry-run, filtered live pass + untouched-state proof, unknown selector fails closed). All three fail against the pre-fix behavior (verified by temporarily reverting the selector forwarding to `None`) and pass with the fix.

Validation (all run in this Linux worktree):
- `make ci-fast` — passed (includes fmt-check and the plugin-skill mirror guardrail).
- `make ci-lint` — passed.
- `cargo test -p orbit-cli --test sweep_workspace --test sweep_root` — passed (3 + 2).
- `cargo test -p orbit-cmd` — passed (131).
- `cargo test -p orbit-cli --bins` — passed (494).
- `git diff --check` clean; `git status --short` shows only the changed files plus the declared new test.
- Not run: full `make ci` (merge gate, owned by CI), and the wider integration-test suites unaffected by this change.

Risks/limits: the live-pass coverage proves no evaluation or scheduler write happens for unselected workspaces; it does not dispatch a real run (that would require an actually-due routine and a pipeline run), so "fires" is established via the baseline/report boundary rather than an end-to-end dispatch. Behavior was exercised on Linux only; the change has no OS-specific paths.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12108-6aa36d6c`
- Behind base: 0
- Ahead of base: 1