### PR TITLE
docs(website): Routines and Auto-Tasks concept, changelog page, task-link landing

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -42,9 +42,12 @@ not by the Pages artifact. Daniel owns the corresponding post-publication
 checks for HSTS and redirects. See the [website validation runbook](../docs/runbooks/website-validation.md)
 for local evidence and manual-publication verification.
 
-Every published page is authored by hand under `src/content/docs/`. Nothing on
-this site is generated at build time, so `npm run build` is a pure function of
-the tracked sources. Before website commands run, a cleanup hook removes the
+Every published page is authored by hand under `src/content/docs/`, with two
+exceptions under `src/pages/`: `/changelog/` renders the repository's tracked
+`CHANGELOG.md` so the site never carries a drifting copy, and `/tasks/` is the
+landing for the task links Orbit mints into pull requests (`public/_redirects`
+sends `/tasks/<id>` there). Nothing on this site is fetched or generated at
+build time, so `npm run build` is a pure function of the tracked sources. Before website commands run, a cleanup hook removes the
 retired generated `src/content/docs/metrics/` directory left by older checkouts.
 Do not author pages in that reserved directory. This hook does not generate
 content.

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -3,6 +3,12 @@ import starlight from '@astrojs/starlight';
 
 export default defineConfig({
   site: 'https://orbit-cli.com',
+  vite: {
+    // src/pages/changelog.astro imports the repository's CHANGELOG.md, one
+    // directory above the site root; the dev server refuses that path unless
+    // it is allow-listed. The build resolves it without this.
+    server: { fs: { allow: ['..'] } },
+  },
   integrations: [
     starlight({
       title: 'Orbit',
@@ -65,6 +71,7 @@ export default defineConfig({
             { slug: 'concepts', label: 'Overview' },
             { slug: 'concepts/tasks', label: 'Tasks' },
             { slug: 'concepts/activities-jobs', label: 'Activities and Jobs' },
+            { slug: 'concepts/scheduling', label: 'Routines and Auto-Tasks' },
             { slug: 'concepts/policies', label: 'Policies' },
             { slug: 'concepts/agents', label: 'Agents' },
           ],
@@ -102,6 +109,10 @@ export default defineConfig({
             { slug: 'contributing/crate-layout', label: 'Crate Layout' },
             { slug: 'contributing/pr-workflow', label: 'PR Workflow' },
           ],
+        },
+        {
+          label: 'Releases',
+          items: [{ label: 'Changelog', link: '/changelog/' }],
         },
       ],
       head: [

--- a/website/public/_redirects
+++ b/website/public/_redirects
@@ -1,0 +1,6 @@
+# Orbit mints `/tasks/<id>` links into pull-request descriptions, but task
+# records are workspace-local and never published here. Land those links on the
+# explainer page with the ID preserved. `:id` matches one path segment, so
+# `/tasks/` itself is not rewritten. A true 410 needs a zone rule, which this
+# artifact does not own.
+/tasks/:id  /tasks/?id=:id  302

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -13,6 +13,7 @@ import Default from '@astrojs/starlight/components/Footer.astro';
       <a href="/getting-started/">Docs</a>
       <a href="/reference/cli/">Reference</a>
       <a href="/how-to/">How-to</a>
+      <a href="/changelog/">Changelog</a>
       <a href="https://github.com/constellation-works/orbit">GitHub</a>
     </nav>
   </div>

--- a/website/src/content/docs/concepts/activities-jobs.md
+++ b/website/src/content/docs/concepts/activities-jobs.md
@@ -27,7 +27,7 @@ are all included in the same union. The effective list is included in the CLI en
 
 ## Job
 
-A job is a workflow. It has schedule state, optional default input, concurrency limits, and ordered steps.
+A job is a workflow. It has schedule state, optional default input, concurrency limits, and ordered steps. A job runs when something invokes it — `orbit run`, a task ship, or a [routine](../scheduling/#routine) firing on the sweep clock.
 
 Step bodies can reference an activity, inline an activity spec, or compose control flow:
 

--- a/website/src/content/docs/concepts/index.md
+++ b/website/src/content/docs/concepts/index.md
@@ -1,27 +1,64 @@
 ---
 title: Concepts
-description: "The core Orbit concepts: tasks, activities, jobs, policies, and agent runtimes."
+description: "The core Orbit concepts: tasks, activities and jobs, routines and auto-tasks, policies, and agent runtimes."
 sidebar:
   order: 1
 ---
 
-## Map
+Orbit is a small number of primitives arranged in layers. Each layer answers
+one question, and each page below describes one layer's contract — what it
+guarantees, what it refuses, and why. For the commands, see the
+[how-to guides](../how-to/).
+
+<nav class="orbit-stack" aria-label="Orbit layers, top to bottom">
+  <a class="orbit-stack-layer" href="./scheduling/">
+    <span class="orbit-stack-q">When</span>
+    <span class="orbit-stack-name">Routines and auto-tasks</span>
+    <span class="orbit-stack-desc">Fire jobs on a cadence; mint recurring chores as tasks.</span>
+  </a>
+  <a class="orbit-stack-layer" href="./tasks/">
+    <span class="orbit-stack-q">What</span>
+    <span class="orbit-stack-name">Tasks</span>
+    <span class="orbit-stack-desc">The durable, reviewable unit of work.</span>
+  </a>
+  <a class="orbit-stack-layer" href="./activities-jobs/">
+    <span class="orbit-stack-q">How</span>
+    <span class="orbit-stack-name">Activities and jobs</span>
+    <span class="orbit-stack-desc">Reusable execution units and the workflows that compose them.</span>
+  </a>
+  <a class="orbit-stack-layer" href="./agents/">
+    <span class="orbit-stack-q">Who</span>
+    <span class="orbit-stack-name">Agents</span>
+    <span class="orbit-stack-desc">Provider CLIs, executors, and the crews tasks run under.</span>
+  </a>
+  <a class="orbit-stack-layer orbit-stack-layer-guard" href="./policies/">
+    <span class="orbit-stack-q">Bounds</span>
+    <span class="orbit-stack-name">Policies</span>
+    <span class="orbit-stack-desc">Filesystem guardrails applied to every layer above.</span>
+  </a>
+</nav>
+
+## Pages
 
 <div class="orbit-card-grid">
-  <a class="orbit-card" href="./tasks/">
+  <a class="orbit-card" href="./tasks/" data-tag="01">
     <h3>Tasks</h3>
-    <p>The durable unit of work.</p>
+    <p>Lifecycle, statuses, the two human approval gates, and the invariants transitions must respect.</p>
   </a>
-  <a class="orbit-card" href="./activities-jobs/">
+  <a class="orbit-card" href="./activities-jobs/" data-tag="02">
     <h3>Activities and Jobs</h3>
-    <p>The execution model behind task shipping.</p>
+    <p>Typed execution units, the orchestration grammar, and how task requirements reach a run.</p>
   </a>
-  <a class="orbit-card" href="./policies/">
+  <a class="orbit-card" href="./scheduling/" data-tag="03">
+    <h3>Routines and Auto-Tasks</h3>
+    <p>The sweep clock, versioned triggers, recurring chores as data, and what unattended never gets.</p>
+  </a>
+  <a class="orbit-card" href="./policies/" data-tag="04">
     <h3>Policies</h3>
-    <p>Filesystem guardrails for runtime execution.</p>
+    <p>Filesystem profiles and the deny rules that bound runtime execution.</p>
   </a>
-  <a class="orbit-card" href="./agents/">
+  <a class="orbit-card" href="./agents/" data-tag="05">
     <h3>Agents</h3>
-    <p>CLI and HTTP-backed agent execution.</p>
+    <p>Provider CLIs and executors, tool allowlists, and crews — the named provider-model assignments tasks run under.</p>
   </a>
 </div>

--- a/website/src/content/docs/concepts/policies.md
+++ b/website/src/content/docs/concepts/policies.md
@@ -2,7 +2,7 @@
 title: Policies
 description: "How Orbit uses filesystem profiles and global deny rules to scope execution."
 sidebar:
-  order: 4
+  order: 5
 ---
 
 ## Definition

--- a/website/src/content/docs/concepts/scheduling.md
+++ b/website/src/content/docs/concepts/scheduling.md
@@ -1,0 +1,169 @@
+---
+title: Routines and Auto-Tasks
+description: "How Orbit schedules unattended work: the sweep clock, routines that fire jobs, and auto-tasks that mint recurring chores as tasks."
+sidebar:
+  order: 4
+---
+
+Tasks describe work and jobs execute it, but neither says *when*. That is the
+scheduling layer's job. Every scheduled fire, whether it ships a backlog or
+mints a weekly chore, follows the same path:
+
+<ol class="orbit-pipeline" aria-label="How a scheduled fire flows through Orbit">
+  <li>
+    <span class="orbit-pipeline-step">Sweep clock</span>
+    <span class="orbit-pipeline-note">The OS wakes <code>orbit sweep</code></span>
+  </li>
+  <li>
+    <span class="orbit-pipeline-step">Routine</span>
+    <span class="orbit-pipeline-note">Due on this host</span>
+  </li>
+  <li>
+    <span class="orbit-pipeline-step">Job run</span>
+    <span class="orbit-pipeline-note">Ordinary run, ordinary history</span>
+  </li>
+  <li>
+    <span class="orbit-pipeline-step">Auto-task</span>
+    <span class="orbit-pipeline-note">Due templates are minted</span>
+  </li>
+  <li>
+    <span class="orbit-pipeline-step">Task</span>
+    <span class="orbit-pipeline-note">Normal lifecycle</span>
+  </li>
+</ol>
+
+## The sweep clock
+
+`orbit sweep` is the scheduler pass. It is stateless in and durable out: it
+loads every routine definition from the registered workspaces that opt in,
+filters them for the current host, fires whatever is due, records what it did,
+and exits. Nothing in Orbit is scheduled unless that pass runs.
+
+The pass is invoked by the operating system, not by a resident daemon. A
+per-user launchd agent (macOS) or systemd user timer (Linux) calls it once a
+minute by default. That is a deliberate trade: minute granularity is a floor
+and event triggers are not possible, but there is no long-lived process to
+supervise, and a wedged pass costs one minute, not the scheduler.
+
+The clock is host infrastructure, configured per machine and never versioned.
+Pausing it stops scheduled sweeps; a manual `orbit sweep` still works, and no
+individual routine's state changes.
+
+## Routine
+
+A routine is a **versioned trigger**. It is one YAML file under
+`.orbit/routines/`, committed to the repository, that says which job fires, on
+what cadence, on which hosts:
+
+```yaml
+schemaVersion: 1
+name: ship_sweep_myrepo
+enabled: true
+hosts: [hm_alpha]
+trigger:
+  cron: "*/20 * * * *"
+  missed_run: skip
+target: job:workspace_ship_pipeline
+policy:
+  timeout_minutes: 120
+  overlap: forbid
+```
+
+The definition is the whole contract. There is no routine registry, no
+in-memory schedule, and no inline command payload: a target is always a catalog
+reference (`job:<name>`), so what a routine can do is exactly what a reviewed
+job can do. To fire a single activity on a schedule, wrap it in a one-step job.
+
+Invariants that shape how routines behave:
+
+- **Explicit hosts.** `hosts` is required and there is no "any host" value.
+  Definitions travel with the repository, so this is how one routine avoids
+  firing on every machine that has a checkout.
+- **Versioned enable, host-local pause.** `enabled` lives in the file and is a
+  reviewed change; `orbit routine pause` is a per-host override that is never
+  synced and survives reboots. Use pause for "not on this machine right now",
+  and `enabled: false` to retire a routine everywhere.
+- **Missed slots collapse.** When a host was asleep through several due slots,
+  `missed_run: skip` waits for the next natural slot and `catch_up_once` fires a
+  single make-up run. Neither replays every missed tick.
+- **Overlap is forbidden by default.** A due fire is skipped while the previous
+  one is in flight; `timeout_minutes` is also the staleness horizon after which
+  a stuck fire stops blocking the next.
+- **Seeded disabled.** `orbit init` writes a default set — task pilot, ship
+  sweep, auto-task scheduler, triage, worktree GC, CI and dependency alert
+  sweeps — every one `enabled: false`. Enabling unattended agent work is an
+  explicit, versioned decision.
+
+All scheduler state — last fire, cursor, pause, run history — is host-local.
+Two hosts sharing a repository share the definitions and nothing else.
+
+## Auto-task
+
+An auto-task is a **task template with a schedule**. Where a routine answers
+"which job fires, and when", an auto-task answers "which recurring chore should
+become a task". It is one YAML file under `.orbit/auto_tasks/`, managed through
+`orbit auto-task`, carrying a cadence, an `enabled` toggle, a dedupe policy, and
+the task it should produce: title, body, acceptance criteria, type, priority,
+tags, crew, required tools.
+
+The mechanism that turns definitions into tasks is deliberately generic. One
+seeded routine, `auto_task_scheduler`, fires the `auto_task_scheduler_pipeline`
+job every minute; that job reads every enabled definition and mints a task from
+each one that is due. Because each definition carries its own schedule, the
+minutely routine is cheap and idempotent, and adding a recurring chore is a new
+definition — never new code and never a new routine.
+
+Invariants that shape how auto-tasks behave:
+
+- **A minted task is an ordinary task.** It enters at the status the definition
+  declares — `backlog` by default, or `proposed` when each instance should be
+  approved by a human — and then follows the normal lifecycle. It carries an
+  `auto-task:<name>` provenance tag.
+- **Dedupe by default.** `skip-if-open` skips a fire while a previous instance
+  is still open, which is what keeps a stalled backlog from accumulating twenty
+  identical chores. `always` opts out per definition.
+- **Manual mint is unconditional and cursor-inert.** `orbit auto-task mint`
+  ignores the schedule, the dedupe policy, and `enabled`, and never moves the
+  scheduler's cursor — so trying a definition never shifts its next fire.
+- **Catch-up collapses.** A downtime gap mints one make-up task, not one per
+  missed slot.
+- **Seeded disabled.** Orbit embeds a small default catalog (QA sweep, friction
+  curation, security review, code review), materialized on init with
+  `enabled: false`. Seeding never mints a task.
+
+## Why both exist
+
+Routines and auto-tasks sit at different heights of the same stack, and it is
+tempting to collapse them. They stay separate because they schedule different
+kinds of thing.
+
+| | Routine | Auto-task |
+|---|---|---|
+| Schedules | A job | A task |
+| Question | Which job, when, on which host? | Which chore becomes a task? |
+| Fires through | `orbit sweep` directly | The generic scheduler routine |
+| Lives in | `.orbit/routines/*.yaml` | `.orbit/auto_tasks/*.yaml` |
+| Adding one means | A new versioned trigger | A new definition, no new trigger |
+| Output | A run in job history | A task in the backlog |
+
+A routine is the right tool when the work is a fixed pipeline — ship what is
+ready, collect worktrees, sweep CI failures — that should just run. An auto-task
+is the right tool when the work is a chore an agent should *reason about* — a
+weekly dependency audit, a daily friction pass — and whose outcome a human may
+want to review as a task. The auto-task path also gets task semantics for free:
+approval gates, dedupe against open instances, review, and audit history.
+
+## What unattended never gets
+
+Scheduling changes *when* work starts, not *what it is allowed to do*. Two
+authorities stay with humans regardless of how a task was created or fired:
+
+- **Entry into the backlog** for a `proposed` task is always a human decision.
+  An auto-task can mint into `proposed`, but nothing scheduled approves it.
+- **Completion out of `review`** can only be granted with `--complete` on an
+  explicit invocation. No workspace setting, environment variable, or routine
+  turns it on; unattended shipment always leaves work in `review`.
+
+See [Tasks](../tasks/#approval) for the two gates, and
+[Schedule Recurring Work](../../how-to/recurring-work/) for installing the
+clock, enabling routines, and writing definitions.

--- a/website/src/content/docs/concepts/tasks.md
+++ b/website/src/content/docs/concepts/tasks.md
@@ -48,10 +48,11 @@ These two gates are independent, and so is the authority that can satisfy them:
   `--complete`, which never reaches back and approves `proposed` work. See
   [Completing work with `--complete`](../../getting-started/workflows/#completing-work-with---complete).
 
-Recurring work minted by an [auto-task
-definition](../../how-to/recurring-work/#3-define-recurring-chores-as-auto-tasks)
-enters at whichever status that definition declares — `backlog` by default, or
-`proposed` when you want to review each instance.
+Recurring work minted by an [auto-task](../scheduling/#auto-task) enters at
+whichever status its definition declares — `backlog` by default, or `proposed`
+when you want to review each instance. See [Schedule Recurring
+Work](../../how-to/recurring-work/#3-define-recurring-chores-as-auto-tasks) for
+defining one.
 
 ### Statuses
 

--- a/website/src/content/docs/how-to/recurring-work.md
+++ b/website/src/content/docs/how-to/recurring-work.md
@@ -10,10 +10,12 @@ Orbit has two layers of scheduling, and they answer different questions.
 | Layer | Question it answers | Where it lives |
 |---|---|---|
 | **Routines** | *Which job should fire, on what cadence, on which host?* | Versioned YAML in `.orbit/routines/` |
-| **Auto-tasks** | *Which recurring chore should become a task?* | Definitions managed by `orbit auto-task` |
+| **Auto-tasks** | *Which recurring chore should become a task?* | Versioned YAML in `.orbit/auto_tasks/`, managed by `orbit auto-task` |
 
 Both are driven by the same clock: `orbit sweep`. Nothing is scheduled until
-that clock runs.
+that clock runs. This guide is the operating procedure; the model behind it —
+why the layers are separate and what each one guarantees — is in
+[Routines and Auto-Tasks](../../concepts/scheduling/).
 
 ## 1. Start the sweep clock
 

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -1,0 +1,36 @@
+---
+// The public "what shipped" surface. It renders the repository's tracked
+// CHANGELOG.md directly so the site never carries a second, drifting copy;
+// the file is compiled at release time (see RELEASING.md), so this page only
+// ever describes released behavior. The build stays a pure function of tracked
+// sources — the import is resolved at build time, nothing is fetched.
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import { Content as ChangelogContent, getHeadings } from '../../../CHANGELOG.md';
+
+// The changelog's own H1 ("Changelog") duplicates the page title; the release
+// sections underneath it are the useful table of contents.
+const headings = getHeadings().filter((heading) => heading.depth >= 2);
+---
+
+<StarlightPage
+  frontmatter={{
+    title: 'Changelog',
+    description: 'Every released Orbit version, newest first, with breaking changes and highlights.',
+    tableOfContents: { minHeadingLevel: 2, maxHeadingLevel: 2 },
+  }}
+  headings={headings}
+>
+  <p>
+    Releases tag on <code>agent-main</code> and merge to <code>main</code>. Each entry below is
+    compiled from the work merged for that version. Task IDs in brackets identify the Orbit task
+    a change was delivered under; searching one on <a
+      href="https://github.com/constellation-works/orbit/pulls?q=is%3Apr+is%3Amerged"
+      >GitHub</a
+    > finds its pull request. Install the current release from <a
+      href="/getting-started/install/">Install Orbit</a
+    >.
+  </p>
+  <div class="orbit-changelog">
+    <ChangelogContent />
+  </div>
+</StarlightPage>

--- a/website/src/pages/tasks/index.astro
+++ b/website/src/pages/tasks/index.astro
@@ -1,0 +1,50 @@
+---
+// Landing for the task links Orbit mints into pull-request descriptions
+// (`[pr] task_url_template`). Task records are workspace-local and are not
+// published, so `/tasks/<id>` used to be a dead surface. `public/_redirects`
+// sends those links here with the ID as a query parameter; the page explains
+// what the ID is and where the delivery can actually be found.
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+---
+
+<StarlightPage
+  frontmatter={{
+    title: 'Task records are not published',
+    description:
+      'Orbit task IDs in pull requests point at workspace-local state. Find the delivery on GitHub instead.',
+    tableOfContents: false,
+  }}
+>
+  <p>
+    You followed a link of the form <code>orbit-cli.com/tasks/&lt;id&gt;</code>. Orbit writes
+    those links into pull-request descriptions so a merged change stays attributable to the
+    task it was delivered under. The task record itself lives in the owning repository's
+    <code>.orbit/</code> state and is not published on this site.
+  </p>
+  <p class="orbit-task-lookup" hidden>
+    Looking for <code data-task-id></code>? Its merged pull request is on <a
+      data-task-search
+      href="https://github.com/constellation-works/orbit/pulls?q=is%3Apr+is%3Amerged">GitHub</a
+    >, and the release that shipped it is in the <a href="/changelog/">changelog</a>.
+  </p>
+  <p>
+    To see what an ID delivered, search merged pull requests for it, or open the
+    <a href="/changelog/">changelog</a>, where each entry cites the task IDs it was compiled from.
+    To inspect a task record in a workspace you have access to, run
+    <code>orbit task show &lt;id&gt;</code>. See <a href="/concepts/tasks/">Tasks</a> for what a
+    record contains.
+  </p>
+</StarlightPage>
+
+<script>
+  // The redirect carries the original ID as `?id=`. Only a well-formed task ID
+  // is echoed back into the page, and only into text and a URL-encoded query.
+  const id = new URLSearchParams(window.location.search).get('id') ?? '';
+  const lookup = document.querySelector<HTMLElement>('.orbit-task-lookup');
+  if (lookup && /^[A-Z][A-Z0-9]{1,15}-\d{1,8}$/.test(id)) {
+    lookup.querySelector('[data-task-id]')!.textContent = id;
+    const search = lookup.querySelector<HTMLAnchorElement>('[data-task-search]')!;
+    search.href = `https://github.com/constellation-works/orbit/pulls?q=${encodeURIComponent(`is:pr is:merged "${id}"`)}`;
+    lookup.hidden = false;
+  }
+</script>

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -1189,6 +1189,164 @@ html:not([data-has-sidebar]) header.header {
   }
 }
 
+/* The changelog page renders the repository's CHANGELOG.md verbatim. Its own
+   H1 duplicates the page title, so it is hidden rather than edited out — the
+   file stays byte-identical to what a release compiles. */
+.orbit-changelog > h1 {
+  display: none;
+}
+
+.orbit-changelog > h2 {
+  border-top: 1px solid var(--sl-color-hairline-light);
+  font-family: var(--sl-font-mono);
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+}
+
+/* Concept-page diagrams. Both are plain HTML so they inherit the theme tokens
+   and stay readable to screen readers; neither depends on JavaScript. */
+
+/* The layer stack on the Concepts overview: one row per layer, top to bottom,
+   with the question each layer answers pinned in the left column. */
+.orbit-stack {
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  margin: 1.5rem 0 2rem;
+  overflow: hidden;
+}
+
+.orbit-stack > * {
+  margin-top: 0;
+}
+
+.orbit-stack-layer {
+  align-items: baseline;
+  background: var(--sl-color-bg-inline-code);
+  border-bottom: 1px solid var(--sl-color-hairline-light);
+  color: var(--sl-color-text);
+  column-gap: 1.25rem;
+  display: grid;
+  grid-template-columns: 5rem minmax(0, 12rem) minmax(0, 1fr);
+  padding: 0.85rem 1.25rem;
+  text-decoration: none;
+  transition: background-color 150ms ease;
+}
+
+.orbit-stack-layer:last-child {
+  border-bottom: 0;
+}
+
+.orbit-stack-layer:hover,
+.orbit-stack-layer:focus-visible {
+  background: var(--sl-color-accent-low);
+}
+
+.orbit-stack-layer:focus-visible {
+  outline: 2px solid var(--sl-color-accent);
+  outline-offset: -2px;
+}
+
+.orbit-stack-layer:hover .orbit-stack-name,
+.orbit-stack-layer:focus-visible .orbit-stack-name {
+  color: var(--sl-color-text-accent);
+}
+
+/* Policies wrap every other layer rather than sitting under them; a top rule
+   in the accent colour marks it as the boundary instead of the next step. */
+.orbit-stack-layer-guard {
+  background: var(--sl-color-bg);
+  border-top: 2px solid var(--sl-color-accent);
+}
+
+.orbit-stack-q {
+  color: var(--sl-color-text-accent);
+  font-family: var(--sl-font-mono);
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.orbit-stack-name {
+  font-size: 0.95rem;
+  font-weight: 650;
+  transition: color 120ms ease;
+}
+
+.orbit-stack-desc {
+  color: var(--sl-color-gray-3);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+/* The fire path on the scheduling page: an ordered list rendered as a chain
+   of steps, each with a one-line note under it. */
+.orbit-pipeline {
+  counter-reset: orbit-pipeline;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  list-style: none;
+  margin: 1.5rem 0 2rem;
+  padding: 0;
+}
+
+.orbit-pipeline > * {
+  margin-top: 0;
+}
+
+.orbit-pipeline li {
+  background: var(--sl-color-bg-inline-code);
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 6px;
+  counter-increment: orbit-pipeline;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 0;
+  padding: 0.85rem 0.9rem 0.85rem 0.9rem;
+  position: relative;
+}
+
+.orbit-pipeline li::before {
+  color: var(--sl-color-text-accent);
+  content: counter(orbit-pipeline, decimal-leading-zero);
+  font-family: var(--sl-font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+}
+
+/* The connector between steps, drawn in the gap so it never overlaps text. */
+.orbit-pipeline li:not(:last-child)::after {
+  border-color: var(--sl-color-text-accent);
+  border-style: solid;
+  border-width: 1.5px 1.5px 0 0;
+  content: "";
+  height: 0.5rem;
+  position: absolute;
+  right: -0.45rem;
+  top: 50%;
+  transform: translateY(-50%) rotate(45deg);
+  width: 0.5rem;
+}
+
+.orbit-pipeline-step {
+  font-size: 0.92rem;
+  font-weight: 650;
+}
+
+.orbit-pipeline-note {
+  color: var(--sl-color-gray-3);
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
+.orbit-pipeline-note code {
+  font-size: 0.75rem;
+}
+
 @media (max-width: 54rem) {
   .sl-markdown-content table {
     display: block;
@@ -1216,6 +1374,20 @@ html:not([data-has-sidebar]) header.header {
   .orbit-card-grid-4,
   .orbit-docs-index {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  /* Five steps in a row is unreadable this narrow; stack them and turn the
+     connector into a down arrow drawn in the row gap. */
+  .orbit-pipeline {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .orbit-pipeline li:not(:last-child)::after {
+    bottom: -0.45rem;
+    left: 1.25rem;
+    right: auto;
+    top: auto;
+    transform: rotate(135deg);
   }
 
   .orbit-dash-frame {
@@ -1283,6 +1455,15 @@ html:not([data-has-sidebar]) header.header {
     grid-template-columns: 1fr;
   }
 
+  .orbit-stack-layer {
+    grid-template-columns: 4.5rem minmax(0, 1fr);
+    row-gap: 0.2rem;
+  }
+
+  .orbit-stack-desc {
+    grid-column: 2;
+  }
+
   .orbit-flow-tab {
     border-right: 0;
   }
@@ -1307,7 +1488,9 @@ html:not([data-has-sidebar]) header.header {
   .orbit-card h3,
   .orbit-copy,
   .orbit-flow-tab,
-  .orbit-flow-tab-name {
+  .orbit-flow-tab-name,
+  .orbit-stack-layer,
+  .orbit-stack-name {
     transition: none;
   }
 


### PR DESCRIPTION
## Summary

**Concepts gap.** The Concepts section covered tasks → activities/jobs → policies → agents but had nothing on the scheduling layer; routines and auto-tasks were only described procedurally in the recurring-work how-to.

- New `concepts/scheduling` — *Routines and Auto-Tasks*: the sweep clock, the routine contract (versioned trigger, explicit hosts, versioned enable vs host-local pause, missed-slot and overlap semantics, seeded disabled), the auto-task contract (task template with a schedule, generic scheduler routine, dedupe, cursor-inert manual mint), a routine-vs-auto-task comparison, and the two authorities unattended work never gets (backlog entry, `--complete`). Sourced from `docs/design/routines` and `docs/design/auto-tasks`.
- Concepts overview reworked from a bare 4-card grid into a layered map (when / what / how / who / bounds) plus a numbered page grid with real one-line summaries.
- Cross-links: Tasks → scheduling for minted-task entry status; Activities and Jobs → what invokes a job; the how-to now points at the concept page and names `.orbit/auto_tasks/` as where definitions live.

**UI/UX.** Two new theme-aware, JS-free CSS components (`.orbit-stack`, `.orbit-pipeline`) with tablet/phone breakpoints and reduced-motion handling, following the existing `.orbit-card` conventions.

**Public "shipped" surface** (from the site-strategy notes): `/changelog/` renders the tracked `CHANGELOG.md` at build time via a `src/pages` route, so there is no second copy to drift; linked from a new *Releases* sidebar group and the footer of every page.

**Dead `/tasks/<id>` contract.** PR descriptions mint `orbit-cli.com/tasks/{task_id}` links into a surface that doesn't exist. `public/_redirects` now sends `/tasks/:id` to a `/tasks/` explainer that says what the ID is, links a GitHub merged-PR search for it, and points at the changelog. Cloudflare Pages `_redirects` can't emit 410; a true 410 needs a zone rule outside this artifact. Retiring `pr.task_url_template` is a separate decision and not touched here.

## Verification

- `npm run check` — 0 errors / 0 warnings / 0 hints
- `npm run build` — 33 pages; the two content warnings (`i18n` collection, `docs → 404`) are present on `agent-main` too
- `npm run validate:security-txt -- dist/.well-known/security.txt` — valid
- Site-wide internal link + anchor check over `dist/` — all resolve
- Browser: concepts overview, scheduling page, changelog, `/tasks/?id=ORB-11598` checked in dark and light, desktop and 375px mobile
- `make ci-fast` — `test_full_invokes_cargo_deny_guard` fails; it fails identically on `agent-main` (`scripts/` untouched by this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
