### PR TITLE
workspace teardown leaves the task store behind and doctor does not flag the orphan

### DIFF
--- a/crates/orbit-cli/src/command/doctor.rs
+++ b/crates/orbit-cli/src/command/doctor.rs
@@ -33,6 +33,10 @@ pub struct DoctorCommand {
     /// Remove known retired `spec.backend` values (`http`, `auto`) from schemaVersion 2 agent-loop activities. Unknown backends and unrelated parse failures are left untouched.
     #[arg(long)]
     pub fix_retired_activity_backends: bool,
+
+    /// Delete task-store partitions whose workspace is no longer registered on this host.
+    #[arg(long)]
+    pub fix_orphan_task_stores: bool,
 }
 
 impl Execute for DoctorCommand {
@@ -98,6 +102,16 @@ impl Execute for DoctorCommand {
                     "Removed retired spec.backend from {} activity file(s).",
                     report.repaired.len()
                 ),
+                remediation: None,
+            });
+        }
+        if self.fix_orphan_task_stores {
+            let removed = runtime.remove_orphan_task_stores()?;
+            eprintln!("Removed {removed} orphaned task-store partition(s).");
+            results.push(WorkspaceDoctorResult {
+                check_name: "fix-orphan-task-stores".to_string(),
+                status: WorkspaceDoctorStatus::Ok,
+                message: format!("Removed {removed} orphaned task-store partition(s)."),
                 remediation: None,
             });
         }

--- a/crates/orbit-cli/src/command/tests/doctor.rs
+++ b/crates/orbit-cli/src/command/tests/doctor.rs
@@ -51,6 +51,7 @@ fn failing_workspace_renders_diagnostics_and_exits_nonzero() {
         remove_graph: false,
         fix_stale_artifacts: false,
         fix_retired_activity_backends: false,
+        fix_orphan_task_stores: false,
     }
     .execute(&runtime)
     .expect("doctor should render a failing report");
@@ -91,6 +92,7 @@ fn warning_only_workspace_keeps_zero_exit_and_structured_rows() {
         remove_graph: false,
         fix_stale_artifacts: false,
         fix_retired_activity_backends: false,
+        fix_orphan_task_stores: false,
     }
     .execute(&runtime)
     .expect("doctor should render a warning report");
@@ -128,6 +130,7 @@ fn fix_stale_locks_records_repair_count_in_payload_doc() {
         remove_graph: false,
         fix_stale_artifacts: false,
         fix_retired_activity_backends: false,
+        fix_orphan_task_stores: false,
     }
     .execute(&runtime)
     .expect("doctor should run repairs and render report");

--- a/crates/orbit-cli/src/command/workspace/teardown.rs
+++ b/crates/orbit-cli/src/command/workspace/teardown.rs
@@ -1,4 +1,5 @@
 use clap::Args;
+use orbit_cmd::{remove_task_store_partition, task_store_partition_path};
 use orbit_core::{OrbitError, OrbitRuntime};
 use orbit_registry::workspace_registry;
 
@@ -66,6 +67,13 @@ impl Execute for WorkspaceTeardownArgs {
                     "deregistered workspace '{}' from registry",
                     ws.name
                 ));
+
+                if remove_task_store_partition(&global_root, &ws_id)? {
+                    removed.push(format!(
+                        "deleted task store {}",
+                        task_store_partition_path(&global_root, &ws_id).display()
+                    ));
+                }
             }
         }
 

--- a/crates/orbit-cli/src/command/workspace/tests/mod.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/mod.rs
@@ -3,3 +3,4 @@ mod init_report;
 mod publication;
 mod shared_root;
 mod source_remote;
+mod teardown;

