### PR TITLE
Ship gate pipeline hardcodes auto_push, so local-mode delivery pushes on repos with no remote

### DIFF
--- a/.orbit/resources/jobs/task_gate_pipeline.yaml
+++ b/.orbit/resources/jobs/task_gate_pipeline.yaml
@@ -68,6 +68,12 @@ spec:
     landing_branch: ""
     # ORB-11187: forwarded to the leaf pipeline unchanged.
     completion: review
+    # ORB-12102: forwarded to the child pipeline, never pinned here. A gated
+    # local run publishes nothing by default — `task_local_pipeline` gates its
+    # `push` step on this value and defaults it to false — so a checkout with
+    # no usable `origin` no longer fails a push it never asked for. A caller
+    # that does want the child to publish passes `auto_push: true` to this job.
+    auto_push: false
     # ORB-11242: opt-in, run-scoped crew restriction. Empty means unrestricted,
     # which is the behavior of every caller that does not pass it. Forwarded
     # unchanged so the leaf/epic jobs this run admits inherit the same window.
@@ -114,7 +120,7 @@ spec:
           landing_branch: "{{ input.landing_branch }}"
           completion: "{{ input.completion }}"
           allowed_crews: "{{ input.allowed_crews }}"
-          auto_push: true
+          auto_push: "{{ input.auto_push }}"
         admission_task_ids: "{{ input.task_ids }}"
         admission_workflow: worktree_setup
         timeout_seconds: "{{ input.dispatch_timeout_seconds }}"

--- a/crates/orbit-core/assets/jobs/task_gate_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_gate_pipeline.yaml
@@ -68,6 +68,12 @@ spec:
     landing_branch: ""
     # ORB-11187: forwarded to the leaf pipeline unchanged.
     completion: review
+    # ORB-12102: forwarded to the child pipeline, never pinned here. A gated
+    # local run publishes nothing by default — `task_local_pipeline` gates its
+    # `push` step on this value and defaults it to false — so a checkout with
+    # no usable `origin` no longer fails a push it never asked for. A caller
+    # that does want the child to publish passes `auto_push: true` to this job.
+    auto_push: false
     # ORB-11242: opt-in, run-scoped crew restriction. Empty means unrestricted,
     # which is the behavior of every caller that does not pass it. Forwarded
     # unchanged so the leaf/epic jobs this run admits inherit the same window.
@@ -114,7 +120,7 @@ spec:
           landing_branch: "{{ input.landing_branch }}"
           completion: "{{ input.completion }}"
           allowed_crews: "{{ input.allowed_crews }}"
-          auto_push: true
+          auto_push: "{{ input.auto_push }}"
         admission_task_ids: "{{ input.task_ids }}"
         admission_workflow: worktree_setup
         timeout_seconds: "{{ input.dispatch_timeout_seconds }}"

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -1337,6 +1337,66 @@ fn gate_pipeline_default_reservation_ttl_covers_child_wait_budget() {
     );
 }
 
+/// [ORB-12102] The gate forwards its own `auto_push` value instead of pinning
+/// the child's push on. Pinning `true` overrode `task_local_pipeline`'s
+/// `auto_push: false` default, so every gated local run pushed — and failed —
+/// on a checkout with no usable `origin`.
+#[test]
+fn gate_pipeline_threads_auto_push_instead_of_pinning_it() {
+    let yaml = DEFAULT_JOB_FILES
+        .iter()
+        .find_map(|(name, yaml)| (*name == "task_gate_pipeline").then_some(*yaml))
+        .expect("task gate pipeline default exists");
+    let asset = load_job_asset(yaml).expect("parse task gate pipeline");
+    let default_input = asset
+        .spec
+        .default_input
+        .as_ref()
+        .expect("task gate pipeline default input");
+    assert_eq!(
+        default_input["auto_push"],
+        Value::Bool(false),
+        "an unattended gate run must default to the leaf's own no-push behavior"
+    );
+
+    let dispatch = asset
+        .spec
+        .steps
+        .iter()
+        .find(|step| step.id == "dispatch_child")
+        .expect("task gate pipeline has child dispatch step");
+    let JobV2StepBody::TargetRef(target) = &dispatch.body else {
+        panic!("expected dispatch target ref, got {:?}", dispatch.body);
+    };
+    let run_input = &target.default_input.as_ref().expect("dispatch input")["run_input"];
+    assert_eq!(
+        run_input["auto_push"],
+        Value::String("{{ input.auto_push }}".to_string()),
+        "the child's push must come from this run's input, not a literal"
+    );
+
+    // PR delivery is unaffected: `task_pr_pipeline` publishes its branch
+    // regardless of the forwarded value, so only the local leaf's push
+    // changes behavior here.
+    let pr_yaml = DEFAULT_JOB_FILES
+        .iter()
+        .find_map(|(name, yaml)| (*name == "task_pr_pipeline").then_some(*yaml))
+        .expect("task pr pipeline default exists");
+    let pr_push = load_job_asset(pr_yaml)
+        .expect("parse task pr pipeline")
+        .spec
+        .steps
+        .iter()
+        .find(|step| step.id == "push")
+        .expect("task pr pipeline has a push step")
+        .when
+        .clone();
+    assert!(
+        !pr_push.unwrap_or_default().contains("auto_push"),
+        "PR publication must not become conditional on the gate's auto_push input"
+    );
+}
+
 /// [ORB-10129] Structural invariants of the triage pipeline: it is
 /// single-flight (`max_active_runs: 1` — one half of the overlap
 /// guarantee, the routine's `overlap: forbid` is the other), an empty

