### PR TITLE
Seeded routine names derive from the checkout directory name, not the workspace name

### DIFF
--- a/crates/orbit-automation/src/routines/loader.rs
+++ b/crates/orbit-automation/src/routines/loader.rs
@@ -201,6 +201,57 @@ fn yaml_files_in(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
     Ok(paths)
 }
 
+/// Every routine name the workspace rooted at `orbit_dir` already claims,
+/// across both origins, mapped to the file that declares it.
+///
+/// Names must be unique across every routine source on a host, so a caller
+/// that is about to write new definitions uses this to detect a collision
+/// before it becomes a load-time error that drops *both* definitions. Files
+/// that fail to parse are skipped: [`collect_routines`] treats them as absent,
+/// so they claim no name.
+pub fn declared_routine_names(orbit_dir: &Path, host_id: &str) -> BTreeMap<String, PathBuf> {
+    let routines_dir = orbit_dir.join(ROUTINES_DIR);
+    let mut declared = BTreeMap::new();
+
+    collect_declared_names(
+        &routines_dir,
+        RoutineOrigin::Committed,
+        host_id,
+        &mut declared,
+    );
+    collect_declared_names(
+        &routines_dir.join(LOCAL_ROUTINES_SUBDIR),
+        RoutineOrigin::Local,
+        host_id,
+        &mut declared,
+    );
+
+    declared
+}
+
+fn collect_declared_names(
+    dir: &Path,
+    origin: RoutineOrigin,
+    host_id: &str,
+    declared: &mut BTreeMap<String, PathBuf>,
+) {
+    let Ok(paths) = yaml_files_in(dir) else {
+        return;
+    };
+    for path in paths {
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let parsed = match origin {
+            RoutineOrigin::Committed => parse_routine_yaml(&raw).ok(),
+            RoutineOrigin::Local => parse_local_routine_yaml(&raw, host_id).ok(),
+        };
+        if let Some(definition) = parsed {
+            declared.entry(definition.name).or_insert(path);
+        }
+    }
+}
+
 fn load_routine_file(
     path: &Path,
     origin: RoutineOrigin,

--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -5,8 +5,10 @@ use clap::Args;
 use orbit_cmd::agent_rules::{InjectionAction, InjectionOutcome, inject_agent_rules};
 use orbit_cmd::registry_runtime::RegisteredRuntimeFactory;
 use orbit_common::fs::io::{atomic_write_bytes, atomic_write_text};
-use orbit_core::OrbitError;
 use orbit_core::bootstrap::init::{InitOptions, init_workspace_at_root};
+use orbit_core::{
+    OrbitError, RoutineNameCollision, RoutineSeedIdentity, default_routine_name_collisions,
+};
 use orbit_registry::workspace_registry;
 use orbit_registry::{HostIdentityState, inspect_host_identity};
 use orbit_types::identity::validate_machine_id;
@@ -169,6 +171,13 @@ impl WorkspaceInitArgs {
 
         let name = self.name.unwrap_or_else(|| dir_name_or_fallback(cwd));
         let id = canonical_workspace_id(&name);
+        // Seeded routine names are suffixed with the registered workspace name,
+        // not the checkout directory, so two checkouts sharing a basename stay
+        // distinct on one host [ORB-12107]. Validate the name before any write.
+        let routine_identity = local_host_id
+            .as_deref()
+            .map(|host_id| RoutineSeedIdentity::new(host_id, &name))
+            .transpose()?;
         let git_remote = detect_git_remote(cwd);
         let default_base_branch = checked_out_branch(cwd);
         // Every read of the registry below feeds the write at the end; the lock
@@ -242,12 +251,16 @@ impl WorkspaceInitArgs {
                     }
                 }
 
+                if let Some(identity) = routine_identity.as_ref() {
+                    reject_colliding_routine_names(&registry, &id, orbit_dir, identity, &name)?;
+                }
+
                 init_workspace_at_root(
                     orbit_dir,
                     InitOptions {
                         refresh_defaults: true,
                         global_root_override: Some(global_root.to_path_buf()),
-                        routine_host_id: local_host_id.clone(),
+                        routine_seed_identity: routine_identity.clone(),
                         // Host detection is a CLI concern: Core seeds config from the
                         // families this adapter reports, never by probing PATH itself.
                         config_seed: Some(config_seed_from_detection(&detect(&RealAgentEnvProbe))),
@@ -403,6 +416,54 @@ pub(super) fn render_task_id_start(task_prefix: Option<&str>, next: u32) -> Stri
         Some(task_prefix) => format!("{task_prefix}-{next:05}"),
         None => format!("{next:05}"),
     }
+}
+
+/// Refuse to seed routines whose names another registered workspace on this
+/// host already declares.
+///
+/// Routine discovery drops *every* definition sharing a name, so a silent
+/// duplicate would disable the colliding workspace's routines too. Checkouts
+/// of the workspace being initialized are excluded: re-initializing rebinds
+/// them rather than adding a second source [ORB-12107].
+fn reject_colliding_routine_names(
+    registry: &WorkspaceRegistry,
+    workspace_id: &str,
+    orbit_dir: &Path,
+    identity: &RoutineSeedIdentity,
+    name: &str,
+) -> Result<(), OrbitError> {
+    let other_orbit_dirs: Vec<PathBuf> = registry
+        .checkouts
+        .iter()
+        .filter(|checkout| checkout.workspace_id != workspace_id && checkout.orbit_dir != orbit_dir)
+        .map(|checkout| checkout.orbit_dir.clone())
+        .collect();
+
+    let collisions = default_routine_name_collisions(identity, &other_orbit_dirs);
+    if collisions.is_empty() {
+        return Ok(());
+    }
+
+    Err(OrbitError::WorkspaceError(format!(
+        "workspace '{name}' would seed routine names another workspace on this host already \
+         defines ({}); routine names must be unique across every routine source on a host, so \
+         rerun `orbit workspace init --name <other-name>`",
+        describe_routine_collisions(&collisions)
+    )))
+}
+
+fn describe_routine_collisions(collisions: &[RoutineNameCollision]) -> String {
+    collisions
+        .iter()
+        .map(|collision| {
+            format!(
+                "'{}' at {}",
+                collision.name,
+                collision.declared_in.display()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 pub(super) fn canonical_workspace_id(name: &str) -> String {

--- a/crates/orbit-cli/src/command/workspace/sync.rs
+++ b/crates/orbit-cli/src/command/workspace/sync.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 use clap::Args;
 use orbit_cmd::registry_runtime::RegisteredRuntimeFactory;
 use orbit_core::{
-    ManagedArtifactOutcome, ManagedArtifactScope, OrbitError, WorkspaceManagedArtifactSyncReport,
-    reconcile_workspace_managed_artifacts,
+    ManagedArtifactOutcome, ManagedArtifactScope, OrbitError, RoutineSeedIdentity,
+    WorkspaceManagedArtifactSyncReport, reconcile_workspace_managed_artifacts,
 };
 use orbit_registry::workspace_registry;
 use orbit_registry::{HostIdentityState, inspect_host_identity};
@@ -42,9 +42,8 @@ impl WorkspaceSyncArgs {
             })
             .max_by_key(|checkout| checkout.repo_root.components().count())
             .ok_or_else(workspace_init_required)?;
-        if workspace_registry::find_workspace_by_id(&registry, &checkout.workspace_id).is_none() {
-            return Err(workspace_init_required());
-        }
+        let workspace = workspace_registry::find_workspace_by_id(&registry, &checkout.workspace_id)
+            .ok_or_else(workspace_init_required)?;
         let host_id = match inspect_host_identity(&global_root)? {
             HostIdentityState::Present(identity) => identity.host_id,
             HostIdentityState::Legacy { .. } | HostIdentityState::Absent => {
@@ -53,15 +52,14 @@ impl WorkspaceSyncArgs {
                 ));
             }
         };
-        let slug = checkout
-            .repo_root
-            .file_name()
-            .map(|name| name.to_string_lossy().into_owned());
+        // Routine names carry the registered workspace name, not the checkout
+        // directory basename, so convergence renders the same binding that
+        // `orbit workspace init` recorded [ORB-12107].
+        let routine_identity = RoutineSeedIdentity::new(&host_id, &workspace.name)?;
         let report = reconcile_workspace_managed_artifacts(
             &global_root,
             &checkout.orbit_dir,
-            Some(&host_id),
-            slug.as_deref(),
+            Some(&routine_identity),
             self.check,
         )?;
         let exit_code = if self.check && report.has_pending_changes() {

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -961,13 +961,6 @@ fn workspace_init_seeds_disabled_routines_and_reinit_preserves_authored_files() 
         .expect("first workspace init");
 
     let routines_dir = workspace.path().join(".orbit/routines");
-    let workspace_slug = workspace
-        .path()
-        .file_name()
-        .expect("workspace directory name")
-        .to_string_lossy()
-        .trim_start_matches('.')
-        .to_ascii_lowercase();
     for (stem, target) in [
         ("auto_task_scheduler", "auto_task_scheduler_pipeline"),
         ("task_triage", "task_triage_pipeline"),
@@ -978,7 +971,7 @@ fn workspace_init_seeds_disabled_routines_and_reinit_preserves_authored_files() 
         let definition = parse_routine_yaml(&yaml).expect("parse seeded routine");
         assert_eq!(
             definition.name,
-            format!("{}-{workspace_slug}", stem.replace('_', "-"))
+            format!("{}-routine-seed-test", stem.replace('_', "-"))
         );
         assert_eq!(definition.hosts, ["init-host"]);
         assert_eq!(definition.target, RoutineTarget::Job(target.to_string()));
@@ -1021,6 +1014,163 @@ policy:
             .expect("parse recreated routine")
             .enabled
     );
+}
+
+/// Routine names are host-wide identifiers, so their per-workspace suffix must
+/// come from the registered workspace name. Seeding from the checkout directory
+/// left `orbit routine show <routine>-<workspace-name>` with nothing to find and
+/// made two `repo`/`src`/`app` checkouts collide on one host [ORB-12107].
+#[test]
+fn seeded_routine_names_follow_the_workspace_name_not_the_checkout_directory() {
+    let base = tempdir().expect("base tempdir");
+    let home = tempdir().expect("home tempdir");
+    seed_host_identity(home.path());
+    let checkout = base.path().join("repo");
+    std::fs::create_dir_all(&checkout).expect("create checkout directory");
+
+    let _env = EnvGuard::acquire().home(home.path()).cwd(&checkout);
+    routine_seed_init("qa-sweep")
+        .execute_without_runtime(None)
+        .expect("workspace init");
+
+    for name in seeded_routine_names(&checkout) {
+        assert!(
+            name.ends_with("-qa-sweep"),
+            "routine '{name}' must be suffixed with the registered workspace name"
+        );
+        assert!(
+            !name.contains("repo"),
+            "routine '{name}' must not carry the checkout directory name"
+        );
+    }
+}
+
+/// Two checkouts whose directories share a basename are the collision the
+/// directory-derived suffix could not survive; distinct workspace names must
+/// keep their seeded routines distinct [ORB-12107].
+#[test]
+fn same_basename_checkouts_with_distinct_names_seed_distinct_routine_names() {
+    let base = tempdir().expect("base tempdir");
+    let home = tempdir().expect("home tempdir");
+    seed_host_identity(home.path());
+    let alpha = base.path().join("a/server");
+    let beta = base.path().join("b/server");
+    std::fs::create_dir_all(&alpha).expect("create first checkout");
+    std::fs::create_dir_all(&beta).expect("create second checkout");
+
+    let env = EnvGuard::acquire().home(home.path()).cwd(&alpha);
+    routine_seed_init("alpha")
+        .execute_without_runtime(None)
+        .expect("first workspace init");
+    let _env = env.cwd(&beta);
+    routine_seed_init("beta")
+        .execute_without_runtime(None)
+        .expect("second workspace init with the same directory basename");
+
+    let alpha_names = seeded_routine_names(&alpha);
+    let beta_names = seeded_routine_names(&beta);
+    assert!(alpha_names.iter().all(|name| name.ends_with("-alpha")));
+    assert!(beta_names.iter().all(|name| name.ends_with("-beta")));
+    assert!(
+        alpha_names.iter().all(|name| !beta_names.contains(name)),
+        "same-basename checkouts must not seed colliding routine names: {alpha_names:?} / {beta_names:?}"
+    );
+}
+
+/// Routine discovery drops *every* definition sharing a name, so a duplicate
+/// would silently disable both workspaces' routines. Init reports it instead,
+/// and leaves the second checkout uninitialized [ORB-12107].
+#[test]
+fn workspace_init_refuses_a_name_whose_seeded_routines_already_exist() {
+    let base = tempdir().expect("base tempdir");
+    let home = tempdir().expect("home tempdir");
+    seed_host_identity(home.path());
+    let alpha = base.path().join("a/server");
+    let beta = base.path().join("b/server");
+    std::fs::create_dir_all(&alpha).expect("create first checkout");
+    std::fs::create_dir_all(&beta).expect("create second checkout");
+
+    let env = EnvGuard::acquire().home(home.path()).cwd(&alpha);
+    routine_seed_init("alpha")
+        .execute_without_runtime(None)
+        .expect("first workspace init");
+
+    // The registered workspace already claims a name the next one would seed —
+    // the shape a directory-derived seed left behind on a host with two
+    // `server` checkouts.
+    let claimed = std::fs::read_to_string(alpha.join(".orbit/routines/task_pilot.yaml"))
+        .expect("read seeded routine")
+        .replace("task-pilot-alpha", "task-pilot-beta");
+    std::fs::write(alpha.join(".orbit/routines/claimed.yaml"), &claimed)
+        .expect("author the claiming routine");
+
+    let _env = env.cwd(&beta);
+    let error = routine_seed_init("beta")
+        .execute_without_runtime(None)
+        .expect_err("a colliding routine name must fail workspace init");
+    let message = error.to_string();
+    assert!(message.contains("task-pilot-beta"), "{message}");
+    assert!(message.contains("--name"), "{message}");
+
+    assert!(
+        !beta.join(".orbit/routines").exists(),
+        "a refused init must not seed routines into the second checkout"
+    );
+    let registry =
+        workspace_registry::load_registry_from(&home.path().join(".orbit").join("workspaces.json"))
+            .expect("load registry");
+    assert!(
+        !registry
+            .workspaces
+            .iter()
+            .any(|workspace| workspace.id == canonical_workspace_id("beta")),
+        "a refused init must not register the workspace"
+    );
+}
+
+fn seed_host_identity(home: &std::path::Path) {
+    let global = home.join(".orbit");
+    std::fs::create_dir_all(&global).expect("create global orbit");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_inithost\"\nhost_id = \"init-host\"\ntask_prefix = \"ORB\"\n",
+    )
+    .expect("write host identity");
+}
+
+fn routine_seed_init(name: &str) -> WorkspaceInitArgs {
+    WorkspaceInitArgs {
+        name: Some(name.to_string()),
+        base_branch: Some("main".to_string()),
+        ship_mode: None,
+        role: None,
+        owner: None,
+        task_id_start: None,
+        mcp: false,
+        inject_agent_rules: false,
+        refresh_defaults: false,
+        force: false,
+    }
+}
+
+/// Names of every managed routine seeded into `checkout`, read back from the
+/// definitions themselves rather than from the seeding inputs.
+fn seeded_routine_names(checkout: &std::path::Path) -> Vec<String> {
+    let routines_dir = checkout.join(".orbit/routines");
+    let mut names: Vec<String> = std::fs::read_dir(&routines_dir)
+        .expect("read seeded routines directory")
+        .map(|entry| entry.expect("routines directory entry").path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "yaml"))
+        .map(|path| {
+            let yaml = std::fs::read_to_string(&path).expect("read seeded routine");
+            parse_routine_yaml(&yaml)
+                .expect("seeded routine parses")
+                .name
+        })
+        .collect();
+    assert!(!names.is_empty(), "init must seed routines");
+    names.sort();
+    names
 }
 
 #[test]

--- a/crates/orbit-core/src/application/routine.rs
+++ b/crates/orbit-core/src/application/routine.rs
@@ -8,9 +8,12 @@
 //! - `__ORBIT_HOST_ID__` — routines v1 has no "any host", so the seeded
 //!   definition pins the host identity supplied by the feature layer.
 //! - `__ORBIT_ROUTINE_NAME__` — routine names must be unique across all
-//!   routine sources on a host, so the seeded name carries a
-//!   workspace-derived suffix (`task-triage-<workspace>`) to keep two
-//!   seeded source workspaces from colliding fail-closed.
+//!   routine sources on a host, so the seeded name carries the registered
+//!   workspace name as a suffix (`task-triage-<workspace-name>`) to keep two
+//!   seeded source workspaces from colliding fail-closed. The suffix comes
+//!   from the workspace name the operator registered, never from the checkout
+//!   directory: two checkouts whose directories share a basename would
+//!   otherwise seed the same names on one host [ORB-12107].
 //!
 //! Seeded routines are inert until the workspace opts into
 //! `[routines] role = "source"`; they exist so a fresh workspace gets
@@ -18,8 +21,9 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use orbit_automation::routines::loader::declared_routine_names;
 use orbit_common::OrbitError;
 use orbit_common::protocol::yaml::parse_routine_yaml;
 
@@ -71,6 +75,105 @@ pub(crate) const DEFAULT_ROUTINE_FILES: &[(&str, &str)] = &[
 const HOST_ID_PLACEHOLDER: &str = "__ORBIT_HOST_ID__";
 const ROUTINE_NAME_PLACEHOLDER: &str = "__ORBIT_ROUTINE_NAME__";
 
+/// The identity a workspace's default routines are materialized against: the
+/// host they pin and the registered workspace name their names are suffixed
+/// with. Both are required, so the two halves travel together and a caller
+/// cannot seed host-pinned routines under unsuffixed, host-wide names.
+///
+/// Construction validates both halves, which is why the fields are private:
+/// an existing value always renders a loadable routine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoutineSeedIdentity {
+    host_id: String,
+    name_suffix: String,
+}
+
+impl RoutineSeedIdentity {
+    /// Build the seed identity for `workspace_name` on `host_id`, rejecting a
+    /// workspace name with no characters usable in a routine name — that name
+    /// would otherwise silently fall back to a host-wide unsuffixed routine.
+    pub fn new(host_id: &str, workspace_name: &str) -> Result<Self, OrbitError> {
+        let host_id = host_id.trim();
+        if host_id.is_empty() {
+            return Err(OrbitError::InvalidInput(
+                "cannot seed default routines without a host id".to_string(),
+            ));
+        }
+
+        let name_suffix = sanitize_routine_name_part(workspace_name);
+        if name_suffix.is_empty() {
+            return Err(OrbitError::InvalidInput(format!(
+                "workspace name '{workspace_name}' has no characters usable in a routine name; \
+                 routine names must stay unique across every routine source on this host, so \
+                 choose a workspace name containing letters or digits"
+            )));
+        }
+
+        Ok(Self {
+            host_id: host_id.to_string(),
+            name_suffix,
+        })
+    }
+
+    pub(crate) fn host_id(&self) -> &str {
+        &self.host_id
+    }
+
+    /// Compose a per-workspace routine name: `<stem>-<workspace-name>`, using
+    /// the routine name charset (lowercase alphanumeric plus `-`/`_`, starting
+    /// alphanumeric). Names must be unique across all routine sources on a
+    /// host, so the workspace suffix is what lets two seeded sources coexist.
+    pub(crate) fn routine_name(&self, file_stem: &str) -> String {
+        format!("{}-{}", file_stem.replace('_', "-"), self.name_suffix)
+    }
+
+    /// Every name this identity would seed, in [`DEFAULT_ROUTINE_FILES`] order.
+    pub fn seeded_routine_names(&self) -> Vec<String> {
+        DEFAULT_ROUTINE_FILES
+            .iter()
+            .map(|(stem, _)| self.routine_name(stem))
+            .collect()
+    }
+}
+
+/// A name this workspace's default routines would take that another workspace
+/// on the same host already declares.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoutineNameCollision {
+    /// The routine name claimed twice.
+    pub name: String,
+    /// The already-existing definition file that claims it.
+    pub declared_in: PathBuf,
+}
+
+/// Names that seeding for `identity` would take from routine definitions
+/// already declared under `other_orbit_dirs` (every registered checkout on
+/// this host except the one being initialized).
+///
+/// A name defined by more than one source is a load-time error that drops
+/// *every* colliding definition, so init reports this instead of writing a
+/// set of routines that can never fire [ORB-12107].
+pub fn default_routine_name_collisions(
+    identity: &RoutineSeedIdentity,
+    other_orbit_dirs: &[PathBuf],
+) -> Vec<RoutineNameCollision> {
+    let seeded: BTreeSet<String> = identity.seeded_routine_names().into_iter().collect();
+    let mut collisions: BTreeMap<String, PathBuf> = BTreeMap::new();
+
+    for orbit_dir in other_orbit_dirs {
+        for (name, path) in declared_routine_names(orbit_dir, identity.host_id()) {
+            if seeded.contains(&name) {
+                collisions.entry(name).or_insert(path);
+            }
+        }
+    }
+
+    collisions
+        .into_iter()
+        .map(|(name, declared_in)| RoutineNameCollision { name, declared_in })
+        .collect()
+}
+
 /// Seed every entry in [`DEFAULT_ROUTINE_FILES`] under `routines_dir`,
 /// resolving the host and routine-name placeholders. Mirrors the activity /
 /// job seeding convention: when `overwrite` is false (plain re-init),
@@ -91,13 +194,13 @@ const ROUTINE_NAME_PLACEHOLDER: &str = "__ORBIT_ROUTINE_NAME__";
 pub(crate) fn seed_default_routines(
     routines_dir: &Path,
     host_id: &str,
-    workspace_slug: Option<&str>,
+    workspace_name: &str,
     overwrite: bool,
 ) -> Result<ManagedAssetReconciliation, OrbitError> {
+    let identity = RoutineSeedIdentity::new(host_id, workspace_name)?;
     reconcile_default_routines(
         routines_dir,
-        host_id,
-        workspace_slug,
+        &identity,
         overwrite,
         ManagedAssetReconcileMode::Apply,
     )
@@ -105,18 +208,10 @@ pub(crate) fn seed_default_routines(
 
 pub(crate) fn reconcile_default_routines(
     routines_dir: &Path,
-    host_id: &str,
-    workspace_slug: Option<&str>,
+    identity: &RoutineSeedIdentity,
     overwrite_bindings: bool,
     mode: ManagedAssetReconcileMode,
 ) -> Result<ManagedAssetReconciliation, OrbitError> {
-    let host_id = host_id.trim();
-    if host_id.is_empty() {
-        return Err(OrbitError::InvalidInput(
-            "cannot reconcile default routines without a host id".to_string(),
-        ));
-    }
-
     let manifest_path = routines_dir.join(MANAGED_ASSET_MANIFEST_FILE);
     let previous =
         load_managed_asset_manifest(&manifest_path, "routine", ManagedAssetLayout::YamlStem)?;
@@ -191,8 +286,8 @@ pub(crate) fn reconcile_default_routines(
     for (name, template) in DEFAULT_ROUTINE_FILES {
         let path = routines_dir.join(format!("{name}.yaml"));
         let requested_binding = RoutineMaterializationBinding {
-            name: routine_name_for(name, workspace_slug),
-            hosts: vec![host_id.to_string()],
+            name: identity.routine_name(name),
+            hosts: vec![identity.host_id().to_string()],
         };
         let template_digest = sha256_hex(template.as_bytes());
         let previous_digest = previous.as_ref().and_then(|value| value.assets.get(*name));
@@ -544,18 +639,6 @@ fn render_routine_template(
     Ok(rendered)
 }
 
-/// Compose a per-workspace routine name: `<stem>-<workspace-slug>`, using
-/// the routine name charset (lowercase alphanumeric plus `-`/`_`, starting
-/// alphanumeric). Names must be unique across all routine sources on a
-/// host, so the workspace suffix is what lets two seeded sources coexist.
-fn routine_name_for(file_stem: &str, workspace_slug: Option<&str>) -> String {
-    let base = file_stem.replace('_', "-");
-    match workspace_slug.map(sanitize_routine_name_part) {
-        Some(slug) if !slug.is_empty() => format!("{base}-{slug}"),
-        _ => base,
-    }
-}
-
 fn sanitize_routine_name_part(raw: &str) -> String {
     let lowered = raw.trim().to_ascii_lowercase();
     let mut out = String::with_capacity(lowered.len());
@@ -582,7 +665,7 @@ mod tests {
     fn seeded_routines_are_valid_disabled_pinned_and_workspace_unique() {
         let root = tempdir().expect("create tempdir");
         let routines_dir = root.path().join(".orbit/routines");
-        let seeded = seed_default_routines(&routines_dir, "test-host", Some("My Repo!"), true)
+        let seeded = seed_default_routines(&routines_dir, "test-host", "My Repo!", true)
             .expect("seed default routines");
         assert_eq!(seeded.refreshed, DEFAULT_ROUTINE_FILES.len());
 
@@ -680,11 +763,12 @@ mod tests {
     fn seeding_preserves_existing_files_unless_overwrite() {
         let root = tempdir().expect("create tempdir");
         let routines_dir = root.path().join("routines");
-        seed_default_routines(&routines_dir, "host-a", None, false).expect("first seed");
+        seed_default_routines(&routines_dir, "host-a", "workspace", false).expect("first seed");
         let path = routines_dir.join("worktree_gc.yaml");
         std::fs::write(&path, "user edited").expect("simulate user edit");
 
-        let seeded = seed_default_routines(&routines_dir, "host-a", None, false).expect("re-seed");
+        let seeded =
+            seed_default_routines(&routines_dir, "host-a", "workspace", false).expect("re-seed");
         assert_eq!(seeded.refreshed, 0);
         assert_eq!(
             std::fs::read_to_string(&path).expect("read"),
@@ -692,11 +776,12 @@ mod tests {
             "plain re-init must not clobber user edits"
         );
 
-        seed_default_routines(&routines_dir, "host-b", None, true).expect("refresh defaults");
+        seed_default_routines(&routines_dir, "host-b", "workspace", true)
+            .expect("refresh defaults");
         let refreshed = std::fs::read_to_string(&path).expect("read refreshed");
         assert!(refreshed.contains("host-b"));
         let definition = parse_routine_yaml(&refreshed).expect("refreshed routine parses");
-        assert_eq!(definition.name, "worktree-gc");
+        assert_eq!(definition.name, "worktree-gc-workspace");
         assert_eq!(
             definition.target,
             RoutineTarget::Job("worktree_gc_pipeline".to_string())
@@ -710,15 +795,14 @@ mod tests {
 
         let root = tempdir().expect("create tempdir");
         let routines_dir = root.path().join("routines");
-        seed_default_routines(&routines_dir, HOST_ID, Some("workspace"), false)
-            .expect("first seed");
+        seed_default_routines(&routines_dir, HOST_ID, "workspace", false).expect("first seed");
 
         let existing = routines_dir.join("task_triage.yaml");
         let original = std::fs::read(&existing).expect("read existing routine bytes");
         let missing = routines_dir.join("task_pilot.yaml");
         std::fs::remove_file(&missing).expect("remove newly introduced routine");
 
-        let seeded = seed_default_routines(&routines_dir, HOST_ID, Some("workspace"), false)
+        let seeded = seed_default_routines(&routines_dir, HOST_ID, "workspace", false)
             .expect("plain re-init");
         assert_eq!(seeded.refreshed, 1, "only the missing default is created");
         assert_eq!(
@@ -743,8 +827,7 @@ mod tests {
     fn reseeding_unchanged_rendered_content_is_a_no_op_not_a_rewrite() {
         let root = tempdir().expect("create tempdir");
         let routines_dir = root.path().join("routines");
-        seed_default_routines(&routines_dir, "host-a", Some("workspace"), true)
-            .expect("first seed");
+        seed_default_routines(&routines_dir, "host-a", "workspace", true).expect("first seed");
 
         let before: Vec<(std::path::PathBuf, std::time::SystemTime)> = DEFAULT_ROUTINE_FILES
             .iter()
@@ -757,7 +840,7 @@ mod tests {
             })
             .collect();
 
-        let reseeded = seed_default_routines(&routines_dir, "host-a", Some("workspace"), true)
+        let reseeded = seed_default_routines(&routines_dir, "host-a", "workspace", true)
             .expect("re-seed unchanged rendered content");
         assert_eq!(reseeded.refreshed, 0, "unchanged routines must not rewrite");
         assert_eq!(reseeded.retired, 0);
@@ -777,7 +860,7 @@ mod tests {
 
         // A different host renders different content, so the digest changes
         // and an overwriting seed does refresh every file.
-        let rehosted = seed_default_routines(&routines_dir, "host-b", Some("workspace"), true)
+        let rehosted = seed_default_routines(&routines_dir, "host-b", "workspace", true)
             .expect("re-seed with a new host id");
         assert_eq!(rehosted.refreshed, DEFAULT_ROUTINE_FILES.len());
     }
@@ -786,7 +869,7 @@ mod tests {
     fn fresh_routine_seeding_matches_rendered_canonical_templates() {
         let root = tempdir().expect("create tempdir");
         let routines_dir = root.path().join("routines");
-        seed_default_routines(&routines_dir, "host-a", Some("workspace"), false)
+        seed_default_routines(&routines_dir, "host-a", "workspace", false)
             .expect("seed canonical routines");
 
         for (stem, template) in DEFAULT_ROUTINE_FILES {
@@ -809,7 +892,7 @@ mod tests {
     fn task_pilot_reseeding_preserves_workspace_overrides() {
         let root = tempdir().expect("create tempdir");
         let routines_dir = root.path().join("routines");
-        seed_default_routines(&routines_dir, "host-a", Some("workspace"), false)
+        seed_default_routines(&routines_dir, "host-a", "workspace", false)
             .expect("seed canonical routines");
         let path = routines_dir.join("task_pilot.yaml");
         let edited = std::fs::read_to_string(&path)
@@ -823,7 +906,7 @@ mod tests {
         assert_eq!(definition.trigger.cron, "*/15 * * * *");
         std::fs::write(&path, &edited).expect("write operator overrides");
 
-        seed_default_routines(&routines_dir, "host-a", Some("workspace"), false)
+        seed_default_routines(&routines_dir, "host-a", "workspace", false)
             .expect("reseed without overwriting workspace choices");
         assert_eq!(
             std::fs::read_to_string(&path).expect("read preserved routine"),
@@ -840,7 +923,7 @@ mod tests {
     fn manifestless_customized_routines_are_adopted_rather_than_called_collisions() {
         let root = tempdir().expect("create tempdir");
         let routines_dir = root.path().join("routines");
-        seed_default_routines(&routines_dir, "host-a", Some("workspace"), false)
+        seed_default_routines(&routines_dir, "host-a", "workspace", false)
             .expect("seed a pre-provenance workspace");
         let manifest_path = routines_dir.join(MANAGED_ASSET_MANIFEST_FILE);
         std::fs::remove_file(&manifest_path).expect("drop the manifest to predate provenance");
@@ -855,7 +938,7 @@ mod tests {
         );
         std::fs::write(&customized, &edited).expect("simulate the documented customization");
 
-        let adopted = seed_default_routines(&routines_dir, "host-a", Some("workspace"), false)
+        let adopted = seed_default_routines(&routines_dir, "host-a", "workspace", false)
             .expect("reconcile the pre-provenance directory");
         assert!(
             adopted.warnings.is_empty(),
@@ -893,7 +976,7 @@ mod tests {
 
         // Provenance now owns the file, so convergence is a no-op instead of
         // repeating the same complaint on every run.
-        let second = seed_default_routines(&routines_dir, "host-a", Some("workspace"), false)
+        let second = seed_default_routines(&routines_dir, "host-a", "workspace", false)
             .expect("second reconcile");
         assert!(second.warnings.is_empty());
         assert_eq!(second.refreshed, 0);
@@ -909,7 +992,7 @@ mod tests {
     fn user_authored_collision_is_still_reported_when_the_manifest_tracks_the_directory() {
         let root = tempdir().expect("create tempdir");
         let routines_dir = root.path().join("routines");
-        seed_default_routines(&routines_dir, "host-a", Some("workspace"), false)
+        seed_default_routines(&routines_dir, "host-a", "workspace", false)
             .expect("seed default routines");
         let manifest_path = routines_dir.join(MANAGED_ASSET_MANIFEST_FILE);
         let mut manifest =
@@ -930,7 +1013,7 @@ mod tests {
             .replace("task-triage-workspace", "my-own-triage");
         std::fs::write(&user_authored, &content).expect("write a user-authored routine");
 
-        let reconciled = seed_default_routines(&routines_dir, "host-a", Some("workspace"), false)
+        let reconciled = seed_default_routines(&routines_dir, "host-a", "workspace", false)
             .expect("reconcile a tracked directory");
         assert!(
             reconciled
@@ -965,7 +1048,7 @@ mod tests {
         )
         .expect("write an unmanageable file");
 
-        let reconciled = seed_default_routines(&routines_dir, "host-a", Some("workspace"), false)
+        let reconciled = seed_default_routines(&routines_dir, "host-a", "workspace", false)
             .expect("reconcile a manifest-less directory");
         assert!(
             reconciled
@@ -984,8 +1067,94 @@ mod tests {
     #[test]
     fn seeding_requires_a_host_id() {
         let root = tempdir().expect("create tempdir");
-        let err = seed_default_routines(&root.path().join("routines"), "  ", None, true)
+        let err = seed_default_routines(&root.path().join("routines"), "  ", "workspace", true)
             .expect_err("empty host id must not seed an unloadable routine");
         assert!(err.to_string().contains("host id"), "{err}");
+    }
+
+    /// Without a usable workspace suffix every workspace on the host would
+    /// seed the same bare `task-pilot` name, so seeding refuses the name
+    /// instead of writing definitions that drop each other at load time.
+    #[test]
+    fn seeding_requires_a_workspace_name_with_usable_characters() {
+        let root = tempdir().expect("create tempdir");
+        let err = seed_default_routines(&root.path().join("routines"), "host-a", " ***", true)
+            .expect_err("unusable workspace name must not seed unsuffixed routines");
+        assert!(err.to_string().contains("routine name"), "{err}");
+    }
+
+    /// The seeded suffix is the registered workspace name, so two checkouts
+    /// whose directories share a basename still seed distinct names, and a
+    /// name mismatch never leaks the directory into the routine [ORB-12107].
+    #[test]
+    fn seeded_names_follow_the_workspace_name_not_the_checkout_directory() {
+        let alpha = RoutineSeedIdentity::new("host-a", "Alpha QA")
+            .expect("workspace name renders a routine suffix");
+        let beta = RoutineSeedIdentity::new("host-a", "beta").expect("second workspace identity");
+
+        assert_eq!(alpha.routine_name("task_pilot"), "task-pilot-alpha-qa");
+        assert_eq!(beta.routine_name("task_pilot"), "task-pilot-beta");
+        assert!(
+            alpha
+                .seeded_routine_names()
+                .iter()
+                .all(|name| !beta.seeded_routine_names().contains(name)),
+            "distinct workspace names must not share a seeded routine name"
+        );
+    }
+
+    /// A name another workspace on the host already declares is reported
+    /// before seeding: routine discovery drops every colliding definition, so
+    /// writing the duplicate would disable both workspaces' routines.
+    #[test]
+    fn collisions_report_names_another_workspace_already_declares() {
+        let root = tempdir().expect("create tempdir");
+        let other_orbit = root.path().join("other/.orbit");
+        seed_default_routines(&other_orbit.join("routines"), "host-a", "server", false)
+            .expect("seed the other workspace");
+
+        let identity = RoutineSeedIdentity::new("host-a", "server").expect("seed identity");
+        let collisions =
+            default_routine_name_collisions(&identity, std::slice::from_ref(&other_orbit));
+        assert_eq!(
+            collisions.len(),
+            DEFAULT_ROUTINE_FILES.len(),
+            "every seeded name collides: {collisions:?}"
+        );
+        assert!(collisions.iter().any(|collision| {
+            collision.name == "task-pilot-server"
+                && collision.declared_in == other_orbit.join("routines/task_pilot.yaml")
+        }));
+
+        let distinct = RoutineSeedIdentity::new("host-a", "other-server").expect("seed identity");
+        assert!(
+            default_routine_name_collisions(&distinct, &[other_orbit]).is_empty(),
+            "a distinct workspace name must not collide"
+        );
+    }
+
+    /// Local definitions share the host-wide name space, so a `local/`
+    /// routine is detected too.
+    #[test]
+    fn collisions_cover_local_routine_definitions() {
+        let root = tempdir().expect("create tempdir");
+        let other_orbit = root.path().join("other/.orbit");
+        let local_dir = other_orbit.join("routines/local");
+        seed_default_routines(&other_orbit.join("routines"), "host-a", "alpha", false)
+            .expect("seed the other workspace");
+        let local = std::fs::read_to_string(other_orbit.join("routines/task_pilot.yaml"))
+            .expect("read a seeded routine to adapt")
+            .replace("task-pilot-alpha", "task-pilot-beta");
+        write_text_with_parent(&local_dir.join("pilot.yaml"), &local).expect("write local routine");
+
+        let identity = RoutineSeedIdentity::new("host-a", "beta").expect("seed identity");
+        let collisions = default_routine_name_collisions(&identity, &[other_orbit]);
+        assert_eq!(
+            collisions
+                .iter()
+                .map(|collision| collision.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["task-pilot-beta"]
+        );
     }
 }

--- a/crates/orbit-core/src/application/tests/managed_assets.rs
+++ b/crates/orbit-core/src/application/tests/managed_assets.rs
@@ -12,6 +12,7 @@ use super::super::MANAGED_ASSET_MANIFEST_FILE;
 use super::super::job::seed_default_jobs;
 use crate::OrbitRuntime;
 use crate::application::job::JobCatalogFilter;
+use crate::application::routine::RoutineSeedIdentity;
 use crate::bootstrap::activity::seed_default_activities;
 use crate::bootstrap::global_defaults::stamp_path;
 use crate::bootstrap::init::{InitOptions, InitResult, init_workspace_at_root};
@@ -414,7 +415,9 @@ mod artifacts {
             InitOptions {
                 refresh_defaults: true,
                 global_root_override: Some(global_root.clone()),
-                routine_host_id: Some("test-host".to_string()),
+                routine_seed_identity: Some(
+                    RoutineSeedIdentity::new("test-host", "repo").expect("routine seed identity"),
+                ),
                 config_seed: Some(ConfigSeed::default()),
                 ..Default::default()
             },

--- a/crates/orbit-core/src/application/tests/workspace_sync.rs
+++ b/crates/orbit-core/src/application/tests/workspace_sync.rs
@@ -5,10 +5,15 @@ use sha2::{Digest, Sha256};
 use tempfile::tempdir;
 
 use crate::application::MANAGED_ASSET_MANIFEST_FILE;
+use crate::application::routine::RoutineSeedIdentity;
 use crate::application::workspace_sync::{
     ManagedArtifactOutcome, reconcile_workspace_managed_artifacts,
 };
 use crate::bootstrap::init::{InitOptions, init_workspace_at_root};
+
+fn seed_identity(host_id: &str, workspace_name: &str) -> RoutineSeedIdentity {
+    RoutineSeedIdentity::new(host_id, workspace_name).expect("routine seed identity")
+}
 
 fn initialized_roots(base: &Path) -> (PathBuf, PathBuf) {
     let global = base.join("global");
@@ -26,7 +31,9 @@ fn initialized_roots(base: &Path) -> (PathBuf, PathBuf) {
         &workspace,
         InitOptions {
             global_root_override: Some(global.clone()),
-            routine_host_id: Some("host-a".to_string()),
+            routine_seed_identity: Some(
+                RoutineSeedIdentity::new("host-a", "alpha").expect("routine seed identity"),
+            ),
             refresh_defaults: true,
             ..Default::default()
         },
@@ -43,6 +50,10 @@ fn sha256(content: &str) -> String {
     format!("{:x}", Sha256::digest(content.as_bytes()))
 }
 
+/// A workspace seeded under an earlier binding — including one whose routine
+/// names came from the checkout directory before [ORB-12107] — keeps the
+/// recorded name and bytes. Convergence reports the drift and renames nothing,
+/// because a routine's run history and state key off its name.
 #[test]
 fn binding_drift_does_not_claim_template_drift_or_rewrite_routines() {
     let root = tempdir().expect("create tempdir");
@@ -54,8 +65,7 @@ fn binding_drift_does_not_claim_template_drift_or_rewrite_routines() {
     let report = reconcile_workspace_managed_artifacts(
         &global,
         &workspace,
-        Some("renamed-host"),
-        Some("different-checkout"),
+        Some(&seed_identity("renamed-host", "different-workspace")),
         false,
     )
     .expect("sync with drifted current binding");
@@ -101,8 +111,7 @@ fn legacy_routine_manifest_check_is_read_only_and_apply_migrates_only_exact_inst
     let checked = reconcile_workspace_managed_artifacts(
         &global,
         &workspace,
-        Some("new-host"),
-        Some("new-suffix"),
+        Some(&seed_identity("new-host", "new-suffix")),
         true,
     )
     .expect("check legacy migration");
@@ -123,8 +132,7 @@ fn legacy_routine_manifest_check_is_read_only_and_apply_migrates_only_exact_inst
     let applied = reconcile_workspace_managed_artifacts(
         &global,
         &workspace,
-        Some("new-host"),
-        Some("new-suffix"),
+        Some(&seed_identity("new-host", "new-suffix")),
         false,
     )
     .expect("apply legacy migration");
@@ -171,8 +179,10 @@ fn real_template_refresh_uses_recorded_binding_and_second_run_is_a_no_op() {
     let applied = reconcile_workspace_managed_artifacts(
         &global,
         &workspace,
-        Some("different-current-host"),
-        Some("different-current-suffix"),
+        Some(&seed_identity(
+            "different-current-host",
+            "different-current-suffix",
+        )),
         false,
     )
     .expect("refresh true template drift");
@@ -184,15 +194,17 @@ fn real_template_refresh_uses_recorded_binding_and_second_run_is_a_no_op() {
             .expect("read refreshed routine"),
     )
     .expect("parse refreshed routine");
-    assert_eq!(routine.name, "task-triage-repo");
+    assert_eq!(routine.name, "task-triage-alpha");
     assert_eq!(routine.hosts, vec!["host-a".to_string()]);
 
     let before = std::fs::read(&manifest_path).expect("snapshot converged manifest");
     let second = reconcile_workspace_managed_artifacts(
         &global,
         &workspace,
-        Some("different-current-host"),
-        Some("different-current-suffix"),
+        Some(&seed_identity(
+            "different-current-host",
+            "different-current-suffix",
+        )),
         false,
     )
     .expect("second sync");
@@ -222,8 +234,7 @@ fn manifestless_customized_routines_are_adopted_and_stay_reconcilable() {
     let checked = reconcile_workspace_managed_artifacts(
         &global,
         &workspace,
-        Some("host-a"),
-        Some("repo"),
+        Some(&seed_identity("host-a", "alpha")),
         true,
     )
     .expect("check a pre-provenance workspace");
@@ -242,8 +253,7 @@ fn manifestless_customized_routines_are_adopted_and_stay_reconcilable() {
     let applied = reconcile_workspace_managed_artifacts(
         &global,
         &workspace,
-        Some("host-a"),
-        Some("repo"),
+        Some(&seed_identity("host-a", "alpha")),
         false,
     )
     .expect("adopt a pre-provenance workspace");
@@ -280,8 +290,7 @@ fn manifestless_customized_routines_are_adopted_and_stay_reconcilable() {
     let refreshed = reconcile_workspace_managed_artifacts(
         &global,
         &workspace,
-        Some("host-a"),
-        Some("repo"),
+        Some(&seed_identity("host-a", "alpha")),
         false,
     )
     .expect("refresh the adopted routine");
@@ -322,8 +331,7 @@ fn sync_refreshes_only_provenance_clean_non_routine_assets_and_retires_safely() 
     let checked = reconcile_workspace_managed_artifacts(
         &global,
         &workspace,
-        Some("host-a"),
-        Some("repo"),
+        Some(&seed_identity("host-a", "alpha")),
         true,
     )
     .expect("check non-routine convergence");
@@ -339,8 +347,13 @@ fn sync_refreshes_only_provenance_clean_non_routine_assets_and_retires_safely() 
     );
     assert!(retired_path.exists());
 
-    reconcile_workspace_managed_artifacts(&global, &workspace, Some("host-a"), Some("repo"), false)
-        .expect("apply non-routine convergence");
+    reconcile_workspace_managed_artifacts(
+        &global,
+        &workspace,
+        Some(&seed_identity("host-a", "alpha")),
+        false,
+    )
+    .expect("apply non-routine convergence");
     assert_eq!(
         std::fs::read_to_string(&current_path).expect("refreshed activity"),
         current
@@ -351,8 +364,7 @@ fn sync_refreshes_only_provenance_clean_non_routine_assets_and_retires_safely() 
     let second = reconcile_workspace_managed_artifacts(
         &global,
         &workspace,
-        Some("host-a"),
-        Some("repo"),
+        Some(&seed_identity("host-a", "alpha")),
         false,
     )
     .expect("second convergence");

--- a/crates/orbit-core/src/application/workspace_sync.rs
+++ b/crates/orbit-core/src/application/workspace_sync.rs
@@ -8,7 +8,7 @@ use orbit_common::protocol::yaml::parse_auto_task_yaml;
 use serde::Serialize;
 
 use super::job::DEFAULT_JOB_FILES;
-use super::routine::reconcile_default_routines;
+use super::routine::{RoutineSeedIdentity, reconcile_default_routines};
 use super::skill::{DEFAULT_SKILL_FILES, inject_skill_template_tokens};
 use super::{
     ManagedAssetAction, ManagedAssetLayout, ManagedAssetOutcome, ManagedAssetReconcileMode,
@@ -96,8 +96,7 @@ impl WorkspaceManagedArtifactSyncReport {
 pub fn reconcile_workspace_managed_artifacts(
     global_root: &Path,
     workspace_orbit_root: &Path,
-    routine_host_id: Option<&str>,
-    workspace_slug: Option<&str>,
+    routine_identity: Option<&RoutineSeedIdentity>,
     check: bool,
 ) -> Result<WorkspaceManagedArtifactSyncReport, OrbitError> {
     let mode = if check {
@@ -186,11 +185,10 @@ pub fn reconcile_workspace_managed_artifacts(
         auto_tasks,
     );
 
-    if let Some(routine_host_id) = routine_host_id {
+    if let Some(routine_identity) = routine_identity {
         let routines = reconcile_default_routines(
             &workspace_orbit_root.join("routines"),
-            routine_host_id,
-            workspace_slug,
+            routine_identity,
             false,
             mode,
         )?;

--- a/crates/orbit-core/src/bootstrap/init.rs
+++ b/crates/orbit-core/src/bootstrap/init.rs
@@ -11,6 +11,7 @@ use crate::OrbitRuntime;
 use crate::application::MANAGED_ASSET_MANIFEST_FILE;
 use crate::application::executor::seed_default_executors;
 use crate::application::job::seed_default_jobs;
+use crate::application::routine::RoutineSeedIdentity;
 use crate::application::skill::{
     default_skill_ids, is_default_skill_file_for_root, seed_default_skills,
 };
@@ -57,9 +58,11 @@ pub struct InitOptions {
     pub global_only: bool,
     /// Explicit global root to seed when preparing a workspace root.
     pub global_root_override: Option<PathBuf>,
-    /// Host id to pin into newly seeded workspace routines. Higher-level
-    /// composition owns host identity and supplies this value explicitly.
-    pub routine_host_id: Option<String>,
+    /// Host and registered workspace name to materialize newly seeded
+    /// workspace routines against. Higher-level composition owns both halves
+    /// of that identity and supplies them explicitly; `None` skips routine
+    /// seeding entirely.
+    pub routine_seed_identity: Option<RoutineSeedIdentity>,
     /// When true, create/update user-level skill symlinks for global skills.
     pub link_global_skills: bool,
     /// Explicit inputs for seeding a fresh `config.toml`: which provider
@@ -290,8 +293,7 @@ pub fn init_workspace_at_root(
                 let reconciliation = reconcile_workspace_managed_artifacts(
                     &global_root,
                     &orbit_root,
-                    options.routine_host_id.as_deref(),
-                    workspace_slug_from_orbit_root(&orbit_root).as_deref(),
+                    options.routine_seed_identity.as_ref(),
                     false,
                 )?;
                 refreshed_default_routines = reconciliation
@@ -367,15 +369,6 @@ pub fn init_workspace_at_root(
         refreshed_default_routines,
         seeded_default_auto_tasks,
     })
-}
-
-/// Derive the routine-name suffix for seeded default routines from the
-/// workspace directory containing `.orbit/`.
-fn workspace_slug_from_orbit_root(orbit_root: &Path) -> Option<String> {
-    orbit_root
-        .parent()
-        .and_then(Path::file_name)
-        .map(|name| name.to_string_lossy().into_owned())
 }
 
 pub(crate) fn global_skills_dir(global_root: &Path) -> PathBuf {
@@ -860,7 +853,9 @@ mod tests {
             InitOptions {
                 global_root_override: Some(global_root.clone()),
                 refresh_defaults: true,
-                routine_host_id: Some("host-a".to_string()),
+                routine_seed_identity: Some(
+                    RoutineSeedIdentity::new("host-a", "repo").expect("routine seed identity"),
+                ),
                 ..Default::default()
             },
         )
@@ -893,7 +888,9 @@ mod tests {
             InitOptions {
                 global_root_override: Some(global_root.clone()),
                 refresh_defaults: true,
-                routine_host_id: Some("host-a".to_string()),
+                routine_seed_identity: Some(
+                    RoutineSeedIdentity::new("host-a", "repo").expect("routine seed identity"),
+                ),
                 ..Default::default()
             },
         )
@@ -910,7 +907,9 @@ mod tests {
                 global_root_override: Some(global_root),
                 force: true,
                 refresh_defaults: true,
-                routine_host_id: Some("host-b".to_string()),
+                routine_seed_identity: Some(
+                    RoutineSeedIdentity::new("host-b", "repo").expect("routine seed identity"),
+                ),
                 ..Default::default()
             },
         )

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -73,6 +73,9 @@ pub use application::operation::{
     OperationDrainRequest, OperationDrainResult, OperationGrantControlRequest,
     OperationGrantControlResult,
 };
+pub use application::routine::{
+    RoutineNameCollision, RoutineSeedIdentity, default_routine_name_collisions,
+};
 pub use application::search::{
     GlobalSearchHit, GlobalSearchKind, GlobalSearchParams, HitWorkspace, WorkspaceSearchReport,
     task_selectors_contain_path,

--- a/crates/orbit-core/tests/sandbox_off.rs
+++ b/crates/orbit-core/tests/sandbox_off.rs
@@ -68,7 +68,7 @@ fn explicit_off_survives_opens_and_sync_then_spawns_bare_without_inner_sandbox()
                 .map(|kind| kind.as_str()),
             Some("off")
         );
-        reconcile_workspace_managed_artifacts(&global, &workspace, None, None, false)
+        reconcile_workspace_managed_artifacts(&global, &workspace, None, false)
             .expect("normal managed resource sync");
         assert_eq!(
             std::fs::read(&executor_path).expect("after sync"),

--- a/docs/design/routines/4_decisions.md
+++ b/docs/design/routines/4_decisions.md
@@ -124,13 +124,23 @@ Routine YAML definitions live in routine-source workspaces and converge via git 
 ORB-10129 ships the triage pipeline as a default, but routines have no global directory: discovery reads `.orbit/routines/*.yaml` from `[routines] role = "source"` workspaces, v1 requires explicit host pinning (no "any host"), and routine names must be unique across all sources on a host — so a static shipped YAML cannot work. The real alternatives were leaving defaults workspace-authored from scratch or adding a global routines directory (a discovery-model change [Routine discovery through workspace registry](#routine-discovery-via-the-workspace-registry-and-a-versioned-routines-rolesource-config-key) deliberately avoided).
 
 ### Decision
-`orbit init` (workspace branch) seeds `DEFAULT_ROUTINE_FILES` templates into `.orbit/routines/`, resolving `__ORBIT_HOST_ID__` via `resolve_host_id` and `__ORBIT_ROUTINE_NAME__` from a workspace-directory slug, validating each rendered document fail-closed before writing. Every default is disabled. The complete set is `auto_task_scheduler`, `task_triage`, `task_pilot`, `ship_sweep`, and `worktree_gc`. Plain re-init creates missing defaults while preserving existing definitions byte-for-byte; destructive `--force` recreates templates. A routine fires only after the workspace is a routine source and its versioned `enabled` field is set true. [ORB-10739]
+`orbit init` (workspace branch) seeds `DEFAULT_ROUTINE_FILES` templates into `.orbit/routines/`, resolving `__ORBIT_HOST_ID__` via `resolve_host_id` and `__ORBIT_ROUTINE_NAME__` from the **registered workspace name**, validating each rendered document fail-closed before writing. Every default is disabled. The complete set is `auto_task_scheduler`, `task_triage`, `task_pilot`, `ship_sweep`, and `worktree_gc`. Plain re-init creates missing defaults while preserving existing definitions byte-for-byte; destructive `--force` recreates templates. A routine fires only after the workspace is a routine source and its versioned `enabled` field is set true. [ORB-10739]
 
 ### Consequences
 - Fresh workspaces get reviewable routine definitions without silently granting scheduled execution.
 - Per-workspace names let multiple seeded source workspaces coexist on one host despite the global name-uniqueness rule.
 - The seeded file pins the initializing host; sharing the repo to another host needs a hand edit of `hosts:` or recreation during destructive initialization.
-- Cost: `orbit init` output depends on the machine it runs on (host id, directory name), and routine template improvements do not overwrite existing workspace-authored files.
+- Cost: `orbit init` output depends on the machine it runs on (host id, workspace name), and routine template improvements do not overwrite existing workspace-authored files.
+
+### Correction: the suffix is the workspace name, not the checkout directory [ORB-12107]
+
+The suffix was originally taken from the directory containing `.orbit/`, so `orbit workspace init --name qa-sweep` inside `.../repo` seeded `task-pilot-repo` while `orbit routine list` reported a `qa-sweep` workspace — `orbit routine show task-pilot-qa-sweep` found nothing. Worse, the directory basename is not unique on a host: any two `repo`/`src`/`app` checkouts seeded identical names, and a name defined twice drops *both* definitions at load time.
+
+`RoutineSeedIdentity` now carries the host id and the registered workspace name together, and is the only way to reach default-routine seeding, so neither `orbit workspace init` nor `orbit workspace sync` can render a name without one. A workspace name with no characters usable in a routine name is rejected rather than silently falling back to an unsuffixed, host-wide name.
+
+`orbit workspace init` also refuses a name whose seeded routines a *different* registered checkout on the host already declares (committed or `local/`), naming each conflicting file, instead of writing a duplicate set that can never fire.
+
+Existing workspaces are **left untouched**: the managed-asset manifest records each routine's materialization binding, and reconciliation keeps the recorded name. A workspace seeded before this change therefore keeps its directory-derived routine names and keeps working; `orbit workspace sync --check` reports the difference as `binding_drift`, naming the workspace-derived name it would render now. Adopting the new name is a deliberate operator action (rename in the definition and its manifest entry, or re-initialize the routines directory) — nothing renames a live routine automatically, because a rename loses the routine's run history and state, which key off the name.
 
 ## Delegate workspace ship routines through a synchronous wrapper job
 


### PR DESCRIPTION
## Task

[ORB-12107](https://orbit-cli.com/tasks/ORB-12107) — Seeded routine names derive from the checkout directory name, not the workspace name

### Description

Found during a full QA sweep of orbit 0.20.0 on the Mac mini (2026-09-10).


 `orbit workspace init --name qa-sweep` in a directory called `repo` seeds routines named
 `worktree-gc-repo`, `task-pilot-repo`, `ship-sweep-repo`, … — the directory basename, not the
 workspace name the operator chose. `orbit routine list` then shows a `qa-sweep` workspace
 whose routines are all `-repo`, and `orbit routine show worktree-gc-qa-sweep` fails.

 Routine names are host-wide identifiers, so two workspaces whose checkout directories share a
 basename (`.../a/server` and `.../b/server`, or any two `repo`/`src`/`app` checkouts) will
 seed colliding routine names on the same host.

 ## Expected
 Seed routine names from the registered workspace name (or its `ws_*` id), and detect a
 name collision at `workspace init` rather than silently emitting duplicates.

### Acceptance Criteria

- Routines seeded by `workspace init --name X` are named `<routine>-X`
- Two checkouts with the same directory basename but different workspace names seed non-colliding routine names
- Existing workspaces keep working — either untouched or migrated deliberately, with the choice documented
- Test covers the mismatched-name and basename-collision cases

## Execution Summary

<details>
<summary>Click to expand</summary>

Seeded routine names now derive from the registered workspace name, and `orbit workspace init` refuses a name whose routines another checkout on the host already declares.

## Change

- `orbit-core` `application/routine.rs`: new `RoutineSeedIdentity { host_id, name_suffix }` (private fields, validating `new()`) is the only way to reach default-routine seeding. It replaces the `(host_id: &str, workspace_slug: Option<&str>)` pair, so a caller can no longer supply a host without a workspace name and fall back to unsuffixed, host-wide names. `routine_name_for` became `RoutineSeedIdentity::routine_name`. Added `default_routine_name_collisions(identity, other_orbit_dirs) -> Vec<RoutineNameCollision>`.
- `orbit-core` `bootstrap/init.rs`: `InitOptions::routine_host_id` → `routine_seed_identity`; deleted `workspace_slug_from_orbit_root` (the checkout-directory derivation that caused the bug).
- `orbit-core` `application/workspace_sync.rs`: `reconcile_workspace_managed_artifacts` takes `Option<&RoutineSeedIdentity>` instead of two `Option<&str>`s.
- `orbit-automation` `routines/loader.rs`: new `declared_routine_names(orbit_dir, host_id) -> BTreeMap<String, PathBuf>` reading committed and `local/` definitions (unparseable files skipped, matching load-time behavior). No new crate edge — Core already depends on Automation.
- `orbit-cli` `workspace/init.rs`: builds the identity from the registered name before any write (so a name with no usable characters fails early), and inside the registry lock rejects collisions against every other registered checkout's `.orbit` (own workspace id / own orbit_dir excluded, so re-init and rename are unaffected).
- `orbit-cli` `workspace/sync.rs`: uses the registered workspace name instead of `repo_root.file_name()`.

## Acceptance criteria

1. **Routines named `<routine>-X`** — met. `workspace init --name X` renders every default from the registered name; the pre-existing CLI test that asserted the directory basename was updated to the workspace name (it was encoding the bug).
2. **Same basename, different names → non-colliding** — met, covered by `same_basename_checkouts_with_distinct_names_seed_distinct_routine_names` (`a/server` + `b/server`).
3. **Existing workspaces keep working** — chosen: **untouched**, documented in `docs/design/routines/4_decisions.md` under "Correction: the suffix is the workspace name, not the checkout directory". The managed-asset manifest records each routine's materialization binding and reconciliation keeps the recorded name, so a pre-change workspace keeps its `-<dirname>` routines and keeps firing; `orbit workspace sync --check` reports the difference as `binding_drift`. Nothing renames automatically (run history and state key off the routine name). Behavior is covered by `binding_drift_does_not_claim_template_drift_or_rewrite_routines`.
4. **Tests cover mismatched-name and basename-collision** — met: CLI `seeded_routine_names_follow_the_workspace_name_not_the_checkout_directory` (init `--name qa-sweep` in a `repo/` directory), `same_basename_checkouts_with_distinct_names_seed_distinct_routine_names`, and `workspace_init_refuses_a_name_whose_seeded_routines_already_exist` (asserts the error names the routine and `--name`, and that no routines or registration are written). Core adds `seeded_names_follow_the_workspace_name_not_the_checkout_directory`, `collisions_report_names_another_workspace_already_declares`, `collisions_cover_local_routine_definitions`, and `seeding_requires_a_workspace_name_with_usable_characters`. All three CLI tests fail against the previous behavior.

## Validation

- `make ci-fast` — passed (exit 0). One informational skip inside it: `test-compiler-cache-namespaces` skipped because this kernel disallows unprivileged user namespaces (bwrap), unrelated to this change.
- `make ci-lint` — passed (exit 0) after fixing one `clippy::cloned_ref_to_slice_refs` in a new test.
- `cargo test -p orbit-core -p orbit-cli -p orbit-automation` — passed (1388 core lib tests + all CLI/automation suites, 0 failures).
- `cargo fmt --all`, `git diff --check`, `git status --short` — clean; only tracked modifications, no untracked or temporary files.
- Full `make ci` not run per workspace policy (CI is the merge gate).

## Scope additions

Beyond the listed `context_files`, these were changed to keep direct consumers consistent and were appended to task scope: `workspace/sync.rs` (the second producer of the routine binding — leaving it on the basename would have made sync disagree with init), `orbit-core/src/lib.rs` (re-export of the new public type used by the CLI), and three test files that call the changed signatures (`application/tests/workspace_sync.rs`, `application/tests/managed_assets.rs`, `tests/sandbox_off.rs`).

## Risk

`reconcile_workspace_managed_artifacts` and `InitOptions` are internal (non-`stable`) surfaces; all in-tree callers were updated. The collision scan reads a handful of YAML files per registered checkout once per `workspace init`, inside the existing registry lock. A host with many registered checkouts pays a proportional but small cost only on init.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12107-6aa37498`
- Behind base: 0
- Ahead of base: 1