--- a/crates/orbit-cli/src/command/workspace/tests/teardown.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/teardown.rs
@@ -1,0 +1,155 @@
+//! [ORB-12109] `workspace teardown` must not leave the deregistered
+//! workspace's global task-store partition behind, and `orbit doctor` must
+//! flag it if it ever does.
+
+use std::path::Path;
+
+use chrono::Utc;
+use orbit_cmd::DoctorCommands;
+use orbit_cmd::task_store::task_workspaces_dir;
+use orbit_core::{OrbitError, OrbitRuntime};
+use orbit_registry::workspace_registry;
+use orbit_types::workspace::{Workspace, WorkspaceCheckout, WorkspaceStatus};
+
+use crate::command::Execute;
+
+use super::super::teardown::WorkspaceTeardownArgs;
+
+fn write_task_bundle(global_root: &Path, workspace_id: &str, task_id: &str) {
+    let bundle = task_workspaces_dir(global_root)
+        .join(workspace_id)
+        .join(task_id);
+    std::fs::create_dir_all(&bundle).expect("create task bundle dir");
+    std::fs::write(bundle.join("task.yaml"), b"id: dummy\n").expect("write bundle file");
+}
+
+fn register(global_root: &Path, workspace_id: &str, repo_root: &Path, orbit_dir: &Path) {
+    let registry_path = workspace_registry::registry_path_for(global_root);
+    let mut registry =
+        workspace_registry::load_registry_from(&registry_path).expect("load registry");
+    let now = Utc::now();
+    workspace_registry::register_workspace(
+        &mut registry,
+        Workspace {
+            id: workspace_id.to_string(),
+            name: workspace_id.to_string(),
+            owner_machine_id: None,
+            git_remote: None,
+            ship_mode: None,
+            base_branch: "main".to_string(),
+            status: WorkspaceStatus::Active,
+            created_at: now,
+            updated_at: now,
+        },
+    )
+    .expect("register workspace");
+    workspace_registry::register_checkout(
+        &mut registry,
+        WorkspaceCheckout::owner(
+            workspace_id.to_string(),
+            repo_root.to_path_buf(),
+            orbit_dir.to_path_buf(),
+        ),
+    )
+    .expect("register checkout");
+    workspace_registry::save_registry_to(&registry, &registry_path).expect("save registry");
+}
+
+#[test]
+fn teardown_deletes_the_task_store_partition_and_doctor_confirms_no_orphan_remains() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let repo_root = temp.path().join("repo");
+    let orbit_dir = repo_root.join(".orbit");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::create_dir_all(&orbit_dir).expect("create workspace root");
+
+    // A second, untouched registered workspace with its own task bundle,
+    // proving teardown and the doctor check both stay scoped to the
+    // workspace actually torn down.
+    let survivor_root = temp.path().join("survivor");
+    let survivor_orbit_dir = survivor_root.join(".orbit");
+    std::fs::create_dir_all(&survivor_orbit_dir).expect("create survivor workspace root");
+    register(
+        &global_root,
+        "ws_survivor",
+        &survivor_root,
+        &survivor_orbit_dir,
+    );
+    write_task_bundle(&global_root, "ws_survivor", "ORB-1");
+
+    register(&global_root, "ws_teardown", &repo_root, &orbit_dir);
+    write_task_bundle(&global_root, "ws_teardown", "ORB-2");
+    write_task_bundle(&global_root, "ws_teardown", "ORB-3");
+    let partition = task_workspaces_dir(&global_root).join("ws_teardown");
+    assert!(
+        partition.is_dir(),
+        "fixture task store must exist before teardown"
+    );
+
+    let runtime = OrbitRuntime::from_roots(&global_root, &orbit_dir).expect("build runtime");
+    WorkspaceTeardownArgs { confirm: true }
+        .execute(&runtime)
+        .expect("teardown");
+
+    assert!(
+        !partition.exists(),
+        "teardown must delete the torn-down workspace's task store"
+    );
+    assert!(
+        task_workspaces_dir(&global_root)
+            .join("ws_survivor")
+            .exists(),
+        "teardown must not touch another workspace's task store"
+    );
+
+    let registry = workspace_registry::load_registry_from(&workspace_registry::registry_path_for(
+        &global_root,
+    ))
+    .expect("load registry after teardown");
+    assert!(
+        workspace_registry::find_workspace_by_id(&registry, "ws_teardown").is_none(),
+        "teardown must still deregister the workspace"
+    );
+
+    // Doctor, run right after teardown, must report no orphaned task-store
+    // partitions — the torn-down partition is gone, and the survivor's is
+    // still registered.
+    let results = runtime.doctor_workspace().expect("doctor after teardown");
+    let row = results
+        .iter()
+        .find(|row| row.check_name == "orphan-task-stores")
+        .expect("orphan-task-stores row present");
+    assert_eq!(row.status, orbit_cmd::WorkspaceDoctorStatus::Ok, "{row:?}");
+}
+
+#[test]
+fn teardown_without_confirm_leaves_the_task_store_and_registration_untouched() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let repo_root = temp.path().join("repo");
+    let orbit_dir = repo_root.join(".orbit");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::create_dir_all(&orbit_dir).expect("create workspace root");
+    register(&global_root, "ws_unconfirmed", &repo_root, &orbit_dir);
+    write_task_bundle(&global_root, "ws_unconfirmed", "ORB-1");
+
+    let runtime = OrbitRuntime::from_roots(&global_root, &orbit_dir).expect("build runtime");
+    let result = WorkspaceTeardownArgs { confirm: false }.execute(&runtime);
+    assert!(matches!(result, Err(OrbitError::InvalidInput(_))));
+
+    assert!(
+        task_workspaces_dir(&global_root)
+            .join("ws_unconfirmed")
+            .exists(),
+        "an unconfirmed teardown must not touch the task store"
+    );
+    let registry = workspace_registry::load_registry_from(&workspace_registry::registry_path_for(
+        &global_root,
+    ))
+    .expect("load registry after unconfirmed teardown");
+    assert!(
+        workspace_registry::find_workspace_by_id(&registry, "ws_unconfirmed").is_some(),
+        "an unconfirmed teardown must not deregister the workspace"
+    );
+}