--- a/crates/orbit-core/src/application/job/tests/exec.rs
+++ b/crates/orbit-core/src/application/job/tests/exec.rs
@@ -8,6 +8,7 @@ mod already_landed;
 mod ci_sweep;
 mod completion;
 mod epic_review_gate;
+mod local_ship;
 mod review_gate;
 
 use chrono::Utc;
@@ -1308,6 +1309,11 @@ fn epic_pipeline_reenters_drain_when_finisher_authors_a_child() {
     assert!(host.current_descendants().is_empty());
 }
 
+/// Rename the engine's own deterministic actions so a scripted host sees
+/// them. The v2 dispatcher routes a known engine action straight into
+/// `execute_engine_action`, never through `RuntimeHost::run_deterministic`,
+/// so a host override alone cannot intercept `worktree_setup`, the `git_*`
+/// actions, or `update_task`.
 pub(super) fn retarget_engine_actions_for_scripted_host(
     job: &mut orbit_types::workflow::activity_job::JobV2,
 ) {

--- a/crates/orbit-core/src/application/job/tests/exec/local_ship.rs
+++ b/crates/orbit-core/src/application/job/tests/exec/local_ship.rs
@@ -1,0 +1,336 @@
+//! [ORB-12102] Gated local delivery into a checkout with no push remote.
+//!
+//! `task_gate_pipeline` used to pin `auto_push: true` into the child run
+//! input, which defeated `task_local_pipeline`'s own `auto_push: false`
+//! default. On a local-ship workspace whose checkout has no usable `origin`
+//! the leaf then ran `git_push`, the push failed, and the failed step
+//! dispatched the `step_failure_recovery` agent — provider time spent on a
+//! step that should never have executed (run `jrun-20260911-0152-3`).
+//!
+//! These tests drive the real gate job and the real leaf job together: the
+//! host scripts the surrounding activities but leaves the pipeline wiring,
+//! the `auto_push` threading, and the `push` step's condition untouched.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+
+use orbit_engine::{DispatchError, ResolvedCliExecutor, RuntimeHost};
+use orbit_tools::{FsAuditLogger, ToolContext};
+use orbit_types::task::TaskStatus;
+use serde_json::{Value, json};
+
+use super::{
+    git_in, resolved_job, retarget_engine_actions_for_scripted_host, seed_default_catalogs,
+    seed_gate_task, test_runtime, try_execute_job, v2_events,
+};
+use crate::OrbitRuntime;
+
+const BASE_BRANCH: &str = "agent-main";
+const CHILD_RUN_ID: &str = "jrun-local-ship-child";
+
+/// The implementation activity is an agent loop in production. Replace the
+/// seeded asset with a deterministic stub so these tests exercise the
+/// delivery tail without a provider.
+fn stub_agent_implement(global_root: &Path) {
+    std::fs::write(
+        global_root.join("resources/activities/agent_implement.yaml"),
+        r#"schemaVersion: 2
+kind: Activity
+metadata:
+  name: agent_implement
+spec:
+  type: deterministic
+  description: Test stub for the bundle implementation step.
+  input_schema_json:
+    type: object
+  output_schema_json:
+    type: object
+  action: test_agent_implement
+  config: {}
+"#,
+    )
+    .expect("stub agent implementation activity");
+}
+
+/// A checkout shaped like a local-ship workspace: a real repository on the
+/// delivery base branch, with no remote to publish to.
+fn init_remoteless_repo(repo_root: &Path) {
+    git_in(repo_root, &["init"]);
+    git_in(repo_root, &["config", "user.name", "Orbit Test"]);
+    git_in(
+        repo_root,
+        &["config", "user.email", "orbit-test@example.invalid"],
+    );
+    std::fs::write(repo_root.join("README.md"), "base\n").expect("write initial file");
+    git_in(repo_root, &["add", "README.md"]);
+    git_in(repo_root, &["commit", "-m", "initial"]);
+    git_in(repo_root, &["checkout", "-b", BASE_BRANCH]);
+
+    let remotes = Command::new("git")
+        .current_dir(repo_root)
+        .arg("remote")
+        .output()
+        .expect("git remote");
+    assert!(
+        String::from_utf8_lossy(&remotes.stdout).trim().is_empty(),
+        "the fixture checkout must have no push remote"
+    );
+}
+
+/// Executes the real `task_local_pipeline` for the gate's `dispatch_child`
+/// step, with the engine's own VCS and task activities scripted the way the
+/// epic pipeline tests script them. The pipeline wiring under test — the
+/// gate's `auto_push` threading and the leaf's `push` condition — stays
+/// untouched.
+struct LocalShipHost<'a> {
+    runtime: &'a OrbitRuntime,
+    repo_root: PathBuf,
+    calls: Mutex<Vec<(String, Value)>>,
+    child_run_input: Mutex<Option<Value>>,
+}
+
+impl<'a> LocalShipHost<'a> {
+    fn new(runtime: &'a OrbitRuntime, repo_root: &Path) -> Self {
+        Self {
+            runtime,
+            repo_root: repo_root.to_path_buf(),
+            calls: Mutex::new(Vec::new()),
+            child_run_input: Mutex::new(None),
+        }
+    }
+
+    fn record(&self, action: &str, input: &Value) {
+        self.calls
+            .lock()
+            .expect("call log")
+            .push((action.to_string(), input.clone()));
+    }
+
+    fn inputs_for(&self, action: &str) -> Vec<Value> {
+        self.calls
+            .lock()
+            .expect("call log")
+            .iter()
+            .filter(|(recorded, _)| recorded == action)
+            .map(|(_, input)| input.clone())
+            .collect()
+    }
+
+    fn actions(&self) -> Vec<String> {
+        self.calls
+            .lock()
+            .expect("call log")
+            .iter()
+            .map(|(recorded, _)| recorded.clone())
+            .collect()
+    }
+
+    fn child_run_input(&self) -> Value {
+        self.child_run_input
+            .lock()
+            .expect("child run input")
+            .clone()
+            .expect("the gate dispatched a child pipeline")
+    }
+
+    fn run_child_pipeline(&self, input: &Value) -> Result<Value, DispatchError> {
+        let job_name = input["job_name"]
+            .as_str()
+            .expect("child job name")
+            .to_string();
+        let run_input = input["run_input"].clone();
+        *self.child_run_input.lock().expect("child run input") = Some(run_input.clone());
+
+        let mut job = resolved_job(self.runtime, &job_name);
+        retarget_engine_actions_for_scripted_host(&mut job);
+        let outcome = try_execute_job(
+            self.runtime,
+            &self.repo_root,
+            self,
+            job,
+            run_input,
+            CHILD_RUN_ID,
+        )?;
+
+        Ok(json!({
+            "run_id": CHILD_RUN_ID,
+            "status": if outcome.success { "succeeded" } else { "failed" },
+        }))
+    }
+}
+
+impl RuntimeHost for LocalShipHost<'_> {
+    fn run_deterministic(
+        &self,
+        action: &str,
+        config: &Value,
+        input: &Value,
+        tool_context: ToolContext,
+    ) -> Result<Value, DispatchError> {
+        let recorded = action.strip_prefix("scripted_").unwrap_or(action);
+        self.record(recorded, input);
+        match recorded {
+            "reserve_locks" => Ok(json!({
+                "reserved": true,
+                "reservation_id": "reservation-local-ship",
+            })),
+            "release_locks" => Ok(json!({ "released": true })),
+            "invoke_and_wait" => self.run_child_pipeline(input),
+            "worktree_setup" => Ok(json!({
+                "workspace_path": self.repo_root.display().to_string(),
+                "job_run_id": CHILD_RUN_ID,
+                "base_ref": format!("refs/heads/{BASE_BRANCH}"),
+                "base_sha": "0000000000000000000000000000000000000000",
+                "head_ref": BASE_BRANCH,
+            })),
+            "test_agent_implement" => Ok(json!({ "summary": "fixture implementation" })),
+            "git_commit" => Ok(json!({ "committed": true, "decision": "committed" })),
+            "git_merge" => Ok(json!({ "merged": true, "decision": "performed" })),
+            "update_task" => Ok(json!({})),
+            "git_push" => Ok(json!({
+                "decision": "performed_create",
+                "branch": BASE_BRANCH,
+            })),
+            _ => <OrbitRuntime as RuntimeHost>::run_deterministic(
+                self.runtime,
+                action,
+                config,
+                input,
+                tool_context,
+            ),
+        }
+    }
+
+    /// Every agent activity in these pipelines — including the
+    /// `step_failure_recovery` hook a failed step dispatches — resolves an
+    /// executor first. Refusing here keeps the fixture from launching a
+    /// provider, and records that something tried.
+    fn resolve_cli_executor(&self, provider: &str) -> Result<ResolvedCliExecutor, DispatchError> {
+        self.record("resolve_cli_executor", &Value::Null);
+        Err(DispatchError::JobExecution(format!(
+            "fixture refuses to launch provider '{provider}'"
+        )))
+    }
+
+    fn tool_context_for_activity(
+        &self,
+        run_id: Option<&str>,
+        fs_profile: Option<&str>,
+        fs_audit: Option<Arc<dyn FsAuditLogger>>,
+        proc_allowed_programs: Option<&[String]>,
+    ) -> ToolContext {
+        <OrbitRuntime as RuntimeHost>::tool_context_for_activity(
+            self.runtime,
+            run_id,
+            fs_profile,
+            fs_audit,
+            proc_allowed_programs,
+        )
+    }
+}
+
+fn started_activities(runtime: &OrbitRuntime, run_id: &str) -> Vec<String> {
+    v2_events(runtime, run_id, "activity.started")
+        .iter()
+        .map(|row| {
+            let payload: Value = serde_json::from_str(&row.payload_json).expect("payload");
+            payload["activity_name"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string()
+        })
+        .collect()
+}
+
+#[test]
+fn gated_local_ship_without_a_remote_never_pushes_or_recovers() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    stub_agent_implement(&global_root);
+    init_remoteless_repo(&repo_root);
+    let task_id = seed_gate_task(&runtime, &repo_root, TaskStatus::InProgress);
+    let host = LocalShipHost::new(&runtime, &repo_root);
+
+    let outcome = try_execute_job(
+        &runtime,
+        &repo_root,
+        &host,
+        resolved_job(&runtime, "task_gate_pipeline"),
+        json!({
+            "task_ids": [task_id.clone()],
+            "mode": "local",
+            "base_branch": BASE_BRANCH,
+            "base_sync": "local",
+        }),
+        "jrun-local-ship-gate",
+    )
+    .expect("a local-ship bundle must deliver on a checkout with no remote");
+
+    assert!(outcome.success);
+    assert!(
+        host.inputs_for("git_push").is_empty(),
+        "local delivery has nothing to publish, yet the leaf pushed: {:?}",
+        host.actions()
+    );
+    assert!(
+        host.inputs_for("resolve_cli_executor").is_empty(),
+        "no step failed, so no recovery agent may be dispatched"
+    );
+    assert!(
+        !started_activities(&runtime, CHILD_RUN_ID).contains(&"step_failure_recovery".to_string()),
+        "the child run must not enter step failure recovery"
+    );
+    assert_eq!(
+        host.child_run_input()["auto_push"],
+        json!(false),
+        "the leaf skipped its push because the gate threaded its own auto_push value"
+    );
+
+    let reviewed = host.inputs_for("update_task");
+    assert_eq!(reviewed.len(), 1, "the bundle still finishes its delivery");
+    assert_eq!(reviewed[0]["task_id"], task_id);
+    assert_eq!(reviewed[0]["status"], "review");
+}
+
+/// The complement of the regression above: threading the value must keep the
+/// push reachable, not disable it. `git_push` is scripted like every other
+/// engine action here, so what this observes is the leaf's `push` condition,
+/// not git's publication behavior.
+#[test]
+fn gated_local_ship_still_pushes_when_the_caller_asks_for_it() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    stub_agent_implement(&global_root);
+    init_remoteless_repo(&repo_root);
+    let task_id = seed_gate_task(&runtime, &repo_root, TaskStatus::InProgress);
+    let host = LocalShipHost::new(&runtime, &repo_root);
+
+    let outcome = try_execute_job(
+        &runtime,
+        &repo_root,
+        &host,
+        resolved_job(&runtime, "task_gate_pipeline"),
+        json!({
+            "task_ids": [task_id],
+            "mode": "local",
+            "base_branch": BASE_BRANCH,
+            "base_sync": "local",
+            "auto_push": true,
+        }),
+        "jrun-local-ship-gate-push",
+    )
+    .expect("an explicit push request must still deliver");
+
+    assert!(outcome.success);
+    assert_eq!(
+        host.child_run_input()["auto_push"],
+        json!(true),
+        "an explicit request reaches the leaf as a typed boolean"
+    );
+    assert_eq!(
+        host.inputs_for("git_push").len(),
+        1,
+        "the leaf must still publish when its caller asked it to"
+    );
+}


