### PR TITLE
step_failure_recovery rewrote the repository's git remote config and turned a failed push green

### DIFF
--- a/.orbit/resources/activities/step_failure_recovery.yaml
+++ b/.orbit/resources/activities/step_failure_recovery.yaml
@@ -7,7 +7,9 @@ spec:
   description: >
     Generic v2 task workflow recovery hook. It diagnoses incomplete work
     conservatively, but for a completed implementation it repairs the normal
-    delivery path or, as a last resort, publishes the candidate itself.
+    delivery path or, as a last resort, publishes the candidate itself. It never
+    writes persistent Git configuration, so a precondition it cannot restore
+    honestly is reported as unrecovered.
   input_schema_json:
     type: object
     additionalProperties: false
@@ -101,6 +103,17 @@ spec:
     commit, the PR — so that the pipeline's remaining steps, or an operator
     reading the world afterwards, find it repaired. Judge every decision below
     against that durable state, never against something you plan to report.
+
+    Repository configuration is out of bounds. Never add, rename, retarget, or
+    remove a Git remote, and never write persistent Git configuration by any
+    other route — `git config` writes, an edited `.git/config`, or an equivalent
+    command. A linked worktree shares `.git/config` with its primary checkout,
+    so such a change outlives the run and rewrites a repository nobody handed
+    you. Orbit refuses these commands at its tool boundary; do not route around
+    them. If the failed step could only succeed after such a change, recovery is
+    not possible: file the friction, report `recovered: false` with the blocker,
+    and let the step fail. Manufacturing a step's precondition is not recovery —
+    it makes a failed publication indistinguishable from a real one.
 
     Input is a JSON object with exactly these keys:
     - failed_step_id: the job step id that failed

--- a/crates/orbit-core/assets/activities/step_failure_recovery.yaml
+++ b/crates/orbit-core/assets/activities/step_failure_recovery.yaml
@@ -7,7 +7,9 @@ spec:
   description: >
     Generic v2 task workflow recovery hook. It diagnoses incomplete work
     conservatively, but for a completed implementation it repairs the normal
-    delivery path or, as a last resort, publishes the candidate itself.
+    delivery path or, as a last resort, publishes the candidate itself. It never
+    writes persistent Git configuration, so a precondition it cannot restore
+    honestly is reported as unrecovered.
   input_schema_json:
     type: object
     additionalProperties: false
@@ -101,6 +103,17 @@ spec:
     commit, the PR — so that the pipeline's remaining steps, or an operator
     reading the world afterwards, find it repaired. Judge every decision below
     against that durable state, never against something you plan to report.
+
+    Repository configuration is out of bounds. Never add, rename, retarget, or
+    remove a Git remote, and never write persistent Git configuration by any
+    other route — `git config` writes, an edited `.git/config`, or an equivalent
+    command. A linked worktree shares `.git/config` with its primary checkout,
+    so such a change outlives the run and rewrites a repository nobody handed
+    you. Orbit refuses these commands at its tool boundary; do not route around
+    them. If the failed step could only succeed after such a change, recovery is
+    not possible: file the friction, report `recovered: false` with the blocker,
+    and let the step fail. Manufacturing a step's precondition is not recovery —
+    it makes a failed publication indistinguishable from a real one.
 
     Input is a JSON object with exactly these keys:
     - failed_step_id: the job step id that failed

--- a/crates/orbit-core/src/bootstrap/activity.rs
+++ b/crates/orbit-core/src/bootstrap/activity.rs
@@ -32,10 +32,14 @@ pub(crate) fn seed_default_activities(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, HashMap};
+    use std::sync::Arc;
 
     use orbit_engine::activity_job::load_activity_asset;
     use orbit_engine::{inject_system_crew_input, resolve_crew_settings};
+    use orbit_policy::PolicyEngine;
+    use orbit_tools::{ToolContext, ToolRegistry};
+    use orbit_types::policy::{FsProfile, PolicyDef};
     use orbit_types::workflow::ActivityV2Spec;
     use orbit_types::workflow::activity_job::{OnDenial, tool_allowed};
     use serde_json::json;