--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -24,9 +24,12 @@ use fs2::FileExt;
 use orbit_common::OrbitError;
 use orbit_core::OrbitRuntime;
 use orbit_core::application::artifact_health::{ArtifactFinding, RetiredActivityBackendRepair};
+use orbit_registry::workspace_registry;
 use orbit_store::maintenance::migration::SUPPORTED_SCHEMA_VERSION;
 use orbit_types::workspace::WorkspacePaths;
 use serde::Serialize;
+
+use crate::task_store::task_workspaces_dir;
 
 /// Outcome of one workspace doctor check.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -125,6 +128,12 @@ pub trait DoctorCommands {
     /// files are left untouched.
     fn repair_retired_activity_backends(&self) -> Result<RetiredActivityBackendRepair, OrbitError>;
 
+    /// Delete task-store partitions under `<global_root>/tasks/workspaces/`
+    /// whose workspace id is no longer present in the registry — left behind
+    /// by a `workspace teardown` run on an older binary, or by removing a
+    /// checkout without running teardown [ORB-12109].
+    fn remove_orphan_task_stores(&self) -> Result<usize, OrbitError>;
+
     /// Cheap store write probe for health endpoints: open the store and
     /// acquire + roll back the write lock without mutating anything.
     fn health_check_store_writable(&self) -> Result<String, OrbitError>;
@@ -141,6 +150,7 @@ impl DoctorCommands for OrbitRuntime {
             doctor_check_job_runs(self),
             doctor_check_task_reservations(self),
             doctor_check_task_relations(self),
+            doctor_check_orphan_task_stores(self),
         ];
         results.extend(doctor_check_definition_artifacts(self));
         Ok(results)
@@ -166,6 +176,31 @@ impl DoctorCommands for OrbitRuntime {
 
     fn repair_retired_activity_backends(&self) -> Result<RetiredActivityBackendRepair, OrbitError> {
         OrbitRuntime::repair_retired_activity_backends(self)
+    }
+
+    fn remove_orphan_task_stores(&self) -> Result<usize, OrbitError> {
+        let global_root = self.global_root();
+        let workspaces_dir = task_workspaces_dir(&global_root);
+        let Some(entries) = read_task_workspaces_dir(&workspaces_dir)? else {
+            return Ok(0);
+        };
+        let registry = workspace_registry::load_registry_from(
+            &workspace_registry::registry_path_for(&global_root),
+        )?;
+
+        let mut removed = 0;
+        for path in entries {
+            let Some(ws_id) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if workspace_registry::find_workspace_by_id(&registry, ws_id).is_some() {
+                continue;
+            }
+            if crate::task_store::remove_task_store_partition(&global_root, ws_id)? {
+                removed += 1;
+            }
+        }
+        Ok(removed)
     }
 
     fn remove_retired_graph_state(&self) -> Result<usize, OrbitError> {
@@ -402,6 +437,116 @@ fn doctor_check_task_reservations(runtime: &OrbitRuntime) -> WorkspaceDoctorResu
         ),
         "Run `orbit doctor --fix-stale-task-locks`.".to_string(),
     )
