### PR TITLE
Reject unassessed complexity on human/agent task.update surfaces

### DIFF
--- a/crates/orbit-cli/src/command/task/tests/update.rs
+++ b/crates/orbit-cli/src/command/task/tests/update.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, error::ErrorKind};
+use clap::{CommandFactory, Parser, error::ErrorKind};
 
 use crate::command::{Cli, Commands};
 
@@ -191,6 +191,36 @@ fn task_update_complexity_uses_add_spellings() {
 
         assert_eq!(args.complexity.expect("complexity").to_string(), complexity);
     }
+}
+
+/// ORB-12116: `unassessed` is reserved for automated creation, so clap must not
+/// offer it on update either — matching `orbit task add`.
+#[test]
+fn task_update_rejects_unassessed_complexity() {
+    assert!(
+        Cli::try_parse_from([
+            "orbit",
+            "task",
+            "update",
+            "ORB-00001",
+            "--complexity",
+            "unassessed",
+        ])
+        .is_err(),
+        "unassessed is not a CLI update value"
+    );
+
+    let mut command = Cli::command();
+    let update = command
+        .find_subcommand_mut("task")
+        .expect("task command")
+        .find_subcommand_mut("update")
+        .expect("task update command");
+    let rendered = update.render_long_help().to_string();
+    assert!(
+        !rendered.contains("unassessed"),
+        "unassessed is reserved for automated creation: {rendered}"
+    );
 }
 
 #[test]

--- a/crates/orbit-core/assets/skills/orbit/references/task-authoring.md
+++ b/crates/orbit-core/assets/skills/orbit/references/task-authoring.md
@@ -21,8 +21,9 @@ Every `orbit.task.*` call needs `model` — your agent family. Never use bare
    inspection step, or an output. "Works correctly" is not a criterion.
 4. **Optionally fill `context_files`** (see below).
 5. **Set `complexity`** (`low` / `medium` / `hard`). It is required at
-   creation. `unassessed` is reserved for automated mint/import and is not
-   an operator create value.
+   creation and on every human or agent update — `orbit.task.update`, `orbit
+   task update`, and the dashboard all reject `unassessed`, which is reserved
+   for automated mint/import and system callers.
 6. **Add assumptions, risks, and rollback notes** to the description when they
    matter.
 7. **Call `orbit.task.add`.** Confirm via the result, or re-fetch with
@@ -65,6 +66,9 @@ job fills them from real inspection. → [orchestration.md](orchestration.md)
   allocates them).
 - Required: `title`, `description`, `workspace`, `complexity`. Strongly prefer
   `acceptance_criteria`.
+- `complexity` stays assessed for its whole life: an update may move it between
+  `low`, `medium`, and `hard`, but a human or agent can never set it back to
+  `unassessed`.
 - `description` should be multi-line markdown for anything non-trivial.
 - Valid `type`: `feature`, `bug`, `refactor`, `chore`.
 - Do not pass `plan` to task creation; author it later through task update.

--- a/crates/orbit-core/src/adapter/tool_host/input.rs
+++ b/crates/orbit-core/src/adapter/tool_host/input.rs
@@ -303,14 +303,15 @@ pub(super) fn parse_task_priority(field: &str, raw: &str) -> Result<TaskPriority
         .map_err(|error| OrbitError::InvalidInput(format!("`{field}` {error}")))
 }
 
