### PR TITLE
Cleanup nits: mcp remove leaves an empty .claude directory; operation grants record actor unknown

### DIFF
--- a/crates/orbit-cli/src/command/mcp/setup/providers/claude.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/claude.rs
@@ -1,3 +1,6 @@
+use std::fs;
+use std::path::Path;
+
 use orbit_core::OrbitError;
 use orbit_types::tool::mcp_advertised_tool_name;
 use serde_json::{Map as JsonMap, Value as JsonValue};
@@ -76,8 +79,35 @@ pub(in crate::command::mcp::setup) fn apply_claude_remove(
             settings.remove(&key);
         }
         write_or_remove_json_object(settings_path, &settings)?;
+
+        if let Some(settings_dir) = settings_path.parent() {
+            remove_dir_if_empty(settings_dir)?;
+        }
     }
     Ok(())
+}
+
+/// Remove `dir` if it exists and is now empty.
+///
+/// `apply_claude_init` calls `write_json_object`, which `create_dir_all`s the
+/// settings file's parent on demand — for a workspace or home root with no
+/// prior `.claude/`, that is this directory. A clean `remove` should leave the
+/// tree as it found it, so once the settings file this function owns is gone,
+/// an empty directory is one `remove` itself created and should go with it.
+/// Any remaining content (a user's `commands/`, unrelated settings, …) means
+/// this directory predates `init` or serves another purpose, so it is left
+/// alone.
+fn remove_dir_if_empty(dir: &Path) -> Result<(), OrbitError> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    let mut entries = fs::read_dir(dir)
+        .map_err(|err| OrbitError::Io(format!("failed to read '{}': {err}", dir.display())))?;
+    if entries.next().is_some() {
+        return Ok(());
+    }
+    fs::remove_dir(dir)
+        .map_err(|err| OrbitError::Io(format!("failed to remove '{}': {err}", dir.display())))
 }
 
 pub(super) fn claude_mcp_server_value(launch: ServerLaunch<'_>) -> JsonValue {

--- a/crates/orbit-cli/src/command/mcp/setup/providers/tests/claude.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/tests/claude.rs
@@ -100,6 +100,92 @@ fn claude_workspace_scope_init_and_remove_preserve_unrelated_entries() {
 }
 
 #[test]
+fn claude_remove_deletes_empty_directory_init_created() {
+    // ORB-12115: `init` calls `write_json_object`, which `create_dir_all`s
+    // `.claude/` when it does not already exist. `remove` deleting only the
+    // settings file it wrote left that directory behind, orphaned and empty.
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    let orbit_root = repo.path().join(".orbit");
+    std::fs::create_dir_all(&orbit_root).expect("create orbit root");
+    assert!(!repo.path().join(".claude").exists(), "precondition");
+
+    run_action(
+        McpAction::Init(ServerLaunch::default()),
+        repo.path(),
+        &orbit_root,
+        ProviderSelectionMode::Explicit(vec![McpProvider::Claude]),
+        Some(home.path().to_path_buf()),
+        ScopeArg::Workspace,
+    )
+    .expect("init claude");
+    assert!(
+        repo.path().join(".claude").is_dir(),
+        "init must create .claude/ when it is absent"
+    );
+
+    run_action(
+        McpAction::Remove,
+        repo.path(),
+        &orbit_root,
+        ProviderSelectionMode::Explicit(vec![McpProvider::Claude]),
+        Some(home.path().to_path_buf()),
+        ScopeArg::Workspace,
+    )
+    .expect("remove claude");
+
+    assert!(
+        !repo.path().join(".claude").exists(),
+        "remove must not leave behind the now-empty directory it created"
+    );
+}
+
+#[test]
+fn claude_remove_preserves_directory_with_unrelated_content() {
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    std::fs::create_dir_all(repo.path().join(".claude").join("commands"))
+        .expect("create unrelated .claude subdirectory");
+    std::fs::write(
+        repo.path().join(".claude").join("commands").join("foo.md"),
+        "unrelated command",
+    )
+    .expect("write unrelated file");
+
+    let orbit_root = repo.path().join(".orbit");
+    std::fs::create_dir_all(&orbit_root).expect("create orbit root");
+
+    run_action(
+        McpAction::Init(ServerLaunch::default()),
+        repo.path(),
+        &orbit_root,
+        ProviderSelectionMode::Explicit(vec![McpProvider::Claude]),
+        Some(home.path().to_path_buf()),
+        ScopeArg::Workspace,
+    )
+    .expect("init claude");
+
+    run_action(
+        McpAction::Remove,
+        repo.path(),
+        &orbit_root,
+        ProviderSelectionMode::Explicit(vec![McpProvider::Claude]),
+        Some(home.path().to_path_buf()),
+        ScopeArg::Workspace,
+    )
+    .expect("remove claude");
+
+    assert!(
+        repo.path()
+            .join(".claude")
+            .join("commands")
+            .join("foo.md")
+            .exists(),
+        "remove must not touch directory content it did not create"
+    );
+}
+
+#[test]
 fn claude_operator_init_writes_single_operator_flag_and_refresh_is_idempotent() {
     let repo = tempdir().expect("repo tempdir");
     let home = tempdir().expect("home tempdir");

--- a/crates/orbit-cli/src/tests/audit_middleware.rs
+++ b/crates/orbit-cli/src/tests/audit_middleware.rs
@@ -89,12 +89,30 @@ fn cli_agent_envelope_records_canonical_actor_family() {
 
 #[test]
 fn cli_without_agent_envelope_records_unknown_actor() {
-    let _env = test_env::unset(AGENT_IDENTITY_ENV.iter().copied());
+    let _env = test_env::unset(AGENT_IDENTITY_ENV.iter().copied().chain(["ORBIT_OPERATOR"]));
 
     let actor = ActorIdentity::from_env();
     assert_eq!(actor.kind, ActorKind::Unknown);
     assert_eq!(actor.label, "unknown");
     assert_eq!(audit_event_for_actor(actor).role, "unknown");
+}
+
+#[test]
+fn cli_operator_override_without_agent_envelope_records_operator_actor() {
+    // ORB-12115: a grant enabled under `ORBIT_OPERATOR=1` previously recorded
+    // `actor: "unknown"` even though the override is itself an audited,
+    // deliberate act — it should name who enabled it.
+    let _env = test_env::scoped(
+        AGENT_IDENTITY_ENV
+            .iter()
+            .map(|name| (*name, None))
+            .chain([("ORBIT_OPERATOR", Some("1"))]),
+    );
+
+    let actor = ActorIdentity::from_env();
+    assert_eq!(actor.kind, ActorKind::Human);
+    assert_eq!(actor.label, "operator");
+    assert_eq!(audit_event_for_actor(actor).role, "operator");
 }
 
 #[test]

--- a/crates/orbit-common/src/governance/authorization.rs
+++ b/crates/orbit-common/src/governance/authorization.rs
@@ -73,6 +73,17 @@ use orbit_types::tool::{McpCapability, RemoteCallerGrant, ToolSessionContext};
 /// trail rather than indistinguishable from an ordinary operator session.
 pub const OPERATOR_OVERRIDE_ENV: &str = "ORBIT_OPERATOR";
 
+/// Whether [`OPERATOR_OVERRIDE_ENV`] is set to a truthy value in this
+/// process's environment.
+///
+/// Exposed so a caller outside this module — actor-identity resolution, in
+/// particular — can tell "an operator deliberately raised this" apart from
+/// "nothing identified the caller" without re-deriving the truthy spellings
+/// this module already owns.
+pub fn operator_override_active() -> bool {
+    env_truthy(OPERATOR_OVERRIDE_ENV)
+}
+
 /// Process-envelope variables that declare the caller to be an agent.
 const AGENT_ENVELOPE_ENV: &[&str] = &["ORBIT_AGENT_NAME", "ORBIT_AGENT_MODEL"];
 

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -22,6 +22,10 @@ use orbit_config::{CodexExecutionPolicy, ExecutionEnvPolicy, PersistenceConfig};
 const ORBIT_AGENT_NAME: &str = "ORBIT_AGENT_NAME";
 const ORBIT_AGENT_MODEL: &str = "ORBIT_AGENT_MODEL";
 
+/// Actor label recorded when [`OPERATOR_OVERRIDE_ENV`](orbit_common::governance::authorization::OPERATOR_OVERRIDE_ENV)
+/// is the only signal identifying the caller.
+const OPERATOR_ACTOR_LABEL: &str = "operator";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ActorKind {
     Unknown,
@@ -61,9 +65,12 @@ impl ActorIdentity {
     /// entry points.
     ///
     /// The environment is not an authentication boundary. Agent values are
-    /// therefore reduced to the same canonical family used by tool dispatch,
-    /// and an absent or inconsistent envelope is recorded as `unknown` rather
-    /// than claiming that a human was present.
+    /// therefore reduced to the same canonical family used by tool dispatch.
+    /// Absent an agent envelope, an explicit operator override is recorded as
+    /// a named human actor rather than `unknown` — the override is itself a
+    /// deliberate, audited act, so the actor it authorizes (a grant, a task
+    /// mutation, …) should say who enabled it instead of claiming nobody did.
+    /// Only a caller with neither signal is recorded as `unknown`.
     pub fn from_env() -> Self {
         let agent = std::env::var(ORBIT_AGENT_NAME)
             .ok()
@@ -72,11 +79,19 @@ impl ActorIdentity {
             .ok()
             .filter(|value| !value.trim().is_empty());
 
-        normalize_agent_family_for_model(agent.as_deref(), model.as_deref())
+        if let Some(actor) = normalize_agent_family_for_model(agent.as_deref(), model.as_deref())
             .ok()
             .flatten()
             .map(Self::agent)
-            .unwrap_or_default()
+        {
+            return actor;
+        }
+
+        if orbit_common::governance::authorization::operator_override_active() {
+            return Self::human(OPERATOR_ACTOR_LABEL);
+        }
+
+        Self::default()
     }
 }
 


### PR DESCRIPTION
## Task

[ORB-12115](https://orbit-cli.com/tasks/ORB-12115) — Cleanup nits: mcp remove leaves an empty .claude directory; operation grants record actor unknown

### Description

Found during a full QA sweep of orbit 0.20.0 on the Mac mini (2026-09-10).


 Two unrelated small defects.

 1. **`orbit mcp remove --claude --scope workspace` leaves an empty `.claude/` directory** in the
    workspace after deleting the settings it created. `mcp init` created the directory; remove
    should leave the tree as it found it (removing the directory only when it is empty and Orbit
    created it).
 2. **Operation grants record `actor: "unknown"`.** A grant created under `ORBIT_OPERATOR=1`
    still stores `"actor": "unknown"` in the grant record and `orbit operation show` output, even
    though the operator override is itself recorded in the audit trail. A grant authorizes
    unattended preparation/promotion for a task set, so its record should name who enabled it.

### Acceptance Criteria

- `orbit mcp remove` leaves no empty Orbit-created directory behind
- An operation grant records a meaningful actor for the operator-override path rather than `unknown`
- Existing grants remain readable
- Tests cover both

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed both QA-flagged defects, scoped to the four given context files plus one small addition (`orbit-common/src/governance/authorization.rs`) needed to expose an existing private helper.

**1. `orbit mcp remove --claude --scope workspace` left an empty `.claude/` directory**
`apply_claude_remove` in `crates/orbit-cli/src/command/mcp/setup/providers/claude.rs` deleted `settings.json` via `write_or_remove_json_object` but never touched its parent directory, even though `apply_claude_init` (via `write_json_object`'s `create_dir_all`) is what creates `.claude/` when it doesn't already exist. Added `remove_dir_if_empty`, called on `settings_path.parent()` after the settings write/remove: it only removes the directory when `fs::read_dir` reports it empty, so pre-existing content (a user's `commands/`, unrelated settings, …) is always preserved — no cross-invocation provenance tracking needed since "created by init and left empty by remove" and "empty after remove" coincide for this single-file directory.
Tests added in `crates/orbit-cli/src/command/mcp/setup/providers/tests/claude.rs`:
- `claude_remove_deletes_empty_directory_init_created` — no `.claude/` before init, gone after remove.
- `claude_remove_preserves_directory_with_unrelated_content` — pre-existing `.claude/commands/foo.md` survives remove.
Scoped to the Claude provider only, matching the reported defect and the given context files; other providers (codex/gemini/grok/etc.) were not touched.

**2. Operation grants recorded `actor: "unknown"` under `ORBIT_OPERATOR=1`**
Root cause: `operation_mode_tools::dispatch` falls back to `runtime.actor_label()` when no explicit agent/model identity is supplied, which resolves to `OrbitContext::actor()` — set once at runtime construction from `ActorIdentity::from_env()` (`crates/orbit-core/src/context.rs`). That function only ever consulted `ORBIT_AGENT_NAME`/`ORBIT_AGENT_MODEL`, never `ORBIT_OPERATOR`, even though `orbit_common::governance::authorization::CallerEnvelope` already reads `ORBIT_OPERATOR` for authorization in the same process (see filed friction F2026-09-124). Fixed by extending `ActorIdentity::from_env()`: absent an agent envelope, if `orbit_common::governance::authorization::operator_override_active()` (new public accessor over the existing private `env_truthy`/`OPERATOR_OVERRIDE_ENV`) is true, it now returns `ActorIdentity::human("operator")` instead of falling through to `unknown`. This is the single point every `runtime.actor_label()` consumer reads, so the fix applies uniformly (grants, task mutations, etc.) rather than only inside the operation-grant path.
Tests added/updated in `crates/orbit-cli/src/tests/audit_middleware.rs`:
- `cli_operator_override_without_agent_envelope_records_operator_actor` (new) — `ORBIT_OPERATOR=1` with no agent envelope now resolves to `ActorKind::Human`, label `"operator"`, and the audited row's `role` is `"operator"`.
- `cli_without_agent_envelope_records_unknown_actor` (updated) — now also unsets `ORBIT_OPERATOR` so the true "nothing identified the caller" path stays correctly tested regardless of ambient environment.

**Existing grants remain readable**: no schema or serialization change — `OperationGrant.actor` is still a plain `String`; only the value computed for new grants changed. Confirmed via the existing `orbit-core` operation grant test suite (unaffected, all passing) and by inspection: no migration or read-path touches this field.

**Validation**
- `cargo test -p orbit-cli --bin orbit mcp::setup::providers::tests::claude` — 5 passed (3 pre-existing + 2 new).
- `cargo test -p orbit-cli --bin orbit tests::audit_middleware::` — 19 passed (18 pre-existing + 1 new).
- `cargo test -p orbit-core operation::tests::grant` — 7 passed (pre-existing, unaffected by the actor-resolution change).
- `cargo test -p orbit-common governance::authorization` — passed (no unit tests in that module; compiles clean with the new `pub fn`).
- `make ci-fast` — passed.
- `make ci-lint` (workspace clippy, warnings denied) — passed, zero warnings.
- `git diff --check` — clean; `git status --short` — only the 5 intended files modified, no stray artifacts.

No deviations, no blockers, no unresolved contradictions in the task comments (there were none).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12115-6aa36ff6`
- Behind base: 0
- Ahead of base: 1