+}
+
+/// Task-store partitions under `<global_root>/tasks/workspaces/<ws_id>/`
+/// whose workspace id is absent from the registry — orphaned by a
+/// `workspace teardown` run on an older binary, or by deleting a checkout
+/// without running teardown [ORB-12109]. Scoped to the whole host, not just
+/// this workspace, because the partition directory is itself host-global.
+fn doctor_check_orphan_task_stores(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
+    let global_root = runtime.global_root();
+    let workspaces_dir = task_workspaces_dir(&global_root);
+    let entries = match read_task_workspaces_dir(&workspaces_dir) {
+        Ok(Some(entries)) => entries,
+        Ok(None) => {
+            return check(
+                "orphan-task-stores",
+                WorkspaceDoctorStatus::Skipped,
+                "no task-store partitions on this host yet".to_string(),
+            );
+        }
+        Err(error) => {
+            return check(
+                "orphan-task-stores",
+                WorkspaceDoctorStatus::Warning,
+                format!("cannot scan {}: {error}", workspaces_dir.display()),
+            );
+        }
+    };
+
+    let registry = match workspace_registry::load_registry_from(
+        &workspace_registry::registry_path_for(&global_root),
+    ) {
+        Ok(registry) => registry,
+        Err(error) => {
+            return check(
+                "orphan-task-stores",
+                WorkspaceDoctorStatus::Warning,
+                format!("cannot read workspace registry: {error}"),
+            );
+        }
+    };
+
+    let mut orphans = Vec::new();
+    for path in &entries {
+        let Some(ws_id) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if workspace_registry::find_workspace_by_id(&registry, ws_id).is_some() {
+            continue;
+        }
+        orphans.push(format!(
+            "{ws_id} ({}, {} task bundle(s))",
+            path.display(),
+            count_task_bundles(path)
+        ));
+    }
+
+    if orphans.is_empty() {
+        return check(
+            "orphan-task-stores",
+            WorkspaceDoctorStatus::Ok,
+            format!(
+                "{} task-store partition(s) scanned, all registered",
+                entries.len()
+            ),
+        );
+    }
+
+    actionable_check(
+        "orphan-task-stores",
+        WorkspaceDoctorStatus::Warning,
+        format!(
+            "{} orphaned task-store partition(s) (workspace no longer registered on this host): {}",
+            orphans.len(),
+            orphans.join("; ")
+        ),
+        "Run `orbit doctor --fix-orphan-task-stores`.".to_string(),
+    )
+}
+
+/// Immediate subdirectories of `<global_root>/tasks/workspaces/`, one per
+/// workspace partition. `None` when the directory has never been created
+/// (fresh host, no task ever committed).
+fn read_task_workspaces_dir(workspaces_dir: &Path) -> Result<Option<Vec<PathBuf>>, OrbitError> {
+    let entries = match std::fs::read_dir(workspaces_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "read {}: {error}",
+                workspaces_dir.display()
+            )));
+        }
+    };
+    let paths = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .collect();
+    Ok(Some(paths))
+}
+
+/// Task bundles directly under one workspace's task-store partition — each
+/// is a subdirectory named for its task id.
+fn count_task_bundles(partition: &Path) -> usize {
+    std::fs::read_dir(partition)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter(|entry| entry.path().is_dir())
+        .count()
 }
 
 /// Delete one dead-holder lock only after acquiring its advisory lock. A

--- a/crates/orbit-cmd/src/lib.rs
+++ b/crates/orbit-cmd/src/lib.rs
@@ -28,6 +28,7 @@ pub mod migrate;
 pub mod registry_routines;
 pub mod registry_runtime;
 pub mod task_owner;
+pub mod task_store;
 pub mod update;
 pub mod workspace_catalog;
 
@@ -38,6 +39,7 @@ pub use activity_v2::{ActivityV2Commands, V2ActivityRunResult};
 pub use diagnostics::DiagnosticsCommands;
 pub use doctor::{DoctorCommands, WorkspaceDoctorResult, WorkspaceDoctorStatus};
 pub use migrate::{MigrateCommands, MigrateStatus, migrate_dry_run_at};