-pub(super) fn parse_task_complexity(field: &str, raw: &str) -> Result<TaskComplexity, OrbitError> {
+fn parse_task_complexity(field: &str, raw: &str) -> Result<TaskComplexity, OrbitError> {
     TaskComplexity::from_str(raw)
         .map_err(|error| OrbitError::InvalidInput(format!("`{field}` {error}")))
 }
 
-/// Parse a complexity that a human or agent may assign at create time.
+/// Parse a complexity that a human or agent may assign on create or update.
 ///
-/// [`TaskComplexity::Unassessed`] is reserved for automated mint/import.
+/// [`TaskComplexity::Unassessed`] is reserved for automated mint/import, so an
+/// agent cannot pass the create assessment and then clear it one update later.
 pub(super) fn parse_assessed_task_complexity(
     field: &str,
     raw: &str,

--- a/crates/orbit-core/src/adapter/tool_host/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/task_tools.rs
@@ -11,8 +11,7 @@ use crate::application::task::{TaskAddParams, TaskUpdateParams, compute_task_add
 
 use super::input::{
     empty_string_to_none, optional_bool_alias, parse_artifacts, parse_assessed_task_complexity,
-    parse_relations, parse_task_complexity, parse_task_priority, parse_task_status,
-    parse_task_type,
+    parse_relations, parse_task_priority, parse_task_status, parse_task_type,
 };
 use super::json::{
     serialize_task, serialize_task_artifact_read, serialize_task_lint_report, task_fields_to_json,
@@ -333,7 +332,7 @@ pub(super) fn update(
                 .map(|value| parse_task_priority("priority", &value))
                 .transpose()?,
             complexity: optional_string(&input, "complexity")?
-                .map(|value| parse_task_complexity("complexity", &value))
+                .map(|value| parse_assessed_task_complexity("complexity", &value))
                 .transpose()?,
             task_type: optional_string_alias(&input, &["type", "task_type", "taskType"])?
                 .map(|value| parse_task_type("type", &value))

--- a/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use orbit_store::maintenance::task_registry::read_workspace_config;
-use orbit_types::task::{TASK_SHOW_PUBLIC_DTO_FIELDS, TaskStatus};
+use orbit_types::task::{TASK_SHOW_PUBLIC_DTO_FIELDS, TaskComplexity, TaskStatus};
 use orbit_types::tool::ToolSessionContext;
 use serde_json::{Value, json};
 
@@ -764,6 +764,81 @@ fn task_update_tool_persists_complexity_without_adding_history() {
         )
         .expect("update omitting complexity succeeds");
     assert_eq!(omitted.get("complexity"), Some(&json!("medium")));
+}
+
+/// ORB-12116: the create-time assessment contract also holds on update, so an
+/// agent cannot assess a task at creation and clear it one call later.
+#[test]
+fn task_update_tool_rejects_unassessed_complexity_and_keeps_the_stored_value() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let added = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Assessed on create",
+                "description": "Update must not be able to undo the assessment.",
+                "complexity": "low",
+                "workspace": ".",
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task add tool succeeds");
+    let task_id = added["id"].as_str().expect("task id");
+
+    let message = invalid_input_message(runtime.execute_tool_command(
+        "orbit.task.update",
+        json!({ "id": task_id, "complexity": "unassessed" }),
+        Some("codex".to_string()),
+        Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+    ));
+    assert_eq!(
+        message,
+        TaskComplexity::Unassessed
+            .require_assessed()
+            .expect_err("unassessed is not an assessed value")
+    );
+
+    let shown = runtime
+        .execute_tool_command(
+            "orbit.task.show",
+            json!({ "id": task_id }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task show succeeds");
+    assert_eq!(
+        shown.get("complexity"),
+        Some(&json!("low")),
+        "a rejected update leaves the stored complexity alone"
+    );
+}
+
+/// Automated callers write through the application layer, not the tool
+/// surface, so task-pilot, auto-task mint and other system paths keep the
+/// ability to store the explicit non-answer.
+#[test]
+fn automated_update_paths_may_still_store_unassessed_complexity() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task = create_task(
+        &runtime,
+        &repo_root,
+        "System owned complexity",
+        "Automated paths keep the explicit non-answer.",
+        TaskStatus::Backlog,
+        &[],
+    );
+
+    let updated = runtime
+        .update_task(
+            &task.id,
+            crate::application::task::TaskUpdateParams {
+                complexity: Some(TaskComplexity::Unassessed),
+                ..Default::default()
+            },
+        )
+        .expect("application-layer update succeeds");
+    assert_eq!(updated.complexity, Some(TaskComplexity::Unassessed));
 }
 
 /// An MCP session started with `orbit mcp serve --orchestrator <crew>` and

--- a/crates/orbit-types/src/task/model.rs
+++ b/crates/orbit-types/src/task/model.rs
@@ -276,8 +276,10 @@ impl FromStr for TaskPriority {
 /// `Low` / `Medium` / `Hard` are operator assessments. `Unassessed` is the
 /// explicit non-answer for automated creation (auto-task mint, unlabeled
 /// import). It is never a silent stand-in for `Medium`. Human and agent
-/// create surfaces accept only assessed values. Persisted `Task.complexity`
-/// stays `Option` so the historical unlabeled set remains `None`.
+/// create *and update* surfaces accept only assessed values, so an agent
+/// cannot satisfy the create assessment and clear it on the next update.
+/// Persisted `Task.complexity` stays `Option` so the historical unlabeled set
+/// remains `None`.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "snake_case")]
@@ -286,8 +288,8 @@ pub enum TaskComplexity {
     Medium,
     Hard,
     /// Explicit non-answer for automated creation. Not offered on CLI
-    /// `--complexity` (clap skips it) and rejected on human/agent create
-    /// surfaces so agents cannot dodge an assessment.
+    /// `--complexity` (clap skips it) and rejected on human/agent create and
+    /// update surfaces so agents cannot dodge an assessment.
     #[cfg_attr(feature = "clap", value(skip))]
     Unassessed,
 }
@@ -327,7 +329,8 @@ impl TaskComplexity {
         !matches!(self, TaskComplexity::Unassessed)
     }
 
-    /// Reject [`TaskComplexity::Unassessed`] on human/agent create surfaces.
+    /// Reject [`TaskComplexity::Unassessed`] on human/agent create and update
+    /// surfaces.
     pub fn require_assessed(self) -> Result<Self, String> {
         if self.is_assessed() {
             Ok(self)

--- a/crates/orbit-web/src/api/tasks.rs
+++ b/crates/orbit-web/src/api/tasks.rs
@@ -596,6 +596,14 @@ pub(super) async fn update_task_action(
     ) {
         return response;
     }
+    let complexity = match body
+        .complexity
+        .map(TaskComplexity::require_assessed)
+        .transpose()
+    {
+        Ok(complexity) => complexity,
+        Err(message) => return bad_request(message),
+    };
     let model = body.model.as_deref().and_then(non_empty_string);
     let params = TaskUpdateParams {
         title: body.title,
@@ -609,7 +617,7 @@ pub(super) async fn update_task_action(
         comment: body.comment,
         status: body.status,
         priority: body.priority,
-        complexity: body.complexity,
+        complexity,
         task_type: body.task_type,
         source_task_id: None,
         planned_by: None,

--- a/crates/orbit-web/src/api/tests/tasks.rs
+++ b/crates/orbit-web/src/api/tests/tasks.rs
@@ -1810,6 +1810,42 @@ async fn create_task_requires_assessed_complexity() {
     );
 }
 
+/// ORB-12116: update carries the same contract as create, so an operator or
+/// agent cannot assess a task and then clear the assessment through PATCH.
+#[tokio::test]
+async fn update_task_requires_assessed_complexity() {
+    let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
+    let task = seed_backlog_task(&runtime, "Assessed through PATCH");
+
+    let assessed = patch_task(runtime.clone(), &task.id, json!({ "complexity": "medium" })).await;
+    assert_eq!(assessed.status(), StatusCode::OK);
+
+    let unassessed = patch_task(
+        runtime.clone(),
+        &task.id,
+        json!({ "complexity": "unassessed" }),
+    )
+    .await;
+    assert_eq!(unassessed.status(), StatusCode::BAD_REQUEST);
+    let message = body_json(unassessed).await["error"]
+        .as_str()
+        .expect("error message")
+        .to_string();
+    assert_eq!(
+        message,
+        TaskComplexity::Unassessed
+            .require_assessed()
+            .expect_err("unassessed is not an assessed value"),
+        "update must reuse the create error"
+    );
+
+    assert_eq!(
+        runtime.get_task(&task.id).expect("read task").complexity,
+        Some(TaskComplexity::Medium),
+        "a rejected update leaves the stored complexity alone"
+    );
+}
+
 /// ORB-10648: the same contract on create — `POST /api/tasks` no longer absorbs
 /// keys it cannot apply. The tailored `workspace` diagnostic (ORB-00042) still
 /// wins for that key, since it is a declared trap field.

--- a/plugin/skills/orbit/references/task-authoring.md
+++ b/plugin/skills/orbit/references/task-authoring.md
@@ -21,8 +21,9 @@ Every `orbit.task.*` call needs `model` — your agent family. Never use bare
    inspection step, or an output. "Works correctly" is not a criterion.
 4. **Optionally fill `context_files`** (see below).
 5. **Set `complexity`** (`low` / `medium` / `hard`). It is required at
-   creation. `unassessed` is reserved for automated mint/import and is not
-   an operator create value.
+   creation and on every human or agent update — `orbit.task.update`, `orbit
+   task update`, and the dashboard all reject `unassessed`, which is reserved
+   for automated mint/import and system callers.
 6. **Add assumptions, risks, and rollback notes** to the description when they
    matter.
 7. **Call `orbit.task.add`.** Confirm via the result, or re-fetch with
@@ -65,6 +66,9 @@ job fills them from real inspection. → [orchestration.md](orchestration.md)
   allocates them).
 - Required: `title`, `description`, `workspace`, `complexity`. Strongly prefer
   `acceptance_criteria`.
+- `complexity` stays assessed for its whole life: an update may move it between
+  `low`, `medium`, and `hard`, but a human or agent can never set it back to
+  `unassessed`.
 - `description` should be multi-line markdown for anything non-trivial.
 - Valid `type`: `feature`, `bug`, `refactor`, `chore`.
 - Do not pass `plan` to task creation; author it later through task update.


### PR DESCRIPTION
## Task

[ORB-12116](https://orbit-cli.com/tasks/ORB-12116) — Reject unassessed complexity on human/agent task.update surfaces

### Description

Complexity is mandatory on every human/agent task *creation* surface: `orbit.task.add` declares it required and validates via `required_string` (crates/orbit-tools/src/builtin/orbit/task/add.rs:119), the CLI `--complexity` is a non-optional clap enum with `Unassessed` skipped (crates/orbit-cli/src/command/task/add.rs:57, crates/orbit-types/src/task/model.rs:291), and the web create handler calls `TaskComplexity::require_assessed()` (crates/orbit-web/src/api/tasks.rs:543). `TaskComplexity::Unassessed` is reserved for system/automated creation (auto-task mint, `system_created: true` in crates/orbit-core/src/application/task/add.rs:82).

The *update* surfaces do not apply the same rule. Verified live on 2026-09-11: `orbit tool run orbit.task.update --input '{"id":"ORB-12113","complexity":"unassessed","model":"claude"}'` succeeded and the task flipped from `low` to `unassessed` (reverted afterwards). An agent can therefore satisfy the creation check and immediately dodge the assessment one call later, and the pilot pipeline's discovery rule (unassessed complexity) turns that into extra pilot work.

Enforce the creation contract on update: human/agent update surfaces (`orbit.task.update` tool, `orbit task update` CLI, web PATCH handler) must reject `complexity: unassessed` with the existing `require_assessed()` error text. System/automated callers (auto-task mint, task-pilot apply, any `system_created`/system-identity path) keep the ability to write `Unassessed`, matching how creation already distinguishes them. Do not touch `orbit.task.add`, CLI add, or web create — they are already correct.

### Acceptance Criteria

- `orbit tool run orbit.task.update --input '{"id":"<task>","complexity":"unassessed","model":"claude"}'` returns an invalid-input error using the `require_assessed()` message and leaves the stored complexity unchanged
- `orbit task update <id> --complexity unassessed` is rejected by clap (value not offered), consistent with `orbit task add`
- Web task update handler rejects `complexity: "unassessed"` with the same error as the create handler
- System/automated update paths (task-pilot apply, auto-task mint, system-identity callers) can still write `Unassessed`; existing task_pilot_pipeline apply behaviour is unchanged
- Regression tests cover the tool, CLI and web update surfaces (mirroring the existing create tests in crates/orbit-tools/src/builtin/orbit/task/tests/add.rs, crates/orbit-cli/src/command/task/tests/add.rs, crates/orbit-web/src/api/tests/tasks.rs)
- plugin/skills/orbit/references/task-authoring.md states that complexity is required on both create and update for humans and agents, and that `unassessed` is system-only

## Execution Summary

<details>
<summary>Click to expand</summary>

Enforced the create-time complexity contract on the human/agent update surfaces.

Changes
- crates/orbit-core/src/adapter/tool_host/task_tools.rs: the `orbit.task.update` host handler now parses `complexity` with `parse_assessed_task_complexity` (was `parse_task_complexity`), so `unassessed` fails with the `require_assessed()` message before any write.
- crates/orbit-core/src/adapter/tool_host/input.rs: doc updated for the create-or-update contract; `parse_task_complexity` is now private (its only caller is the assessed wrapper).
- crates/orbit-web/src/api/tasks.rs: `update_task_action` (PATCH /api/tasks/:id) runs `TaskComplexity::require_assessed()` on the optional body field and returns the same 400 text as the create handler.
- crates/orbit-types/src/task/model.rs: docs on `TaskComplexity`, `Unassessed`, and `require_assessed` now state create *and* update.
- crates/orbit-cli: no code change needed - `Unassessed` is `#[value(skip)]`, so clap already rejects `--complexity unassessed` on update; added a regression test that pins it.
- Skill reference: canonical asset crates/orbit-core/assets/skills/orbit/references/task-authoring.md edited and mirrored to plugin/skills/orbit/... via scripts/sync-plugin-skills.sh (the ci-fast guardrail treats plugin/ as a generated mirror, so the listed plugin file cannot be edited alone).

Scope additions (appended to context_files): the tool-host handler/input pair and its tests, the CLI and web test files, and the canonical skill asset. The task listed crates/orbit-tools/src/builtin/orbit/task/update.rs, but that crate only declares the schema; the complexity value check lives in the orbit-core tool host, so the behavioural change and its test landed there. orbit.task.add, CLI add, and the web create handler are untouched.

Acceptance criteria
1. Tool rejects `unassessed` and leaves the stored value - met: crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs::task_update_tool_rejects_unassessed_complexity_and_keeps_the_stored_value asserts the error equals the `require_assessed()` message and that orbit.task.show still reports `low`.
2. CLI rejects `--complexity unassessed` - met: crates/orbit-cli/src/command/task/tests/update.rs::task_update_rejects_unassessed_complexity asserts the parse fails and that `unassessed` never appears in `task update --help`.
3. Web update rejects with the create error - met: crates/orbit-web/src/api/tests/tasks.rs::update_task_requires_assessed_complexity asserts 400, the exact `require_assessed()` message, and that the stored complexity stays `medium`.
4. System/automated paths unchanged - met: the check sits only on the tool-host and web request handlers; task-pilot apply writes through AtomicTaskMutationParams, and auto-task mint / CI-failure / dependabot tasks build TaskAddParams directly. New test automated_update_paths_may_still_store_unassessed_complexity asserts runtime.update_task still stores Unassessed; the existing task_pilot and backlog-exclusion suites pass unchanged.
5. Regression tests on all three surfaces - met (see 1-3).
6. Authoring reference states the rule - met: step 5 plus a new operating rule say complexity is required on create and update and that `unassessed` is system-only.

Validation (worktree orbit-jrun-20260911-0347-3, HEAD 58f9ab1856e982f6353ef0f6b15d00c9dbfa0b93, uncommitted tree)
- PASSED: cargo fmt --all
- PASSED: make ci-fast (first run failed on the sync-plugin-skills guardrail until the canonical asset was updated; re-run clean)
- PASSED: make ci-lint (workspace-wide clippy, warnings denied)
- PASSED: cargo test -p orbit-core --lib (1388 passed)
- PASSED: cargo test -p orbit-web --lib (380 passed)
- PASSED: cargo test -p orbit-tools
- PASSED: cargo test -p orbit-cli task_update_rejects_unassessed_complexity
- NOT RUN: full make ci (workspace policy: CI is the merge gate). No live `orbit tool run orbit.task.update` against production state: a mutable fixture would need a disposable-HOME child process, and the tool-host test exercises the same runtime path end to end.

Risks/deviations: none known. git diff --check is clean; git status --short shows only the nine intended tracked modifications.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12116-6aa379de`
- Behind base: 0
- Ahead of base: 1