### PR TITLE
orbit init seeds the global root before validating --task-prefix, leaving a partial root on failure

### DIFF
--- a/crates/orbit-cli/src/command/init/command.rs
+++ b/crates/orbit-cli/src/command/init/command.rs
@@ -3,11 +3,11 @@ use orbit_core::bootstrap::init::{InitOptions, init_global};
 use orbit_core::{OrbitError, OrbitRuntime};
 use orbit_registry::workspace_registry::global_orbit_dir;
 use orbit_registry::{
-    HostIdentityOutcome, NewHostIdentity, ensure_host_identity, os_hostname,
-    validate_new_task_prefix,
+    HostIdentityOutcome, HostIdentityState, NewHostIdentity, ensure_host_identity,
+    inspect_host_identity, os_hostname, validate_new_task_prefix,
 };
 use std::io::{self, BufRead, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::collect_config_seed_for_init;
 use crate::command::{CommandOut, CommandOutput, Execute};
@@ -57,6 +57,17 @@ impl InitCommand {
     }
 
     fn run(self, root_override: Option<&Path>) -> Result<(), OrbitError> {
+        // Reject a malformed or (non-interactively) missing --host-name/
+        // --task-prefix before anything is written: skills, activities, jobs,
+        // executors, and config.toml all seed ahead of the host identity, so
+        // a late validation error left a half-initialized root behind
+        // [ORB-12112].
+        reject_invalid_fresh_identity_inputs(
+            root_override,
+            self.non_interactive,
+            self.host_name.as_deref(),
+            self.task_prefix.as_deref(),
+        )?;
         let config_seed =
             collect_config_seed_for_init(root_override, self.force, self.non_interactive)?;
         let result = init_global(
@@ -96,6 +107,78 @@ impl InitCommand {
     }
 }
 
+fn resolve_global_root(root_override: Option<&Path>) -> Result<PathBuf, OrbitError> {
+    match root_override {
+        Some(root) => Ok(root.to_path_buf()),
+        None => global_orbit_dir(),
+    }
+}
+
+/// Validate operator-supplied `--host-name`/`--task-prefix` inputs for a fresh
+/// host identity. Called both before `orbit init` writes anything (so a
+/// rejected or, under `--non-interactive`, missing value leaves no partial
+/// root [ORB-12112]) and again inside the identity-creation closure, which
+/// stays self-sufficient against a racing concurrent create. A present or
+/// legacy identity never reaches this function — both callers only consult it
+/// when the identity is confirmed absent.
+fn validate_fresh_identity_flags(
+    non_interactive: bool,
+    host_name: Option<&str>,
+    task_prefix: Option<&str>,
+) -> Result<(), OrbitError> {
+    match host_name {
+        Some(name) if name.trim().is_empty() => {
+            return Err(OrbitError::InvalidInput(
+                "host name must not be empty".to_string(),
+            ));
+        }
+        None if non_interactive => {
+            return Err(OrbitError::InvalidInput(
+                "host identity is absent; pass --host-name and --task-prefix \
+                 to initialize a fresh host non-interactively"
+                    .to_string(),
+            ));
+        }
+        _ => {}
+    }
+    match task_prefix {
+        Some(prefix) => {
+            validate_new_task_prefix(prefix)?;
+        }
+        None if non_interactive => {
+            return Err(OrbitError::InvalidInput(
+                "host identity is absent; pass --task-prefix <PREFIX> (2-5 uppercase ASCII letters) \
+                 to initialize a fresh host non-interactively"
+                    .to_string(),
+            ));
+        }
+        None => {}
+    }
+    Ok(())
+}
+
+/// Reject a malformed, or under `--non-interactive` missing, `--host-name`/
+/// `--task-prefix` before `orbit init` writes anything. These flags are only
+/// consulted when the host identity is absent (a fresh create) — a present or
+/// legacy identity ignores them entirely, so this check is skipped on the
+/// idempotent re-init path, matching [`ensure_host_identity_for_init`]'s own
+/// condition.
+fn reject_invalid_fresh_identity_inputs(
+    root_override: Option<&Path>,
+    non_interactive: bool,
+    host_name: Option<&str>,
+    task_prefix: Option<&str>,
+) -> Result<(), OrbitError> {
+    let global_root = resolve_global_root(root_override)?;
+    if !matches!(
+        inspect_host_identity(&global_root)?,
+        HostIdentityState::Absent
+    ) {
+        return Ok(());
+    }
+    validate_fresh_identity_flags(non_interactive, host_name, task_prefix)
+}
+
 /// Create or migrate this machine's host identity. Host name and task prefix are only
 /// consulted when the identity is absent (a fresh create); a present identity
 /// is preserved unchanged and a legacy file is migrated without prompting.
@@ -105,31 +188,19 @@ fn ensure_host_identity_for_init(
     host_name: Option<String>,
     task_prefix: Option<String>,
 ) -> Result<(), OrbitError> {
-    let global_root = match root_override {
-        Some(root) => root.to_path_buf(),
-        None => global_orbit_dir()?,
-    };
+    let global_root = resolve_global_root(root_override)?;
     let outcome = ensure_host_identity(&global_root, move || {
+        validate_fresh_identity_flags(
+            non_interactive,
+            host_name.as_deref(),
+            task_prefix.as_deref(),
+        )?;
         let host_id = match host_name {
             Some(name) => name,
-            None if non_interactive => {
-                return Err(OrbitError::InvalidInput(
-                    "host identity is absent; pass --host-name and --task-prefix \
-                     to initialize a fresh host non-interactively"
-                        .to_string(),
-                ));
-            }
             None => prompt_host_name()?,
         };
         let task_prefix = match task_prefix {
-            Some(prefix) => validate_new_task_prefix(&prefix)?,
-            None if non_interactive => {
-                return Err(OrbitError::InvalidInput(
-                    "host identity is absent; pass --task-prefix <PREFIX> (2-5 uppercase ASCII letters) \
-                     to initialize a fresh host non-interactively"
-                        .to_string(),
-                ));
-            }
+            Some(prefix) => prefix,
             None => prompt_task_prefix()?,
         };
         Ok(NewHostIdentity {

--- a/crates/orbit-cli/src/command/tests/init.rs
+++ b/crates/orbit-cli/src/command/tests/init.rs
@@ -284,7 +284,11 @@ fn init_migrates_legacy_host_toml() {
     );
 }
 
-/// A fresh host initialized non-interactively without --host-name fails closed.
+/// A fresh host initialized non-interactively without --host-name fails closed
+/// and writes nothing at all to the target root — skills, activities, jobs,
+/// executors, and config.toml all seed ahead of the host identity check, so a
+/// late failure previously left a half-initialized `.orbit` behind
+/// [ORB-12112].
 #[test]
 fn non_interactive_missing_host_name_fails_closed() {
     let home = tempdir().expect("home tempdir");
@@ -294,12 +298,13 @@ fn non_interactive_missing_host_name_fails_closed() {
     let error = init_host(&root, None, Some("DE")).expect_err("missing host name must fail closed");
     assert!(error.to_string().contains("--host-name"), "{error}");
     assert!(
-        !root.join("host.toml").exists(),
-        "no identity should be written on the failure path"
+        !root.exists(),
+        "no file should be written to the target root on the failure path"
     );
 }
 
-/// A fresh non-interactive init requires an explicit task prefix.
+/// A fresh non-interactive init requires an explicit task prefix, and rejects
+/// it before writing anything to the target root.
 #[test]
 fn non_interactive_missing_task_prefix_fails_closed() {
     let home = tempdir().expect("home tempdir");
@@ -308,10 +313,17 @@ fn non_interactive_missing_task_prefix_fails_closed() {
 
     let error = init_host(&root, Some("dk-mac"), None).expect_err("missing prefix must fail");
     assert!(error.to_string().contains("--task-prefix"), "{error}");
-    assert!(!root.join("host.toml").exists());
+    assert!(
+        !root.exists(),
+        "no file should be written to the target root on the failure path"
+    );
 }
 
-/// Reserved and malformed fresh task-prefix choices fail before identity write.
+/// Reserved and malformed fresh task-prefix choices fail before any file is
+/// written to the target root — not just before the host identity write. The
+/// 28 skills, 46 activities, 14 jobs, 10 executors, and config.toml all seed
+/// ahead of host identity, so validating the prefix only at that point left a
+/// half-initialized root on a typo [ORB-12112].
 #[test]
 fn invalid_task_prefixes_fail_closed() {
     for prefix in ["ORB", "ADR", "L", "F", "de", "D", "ABCDEF", " DE"] {
@@ -320,8 +332,27 @@ fn invalid_task_prefixes_fail_closed() {
         let root = home.path().join(".orbit");
 
         init_host(&root, Some("dk-mac"), Some(prefix)).expect_err("invalid prefix must fail");
-        assert!(!root.join("host.toml").exists(), "prefix {prefix}");
+        assert!(
+            !root.exists(),
+            "prefix {prefix}: no file should be written to the target root on the failure path"
+        );
     }
+}
+
+/// An empty --host-name is rejected on a fresh host before anything is
+/// written to the target root.
+#[test]
+fn empty_host_name_fails_closed() {
+    let home = tempdir().expect("home tempdir");
+    let _env = EnvGuard::acquire().home(home.path());
+    let root = home.path().join(".orbit");
+
+    let error = init_host(&root, Some("   "), Some("DE")).expect_err("blank host name must fail");
+    assert!(error.to_string().contains("host name"), "{error}");
+    assert!(
+        !root.exists(),
+        "no file should be written to the target root on the failure path"
+    );
 }
 
 /// Ordinary CLI `orbit init` (refresh_defaults, no --force) must keep an


### PR DESCRIPTION
## Task

[ORB-12112](https://orbit-cli.com/tasks/ORB-12112) — orbit init seeds the global root before validating --task-prefix, leaving a partial root on failure

### Description

Found during a full QA sweep of orbit 0.20.0 on the Mac mini (2026-09-10).


 ```
 orbit init --root /tmp/fresh --non-interactive --host-name x --task-prefix abc
 # error: invalid input: task prefix must be 2-5 uppercase ASCII letters
 ls /tmp/fresh   # resources/  skills/  config.toml   (no host.toml)
 ```

 The 28 skills, 46 activities, 14 jobs, 10 executors and `config.toml` are all written before
 the prefix is checked, so a typo leaves a rootless half-initialized directory with no host
 identity. Re-running with a valid prefix does recover, so this is a tidiness/least-surprise
 issue rather than a corruption one.

 ## Expected
 Validate `--task-prefix` and `--host-name` before any file is written.

### Acceptance Criteria

- A rejected `--task-prefix` or `--host-name` writes nothing to the target root
- A valid init is unchanged, including the idempotent re-init path
- Test asserts the target directory is untouched after a rejected prefix

## Execution Summary

<details>
<summary>Click to expand</summary>

Root cause: `InitCommand::run` (crates/orbit-cli/src/command/init/command.rs) called `init_global` (writes skills/resources/config.toml) before `ensure_host_identity_for_init` validated `--host-name`/`--task-prefix`, so a rejected or (non-interactively) missing flag still left a half-initialized `.orbit` root.

Fix: added `reject_invalid_fresh_identity_inputs`, called at the top of `run()` before any write. It resolves the global root and calls the existing read-only `orbit_registry::inspect_host_identity` (safe even when the root doesn't exist yet — returns `Absent`). Only when the identity is `Absent` (a fresh host — a present/legacy identity ignores these flags entirely, so the idempotent re-init path is unaffected) does it validate the supplied flags via a new shared helper `validate_fresh_identity_flags`, which now also runs inside `ensure_host_identity_for_init`'s creation closure (replacing that closure's previous duplicated inline checks) so the closure stays correct standalone against a racing concurrent create. No new dependency edges; both crates were already used here.

Acceptance criteria:
1. "A rejected --task-prefix or --host-name writes nothing to the target root" — met: validation now runs strictly before `collect_config_seed_for_init`/`init_global`.
2. "A valid init is unchanged, including the idempotent re-init path" — met: the Absent-state gate means a present/legacy identity (repeat init) never invokes the new validation, matching prior behavior exactly.
3. "Test asserts the target directory is untouched after a rejected prefix" — met: strengthened `invalid_task_prefixes_fail_closed`, `non_interactive_missing_host_name_fails_closed`, `non_interactive_missing_task_prefix_fails_closed` to assert `!root.exists()` (previously only checked `host.toml`), and added `empty_host_name_fails_closed` for the blank-name case.

Validation:
- `cargo build -p orbit-cli`: passed.
- `cargo clippy -p orbit-cli --all-targets -- -D warnings`: passed, no warnings.
- `cargo fmt -p orbit-cli -- --check`: passed.
- `cargo test -p orbit-cli --bin orbit` (full crate, 501 tests incl. the 9 init tests): all passed.
- `make ci-fast`: passed.
- `make ci-lint` (workspace clippy, all targets, warnings denied): passed, no warnings.
- Manually reproduced the original bug pre-fix (confirmed config.toml/skills/resources were written despite a rejected/missing prefix) and confirmed it no longer reproduces post-fix.

Scope: only the two context_files were touched (crates/orbit-cli/src/command/init/command.rs, crates/orbit-cli/src/command/tests/init.rs). No unrelated files changed. `git status --short` shows only these two modified files; `git diff --check` is clean.

No blockers, no friction filed (straightforward root-cause fix, no contradicted assumptions or >10min gotchas). Changes left uncommitted per pipeline ownership of commit/PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12112-6aa376f8`
- Behind base: 0
- Ahead of base: 1