+pub use task_store::{remove_task_store_partition, task_store_partition_path};
 
 /// One-stop import for every runtime extension trait this crate defines.
 pub mod prelude {

--- a/crates/orbit-cmd/src/task_store.rs
+++ b/crates/orbit-cmd/src/task_store.rs
@@ -1,0 +1,35 @@
+//! Task-store partition paths, shared by `workspace teardown` and `doctor`'s
+//! orphan-partition check/fix [ORB-12109].
+//!
+//! `orbit-store` owns the per-workspace bundle layout
+//! (`<global_root>/tasks/workspaces/<workspace_id>/`) but knows nothing
+//! about the workspace registry; this module is the composition seam that
+//! lets a caller resolve or remove one workspace's partition without
+//! reaching around `orbit-store` from `orbit-cli`.
+
+use std::path::{Path, PathBuf};
+
+use orbit_common::OrbitError;
+pub use orbit_store::maintenance::task_registry::task_workspaces_dir;
+
+/// Path to one workspace's task-store partition under
+/// `<global_root>/tasks/workspaces/<workspace_id>/`.
+pub fn task_store_partition_path(global_root: &Path, workspace_id: &str) -> PathBuf {
+    task_workspaces_dir(global_root).join(workspace_id)
+}
+
+/// Delete one workspace's task-store partition if present. Returns whether
+/// anything was removed.
+pub fn remove_task_store_partition(
+    global_root: &Path,
+    workspace_id: &str,
+) -> Result<bool, OrbitError> {
+    let path = task_store_partition_path(global_root, workspace_id);
+    if !path.is_dir() {
+        return Ok(false);
+    }
+    std::fs::remove_dir_all(&path).map_err(|error| {
+        OrbitError::Io(format!("remove task store {}: {error}", path.display()))
+    })?;
+    Ok(true)
+}

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -5,7 +5,10 @@ use std::path::Path;
 
 use chrono::Utc;
 use fs2::FileExt;
+use orbit_registry::workspace_registry;
+use orbit_store::maintenance::task_registry::task_workspaces_dir;
 use orbit_types::workflow::{JobRun, JobRunState};
+use orbit_types::workspace::{Workspace, WorkspaceStatus};
 use sha2::{Digest, Sha256};
 
 use orbit_core::OrbitRuntime;
@@ -53,14 +56,45 @@ fn split_root_runtime(temp: &tempfile::TempDir) -> OrbitRuntime {
         .expect("build split-root runtime")
 }
 
+fn write_registered_workspace(global_root: &Path, workspace_id: &str, name: &str) {
+    let registry_path = workspace_registry::registry_path_for(global_root);
+    let mut registry =
+        workspace_registry::load_registry_from(&registry_path).expect("load registry");
+    let now = Utc::now();
+    workspace_registry::register_workspace(
+        &mut registry,
+        Workspace {
+            id: workspace_id.to_string(),
+            name: name.to_string(),
+            owner_machine_id: None,
+            git_remote: None,
+            ship_mode: None,
+            base_branch: "main".to_string(),
+            status: WorkspaceStatus::Active,
+            created_at: now,
+            updated_at: now,
+        },
+    )
+    .expect("register workspace");
+    workspace_registry::save_registry_to(&registry, &registry_path).expect("save registry");
+}
+
+fn write_task_bundle(global_root: &Path, workspace_id: &str, task_id: &str) {
+    let bundle = task_workspaces_dir(global_root)
+        .join(workspace_id)
+        .join(task_id);
+    fs::create_dir_all(&bundle).expect("create task bundle dir");
+    fs::write(bundle.join("task.yaml"), b"id: dummy\n").expect("write bundle file");
+}
+
 #[test]
 fn healthy_fresh_workspace_has_no_failures() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     let results = runtime.doctor_workspace().expect("doctor");
 
-    // Eight infrastructure checks plus one definition-artifact row per kind
+    // Nine infrastructure checks plus one definition-artifact row per kind
     // (skills, jobs, activities, auto-tasks, routines).
-    assert_eq!(results.len(), 13, "one row per check: {results:?}");
+    assert_eq!(results.len(), 14, "one row per check: {results:?}");
     assert!(
         results
             .iter()
@@ -99,6 +133,11 @@ fn healthy_fresh_workspace_has_no_failures() {
     // No tasks yet → no unresolved relation/dependency targets.
     assert_eq!(
         status_of(&results, "task-relations").status,
+        WorkspaceDoctorStatus::Ok
+    );
+    // No task ever committed on this host → no partitions to flag as orphaned.
+    assert_eq!(
+        status_of(&results, "orphan-task-stores").status,
         WorkspaceDoctorStatus::Ok
     );
 }
@@ -855,5 +894,96 @@ fn missing_shipped_activity_default_is_an_error_not_healthy() {
             .iter()
             .any(|row| row.status == WorkspaceDoctorStatus::Error),
         "a missing shipped default must not leave the workspace looking healthy: {results:?}"
+    );
+}
+
+/// [ORB-12109] A task-store partition whose workspace is still registered on
+/// this host is healthy, not an orphan.
+#[test]
+fn registered_task_store_partition_is_not_an_orphan() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let global_root = temp.path().join("global");
+    write_registered_workspace(&global_root, "ws_registered", "registered");
+    write_task_bundle(&global_root, "ws_registered", "ORB-1");
+
+    let results = runtime.doctor_workspace().expect("doctor");
+    let row = status_of(&results, "orphan-task-stores");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Ok, "{row:?}");
+    assert!(
+        row.message.contains("1 task-store partition"),
+        "{}",
+        row.message
+    );
+}
+
+/// [ORB-12109] A task-store partition whose workspace id no longer resolves
+/// in the registry — left behind by `workspace teardown` on an older binary,
+/// or by deleting a checkout without running teardown — is named with its
+/// path and an exact repair command.
+#[test]
+fn orphan_task_store_partition_is_reported_with_path_and_remediation() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let global_root = temp.path().join("global");
+    write_registered_workspace(&global_root, "ws_registered", "registered");
+    write_task_bundle(&global_root, "ws_registered", "ORB-1");
+    write_task_bundle(&global_root, "ws_orphan", "ORB-2");
+    write_task_bundle(&global_root, "ws_orphan", "ORB-3");
+
+    let results = runtime.doctor_workspace().expect("doctor");
+    let row = status_of(&results, "orphan-task-stores");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Warning, "{row:?}");
+    assert!(row.message.contains("ws_orphan"), "{}", row.message);
+    assert!(
+        row.message.contains(
+            &task_workspaces_dir(&global_root)
+                .join("ws_orphan")
+                .to_string_lossy()
+                .into_owned()
+        ),
+        "message names the orphaned partition path: {}",
+        row.message
+    );
+    assert!(row.message.contains("2 task bundle(s)"), "{}", row.message);
+    assert!(
+        !row.message.contains("ws_registered"),
+        "registered partition must not be reported: {}",
+        row.message
+    );
+    assert_eq!(
+        row.remediation.as_deref(),
+        Some("Run `orbit doctor --fix-orphan-task-stores`.")
+    );
+}
+
+/// [ORB-12109] `--fix-orphan-task-stores` deletes only the unregistered
+/// partition, leaving the registered one untouched, and doctor is healthy
+/// again afterward — the teardown-then-doctor regression path.
+#[test]
+fn fix_orphan_task_stores_removes_only_the_unregistered_partition() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let global_root = temp.path().join("global");
+    write_registered_workspace(&global_root, "ws_registered", "registered");
+    write_task_bundle(&global_root, "ws_registered", "ORB-1");
+    write_task_bundle(&global_root, "ws_orphan", "ORB-2");
+
+    let removed = runtime
+        .remove_orphan_task_stores()
+        .expect("remove orphan task stores");
+    assert_eq!(removed, 1);
+    assert!(!task_workspaces_dir(&global_root).join("ws_orphan").exists());
+    assert!(
+        task_workspaces_dir(&global_root)
+            .join("ws_registered")
+            .exists()
+    );
+
+    let results = runtime.doctor_workspace().expect("doctor after fix");
+    assert_eq!(
+        status_of(&results, "orphan-task-stores").status,
+        WorkspaceDoctorStatus::Ok,
+        "{results:?}"
     );
 }