### PR DESCRIPTION
## Task

[ORB-12102](https://orbit-cli.com/tasks/ORB-12102) — Ship gate pipeline hardcodes auto_push, so local-mode delivery pushes on repos with no remote

### Description

Found during a full QA sweep of orbit 0.20.0 on the Mac mini (2026-09-10).


 `crates/orbit-core/assets/jobs/task_gate_pipeline.yaml` sets `auto_push: true` in the
 `dispatch_child` step's `run_input`, unconditionally, for both `task_local_pipeline` and
 `task_pr_pipeline`. `task_local_pipeline` declares `auto_push: false` in its own
 `default_input` and gates its `push` step on `{{ input.auto_push }} == true`, so the gate's
 hardcoded value defeats that default for every gated run.

 Consequence on a local-ship workspace whose checkout has no usable `origin`: the `push`
 step runs, `git_push` fails, and `step_failure_recovery` is dispatched — an agent
 invocation costing ~80s of provider time per run for a step that should never have
 executed.

 ## Repro
 1. `git init` a repo with no remote, `orbit workspace init --ship-mode local`.
 2. File a small task, `orbit run ship <id>`.
 3. Watch `orbit run events <child-run-id>`: `push` → `activity.finished outcome=error` →
    `activity.started activity=step_failure_recovery type=agent_loop`.

 Observed on run `jrun-20260911-0152-3` (task_local_pipeline, luna/codex).

 ## Expected
 The gate should thread the wrapper's effective `auto_push` rather than pinning `true`, and
 `git_push` should resolve to a no-op (not an error) when the workspace has no push remote
 configured — a local-only delivery has nothing to publish.

### Acceptance Criteria

- `task_gate_pipeline` no longer pins `auto_push: true`; the value comes from the wrapper input or the child job's own default
- A local-ship run in a repo with no `origin` completes without entering `step_failure_recovery`
- A PR-mode run still pushes exactly as it does today
- Regression test covers the local-ship-without-remote path end to end

## Execution Summary

<details>
<summary>Click to expand</summary>

Threaded `auto_push` through `task_gate_pipeline` instead of pinning it, and covered the local-ship-without-remote path with an end-to-end regression test.

Change
- `crates/orbit-core/assets/jobs/task_gate_pipeline.yaml`: `dispatch_child.run_input.auto_push` is now `{{ input.auto_push }}`, and the job declares `auto_push: false` in `default_input` (matching `task_local_pipeline`'s own default, with a comment naming the reason). A caller that wants the child to publish passes `auto_push: true` to the gate; the template renders back to a typed JSON boolean, so the leaf's `when: {{ input.auto_push }} == true` sees a real bool.
- `.orbit/resources/jobs/task_gate_pipeline.yaml`: same two edits applied to the tracked dogfood copy (its deliberate `max_active_runs: 15` override is preserved). Tracked modification, no new scope needed.
- `crates/orbit-core/src/application/job/tests/exec/local_ship.rs` (new, declared in scope): two tests driving the real gate job and the real `task_local_pipeline` together against a real git checkout with no remote.
- `crates/orbit-core/src/application/job/tests/catalog.rs`: structural test `gate_pipeline_threads_auto_push_instead_of_pinning_it`.
- `crates/orbit-core/src/application/job/tests/exec.rs`: registers the new module and adds a doc comment on `retarget_engine_actions_for_scripted_host` explaining why scripted hosts must rename engine actions (see friction below).
- `crates/orbit-core/assets/jobs/task_local_pipeline.yaml` needed no change; its `auto_push: false` default and gated `push` step were already correct.

Acceptance criteria
1. No longer pins `auto_push: true` — PASS. The gate forwards `{{ input.auto_push }}`; the value comes from the wrapper's run input, falling back to the gate default `false`, which is the leaf's own default. Verified structurally (catalog test) and behaviorally (exec test asserts the child run input is `false`).
2. Local-ship run with no `origin` completes without `step_failure_recovery` — PASS. `gated_local_ship_without_a_remote_never_pushes_or_recovers` runs the gate in `mode: local` against a freshly initialized repo asserted to have no remotes; the run succeeds, `git_push` is never dispatched, no CLI executor is resolved (so no recovery agent could start), and the child run's `activity.started` audit events contain no `step_failure_recovery`.
3. PR-mode run still pushes as today — PASS by construction and asserted: `task_pr_pipeline` gates `push` on `steps.commit.output.skipped_no_diff_expected != true` and never reads `auto_push`; the catalog test now asserts that its `push` condition does not reference `auto_push`. Forwarding the key to the PR child is inert exactly as the previous literal `true` was.
4. Regression test covers the path end to end — PASS, and the fault is demonstrated: with `auto_push: true` restored in the asset, `gated_local_ship_without_a_remote_never_pushes_or_recovers` fails on the push assertion (recorded action log ends `... update_task, git_push ...`) and the catalog test fails on the literal. Both pass with the fix.

Validation (all run in this worktree)
- `cargo test -p orbit-core --lib` — PASSED (1383 passed, 0 failed, 2 ignored).
- `cargo test -p orbit-core --lib job::tests` — PASSED (128 passed) after the final formatting/doc pass.
- `make ci-fast` — PASSED (one sub-check self-reports `skip: cannot create a mount namespace` for compiler-cache namespaces; environmental, pre-existing).
- `make ci-lint` (workspace clippy, all targets, warnings denied) — PASSED.
- `cargo fmt --all`, `git diff --check`, `git status --short` — clean; the only untracked path is the declared new test file.
- Fault-detection check: temporarily reverted the asset to `auto_push: true`, confirmed both new tests fail, then restored the fix and re-ran them green.

Not done / risks
- The task description's secondary expectation — making `git_push` a no-op when the workspace has no push remote — was deliberately not implemented. No acceptance criterion covers it, it lives outside the declared scope (`crates/orbit-engine/.../vcs/push.rs`), and turning a missing `origin` into a silent success would mask a real misconfiguration on the PR path, where `pr_open` would then fail with a less direct error. Criterion 2 is satisfied without it because the push step no longer runs at all in a gated local run.
- Behavior change worth naming: a gated local-mode run in a workspace that *does* have a remote no longer pushes the base branch unless the caller asks. That is the documented meaning of local delivery (`orbit` skill orchestration reference: "the leaf job's `auto_push` input controls its optional push"), and `task_auto_pipeline` does not forward `auto_push`, so `orbit run ship --mode local` now never publishes. Raising it to the wrapper would be a separate, larger scope change.
- No current documentation asserted the old pinned behavior, so no doc updates were required.
- Friction F2026-09-123 filed: the v2 dispatcher routes engine deterministic actions straight to `execute_engine_action`, so scripted `RuntimeHost` overrides cannot intercept them (and overriding `has_deterministic_action` breaks the `scripted_*` rename). Mitigated in-repo by the new doc comment.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12102-6aa36d69`
- Behind base: 0
- Ahead of base: 1