### PR TITLE
Sibling top-level job runs get IDs that look like child runs

### DIFF
--- a/crates/orbit-cli/src/command/run/format.rs
+++ b/crates/orbit-cli/src/command/run/format.rs
@@ -1,4 +1,14 @@
-use orbit_types::workflow::{JobRunState, PipelineState};
+use orbit_types::workflow::{JobRunState, PipelineState, run_id_role};
+
+/// Which side of a parent/child relationship a run id declares.
+///
+/// Sibling top-level runs and a run's own children share a minute stem, so the
+/// marked sequence in the id is what tells them apart [ORB-12111]. An id minted
+/// before the markers existed reads as unmarked rather than being assigned a
+/// role its suffix never encoded.
+pub(crate) fn format_run_role(run_id: &str) -> String {
+    run_id_role(run_id).map_or_else(|| "unmarked".to_string(), |role| role.to_string())
+}
 
 pub(crate) fn summarize_error_message(raw: Option<&str>) -> String {
     let value = raw.unwrap_or("-").replace('\n', " ");

--- a/crates/orbit-cli/src/command/run/history.rs
+++ b/crates/orbit-cli/src/command/run/history.rs
@@ -6,14 +6,16 @@ use serde_json::json;
 use crate::command::{Block, CommandOut, Execute, Payload};
 use crate::output::color::Domain;
 
-use super::format::{format_timestamp, format_waiting_line, summarize_error_message};
+use super::format::{
+    format_run_role, format_timestamp, format_waiting_line, summarize_error_message,
+};
 use super::job::cli_job_run_to_json;
 
 pub(crate) const DEFAULT_HISTORY_LIMIT: usize = 50;
 
 #[derive(Args)]
 #[command(
-    after_help = "JSON shape: {\"runs\":[<job-run>]}\nExamples:\n  orbit run history\n  orbit run history -j task_local_pipeline --limit 20\n  orbit run history --json"
+    after_help = "JSON shape: {\"runs\":[<job-run>]}\nROLE says how a run was submitted: top-level directly, child by a parent run.\nRun ids minted before role markers existed read as unmarked.\nExamples:\n  orbit run history\n  orbit run history -j task_local_pipeline --limit 20\n  orbit run history --json"
 )]
 pub struct RunHistoryArgs {
     /// Filter to one job ID
@@ -66,7 +68,13 @@ pub(crate) fn run_history_payload(
 
     use crate::output::table::{Column, Table};
     let include_job_id = job_id.is_none();
-    let mut columns = vec![Column::new("RUN_ID").fixed()];
+    let mut columns = vec![
+        Column::new("RUN_ID").fixed(),
+        // Sibling top-level runs and one run's children share a minute stem, so
+        // the id's own role marker is what keeps a listing from reading as a
+        // single run tree when it is several [ORB-12111].
+        Column::new("ROLE").fixed(),
+    ];
     if include_job_id {
         columns.push(Column::new("JOB_ID").fixed());
     }
@@ -83,7 +91,10 @@ pub(crate) fn run_history_payload(
     for run in &runs {
         use comfy_table::Cell;
         let last = run.steps.last();
-        let mut row = vec![Cell::new(&run.run_id)];
+        let mut row = vec![
+            Cell::new(&run.run_id),
+            Cell::new(format_run_role(&run.run_id)),
+        ];
         if include_job_id {
             row.push(Cell::new(&run.job_id));
         }

--- a/crates/orbit-cli/src/command/run/steps.rs
+++ b/crates/orbit-cli/src/command/run/steps.rs
@@ -8,8 +8,8 @@ use crate::command::{CommandOut, Payload};
 use crate::output::color::Domain;
 
 use super::format::{
-    format_admissions_stop_line, format_child_dispatch_lines, format_duration, format_timestamp,
-    format_waiting_line, format_worker_limit_line, summarize_error_message,
+    format_admissions_stop_line, format_child_dispatch_lines, format_duration, format_run_role,
+    format_timestamp, format_waiting_line, format_worker_limit_line, summarize_error_message,
 };
 
 pub(crate) fn resolve_run(
@@ -164,7 +164,12 @@ pub(crate) fn run_header_text(run: &JobRun) -> String {
 pub(crate) fn run_header_text_with_state(run: &JobRun, state: Option<&PipelineState>) -> String {
     use crate::output::color::{Domain, bold, dimmed, text};
     let mut lines = vec![
-        format!("{} {}", bold("Run ID:"), run.run_id),
+        format!(
+            "{} {} ({})",
+            bold("Run ID:"),
+            run.run_id,
+            format_run_role(&run.run_id)
+        ),
         format!("{} {}", bold("Job ID:"), run.job_id),
         format!(
             "{} {}",
@@ -305,7 +310,12 @@ pub(crate) fn step_record_payload(
 
     use crate::output::color::{Domain, bold, dimmed, text};
     let mut lines = vec![
-        format!("{} {}", bold("Run ID:"), run.run_id),
+        format!(
+            "{} {} ({})",
+            bold("Run ID:"),
+            run.run_id,
+            format_run_role(&run.run_id)
+        ),
         format!("{} {}", bold("Job ID:"), run.job_id),
         format!("{} {}", bold("Target ID:"), step.target_id),
         format!("{} {}", bold("Target Type:"), step.target_type),

--- a/crates/orbit-cli/src/command/run/tests/format.rs
+++ b/crates/orbit-cli/src/command/run/tests/format.rs
@@ -151,3 +151,13 @@ fn admissions_stop_line_names_the_actor_and_is_absent_when_unset() {
     assert!(line.contains("Admissions: stopped by operator"), "{line}");
     assert!(line.contains("reason=done for the day"), "{line}");
 }
+
+/// [ORB-12111] The role a run id declares is what keeps a `run history`
+/// listing of same-minute runs from reading as one run tree.
+#[test]
+fn run_role_reads_the_id_and_admits_when_it_cannot() {
+    assert_eq!(format_run_role("jrun-20260911-0146-t2"), "top-level");
+    assert_eq!(format_run_role("jrun-20260911-0146-c2"), "child");
+    assert_eq!(format_run_role("jrun-20260911-0146-2"), "unmarked");
+    assert_eq!(format_run_role("jrun-20260911-0146"), "unmarked");
+}

--- a/crates/orbit-core/src/application/job/run/projection.rs
+++ b/crates/orbit-core/src/application/job/run/projection.rs
@@ -1,6 +1,6 @@
 //! Shared JSON projection for persisted job runs.
 
-use orbit_types::workflow::{JobRun, PipelineState};
+use orbit_types::workflow::{JobRun, PipelineState, run_id_role};
 use serde_json::{Value, json};
 
 /// Durable provider/model evidence for one completed agent invocation.
@@ -23,6 +23,11 @@ pub struct ActivityInvocationEvidence {
 /// actually admitting under, which a reader needs exactly when explaining a
 /// finished drain. Waiting reasons are momentary, so terminal runs omit them.
 /// Presentation adapters may add intentionally surface-specific fields.
+///
+/// `run_role` is the run id's own claim about how the run was submitted, and is
+/// null for ids minted before role markers existed [ORB-12111]. It never
+/// overrides `child_dispatches`, which remains the record of who dispatched
+/// whom.
 pub fn job_run_to_json(run: &JobRun, state: Option<&PipelineState>) -> Value {
     let last = run.steps.last();
     let child_dispatches = serde_json::to_value(
@@ -71,6 +76,7 @@ pub fn job_run_to_json(run: &JobRun, state: Option<&PipelineState>) -> Value {
         "drain_worker_limit": drain_worker_limit,
         "drain_admissions_stop": drain_admissions_stop,
         "run_id": run.run_id,
+        "run_role": run_id_role(&run.run_id).map(|role| role.to_string()),
         "job_id": run.job_id,
         "attempt": run.attempt,
         "state": run.state.to_string(),

--- a/crates/orbit-store/src/driver/sqlite/job_run_store/backend.rs
+++ b/crates/orbit-store/src/driver/sqlite/job_run_store/backend.rs
@@ -9,7 +9,7 @@ use orbit_common::{NotFoundKind, OrbitError};
 use orbit_types::identity::Crew;
 use orbit_types::workflow::{
     ChildDispatch, JobRun, JobRunStartOutcome, JobRunState, JobRunStep, KnowledgeRunMetrics,
-    PipelineState, RunEvent, RunStateUpdate,
+    PipelineState, RunEvent, RunIdRole, RunStateUpdate,
 };
 use rusqlite::{OptionalExtension, TransactionBehavior};
 
@@ -63,25 +63,6 @@ impl SqliteJobRunStore {
                 Ok(found)
             })
     }
-
-    fn next_run_id(&self, job_id: &str) -> Result<String, OrbitError> {
-        let base = format!("jrun-{}", Utc::now().format("%Y%m%d-%H%M"));
-        for suffix in 1..1024_u32 {
-            let candidate = if suffix == 1 {
-                base.clone()
-            } else {
-                format!("{base}-{suffix}")
-            };
-            if self
-                .store
-                .get_job_run_for_workspace(&self.workspace_id, &candidate)?
-                .is_none()
-            {
-                return Ok(candidate);
-            }
-        }
-        Ok(format!("{base}-{job_id}"))
-    }
 }
 
 impl JobRunStoreBackend for SqliteJobRunStore {
@@ -126,7 +107,7 @@ impl JobRunStoreBackend for SqliteJobRunStore {
                 return Ok(run);
             }
             let now=Utc::now();
-            let id=next_run_id_conn(conn,&self.workspace_id,job_id,now)?;
+            let id=next_run_id_conn(conn,&self.workspace_id,RunIdRole::TopLevel,now)?;
             let run=JobRun {run_id:id.clone(),job_id:job_id.into(),attempt:1,state:JobRunState::Pending,scheduled_at:now,started_at:None,finished_at:None,duration_ms:None,created_at:now,pid:None,pid_start_time:None,input:Some(input.clone()),retry_source_run_id:None,knowledge_metrics:None,resolved_crew:None,crew_model:None,steps:Vec::new()};
             let state=PipelineState::new(id.clone(),job_id.into(),input.clone());
             upsert_job_run_for_workspace_conn(conn,&self.workspace_id,&run,Some(&state))?;
@@ -183,28 +164,37 @@ impl JobRunStoreBackend for SqliteJobRunStore {
         retry_source_run_id: Option<String>,
     ) -> Result<JobRun, OrbitError> {
         validate_path_stem(job_id, "job")?;
-        let run = JobRun {
-            run_id: self.next_run_id(job_id)?,
-            job_id: job_id.to_string(),
-            attempt,
-            state: JobRunState::Pending,
-            scheduled_at,
-            started_at: None,
-            finished_at: None,
-            duration_ms: None,
-            created_at: Utc::now(),
-            pid: None,
-            pid_start_time: None,
-            input,
-            retry_source_run_id,
-            knowledge_metrics: None,
-            resolved_crew: None,
-            crew_model: None,
-            steps: Vec::new(),
-        };
+        let created_at = Utc::now();
+        // [ORB-12111] Id allocation and the insert share one immediate
+        // transaction. Two top-level submissions in the same minute compete for
+        // the same sequence, and a candidate probed outside the write would let
+        // the loser upsert over the sibling that committed first.
         self.store
-            .upsert_job_run_for_workspace(&self.workspace_id, &run, None)?;
-        Ok(run)
+            .with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+                let run_id =
+                    next_run_id_conn(&tx.tx, &self.workspace_id, RunIdRole::TopLevel, created_at)?;
+                let run = JobRun {
+                    run_id,
+                    job_id: job_id.to_string(),
+                    attempt,
+                    state: JobRunState::Pending,
+                    scheduled_at,
+                    started_at: None,
+                    finished_at: None,
+                    duration_ms: None,
+                    created_at,
+                    pid: None,
+                    pid_start_time: None,
+                    input,
+                    retry_source_run_id,
+                    knowledge_metrics: None,
+                    resolved_crew: None,
+                    crew_model: None,
+                    steps: Vec::new(),
+                };
+                upsert_job_run_for_workspace_conn(&tx.tx, &self.workspace_id, &run, None)?;
+                Ok(run)
+            })
     }
 
     /// [ORB-11310] The admissions-stop flag and durable child creation share
@@ -277,7 +267,7 @@ impl JobRunStoreBackend for SqliteJobRunStore {
                 let run_id = next_run_id_conn(
                     &tx.tx,
                     &self.workspace_id,
-                    &params.job_id,
+                    RunIdRole::Child,
                     params.scheduled_at,
                 )?;
                 let run = JobRun {

--- a/crates/orbit-store/src/driver/sqlite/job_run_store/queries.rs
+++ b/crates/orbit-store/src/driver/sqlite/job_run_store/queries.rs
@@ -5,7 +5,10 @@ use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
 use orbit_common::OrbitError;
-use orbit_types::workflow::{JobRun, JobRunState, JobRunStep, JobTargetType, PipelineState};
+use orbit_types::workflow::{
+    JobRun, JobRunState, JobRunStep, JobTargetType, PipelineState, RunIdRole, run_id_candidate,
+    run_id_minute_stem,
+};
 use rusqlite::OptionalExtension;
 
 use crate::contracts::{JobRunOrder, JobRunQuery};
@@ -249,19 +252,30 @@ pub(super) fn upsert_job_run_for_workspace_conn(
     Ok(())
 }
 
+/// Sequence ceiling for one role inside one minute stem.
+const MAX_RUN_ID_SEQUENCE: u32 = 1023;
+
+/// Allocate the next free run id of `role` for the minute `submitted_at` falls
+/// in.
+///
+/// Each role numbers its own sequence, so a run's children never consume the
+/// numbers its top-level siblings would take and neither borrows the other's
+/// shape [ORB-12111]. Call this inside the same transaction that inserts the
+/// run: the probe below is only as good as the write it commits with.
+///
+/// Exhausting the sequence is an error rather than a fallback id. Roughly a
+/// thousand runs of one role in one workspace inside one minute is already
+/// pathological, and any id returned without a free-slot probe behind it would
+/// upsert over the live run already holding it.
 pub(super) fn next_run_id_conn(
     conn: &rusqlite::Connection,
     workspace_id: &str,
-    job_id: &str,
+    role: RunIdRole,
     submitted_at: DateTime<Utc>,
 ) -> Result<String, OrbitError> {
-    let base = format!("jrun-{}", submitted_at.format("%Y%m%d-%H%M"));
-    for suffix in 1..1024_u32 {
-        let candidate = if suffix == 1 {
-            base.clone()
-        } else {
-            format!("{base}-{suffix}")
-        };
+    let stem = run_id_minute_stem(submitted_at);
+    for sequence in 1..=MAX_RUN_ID_SEQUENCE {
+        let candidate = run_id_candidate(&stem, role, sequence);
         let exists = conn
             .query_row(
                 "SELECT 1 FROM job_runs WHERE workspace_id = ?1 AND run_id = ?2",
@@ -275,7 +289,10 @@ pub(super) fn next_run_id_conn(
             return Ok(candidate);
         }
     }
-    Ok(format!("{base}-{job_id}"))
+
+    Err(OrbitError::Store(format!(
+        "run id sequence exhausted: {MAX_RUN_ID_SEQUENCE} {role} runs already recorded for {stem}"
+    )))
 }
 
 pub(super) fn get_job_run_for_workspace_conn(

--- a/crates/orbit-store/src/driver/sqlite/job_run_store/tests/backend.rs
+++ b/crates/orbit-store/src/driver/sqlite/job_run_store/tests/backend.rs
@@ -3,12 +3,16 @@ use std::thread;
 use std::time::Duration;
 
 use chrono::Utc;
-use orbit_types::workflow::{JobRunState, JobTargetType, KnowledgeRunMetrics};
+use orbit_types::workflow::{
+    JobRunState, JobTargetType, KnowledgeRunMetrics, PipelineState, RunIdRole, run_id_role,
+};
 use tempfile::TempDir;
 
 use super::super::SqliteJobRunStore;
 use crate::Store;
-use crate::contracts::{JobRunStepParams, JobRunStoreBackend};
+use crate::contracts::{
+    ChildJobRunAdmissionOutcome, ChildJobRunAdmissionParams, JobRunStepParams, JobRunStoreBackend,
+};
 
 #[test]
 fn job_run_lifecycle_round_trips() {
@@ -154,4 +158,68 @@ fn update_run_serializes_concurrent_mutations_without_torn_write() {
         .expect("run");
     assert_eq!(loaded.resolved_crew.as_deref(), Some("crew-a"));
     assert!(loaded.knowledge_metrics.is_some());
+}
+
+/// [ORB-12111] Two direct submissions a second apart land in the same minute
+/// stem, and so does the first one's own child dispatch. A bare sequence
+/// number made the sibling and the child read identically, so a run listing of
+/// the three looked like one run tree when it is two. Each id now names the
+/// role it was minted for.
+#[test]
+fn same_minute_siblings_and_children_get_role_marked_ids() {
+    let backend = SqliteJobRunStore::new(Store::open_in_memory().expect("store"), "ws_a");
+    let submitted_at = Utc::now();
+
+    let first = backend
+        .insert_job_run("task_ship_pipeline", 1, submitted_at, None, None)
+        .expect("first submission");
+    let second = backend
+        .insert_job_run("task_ship_pipeline", 1, submitted_at, None, None)
+        .expect("second submission in the same minute");
+
+    assert_ne!(first.run_id, second.run_id);
+    assert_eq!(run_id_role(&first.run_id), Some(RunIdRole::TopLevel));
+    assert_eq!(run_id_role(&second.run_id), Some(RunIdRole::TopLevel));
+
+    let parent_state = PipelineState::new(
+        first.run_id.clone(),
+        first.job_id.clone(),
+        serde_json::json!({}),
+    );
+    backend
+        .write_run_state(&first.run_id, &parent_state)
+        .expect("seed parent state");
+    let child = match backend
+        .admit_child_job_run(&ChildJobRunAdmissionParams {
+            parent_run_id: first.run_id.clone(),
+            parent_step_id: Some("leaf_invoke".to_string()),
+            job_id: "task_gate_pipeline".to_string(),
+            action: "invoke_detached".to_string(),
+            blocking: false,
+            attempt: 1,
+            scheduled_at: submitted_at,
+            input: None,
+            authority: None,
+        })
+        .expect("admit child")
+    {
+        ChildJobRunAdmissionOutcome::Admitted(child) => *child,
+        other => panic!("parent was admitting, got {other:?}"),
+    };
+
+    assert_eq!(run_id_role(&child.run_id), Some(RunIdRole::Child));
+    assert_ne!(child.run_id, second.run_id);
+
+    // The id's claim and the durable lineage agree: the child belongs to the
+    // first run, and the second top-level run is nobody's child.
+    let linked = backend
+        .read_run_state(&first.run_id)
+        .expect("read parent state")
+        .expect("parent state")
+        .child_dispatches
+        .iter()
+        .map(|dispatch| dispatch.child_run_id.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(linked, vec![child.run_id.clone()]);
+    assert!(!linked.contains(&second.run_id));
 }

--- a/crates/orbit-types/src/workflow/mod.rs
+++ b/crates/orbit-types/src/workflow/mod.rs
@@ -9,6 +9,7 @@ mod job;
 pub mod operation;
 mod review;
 mod routine;
+mod run_id;
 mod run_state;
 mod ship;
 mod skill;
@@ -68,6 +69,7 @@ pub use routine::{
     MissedRunPolicy, OverlapPolicy, ROUTINE_SCHEMA_VERSION, RoutineDefinition, RoutinePolicy,
     RoutineRetries, RoutineTarget, RoutineTrigger,
 };
+pub use run_id::{RunIdRole, run_id_candidate, run_id_minute_stem, run_id_role};
 pub use run_state::{
     DrainAdmissionsStop, DrainWorkerLimit, FailureActivityCheckpoint, PipelineState,
 };

--- a/crates/orbit-types/src/workflow/run_id.rs
+++ b/crates/orbit-types/src/workflow/run_id.rs
@@ -1,0 +1,85 @@
+//! Job run identifier composition and the role a run id declares.
+//!
+//! A minted id is `jrun-<YYYYmmdd-HHMM>-<role><sequence>`. Runs pile into one
+//! minute stem from two unrelated directions — a second direct submission and
+//! the first run's own child dispatch both land there — so a bare sequence
+//! number left a top-level run and an unrelated run's child reading
+//! identically [ORB-12111]. The role letter is what makes the id alone answer
+//! which one it is.
+//!
+//! Ids minted before the role letter existed carry a bare stem or a plain
+//! numeric sequence. They stay readable, and [`run_id_role`] reports `None`
+//! for them rather than claiming a role their suffix never encoded.
+
+use std::fmt;
+
+use chrono::{DateTime, Utc};
+
+/// Prefix shared by every job run id.
+const RUN_ID_PREFIX: &str = "jrun-";
+
+/// Whether a run was submitted on its own or dispatched by a parent run.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RunIdRole {
+    /// Submitted directly: a CLI submission, an automation key, or a resume.
+    TopLevel,
+    /// Dispatched by a running parent's activity.
+    Child,
+}
+
+impl RunIdRole {
+    /// The letter this role writes into a minted id. Each role numbers its own
+    /// sequence, so `-t2` and `-c2` can share a minute without colliding.
+    const fn marker(self) -> char {
+        match self {
+            Self::TopLevel => 't',
+            Self::Child => 'c',
+        }
+    }
+
+    /// The inverse of [`Self::marker`], kept beside it so the two stay in step.
+    const fn from_marker(marker: char) -> Option<Self> {
+        match marker {
+            't' => Some(Self::TopLevel),
+            'c' => Some(Self::Child),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for RunIdRole {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::TopLevel => "top-level",
+            Self::Child => "child",
+        };
+        formatter.write_str(label)
+    }
+}
+
+/// The stem every run submitted in the same minute shares.
+pub fn run_id_minute_stem(submitted_at: DateTime<Utc>) -> String {
+    format!("{RUN_ID_PREFIX}{}", submitted_at.format("%Y%m%d-%H%M"))
+}
+
+/// The `sequence`-th id of `role` within `minute_stem`, counting from 1.
+pub fn run_id_candidate(minute_stem: &str, role: RunIdRole, sequence: u32) -> String {
+    format!("{minute_stem}-{}{sequence}", role.marker())
+}
+
+/// The role `run_id` declares, or `None` when its suffix encodes no role.
+pub fn run_id_role(run_id: &str) -> Option<RunIdRole> {
+    if !run_id.starts_with(RUN_ID_PREFIX) {
+        return None;
+    }
+
+    let suffix = run_id.rsplit_once('-')?.1;
+    let mut characters = suffix.chars();
+    let role = RunIdRole::from_marker(characters.next()?)?;
+
+    // A marker without a sequence is some other suffix that happens to start
+    // with the same letter, not a role.
+    let sequence = characters.as_str();
+    let numbered = !sequence.is_empty() && sequence.bytes().all(|byte| byte.is_ascii_digit());
+    numbered.then_some(role)
+}

--- a/crates/orbit-types/src/workflow/tests/mod.rs
+++ b/crates/orbit-types/src/workflow/tests/mod.rs
@@ -1,5 +1,6 @@
 mod auto_task;
 mod executor_def;
 mod job;
+mod run_id;
 mod run_state;
 mod ship;

--- a/crates/orbit-types/src/workflow/tests/run_id.rs
+++ b/crates/orbit-types/src/workflow/tests/run_id.rs
@@ -1,0 +1,44 @@
+use chrono::{TimeZone, Utc};
+
+use crate::workflow::{RunIdRole, run_id_candidate, run_id_minute_stem, run_id_role};
+
+#[test]
+fn minted_ids_declare_their_role() {
+    let stem = run_id_minute_stem(
+        Utc.with_ymd_and_hms(2026, 9, 11, 1, 46, 12)
+            .single()
+            .expect("submission instant"),
+    );
+    assert_eq!(stem, "jrun-20260911-0146");
+
+    let sibling = run_id_candidate(&stem, RunIdRole::TopLevel, 2);
+    let child = run_id_candidate(&stem, RunIdRole::Child, 2);
+
+    assert_eq!(sibling, "jrun-20260911-0146-t2");
+    assert_eq!(child, "jrun-20260911-0146-c2");
+    assert_ne!(sibling, child);
+    assert_eq!(run_id_role(&sibling), Some(RunIdRole::TopLevel));
+    assert_eq!(run_id_role(&child), Some(RunIdRole::Child));
+}
+
+/// Ids minted before role markers existed say nothing about their role, and
+/// saying so is the point: guessing would relabel an old child as top-level.
+#[test]
+fn ids_without_a_role_marker_report_no_role() {
+    for legacy in [
+        "jrun-20260911-0146",
+        "jrun-20260911-0146-2",
+        "jrun-20260911-0146-ci_failure_sweep_pipeline",
+        "jrun-20260911-0146-t",
+        "jrun-20260911-0146-x1",
+        "run-20260911-0146-t1",
+    ] {
+        assert_eq!(run_id_role(legacy), None, "unexpected role for {legacy}");
+    }
+}
+
+#[test]
+fn role_renders_an_operator_facing_label() {
+    assert_eq!(RunIdRole::TopLevel.to_string(), "top-level");
+    assert_eq!(RunIdRole::Child.to_string(), "child");
+}

--- a/docs/runbooks/stuck-job-runs.md
+++ b/docs/runbooks/stuck-job-runs.md
@@ -114,11 +114,18 @@ Example after a worker was SIGKILLed mid-step:
 
 ```text
 $ orbit run history --limit 1
-│ RUN_ID                 JOB_ID            ATTEMPT   STATE         ERROR_MESSAGE                              │
-│ jrun-20260704-0927-2   demo_sleep_long   1         interrupted   job run marked interrupted because         │
-│                                                                  recorded worker process is no longer alive │
-│                                                                  (reason=process_not_found, pid=154953, …)  │
+│ RUN_ID                  ROLE        JOB_ID            ATTEMPT   STATE         ERROR_MESSAGE                  │
+│ jrun-20260704-0927-t2   top-level   demo_sleep_long   1         interrupted   job run marked interrupted     │
+│                                                                               because recorded worker        │
+│                                                                               process is no longer alive     │
+│                                                                               (reason=process_not_found, …)  │
 ```
+
+`ROLE` reads the run id itself. A directly submitted run and another run's child land in the
+same minute stem, so the marked sequence — `-t2` for the second top-level submission of that
+minute, `-c2` for a second child — is what keeps sibling runs from reading as one run tree.
+Ids minted before role markers existed report `unmarked`; use `orbit run show <parent>`, which
+names each child it dispatched, to establish their lineage.
 
 ## Cancel a conclusively stuck run
 


### PR DESCRIPTION
## Task

[ORB-12111](https://orbit-cli.com/tasks/ORB-12111) — Sibling top-level job runs get IDs that look like child runs

### Description

Found during a full QA sweep of orbit 0.20.0 on the Mac mini (2026-09-10).


 Two independent `orbit run ship` invocations in the same minute produced `jrun-20260911-0146`
 and `jrun-20260911-0146-4`. The `-N` suffix is also how child runs are named
 (`jrun-20260911-0146-2` was the gate child of the *first* run), so a top-level run and a
 child of an unrelated run are indistinguishable by ID. `orbit run history` output then reads
 as one run tree when it is two.

 ## Expected
 Disambiguate top-level runs from children — a distinct suffix namespace, finer timestamp
 granularity, or an explicit marker — so that a run ID alone identifies its role.

### Acceptance Criteria

- A second top-level run submitted in the same minute gets an ID not confusable with a child run
- `orbit run history` / `run show` make the parent/child relationship unambiguous
- Existing run IDs remain readable
- Test covers two top-level submissions within one minute

## Execution Summary

<details>
<summary>Click to expand</summary>

Every minted job run id now carries a role marker, so the id alone says whether a run was submitted directly or dispatched by a parent.

## What changed

- **New `orbit-types::workflow::run_id`** (`crates/orbit-types/src/workflow/run_id.rs`): owns id composition. Minted ids are `jrun-<YYYYmmdd-HHMM>-<role><sequence>`, `t` for top-level and `c` for child, each role numbering its own sequence so `-t2` and `-c2` coexist in one minute. `run_id_role()` parses the marker and returns `None` for ids minted before markers existed rather than relabelling them. Private submodule + `pub use` in `workflow/mod.rs`, sibling tests, per the crate's module shape.
- **`job_run_store/queries.rs`**: `next_run_id_conn` takes a `RunIdRole` instead of a job id and allocates from that role's sequence. Sequence exhaustion (1023 runs of one role in one minute) is now an error instead of the old `-<job_id>` fallback, which returned an id with no free-slot probe behind it and could upsert over the live run holding it.
- **`job_run_store/backend.rs`**: deleted the duplicate non-transactional `next_run_id` helper; `insert_job_run` allocates and inserts inside one `IMMEDIATE` transaction, so two same-minute top-level submissions cannot both claim one id. Automation runs allocate as top-level; `admit_child_job_run` allocates as child.
- **Surfaces**: `orbit run history` gains a `ROLE` column (and an `after_help` note); `orbit run show` names the role beside the run id in both the run and per-step headers; the shared `job_run_to_json` projection gains `run_role` (null for unmarked ids) so JSON/MCP/web readers match the tables. The parent's existing `Child <id> job=… step=…` lines remain the durable lineage record.
- **Docs**: refreshed the `orbit run history` sample in `docs/runbooks/stuck-job-runs.md` and explained what `ROLE`/`unmarked` mean.

Scope additions beyond the four listed context files, all needed to satisfy the criteria: the new orbit-types module and its registration/tests (id composition has one owner, shared by store and CLI), the three CLI run files plus their formatter test (criterion 2), the shared core projection (so `--json` readers see the same role as the tables), and the runbook (its sample output described live behavior that changed).

## Acceptance criteria

1. **Second same-minute top-level run is not confusable with a child** — top-level ids are `-t<N>`, child ids `-c<N>`; the QA scenario (`jrun-…-0146` + `jrun-…-0146-4` vs the gate child `jrun-…-0146-2`) now mints `-t1`, `-t2`, `-c1`. Covered by `same_minute_siblings_and_children_get_role_marked_ids`.
2. **`run history` / `run show` unambiguous** — history has a `ROLE` column, show prints `Run ID: <id> (child)`, and the parent still lists each child it dispatched. Formatter covered by `run_role_reads_the_id_and_admits_when_it_cannot`; the table/header wiring itself is not asserted by a test.
3. **Existing run ids remain readable** — no id is rewritten, nothing parses ids for lookup, and `run_id_role` reports "unmarked" for legacy `jrun-<stem>` / `-<N>` ids instead of guessing. Covered by `ids_without_a_role_marker_report_no_role`.
4. **Test covers two top-level submissions within one minute** — `same_minute_siblings_and_children_get_role_marked_ids` inserts two top-level runs with one `submitted_at`, then admits a child of the first, and asserts distinct ids, correct roles, and that the durable `child_dispatches` link agrees with the ids.

## Validation

- `make ci-fast` — passed (one guardrail self-reports skip: `test-compiler-cache-namespaces`, no user namespaces on this host).
- `make ci-lint` — passed.
- `cargo test -p orbit-types -p orbit-store --lib` — passed (includes the three new run-id tests and the new store test).
- `cargo test -p orbit-core -p orbit-cli -p orbit-web -p orbit-cmd --lib` — passed (covers the shared projection's consumers).
- Not run: crate-root integration suites (`crates/orbit-cli/tests/**`) and the full `make ci`, which is the PR merge gate.
- Not run: a live end-to-end `orbit run ship` / `orbit run history` render. Creating runs from this shell is a mutable fixture operation inside a managed worker, which workspace rules forbid; a read-only `--help` render of the new column text was attempted and denied by the sandbox (`./target/debug/orbit run history --help`). Behavior is therefore established at the store boundary that mints ids and at the formatter that renders roles, not by an observed terminal session.

## Risks

- Ids are three characters longer and the first run of a minute is no longer the bare stem (`jrun-…-0146-t1`, and worktrees `orbit-jrun-…-t1`). Nothing parses or reconstructs run ids, so this is cosmetic, but operators used to the bare form will notice.
- Legacy ids stay genuinely ambiguous; `ROLE` says `unmarked` for them rather than inventing a role. Lineage for those runs still comes from the parent's child-dispatch lines.
- A resumed child run is submitted directly and so mints a top-level id; that matches the documented meaning ("how the run was submitted"), and `retry_source_run_id` still records the lineage.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12111-6aa36d6a`
- Behind base: 0
- Ahead of base: 1