--- a/crates/orbit-store/src/driver/sqlite/task_registry/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/mod.rs
@@ -26,6 +26,14 @@ pub fn task_registry_path(global_root: &Path) -> PathBuf {
     global_root.join("tasks").join("index.sqlite")
 }
 
+/// Root directory of the per-workspace task bundle partitions
+/// (`<global_root>/tasks/workspaces/<workspace_id>/`), mirroring the
+/// `workspaces_dir` the store itself derives from [`task_registry_path`]'s
+/// parent in `store.rs`.
+pub fn task_workspaces_dir(global_root: &Path) -> PathBuf {
+    global_root.join("tasks").join("workspaces")
+}
+
 pub use crate::contracts::{
     AllocatorSeedOutcome, BindWorkspaceParams, DanglingRelationTarget, RegisterWorkspaceParams,
     TaskBundleBinding, TaskIndexFilter, WorkspaceBinding, WorkspaceCheckoutBinding,

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -4,8 +4,8 @@ summary: Check Orbit workspace, database, dashboard, log-sink, job-run, and rout
 tags: [operations, health, doctor, dashboard, routines]
 paths: ["crates/orbit-cmd/src/doctor.rs", "crates/orbit-core/src/application/job/run/reconcile.rs"]
 related_features: [orbit-core, activity-job, routines]
-related_artifacts: [ORB-10005, ORB-10070, ORB-10473, ORB-10501, ORB-10558, ORB-10986, ORB-11791]
-last_validated: 2026-09-08
+related_artifacts: [ORB-10005, ORB-10070, ORB-10473, ORB-10501, ORB-10558, ORB-10986, ORB-11791, ORB-12109]
+last_validated: 2026-09-11
 ---
 
 # Check Orbit Health
@@ -28,6 +28,7 @@ Every check degrades to a row rather than aborting unless the store itself canno
 | `job-runs` | orphaned `pending` or `running` runs with no live worker process |
 | `task-reservations` | active reservations whose owner run or terminal task association proves the reservation stale |
 | `task-relations` | unresolved relation/dependency targets that would block a task-index rebuild |
+| `orphan-task-stores` | task-store partitions (`~/.orbit/tasks/workspaces/<ws_id>/`) whose workspace is no longer registered on this host |
 | `artifacts-*` | skills, jobs, activities, auto-tasks, and routines on disk: stale, deprecated, residual, catalog-invalid, or a previously reconciled shipped default that is missing |
 
 Example:
@@ -45,6 +46,7 @@ $ orbit doctor
 │ job-runs         ok        no orphaned job runs                                              │
 │ task-reservations ok       no conclusively stale active task reservations                    │
 │ task-relations   ok        no unresolved relation/dependency targets                        │
+│ orphan-task-stores ok      2 task-store partition(s) scanned, all registered                │
 0 failure(s), 1 warning(s).
 ```
 
@@ -80,8 +82,8 @@ This is distinct from `--fix-stale-locks`, which handles dead-holder filesystem 
 
 There is deliberately no blanket `--fix` or resolve-all option. Configuration repair, database
 recovery, job cancellation, graph cleanup, id-allocation retirement, filesystem lock deletion,
-task-reservation release, and retired activity-backend cleanup have different evidence and
-safety gates, so each repair remains explicit and safety-scoped.
+task-reservation release, retired activity-backend cleanup, and orphan task-store deletion have
+different evidence and safety gates, so each repair remains explicit and safety-scoped.
 
 For definition convergence after installing a new Orbit binary, or to restore a shipped
 default that was deleted by hand, use `orbit workspace sync` rather than a doctor repair.
@@ -92,6 +94,22 @@ Doctor reports a missing shipped default as an `artifacts-*` error (it does not 
 warm-open defaults stamp, and it does not rewrite the file); run `orbit init` or
 `orbit workspace sync` to restore it. Doctor performs only the specific repair named by an
 individual flag; neither command upgrades the binary or pulls a remote repository.
+
+### Reclaim orphaned task stores
+
+`orbit workspace teardown --confirm` deregisters the workspace and deletes both the checkout's
+`.orbit/` and its global task-store partition
+(`~/.orbit/tasks/workspaces/<ws_id>/`) in one step. `orphan-task-stores` exists for partitions a
+prior teardown on an older binary left behind, or a checkout removed without running teardown at
+all: each warning names the orphaned workspace id, its partition path, and its task-bundle
+count. Repair with:
+
+```sh
+orbit doctor --fix-orphan-task-stores
+```
+
+The repair loads the registry once, then deletes only the partitions it finds with no matching
+workspace id; it is idempotent, and running it again after a partition is gone is a no-op.
 
 ### Repair retired activity backends
 


### PR DESCRIPTION
## Task

[ORB-12109](https://orbit-cli.com/tasks/ORB-12109) — workspace teardown leaves the task store behind and doctor does not flag the orphan

### Description

Found during a full QA sweep of orbit 0.20.0 on the Mac mini (2026-09-10).


 `orbit workspace teardown --confirm` reports exactly two actions — deregistered the workspace,
 deleted `<checkout>/.orbit` — but leaves `~/.orbit/tasks/workspaces/<ws_id>/` fully populated
 (8 task bundles, 136 KiB, in the QA case). The result:

 - The task IDs still resolve in the host registry and fail with *"owned by workspace '<name>'
   (<ws_id>), which has no readable local checkout on this machine; restore or re-register that
   checkout"* — accurate, but the operator was told teardown was complete.
 - `orbit doctor` has no check for a task store whose workspace is no longer registered, so the
   orphan is invisible and grows with each teardown.

 If retention is deliberate (a safety net against accidental teardown), that is defensible —
 but then teardown must say so and there must be a supported way to reclaim it.

 ## Expected
 Either remove the task store as part of teardown, or keep it and (a) say so in the teardown
 output with the path, (b) add a `doctor` check that reports orphaned task stores, and (c)
 provide the supported reclamation command.

### Acceptance Criteria

- Teardown output accounts for `~/.orbit/tasks/workspaces/<ws_id>/` — deleted, or retained with its path and how to reclaim it
- `orbit doctor` reports a task store whose workspace is not registered on this host
- Existing teardown safety (the `--confirm` gate and operator capability) is unchanged
- Test covers teardown followed by the doctor check

## Execution Summary

<details>
<summary>Click to expand</summary>

Chose the "delete as part of teardown" branch of the bug's two expected fixes, plus the doctor check regardless (the doctor check is independently required and also catches orphans left by a pre-fix binary or a checkout deleted without teardown).

Changes:
- `orbit-store`: added `task_workspaces_dir(global_root)` next to `task_registry_path`, mirroring the path `TaskRegistryStore::open` derives internally.
- `orbit-cmd` (new `task_store.rs`, re-exported at crate root and in no prelude since it's not a runtime-extension trait): `task_store_partition_path` and `remove_task_store_partition` — the registry+task-store composition seam, consistent with the crate's stated job.
- `orbit-cmd/doctor.rs`: new `orphan-task-stores` check (Warning, names each orphaned workspace id, its partition path, and task-bundle count; remediation `orbit doctor --fix-orphan-task-stores`) and `DoctorCommands::remove_orphan_task_stores` repair method, following the existing `--fix-*` pattern (own evidence/safety gate, no blanket fix).
- `orbit-cli/command/doctor.rs`: wired `--fix-orphan-task-stores` the same way as the other fix flags.
- `orbit-cli/command/workspace/teardown.rs`: after deregistering the workspace, deletes its task-store partition and reports it in the printed "removed" list (`deleted task store <path>`) — the `--confirm` gate and every existing safety check (global-root guard, `.orbit`-suffix guard) are untouched; the new step only runs inside the existing "workspace found in registry" branch.
- `docs/runbooks/health-checks.md`: added the `orphan-task-stores` row to the check table, an examples line, a "Reclaim orphaned task stores" section, and the artifact/date frontmatter update.

Acceptance criteria:
1. Teardown output accounts for the task store: now deletes it and reports the deleted path in the same "removed" list as the other steps. Verified by `teardown_deletes_the_task_store_partition_and_doctor_confirms_no_orphan_remains`.
2. `orbit doctor` reports a task store whose workspace isn't registered: new `orphan-task-stores` check, Warning status, names id/path/bundle count. Verified by `orphan_task_store_partition_is_reported_with_path_and_remediation` (orbit-cmd) and the teardown-then-doctor test (orbit-cli).
3. Existing `--confirm` gate/safety unchanged: no existing checks were touched; new logic is additive inside the already-gated deregistration branch. Verified by `teardown_without_confirm_leaves_the_task_store_and_registration_untouched` (asserts no side effects without --confirm) plus all pre-existing teardown safety guards are untouched in the diff.
4. Test covers teardown followed by doctor: `teardown_deletes_the_task_store_partition_and_doctor_confirms_no_orphan_remains` in `crates/orbit-cli/src/command/workspace/tests/teardown.rs` runs teardown then calls `doctor_workspace()` on the same runtime and asserts the `orphan-task-stores` row is `Ok`, including a second untouched registered workspace to prove scoping.

Validation:
- `make ci-fast` — passed (after `cargo fmt --all`).
- `make ci-lint` — passed, no warnings.
- `cargo test -p orbit-store -p orbit-cmd -p orbit-cli --bin orbit` — passed (all suites green: orbit-store 134/134, orbit-cmd 511/511 incl. new doctor tests, orbit-cli 496/496 incl. new teardown tests).
- `git diff --check` / `git status --short` — clean, no stray artifacts; only the intended 9 modified + 2 new files.
- Full `make ci` was not run locally per workspace policy (it's the PR merge gate).

Two new source files created (declared via context_files): `crates/orbit-cmd/src/task_store.rs`, `crates/orbit-cli/src/command/workspace/tests/teardown.rs`. Left all changes uncommitted for the pipeline to commit/PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12109-6aa36d69`
- Behind base: 0
- Ahead of base: 1