@@ -563,6 +567,137 @@ backend = "cli"
             }
             _ => panic!("expected agent_loop activity"),
         }
+    }
+
+    /// [ORB-12103] Recovery once "repaired" a failed push by adding an `origin`
+    /// that pointed at the primary checkout a linked worktree shares its
+    /// `.git/config` with, turning a failed publication green. The boundary is
+    /// now both stated in the contract and enforced by the only subprocess
+    /// surface the activity has: `proc.spawn` refuses a `git` invocation that
+    /// would write persistent repository configuration.
+    #[test]
+    fn step_failure_recovery_cannot_write_persistent_git_configuration() {
+        let (_, yaml) = DEFAULT_ACTIVITY_FILES
+            .iter()
+            .find(|(name, _)| *name == "step_failure_recovery")
+            .expect("step failure recovery activity is seeded");
+        let workspace_yaml =
+            include_str!("../../../../.orbit/resources/activities/step_failure_recovery.yaml");
+        assert_eq!(
+            *yaml, workspace_yaml,
+            "shipped and workspace step_failure_recovery resources must remain byte-identical"
+        );
+        let asset = load_activity_asset(yaml).expect("parse step failure recovery activity");
+        let ActivityV2Spec::AgentLoop(spec) = asset.spec.spec else {
+            panic!("expected agent_loop activity");
+        };
+        for stated in [
+            "Repository configuration is out of bounds.",
+            "Manufacturing a step's precondition is not recovery",
+            "report `recovered: false`",
+        ] {
+            assert!(
+                spec.instruction.contains(stated),
+                "recovery contract must state `{stated}`"
+            );
+        }
+        let programs = spec.proc_allowed_programs.clone().unwrap_or_default();
+        assert!(
+            programs.iter().any(|program| program == "git"),
+            "recovery still inspects and delivers with git, so the refusal below is the boundary"
+        );
+
+        let repo = tempdir().expect("create tempdir");
+        let repo_path = repo.path().to_string_lossy().into_owned();
+        run_git(repo.path(), &["init"]).expect("git init");
+        let ctx = recovery_tool_context(repo.path(), programs);
+        let mut registry = ToolRegistry::new();
+        registry.register_builtins();
+
+        let denial = registry
+            .execute(
+                "proc.spawn",
+                &ctx,
+                json!({
+                    "program": "git",
+                    "args": ["-C", repo_path, "remote", "add", "origin", repo_path],
+                }),
+            )
+            .expect_err("recovery must not be able to write a git remote");
+        assert!(
+            matches!(&denial, OrbitError::PolicyDenied(message)
+                if message.contains("persistent repository configuration")),
+            "expected the configuration boundary to refuse the call, got: {denial}"
+        );
+        assert_eq!(
+            run_git(repo.path(), &["remote"]).expect("list remotes"),
+            "",
+            "the refused call must leave repository configuration untouched"
+        );
+
+        // The refusal is specific to configuration writes, not to git itself:
+        // the same context still reaches the boundary for inspection. (The child
+        // can fail for host reasons — no Landlock, no git — so only the
+        // configuration refusal itself is asserted against.)
+        if let Err(error) = registry.execute(
+            "proc.spawn",
+            &ctx,
+            json!({ "program": "git", "args": ["remote", "-v"] }),
+        ) {
+            assert!(
+                !error
+                    .to_string()
+                    .contains("persistent repository configuration"),
+                "read-only git inspection must not hit the configuration boundary: {error}"
+            );
+        }
+    }
+
+    /// The tool context `step_failure_recovery` runs with: activity-scoped, its
+    /// own program allowlist, and workspace-wide filesystem access.
+    fn recovery_tool_context(workspace_root: &Path, programs: Vec<String>) -> ToolContext {
+        let mut fs_profiles = HashMap::new();
+        fs_profiles.insert(
+            "implementer".to_string(),
+            FsProfile {
+                read: vec!["./**".to_string()],
+                modify: vec!["./**".to_string()],
+            },
+        );
+        let policy = PolicyDef {
+            name: "test".to_string(),
+            description: None,
+            deny_read: Vec::new(),
+            deny_modify: Vec::new(),
+            fs_profiles,
+            created_at: None,
+            updated_at: None,
+        };
+        ToolContext {
+            workspace_root: Some(workspace_root.to_path_buf()),
+            policy_engine: Some(Arc::new(
+                PolicyEngine::from_def(&policy).expect("policy engine"),
+            )),
+            fs_profile: Some("implementer".to_string()),
+            proc_allowed_programs: programs,
+            proc_spawn_activity_scoped: true,
+            ..Default::default()
+        }
+    }
+
+    fn run_git(repo: &Path, args: &[&str]) -> Result<String, OrbitError> {
+        let output = std::process::Command::new("git")
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .map_err(|error| OrbitError::Execution(format!("git {args:?}: {error}")))?;
+        if !output.status.success() {
+            return Err(OrbitError::Execution(format!(
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
     }
 
     #[test]

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/git_ops.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/git_ops.rs
@@ -112,6 +112,82 @@ fn push_batch_disables_tracked_repository_hooks() {
     assert!(repo.join(".git/pre-push-marker").exists());
 }
 
+/// [ORB-12103] A self-pointing `origin` makes `ls-remote` echo the local branch
+/// back, which previously produced `decision: reused_current` and a green push
+/// step for a branch that was never published anywhere.
+#[test]
+fn push_refuses_an_origin_that_is_this_same_repository() {
+    let temp = initialized_git_repo();
+    let repo = temp.path();
+    git_success(repo, &["remote", "add", "origin", repo.to_str().unwrap()])
+        .expect("self-pointing remote");
+    let branch = git_output(repo, &["branch", "--show-current"]).unwrap();
+    let host = CommitTestHost::new(Vec::new(), repo.to_path_buf());
+
+    let error = push_batch_changes_inner(&host, &json!({"branch": branch}), repo)
+        .expect_err("a push into this same repository must not report success");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("is this same repository") && message.contains(&branch),
+        "denial must explain that nothing was published, got: {message}"
+    );
+}
+
+/// The observed shape of the fault: a linked worktree shares `.git/config` with
+/// its primary checkout, so an `origin` naming that checkout is the worktree's
+/// own repository too.
+#[test]
+fn push_refuses_an_origin_naming_the_primary_checkout_of_this_worktree() {
+    let temp = initialized_git_repo();
+    let repo = temp.path();
+    git_success(repo, &["remote", "add", "origin", repo.to_str().unwrap()])
+        .expect("self-pointing remote");
+    let worktree = temp.path().join("linked-worktree");
+    git_success(
+        repo,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "task-branch",
+            worktree.to_str().unwrap(),
+        ],
+    )
+    .expect("linked worktree");
+    let host = CommitTestHost::new(Vec::new(), worktree.clone());
+
+    let error = push_batch_changes_inner(&host, &json!({"branch": "task-branch"}), &worktree)
+        .expect_err("a push into the primary checkout must not report success");
+
+    assert!(
+        error.to_string().contains("is this same repository"),
+        "denial must identify the shared repository, got: {error}"
+    );
+}
+
+/// A remote naming a different repository on disk stays a real publication
+/// target, so the guard must not turn local-remote fixtures into failures.
+#[test]
+fn push_accepts_a_distinct_local_repository_as_origin() {
+    let temp = initialized_git_repo();
+    let repo = temp.path();
+    let remote = tempfile::tempdir().expect("remote");
+    git_success(remote.path(), &["init", "--bare"]).expect("bare remote");
+    git_success(
+        repo,
+        &["remote", "add", "origin", remote.path().to_str().unwrap()],
+    )
+    .expect("configure remote");
+    let branch = git_output(repo, &["branch", "--show-current"]).unwrap();
+    let host = CommitTestHost::new(Vec::new(), repo.to_path_buf());
+
+    let result = push_batch_changes_inner(&host, &json!({"branch": branch}), repo)
+        .expect("push to a distinct repository");
+
+    assert_eq!(result["decision"], "performed_create");
+}
+
 #[test]
 fn commit_child_environment_excludes_parent_secrets() {
     let exact_test = concat!(

--- a/crates/orbit-engine/src/executor/automation/vcs/push.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/push.rs
@@ -56,6 +56,8 @@ pub(super) fn push_batch_changes_inner<H: RuntimeHost + ?Sized>(
         ));
     }
 
+    ensure_origin_publishes_elsewhere(workspace_path, &branch)?;
+
     let local_sha = commit_sha(workspace_path, &branch)?;
     let remote_sha = remote_branch_sha(workspace_path, &branch)?;
     let decision = push_decision(workspace_path, &branch, &local_sha, remote_sha.as_deref())?;
@@ -99,6 +101,60 @@ pub(super) fn push_batch_changes_inner<H: RuntimeHost + ?Sized>(
         remote_sha.as_deref(),
         force_with_lease,
     ))
+}
+
+/// Refuse to push into the repository we are pushing from.
+///
+/// A push step proves publication only when `origin` is some other repository.
+/// When `origin` points back at this checkout — the primary checkout a linked
+/// worktree shares its `.git` with, for instance — `ls-remote` echoes the local
+/// branch straight back, and the step would report `reused_current` for a branch
+/// that reached no publication target at all. Failing here keeps a failed push
+/// distinguishable from a successful one even if something outside the pipeline
+/// wrote that remote into the repository's configuration [ORB-12103].
+fn ensure_origin_publishes_elsewhere(
+    workspace_path: &Path,
+    branch: &str,
+) -> Result<(), OrbitError> {
+    let url = git_output(workspace_path, &["remote", "get-url", "origin"]).map_err(|error| {
+        OrbitError::Execution(format!(
+            "git_push: workspace '{}' has no usable 'origin' remote to publish '{branch}' to: {error}",
+            workspace_path.display()
+        ))
+    })?;
+    let Some(local_remote) = local_remote_path(workspace_path, &url) else {
+        return Ok(());
+    };
+    let (Some(remote_repository), Some(local_repository)) = (
+        repository_identity(&local_remote),
+        repository_identity(workspace_path),
+    ) else {
+        return Ok(());
+    };
+    if remote_repository != local_repository {
+        return Ok(());
+    }
+    Err(OrbitError::Execution(format!(
+        "git_push: remote 'origin' ('{url}') is this same repository ('{}'), so pushing '{branch}' \
+         there publishes nothing; point 'origin' at a real publication remote",
+        local_repository.display()
+    )))
+}
+
+/// The filesystem path `url` names, when it names one. A transport URL or an
+/// `scp`-style address resolves to no existing directory and yields `None`.
+fn local_remote_path(workspace_path: &Path, url: &str) -> Option<PathBuf> {
+    let candidate = url.strip_prefix("file://").unwrap_or(url);
+    let resolved = workspace_path.join(candidate);
+    resolved.is_dir().then_some(resolved)
+}
+
+/// The repository a path belongs to, identified by its common Git directory so
+/// that a linked worktree and its primary checkout compare equal.
+fn repository_identity(path: &Path) -> Option<PathBuf> {
+    let common_dir = git_output(path, &["rev-parse", "--git-common-dir"]).ok()?;
+    let resolved = path.join(common_dir);
+    Some(std::fs::canonicalize(&resolved).unwrap_or(resolved))
 }
 
 fn resolve_workspace_path<H: RuntimeHost + ?Sized>(

--- a/crates/orbit-tools/src/builtin/proc/git_config.rs
+++ b/crates/orbit-tools/src/builtin/proc/git_config.rs
@@ -1,0 +1,127 @@
+//! Persistent Git configuration is out of bounds for `proc.spawn`.
+//!
+//! An activity runs inside a linked worktree that shares `.git/config` with its
+//! primary checkout, so a single `git remote add` performed by an agent rewrites
+//! repository state that outlives the run — and can manufacture the very
+//! precondition a publication step is supposed to prove. Orbit's own delivery
+//! steps configure remotes through private VCS operations, never through this
+//! tool, so refusing configuration writes here removes an escape hatch without
+//! taking away a supported flow. Reads stay allowed: diagnosing a failure needs
+//! `git remote -v` and `git config --get`.
+//!
+//! The rule covers the two commands that write configuration directly, `git
+//! config` and `git remote`, and it fails closed: a form this module cannot
+//! recognize as a read is refused.
+
+use orbit_common::OrbitError;
+use orbit_common::tracing;
+
+/// Git's own options that consume the following argument, so the scan does not
+/// mistake an option value for the subcommand.
+const VALUE_TAKING_GIT_OPTIONS: &[&str] = &["-C", "-c", "--git-dir", "--work-tree", "--namespace"];
+
+/// `git config` invocations that only read, in both the flag form and the
+/// subcommand form Git 2.46 introduced.
+const CONFIG_READ_FLAGS: &[&str] = &[
+    "--get",
+    "--get-all",
+    "--get-regexp",
+    "--get-urlmatch",
+    "--get-color",
+    "--get-colorbool",
+    "--list",
+    "-l",
+];
+const CONFIG_READ_SUBCOMMANDS: &[&str] = &["get", "list"];
+
+/// `git remote` invocations that only report. Every other remote subcommand —
+/// `add`, `rename`, `remove`, `set-url`, `set-head`, … — writes `.git/config`.
+const REMOTE_READ_SUBCOMMANDS: &[&str] = &["show", "get-url"];
+
+/// Refuse a `git` invocation that would write persistent repository
+/// configuration. Non-`git` programs pass through untouched.
+pub(super) fn enforce_no_persistent_git_config(
+    tool_name: &str,
+    program: &str,
+    args: &[String],
+) -> Result<(), OrbitError> {
+    if !is_git_program(program) {
+        return Ok(());
+    }
+    let Some((subcommand, rest)) = git_subcommand(args) else {
+        return Ok(());
+    };
+    let writes_config = match subcommand {
+        "config" => !is_read_only_config(rest),
+        "remote" => !is_read_only_remote(rest),
+        _ => false,
+    };
+    if !writes_config {
+        return Ok(());
+    }
+
+    tracing::warn!(
+        target: "orbit.policy.deny",
+        tool = tool_name,
+        path = program,
+        profile = "proc.persistent_git_config",
+        matched_rule = subcommand,
+    );
+    Err(OrbitError::PolicyDenied(format!(
+        "`git {subcommand}` would write persistent repository configuration, which {tool_name} \
+         never permits: a worktree shares `.git/config` with its primary checkout, so the change \
+         would outlive this run. Read-only queries such as `git config --get` and `git remote -v` \
+         remain available."
+    )))
+}
+
+fn is_git_program(program: &str) -> bool {
+    let file_name = std::path::Path::new(program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(program);
+    let stem = file_name.strip_suffix(".exe").unwrap_or(file_name);
+    stem.eq_ignore_ascii_case("git")
+}
+
+/// The first positional argument, skipping Git's own leading options.
+fn git_subcommand(args: &[String]) -> Option<(&str, &[String])> {
+    let mut index = 0;
+    while let Some(arg) = args.get(index) {
+        if !arg.starts_with('-') {
+            return Some((arg.as_str(), &args[index + 1..]));
+        }
+        if VALUE_TAKING_GIT_OPTIONS.contains(&arg.as_str()) {
+            index += 1;
+        }
+        index += 1;
+    }
+    None
+}
+
+fn is_read_only_config(args: &[String]) -> bool {
+    let positional = args.iter().find(|arg| !arg.starts_with('-'));
+    if positional.is_some_and(|arg| CONFIG_READ_SUBCOMMANDS.contains(&arg.as_str())) {
+        return true;
+    }
+    // The flag form reads only when it names a read mode and carries no second
+    // positional to store: `git config --get a.b` reads, `git config a.b value`
+    // writes. The rule fails closed, so a read that spends a second positional
+    // — `--get-urlmatch`, or `--file <path>` with the path detached from its
+    // option — is refused along with the writes.
+    let read_flag = args
+        .iter()
+        .any(|arg| CONFIG_READ_FLAGS.contains(&arg.as_str()));
+    read_flag && args.iter().filter(|arg| !arg.starts_with('-')).count() <= 1
+}
+
+fn is_read_only_remote(args: &[String]) -> bool {
+    match args.iter().find(|arg| !arg.starts_with('-')) {
+        None => true,
+        Some(subcommand) => REMOTE_READ_SUBCOMMANDS.contains(&subcommand.as_str()),
+    }
+}
+
+#[cfg(test)]
+#[path = "tests/git_config.rs"]
+mod tests;

--- a/crates/orbit-tools/src/builtin/proc/mod.rs
+++ b/crates/orbit-tools/src/builtin/proc/mod.rs
@@ -1,3 +1,4 @@
+mod git_config;
 pub mod spawn;
 pub mod which;
 

--- a/crates/orbit-tools/src/builtin/proc/spawn.rs
+++ b/crates/orbit-tools/src/builtin/proc/spawn.rs
@@ -13,6 +13,7 @@ use orbit_types::policy::{FsOperation, ResolvedFsProfile};
 use orbit_types::tool::{ToolParam, ToolSchema};
 use serde_json::Value;
 
+use super::git_config::enforce_no_persistent_git_config;
 use crate::{TIMEOUT_DEFAULT_MS, TIMEOUT_LONG_MS, Tool, ToolContext};
 
 pub struct ProcSpawnTool;
@@ -67,6 +68,8 @@ impl Tool for ProcSpawnTool {
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
+
+        enforce_no_persistent_git_config("proc.spawn", &program, &args)?;
 
         let request = spawn_request(ctx, program, args, proc_spawn_timeout_ms(&input));
         let exec_result = run_process(&request, &ActivityFsSandbox::new(ctx)?)?;

--- a/crates/orbit-tools/src/builtin/proc/tests/git_config.rs
+++ b/crates/orbit-tools/src/builtin/proc/tests/git_config.rs
@@ -1,0 +1,106 @@
+use orbit_common::OrbitError;
+
+use super::enforce_no_persistent_git_config;
+
+fn refuse(args: &[&str]) -> String {
+    let args: Vec<String> = args.iter().map(ToString::to_string).collect();
+    match enforce_no_persistent_git_config("proc.spawn", "git", &args) {
+        Err(OrbitError::PolicyDenied(message)) => message,
+        Err(other) => panic!("expected a policy denial, got: {other}"),
+        Ok(()) => panic!("`git {}` must be refused", args.join(" ")),
+    }
+}
+
+fn allow(args: &[&str]) {
+    let args: Vec<String> = args.iter().map(ToString::to_string).collect();
+    enforce_no_persistent_git_config("proc.spawn", "git", &args)
+        .unwrap_or_else(|error| panic!("`git {}` must be allowed: {error}", args.join(" ")));
+}
+
+/// The mutation observed in ORB-12103: a recovery agent adding an `origin` that
+/// points at the primary checkout, which a linked worktree shares.
+#[test]
+fn adding_a_remote_is_refused_even_with_a_directory_override() {
+    let message = refuse(&[
+        "-C",
+        "/tmp/worktree",
+        "remote",
+        "add",
+        "origin",
+        "/tmp/repo",
+    ]);
+    assert!(
+        message.contains("`git remote`") && message.contains(".git/config"),
+        "denial must name the boundary it enforces, got: {message}"
+    );
+}
+
+#[test]
+fn every_remote_mutation_subcommand_is_refused() {
+    for subcommand in ["add", "rename", "remove", "rm", "set-url", "set-head"] {
+        refuse(&["remote", subcommand, "origin", "value"]);
+    }
+}
+
+#[test]
+fn config_writes_are_refused_in_flag_and_subcommand_form() {
+    refuse(&["config", "remote.origin.url", "/tmp/repo"]);
+    refuse(&["config", "--global", "user.email", "agent@example.com"]);
+    refuse(&["config", "--unset", "remote.origin.url"]);
+    refuse(&["config", "set", "remote.origin.url", "/tmp/repo"]);
+    refuse(&["config", "--file", ".git/config", "remote.origin.url", "x"]);
+}
+
+#[test]
+fn read_only_git_inspection_still_runs() {
+    allow(&["remote", "-v"]);
+    allow(&["remote", "show", "origin"]);
+    allow(&["remote", "get-url", "origin"]);
+    allow(&["config", "--get", "remote.origin.url"]);
+    allow(&["config", "--list"]);
+    allow(&["config", "get", "remote.origin.url"]);
+    allow(&["-C", "/tmp/worktree", "status", "--porcelain"]);
+    allow(&["log", "--oneline", "-n", "5"]);
+    allow(&[]);
+}
+
+/// `-c` configures one invocation and leaves nothing behind, so it stays
+/// allowed — but it must not hide the subcommand from the scan.
+#[test]
+fn per_invocation_overrides_do_not_mask_the_subcommand() {
+    allow(&["-c", "core.hooksPath=/dev/null", "commit", "-m", "message"]);
+    refuse(&[
+        "-c",
+        "core.hooksPath=/dev/null",
+        "remote",
+        "add",
+        "origin",
+        "/tmp/repo",
+    ]);
+}
+
+#[test]
+fn other_programs_are_not_inspected() {
+    let args: Vec<String> = ["remote", "add", "origin", "/tmp/repo"]
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    enforce_no_persistent_git_config("proc.spawn", "/usr/bin/rg", &args).expect("non-git program");
+}
+
+#[test]
+fn git_is_recognized_through_its_path_and_executable_suffix() {
+    let args: Vec<String> = ["remote", "add", "origin", "/tmp/repo"]
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    for program in ["/usr/bin/git", "git.exe"] {
+        assert!(
+            matches!(
+                enforce_no_persistent_git_config("proc.spawn", program, &args),
+                Err(OrbitError::PolicyDenied(_))
+            ),
+            "`{program}` must be recognized as git"
+        );
+    }
+}


### PR DESCRIPTION
## Task

[ORB-12103](https://orbit-cli.com/tasks/ORB-12103) — step_failure_recovery rewrote the repository's git remote config and turned a failed push green

### Description

Found during a full QA sweep of orbit 0.20.0 on the Mac mini (2026-09-10).


 When the `push` step of `task_local_pipeline` failed on a checkout with no usable `origin`,
 the `step_failure_recovery` agent "recovered" by running, inside the assigned worktree:

 ```
 git -C <worktree> remote add origin <the primary checkout path>
 ```

 Because a linked worktree shares `.git/config` with its main checkout, this wrote a
 self-pointing `origin` into the **primary checkout's** git config — durable repository
 state well outside the run's own worktree. The retried `push` then reported
 `decision: reused_current, remote_sha_before == local_sha` and the step, child run, and
 whole ship run all finished `success`.

 Two problems, either of which is independently serious:
 1. Recovery is allowed to mutate repository/git configuration that outlives the run.
 2. A "recovery" that only manufactures the precondition makes a genuinely failed
    publication step indistinguishable from a successful one.

 The recovery agent did correctly file a friction record for the underlying push failure,
 so the reporting half of its contract worked.

 Observed on run `jrun-20260911-0152-3` (activity `step_failure_recovery`, codex/luna).

 ## Expected
 Recovery must not write git remote/config state. Where recovery cannot restore the
 precondition without changing durable repository configuration, it should report
 `recovered: false` and let the step fail honestly.

### Acceptance Criteria

- `step_failure_recovery` cannot add, rename, or rewrite git remotes or other persistent git config, in the worktree or the shared checkout
- Its contract/prompt states the boundary explicitly, and a run that would need such a change reports recovery as not possible
- A push step whose precondition was never legitimately satisfied does not report success
- Test covers recovery attempting the forbidden mutation and being refused

## Execution Summary

<details>
<summary>Click to expand</summary>

Closed the two failure modes from the QA sweep: recovery can no longer write durable git configuration, and a push cannot report success against a remote that is this same repository.

## What changed
- `crates/orbit-tools/src/builtin/proc/git_config.rs` (new): `proc.spawn` refuses a `git` invocation that writes persistent repository configuration — `git config` writes (flag form and the 2.46 `set`/`unset` subcommand form) and every mutating `git remote` subcommand (`add`, `rename`, `remove`, `rm`, `set-url`, `set-head`, ...). Read-only inspection (`git remote -v|show|get-url`, `git config --get|--list`) still runs. Leading git options are skipped so `git -C <path> remote add` and `git -c k=v remote add` are caught; the rule fails closed on any form it cannot recognize as a read. Denials emit the existing `orbit.policy.deny` warn fields. Wired into `ProcSpawnTool::execute` after the program allowlist (`spawn.rs`, `mod.rs`).
- `crates/orbit-core/assets/activities/step_failure_recovery.yaml` + byte-identical mirror `.orbit/resources/activities/step_failure_recovery.yaml`: the contract now states the boundary ("Repository configuration is out of bounds", never write persistent git config, Orbit refuses it at the tool boundary) and requires reporting `recovered: false` with the blocker plus the friction when the failed step could only succeed after such a change ("Manufacturing a step's precondition is not recovery"). The `description` says the same in one line.
- `crates/orbit-engine/src/executor/automation/vcs/push.rs`: `push_batch_changes_inner` now calls `ensure_origin_publishes_elsewhere` before reading any SHA. A missing `origin` fails with an explicit message; a local-path `origin` whose canonical `--git-common-dir` equals the workspace's (self-pointing remote, or the primary checkout of a linked worktree) fails instead of returning `decision: reused_current`. Non-local remotes and distinct local repositories are unaffected.

## Acceptance criteria
1. *Cannot rewrite remotes/config* — enforced at `proc.spawn`, the subprocess surface the activity is granted; verified against the shipped activity's own `proc_allowed_programs` and asserted to leave `git remote` empty. Limitation below.
2. *Contract states it; unrecoverable runs report not possible* — contract paragraph added and asserted by test; the paragraph mandates `recovered: false`.
3. *Push with an unsatisfied precondition does not report success* — the self-pointing/worktree cases now error; proven to previously return `reused_current` with `remote_sha_before == local_sha` (see fault demo below).
4. *Test covers the forbidden mutation being refused* — `orbit-core` `step_failure_recovery_cannot_write_persistent_git_configuration` runs the real recovery grant through `proc.spawn` with `git -C <repo> remote add origin <repo>` and asserts the policy denial plus untouched config; `orbit-tools` `builtin::proc::git_config::tests` cover the argv rules; three push tests in `orbit-engine` cover the delivery side.

## Fault demonstration (guards temporarily disabled, then restored)
- Without the push guard: both new push tests failed with `{"decision": "reused_current", "remote_sha_before" == "local_sha"}` — the exact output reported on jrun-20260911-0152-3.
- Without the proc.spawn guard: the recovery activity's own tool context ran `git remote add origin` to exit code 0, confirming nothing else (including the fs sandbox) was stopping it.

## Validation
- `cargo test -p orbit-tools --lib builtin::proc` — passed (14).
- `cargo test -p orbit-tools --test proc_spawn_lockdown` — passed (13).
- `cargo test -p orbit-engine --lib executor::automation::vcs` — passed (264).
- `cargo test -p orbit-engine --lib activity_job::job_executor::tests::recovery` — passed (24).
- `cargo test -p orbit-core --lib bootstrap` — passed (37).
- `make ci-fast` — passed (exit 0; includes the activity-mirror check).
- `make ci-lint` — passed (exit 0), plus a targeted `cargo clippy -p orbit-tools -p orbit-core -p orbit-engine --all-targets -- -D warnings` after the final doc edits.
- Not run: full `make ci` (CI merge gate per workspace policy). Linux only; no macOS verification, though nothing here is platform-specific beyond git behavior.

## Risks and limits
- The `proc.spawn` guard binds Orbit-mediated subprocesses. A provider harness's own shell tool is outside Orbit's tool gate (documented in `agent_invoke.yaml`), so for that path the contract text plus the push guard are the controls; the push guard makes the manufactured precondition useless regardless of how the remote was written.
- The push guard detects a same-repository `origin` only when it resolves to a local path (including `file://`); a loopback transport URL (`ssh://localhost/...`) is not detected.
- Conservative denials: `git remote prune|update` and two-positional `git config` reads (e.g. `--get-urlmatch`, `--file <path> --get k`) are refused; no shipped flow uses them.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12103-6aa36d6b`
- Behind base: 0
- Ahead of base: 1