### PR TITLE
Exempt no-diff-expected tasks from assessed-complexity admission

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use orbit_common::fs::path::workspace_relative_paths_overlap;
 use orbit_engine::DispatchError;
 use orbit_types::task::{
-    Task, TaskComplexity, TaskPriority, TaskReferenceIndex, TaskStatus, TaskType,
-    task_dependencies_ready_with_index,
+    NO_DIFF_EXPECTED_TAG, Task, TaskComplexity, TaskPriority, TaskReferenceIndex, TaskStatus,
+    TaskType, task_dependencies_ready_with_index,
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -44,6 +44,8 @@ pub(super) enum BacklogTaskExclusionReason {
     GroupMemberConflict,
     /// Automated work must be prepared before an implementation lane can
     /// consume it; urgency does not substitute for a complexity assessment.
+    /// Work tagged [`NO_DIFF_EXPECTED_TAG`] is exempt — see
+    /// [`clears_complexity_gate`].
     UnassessedComplexity,
 }
 
@@ -177,7 +179,7 @@ pub(super) fn list_backlog_tasks(
                     message: format!("load task {task_id}: {err}"),
                 }
             })?;
-            if task.complexity.is_some_and(TaskComplexity::is_assessed) {
+            if clears_complexity_gate(&task) {
                 tasks.push(task);
             } else {
                 excluded.push(BacklogTaskExclusion {
@@ -283,7 +285,7 @@ pub(super) fn backlog_snapshot(
     sort_tasks_for_automatic_dispatch(&mut backlog);
     let mut excluded = Vec::new();
     backlog.retain(|task| {
-        if task.complexity.is_some_and(TaskComplexity::is_assessed) {
+        if clears_complexity_gate(task) {
             return true;
         }
         excluded.push(BacklogTaskExclusion {
@@ -391,6 +393,23 @@ pub(super) fn backlog_snapshot(
         excluded,
         lock_holders,
     })
+}
+
+/// The one complexity-admission rule, shared by automatic backlog selection,
+/// explicit ship selection, and the readiness diagnostic that reports their
+/// exclusions.
+///
+/// An implementation lane needs a complexity assessment to size the work it is
+/// about to do. Work tagged exactly `no-diff-expected` produces its durable
+/// result outside the repository, so requiring task-pilot preparation only to
+/// clear this gate withholds operational work for a judgement it does not
+/// consume [ORB-12118]. The exemption is the tag alone: automated mint
+/// provenance does not grant it, and nothing here rewrites the task's stored
+/// complexity — an exempt task keeps `unassessed` and resolves its crew from
+/// the configured crew or the workspace default.
+fn clears_complexity_gate(task: &Task) -> bool {
+    task.complexity.is_some_and(TaskComplexity::is_assessed)
+        || task.tags.iter().any(|tag| tag == NO_DIFF_EXPECTED_TAG)
 }
 
 pub(super) fn sort_tasks_for_automatic_dispatch(tasks: &mut [Task]) {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/backlog_exclusion.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/backlog_exclusion.rs
@@ -852,3 +852,209 @@ fn dispatch_order_is_independent_of_the_input_order() {
     // meaningful ordering rather than two identically-sorted no-ops.
     assert_eq!(forward[0].priority, TaskPriority::Critical);
 }
+
+/// Seed a backlog task with an exact tag set and complexity, so the
+/// complexity-admission rule can be exercised across tagged/untagged and
+/// manual/auto-task origins [ORB-12118].
+fn seed_tagged_backlog_task(
+    runtime: &OrbitRuntime,
+    title: &str,
+    complexity: TaskComplexity,
+    tags: &[&str],
+) -> Task {
+    runtime
+        .add_task(TaskAddParams {
+            title: title.to_string(),
+            description: format!("Fixture task: {title}"),
+            acceptance_criteria: vec!["Fixture task is observable.".to_string()],
+            plan: "Fixture plan.".to_string(),
+            tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+            workspace_path: Some(".".to_string()),
+            priority: TaskPriority::Medium,
+            complexity,
+            task_type: Some(TaskType::Chore),
+            status: Some(TaskStatus::Backlog),
+            system_created: tags.iter().any(|tag| tag.starts_with("auto-task:")),
+            ..TaskAddParams::default()
+        })
+        .expect("seed tagged backlog task")
+}
+
+/// A record written before complexity was persisted at all: the field is
+/// absent rather than `unassessed`.
+fn seed_backlog_task_without_complexity(
+    runtime: &OrbitRuntime,
+    title: &str,
+    tags: &[&str],
+) -> String {
+    runtime
+        .stores()
+        .task_records()
+        .create(orbit_store::TaskCreateParams {
+            actor: "test".to_string(),
+            parent_id: None,
+            title: title.to_string(),
+            description: "Fixture task with no stored complexity.".to_string(),
+            acceptance_criteria: vec!["Fixture task is observable.".to_string()],
+            dependencies: Vec::new(),
+            relations: Vec::new(),
+            tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+            required_tools: Vec::new(),
+            plan: "Fixture plan.".to_string(),
+            execution_summary: String::new(),
+            context_files: Vec::new(),
+            workspace_path: Some(".".to_string()),
+            repo_root: None,
+            created_by: Some("test".to_string()),
+            planned_by: None,
+            implemented_by: None,
+            status: TaskStatus::Backlog,
+            priority: TaskPriority::Medium,
+            complexity: None,
+            task_type: TaskType::Chore,
+            external_refs: Vec::new(),
+            source_task_id: None,
+            crew: None,
+            orchestrator: None,
+            comments: Vec::new(),
+        })
+        .expect("create task without complexity")
+        .id
+}
+
+#[test]
+fn no_diff_expected_tasks_clear_the_complexity_gate_in_both_selection_modes() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let manual_unassessed = seed_tagged_backlog_task(
+        &runtime,
+        "Operational check",
+        TaskComplexity::Unassessed,
+        &["no-diff-expected"],
+    );
+    let auto_unassessed = seed_tagged_backlog_task(
+        &runtime,
+        "[auto-task] Review recently merged changes",
+        TaskComplexity::Unassessed,
+        &["code-review", "no-diff-expected", "auto-task:code-review"],
+    );
+    let absent_complexity = seed_backlog_task_without_complexity(
+        &runtime,
+        "Legacy operational check",
+        &["no-diff-expected"],
+    );
+    let assessed = seed_tagged_backlog_task(
+        &runtime,
+        "Assessed operational check",
+        TaskComplexity::Medium,
+        &["no-diff-expected"],
+    );
+
+    let automatic = list_backlog_tasks(&runtime, json!({}));
+    let selected = output_task_ids(&automatic);
+
+    for task_id in [
+        &manual_unassessed.id,
+        &auto_unassessed.id,
+        &absent_complexity,
+        &assessed.id,
+    ] {
+        assert!(
+            selected.contains(task_id),
+            "exempt task {task_id} should clear the complexity gate automatically"
+        );
+    }
+    assert_eq!(automatic["excluded"], json!([]));
+
+    let explicit = list_backlog_tasks(
+        &runtime,
+        json!({ "task_ids": [
+            manual_unassessed.id,
+            auto_unassessed.id,
+            absent_complexity,
+            assessed.id,
+        ] }),
+    );
+
+    assert_eq!(output_task_ids(&explicit).len(), 4);
+    assert_eq!(explicit["excluded"], json!([]));
+}
+
+#[test]
+fn the_complexity_gate_still_withholds_untagged_work_of_either_origin() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let auto_finding = seed_tagged_backlog_task(
+        &runtime,
+        "[auto-task] Repair the confirmed finding",
+        TaskComplexity::Unassessed,
+        &["code-review", "auto-task:code-review"],
+    );
+    let manual_unassessed = seed_tagged_backlog_task(
+        &runtime,
+        "Implementation awaiting assessment",
+        TaskComplexity::Unassessed,
+        &[],
+    );
+    let near_miss = seed_tagged_backlog_task(
+        &runtime,
+        "Nearly exempt",
+        TaskComplexity::Unassessed,
+        &["no-diff-needed"],
+    );
+    let absent_complexity =
+        seed_backlog_task_without_complexity(&runtime, "Legacy implementation", &[]);
+
+    let automatic = list_backlog_tasks(&runtime, json!({}));
+
+    assert_eq!(automatic["task_ids"], json!([]));
+    for task_id in [
+        &auto_finding.id,
+        &manual_unassessed.id,
+        &near_miss.id,
+        &absent_complexity,
+    ] {
+        assert_eq!(
+            excluded_entry(&automatic, task_id)["reason"],
+            "unassessed_complexity",
+            "task {task_id} must stay withheld without the exact no-diff-expected tag"
+        );
+    }
+
+    let explicit = list_backlog_tasks(&runtime, json!({ "task_ids": [near_miss.id] }));
+    assert_eq!(explicit["task_ids"], json!([]));
+    assert_eq!(
+        excluded_entry(&explicit, &near_miss.id)["reason"],
+        "unassessed_complexity"
+    );
+}
+
+#[test]
+fn the_no_diff_expected_exemption_does_not_relax_dependency_readiness() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let dependency = seed_task_with_dependencies(
+        &runtime,
+        "Unfinished dependency",
+        TaskStatus::InProgress,
+        vec![],
+    );
+    let exempt = runtime
+        .add_task(TaskAddParams {
+            title: "Operational check behind a dependency".to_string(),
+            description: "Fixture task".to_string(),
+            acceptance_criteria: vec!["Fixture task is observable.".to_string()],
+            dependencies: vec![dependency.id.clone()],
+            tags: vec!["no-diff-expected".to_string()],
+            plan: "Fixture plan.".to_string(),
+            workspace_path: Some(".".to_string()),
+            priority: TaskPriority::Medium,
+            complexity: TaskComplexity::Unassessed,
+            task_type: Some(TaskType::Chore),
+            status: Some(TaskStatus::Backlog),
+            ..TaskAddParams::default()
+        })
+        .expect("seed dependent exempt task");
+
+    let output = list_backlog_tasks(&runtime, json!({}));
+
+    assert!(!output_task_ids(&output).contains(&exempt.id));
+    assert_eq!(output["excluded"], json!([]));
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_assessment.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_assessment.rs
@@ -1,6 +1,8 @@
 //! Explainable task-pilot complexity assessment and persistence fixtures.
 
+use chrono::{Duration, Utc};
 use orbit_types::task::{Task, TaskComplexity, TaskPriority, TaskStatus, TaskType};
+use orbit_types::workflow::{AutoTaskSchedule, AutoTaskTemplate, DedupePolicy};
 use serde_json::{Value, json};
 
 use super::super::task_pilot::{apply, member_ready, prepare};
@@ -8,6 +10,8 @@ use crate::OrbitRuntime;
 use crate::adapter::engine_host::v2_host::test_support::{
     runtime_with_workspace_layout, write_workspace_file,
 };
+use crate::application::auto_tasks::AutoTaskAddParams;
+use crate::application::auto_tasks::scheduler::{SchedulerOptions, run_auto_task_scheduler_at};
 use crate::application::task::{TaskAddParams, TaskUpdateParams};
 
 fn seed_task(runtime: &OrbitRuntime, title: &str) -> Task {
@@ -148,4 +152,141 @@ fn missing_evidence_stays_unassessed_with_an_actionable_preparation_outcome() {
     let current = runtime.get_task(&task.id).expect("unassessed task");
     assert_eq!(current.complexity, Some(TaskComplexity::Unassessed));
     assert_eq!(current.context_files, vec!["file:src/investigate.rs"]);
+}
+
+/// The operational shape behind ORB-12099: an auto-task-minted
+/// `no-diff-expected` review whose durable result lives outside the repository,
+/// so its assessment never produces selectors.
+fn host_operational_assessment(task: &Task, complexity: &str) -> Value {
+    // The selector the shared fixture proposes is replaced by the empty list
+    // this disposition requires.
+    let mut assessment = assessment(task, "file:src/unused.rs", complexity);
+    assessment["context_files_after"] = json!([]);
+    assessment["disposition"] = json!("host_operational");
+    assessment["evidence"] = json!(
+        "The task is tagged no-diff-expected; its durable deliverable is filed Orbit tasks plus a review cursor."
+    );
+    assessment["recommended_crew"] = json!("opus");
+    assessment
+}
+
+fn task_pilot_audits(runtime: &OrbitRuntime, task_id: &str) -> Vec<Value> {
+    runtime
+        .get_task_history(task_id)
+        .expect("task history")
+        .into_iter()
+        .filter(|event| event.event == "task_pilot_applied")
+        .map(|event| {
+            let note = event.note.expect("task_pilot_applied note");
+            let (_receipt, audit) = note.split_once('\n').expect("audit payload");
+            serde_json::from_str::<Value>(audit).expect("audit json")
+        })
+        .collect()
+}
+
+/// ORB-12099 reported a successful task-pilot event (`unassessed` -> `hard`)
+/// against a task that later read `unassessed`, and asked whether the
+/// assessment failed to persist. It did not: the durable history carries two
+/// `task_pilot_applied` audits, and the second one — a later pass that reported
+/// `unassessed` with evidence gaps — is the legitimate write that changed the
+/// value. This pins both halves: an applied assessment is durably readable
+/// across a runtime reopen and survives an auto-task refresh untouched, and a
+/// subsequent assessment changes it only through its own audited write.
+#[test]
+fn an_applied_assessment_is_durable_and_only_a_later_audited_pass_changes_it() {
+    let (root, runtime, repo_root) = runtime_with_workspace_layout();
+    runtime
+        .auto_task_add(AutoTaskAddParams {
+            name: "code-review".to_string(),
+            description: "Review recently merged changes".to_string(),
+            schedule: AutoTaskSchedule::Interval { every_minutes: 60 },
+            template: AutoTaskTemplate {
+                title: "[auto-task] Review recently merged changes".to_string(),
+                description: "Review the code merged since the last sweep.".to_string(),
+                acceptance_criteria: vec!["Findings are filed as tasks.".to_string()],
+                task_type: TaskType::Chore,
+                tags: vec!["code-review".to_string(), "no-diff-expected".to_string()],
+                required_tools: vec![],
+                priority: TaskPriority::Medium,
+                crew: Some("opus".to_string()),
+                status: TaskStatus::Backlog,
+            },
+            dedupe: DedupePolicy::SkipIfOpen,
+        })
+        .expect("add auto-task definition");
+    let minted = runtime.auto_task_mint("code-review").expect("mint review");
+    assert_eq!(minted.complexity, Some(TaskComplexity::Unassessed));
+
+    let prepared = prepare_task(&runtime, &repo_root, &minted);
+    let applied = apply_assessment(
+        &runtime,
+        &repo_root,
+        prepared,
+        &minted,
+        host_operational_assessment(&minted, "hard"),
+    );
+    assert_eq!(applied["status"], "succeeded");
+    assert_eq!(
+        runtime.get_task(&minted.id).expect("assessed").complexity,
+        Some(TaskComplexity::Hard)
+    );
+
+    // Durable, not merely in-memory: a second runtime over the same roots reads
+    // the assessed value back.
+    let reopened = OrbitRuntime::from_roots(
+        &root.path().join("home/.orbit"),
+        &root.path().join("repo/.orbit"),
+    )
+    .expect("reopen runtime");
+    assert_eq!(
+        reopened.get_task(&minted.id).expect("reopened").complexity,
+        Some(TaskComplexity::Hard)
+    );
+
+    // Auto-task refresh sees an open instance, skips, and rewrites nothing.
+    let outcome = run_auto_task_scheduler_at(
+        &reopened,
+        Utc::now() + Duration::hours(2),
+        SchedulerOptions::default(),
+    )
+    .expect("auto-task refresh pass");
+    assert!(
+        outcome
+            .reports
+            .iter()
+            .all(|report| report.action != "fired"),
+        "an open instance must suppress a duplicate mint"
+    );
+    assert_eq!(
+        reopened
+            .get_task(&minted.id)
+            .expect("after refresh")
+            .complexity,
+        Some(TaskComplexity::Hard)
+    );
+
+    // A later pass that cannot support a rating is a legitimate audited write,
+    // not a lost one: both audits remain readable, in order.
+    let reprepared = prepare_task(
+        &runtime,
+        &repo_root,
+        &runtime.get_task(&minted.id).expect("current"),
+    );
+    let mut regression = host_operational_assessment(&minted, "unassessed");
+    regression["confidence"] = json!("low");
+    regression["evidence_gaps"] =
+        json!(["The full cursor-to-HEAD review has not been completed at the pinned revision."]);
+    let reapplied = apply_assessment(&runtime, &repo_root, reprepared, &minted, regression);
+    assert_eq!(reapplied["status"], "succeeded");
+
+    let audits = task_pilot_audits(&runtime, &minted.id);
+    assert_eq!(audits.len(), 2);
+    assert_eq!(audits[0]["complexity_before"], json!("unassessed"));
+    assert_eq!(audits[0]["complexity_after"], json!("hard"));
+    assert_eq!(audits[1]["complexity_before"], json!("hard"));
+    assert_eq!(audits[1]["complexity_after"], json!("unassessed"));
+    assert_eq!(
+        runtime.get_task(&minted.id).expect("reassessed").complexity,
+        Some(TaskComplexity::Unassessed)
+    );
 }

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
@@ -55,7 +55,7 @@ fn verified_no_diff_assessment(task: &Task) -> Value {
 }
 
 #[test]
-fn minted_no_diff_auto_task_is_prepared_without_selectors_then_admitted() {
+fn minted_no_diff_auto_task_is_admitted_unassessed_and_still_assessable() {
     let (_root, runtime, repo_root) = runtime_with_workspace_layout();
     runtime
         .auto_task_add(AutoTaskAddParams {
@@ -83,13 +83,14 @@ fn minted_no_diff_auto_task_is_prepared_without_selectors_then_admitted() {
     assert!(minted.tags.iter().any(|tag| tag == "no-diff-expected"));
     assert!(minted.tags.iter().any(|tag| tag == "auto-task:qa-review"));
 
+    // The `no-diff-expected` tag exempts the task from the assessed-complexity
+    // gate, so it is admissible before task-pilot ever sees it [ORB-12118].
     let before = classify(&runtime);
     assert!(
-        !before["loose_task_ids"]
+        before["loose_task_ids"]
             .as_array()
             .expect("admitted tasks")
-            .iter()
-            .any(|task_id| task_id == &minted.id)
+            .contains(&json!(minted.id))
     );
 
     let prepared = prepare(
@@ -1909,4 +1910,92 @@ fn classifier_uses_captured_cli_pool_instead_of_current_configuration() {
         json!({"run_id": coordinator.run_id, "allowed_crews": ["terra"]}),
     );
     assert_eq!(result["loose_task_ids"], json!([task.id]));
+}
+
+#[test]
+fn readiness_agrees_with_admission_on_the_no_diff_expected_complexity_exemption() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let exempt = seed_unassessed_task(&runtime, "Operational check", &["no-diff-expected"]);
+    let implementation = seed_unassessed_task(&runtime, "Repair the finding", &["code-review"]);
+    let blocked_dependency = seed_list_backlog_task(
+        &runtime,
+        "Unfinished dependency",
+        TaskStatus::InProgress,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        None,
+        vec![],
+    );
+    let dependent_exempt = runtime
+        .add_task(TaskAddParams {
+            title: "Operational check behind a dependency".to_string(),
+            description: "Fixture task".to_string(),
+            acceptance_criteria: vec!["Fixture outcome is observable.".to_string()],
+            dependencies: vec![blocked_dependency.id.clone()],
+            tags: vec!["no-diff-expected".to_string()],
+            plan: "Fixture plan.".to_string(),
+            workspace_path: Some(".".to_string()),
+            priority: TaskPriority::Medium,
+            complexity: TaskComplexity::Unassessed,
+            task_type: Some(TaskType::Chore),
+            status: Some(TaskStatus::Backlog),
+            ..TaskAddParams::default()
+        })
+        .expect("seed dependent exempt task");
+
+    let output = readiness(
+        &runtime,
+        &[
+            exempt.id.clone(),
+            implementation.id.clone(),
+            dependent_exempt.id.clone(),
+        ],
+        None,
+    );
+
+    assert_eq!(readiness_task(&output, &exempt.id)["eligible"], json!(true));
+    assert_eq!(readiness_task(&output, &exempt.id)["reason"], "ready");
+    assert_eq!(
+        readiness_task(&output, &implementation.id)["reason"],
+        "task_pilot_preparation_required"
+    );
+    assert_eq!(
+        readiness_task(&output, &implementation.id)["eligible"],
+        json!(false)
+    );
+    // Other exclusions stay visible and enforced for an exempt task.
+    assert_eq!(
+        readiness_task(&output, &dependent_exempt.id)["reason"],
+        "unmet_dependency"
+    );
+    assert_eq!(
+        readiness_task(&output, &dependent_exempt.id)["eligible"],
+        json!(false)
+    );
+    // Admission itself never rewrites the stored non-answer.
+    assert_eq!(
+        runtime
+            .get_task(&exempt.id)
+            .expect("exempt task")
+            .complexity,
+        Some(TaskComplexity::Unassessed)
+    );
+}
+
+fn seed_unassessed_task(runtime: &OrbitRuntime, title: &str, tags: &[&str]) -> Task {
+    runtime
+        .add_task(TaskAddParams {
+            title: title.to_string(),
+            description: format!("Fixture task: {title}"),
+            acceptance_criteria: vec!["Fixture outcome is observable.".to_string()],
+            tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+            plan: "Fixture plan.".to_string(),
+            workspace_path: Some(".".to_string()),
+            priority: TaskPriority::Medium,
+            complexity: TaskComplexity::Unassessed,
+            task_type: Some(TaskType::Chore),
+            status: Some(TaskStatus::Backlog),
+            ..TaskAddParams::default()
+        })
+        .expect("seed unassessed task")
 }

--- a/crates/orbit-core/src/application/job/tests/crew_pools.rs
+++ b/crates/orbit-core/src/application/job/tests/crew_pools.rs
@@ -411,3 +411,51 @@ fn explicit_run_crew_wins_and_ordinary_ship_admission_has_no_pool_policy() {
         "astra"
     );
 }
+
+/// [ORB-12118] `no-diff-expected` work is admitted without an assessed
+/// complexity, so its crew must come from the task's own configuration or the
+/// workspace default — never from a complexity-derived pool, and never by
+/// rewriting the stored non-answer to obtain one.
+#[test]
+fn exempt_no_diff_expected_tasks_route_on_their_crew_or_the_workspace_default() {
+    let (_root, runtime, _, _) =
+        test_runtime_with_workspace_config("[workflow]\nmedium_complexity_crews = [\"grok\"]\n");
+    let parent = coordinator(&runtime, json!({}));
+    let configured = no_diff_expected_task(&runtime, Some("astra"));
+    let inherited = no_diff_expected_task(&runtime, None);
+
+    let configured_input = admit(&runtime, &parent, &configured, 0);
+    assert_eq!(configured_input["crew"], "astra");
+    assert_eq!(configured_input["crew_selection"]["source"], "task.crew");
+    assert_eq!(
+        configured_input["crew_selection"]["complexity"],
+        "unassessed"
+    );
+
+    let inherited_input = admit(&runtime, &parent, &inherited, 0);
+    assert_eq!(inherited_input["crew"], "opus");
+    assert_eq!(inherited_input["crew_selection"]["source"], "default");
+
+    for task in [&configured, &inherited] {
+        assert_eq!(
+            runtime.get_task(&task.id).expect("task").complexity,
+            Some(TaskComplexity::Unassessed),
+            "admission must not fabricate an assessed complexity"
+        );
+    }
+}
+
+fn no_diff_expected_task(runtime: &OrbitRuntime, crew: Option<&str>) -> Task {
+    runtime
+        .add_task(TaskAddParams {
+            title: "Operational no-diff fixture".into(),
+            description: "Exercise crew routing without an assessment".into(),
+            plan: "Inspect admission evidence".into(),
+            tags: vec!["no-diff-expected".to_string()],
+            complexity: TaskComplexity::Unassessed,
+            crew: crew.map(ToOwned::to_owned),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("task")
+}

--- a/docs/design/automation-triggers/2_design.md
+++ b/docs/design/automation-triggers/2_design.md
@@ -453,7 +453,9 @@ repair's certainty, behavioral change, coupling, validation difficulty,
 rationale, confidence, evidence gaps, validation approach, and reassessment
 triggers. Its apply step commits concrete selectors, complexity, audit evidence,
 and the idempotency receipt at one task-bundle boundary. Automatic admission
-then rejects any still-unassessed task, including urgent security work; missing
+then rejects any still-unassessed task, including urgent security work, except
+one tagged exactly `no-diff-expected`, which is admitted without an assessment
+because an implementation lane sizes no diff for it [ORB-12118]; missing
 validation permission is a readiness blocker rather than a complexity or
 priority inference. The low/medium/hard examples in the activity contract are
 deterministic policy fixtures, not a claim about live-model accuracy.

--- a/docs/design/operation-mode/2_design.md
+++ b/docs/design/operation-mode/2_design.md
@@ -87,7 +87,10 @@ leaving crew recommendations advisory. The receipt event retains the complete
 assessment rationale, confidence, evidence gaps, validation approach, and
 reassessment triggers. Missing evidence leaves complexity `unassessed`, and
 automatic implementation admission excludes that task until preparation can
-produce an assessed result; priority remains an independent urgency signal.
+produce an assessed result, unless it carries the exact `no-diff-expected` tag
+— operational work whose durable result is not a repository diff is admitted on
+the tag alone and routes on its configured crew or the workspace default
+[ORB-12118]. Priority remains an independent urgency signal.
 There is no reusable general promotion-readiness certificate today.
 
 The [CI-failure admission seam](../../../crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_admission.rs)


### PR DESCRIPTION
## Task

[ORB-12118](https://orbit-cli.com/tasks/ORB-12118) — Exempt no-diff-expected tasks from assessed-complexity admission

### Description

## Problem
Tasks tagged `no-diff-expected` can be withheld from pipeline admission solely because complexity is missing or `unassessed`. Operational tasks should not require task-pilot preparation merely to clear this complexity gate. Daniel explicitly requests an exemption based on the `no-diff-expected` tag, not auto-task provenance.

Current code in crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs requires assessed complexity in both explicit-ID and automatic backlog selection. Readiness exposes this as `task_pilot_preparation_required`.

## Reported evidence
ORB-12099 ([auto-task] Review recently merged changes) currently has tags `code-review`, `no-diff-expected`, and `auto-task:code-review`; the authoritative task read on 2026-09-11 reports backlog, complexity `unassessed`. Daniel supplied a task-pilot event timestamped 2026-09-10 19:37 with operation_id 298a69eb549239d0a98d98e140600a0a5078eab80648c81bef305e123ae3a0a5, disposition `host_operational`, complexity_before `unassessed`, complexity_after `hard`, and recommended crew `opus`. The event reports success, but differs from the current record; investigate persistence, subsequent writes, and event provenance before attributing a cause.

## Desired behavior and constraints
Use one consistent admission rule: assessed complexity OR the exact `no-diff-expected` tag. Apply it to automatic selection, explicit ship selection, and readiness diagnostics. Preserve other admission and execution safeguards. Auto-task origin alone must not grant the exemption. Do not fabricate an assessed complexity just to pass admission; resolve execution crew using the existing configured crew/default policy when complexity is absent. Task-pilot may still assess these tasks voluntarily. Verify its durable update behavior and repair any reproduced loss/reset or misleading success event associated with this case.

### Acceptance Criteria

- Deterministic admission tests show tasks tagged exactly `no-diff-expected` with either missing or `unassessed` complexity pass the complexity gate for both automatic backlog selection and explicit `orbit run ship` selection.
- Readiness agrees with actual admission and does not report `task_pilot_preparation_required` solely due to missing/unassessed complexity for exempt tasks; other exclusions remain visible and enforced.
- Tasks without `no-diff-expected`, including auto-task-generated implementation/finding tasks, remain excluded when complexity is missing or unassessed. Assessed tasks retain existing behavior.
- An exempt task can reach execution with its configured crew or the existing workspace default without a complexity-derived routing error and without silently rewriting complexity.
- Investigate the ORB-12099 task-pilot event/current-record discrepancy using available durable evidence, record the established cause or explicit evidence gap, and verify with deterministic coverage that a successful task-pilot assessment is durably readable and is not unintentionally reset by auto-task refresh/reconciliation. Fix any reproduced defect within this flow; distinguish legitimate later changes from failed persistence.
- Regression coverage includes tagged and untagged tasks, manual and auto-task origins, absent/unassessed/assessed complexity, and preservation of dependency and other admission gates. Relevant checks pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented the `no-diff-expected` exemption to the assessed-complexity admission gate, plus the ORB-12099 investigation.

## Change
- crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs: added `clears_complexity_gate(task)` — assessed complexity OR the exact `no-diff-expected` tag — and used it at the only two admission sites: explicit `task_ids` selection (used by `orbit run ship` / `task_auto_pipeline`) and the automatic `backlog_snapshot` retain. Readiness (`explain_workspace_auto_readiness`) reads the same snapshot exclusions, so `task_pilot_preparation_required` disappears for exempt tasks without a second rule. No complexity is rewritten anywhere; crew resolution keeps falling through `auto_task_crew_candidates` to `task.crew` or the workspace default because no pool exists for `unassessed`.
- Design docs updated in the same change: docs/design/operation-mode/2_design.md and docs/design/automation-triggers/2_design.md both stated that admission rejects every unassessed task.

## Criteria
1. Exempt tasks pass both selection modes — PASS: `no_diff_expected_tasks_clear_the_complexity_gate_in_both_selection_modes` covers missing complexity (record created with `complexity: None`) and `unassessed`, manual and auto-task origin, automatic and explicit `task_ids` selection.
2. Readiness agrees, other exclusions stay — PASS: `readiness_agrees_with_admission_on_the_no_diff_expected_complexity_exemption` asserts `ready` for an exempt task, `task_pilot_preparation_required` for an untagged one, and `unmet_dependency` for an exempt task behind an in-progress dependency.
3. Untagged work still withheld — PASS: `the_complexity_gate_still_withholds_untagged_work_of_either_origin` (auto-task finding, manual task, `no-diff-needed` near miss, absent complexity) plus the pre-existing assessed-task tests.
4. Execution routing — PASS: `exempt_no_diff_expected_tasks_route_on_their_crew_or_the_workspace_default` admits an exempt task through `install_auto_crew_admission`: configured crew wins with source `task.crew`, otherwise the default (`opus`, source `default`), `crew_selection.complexity` stays `unassessed`, and the stored complexity is unchanged.
5. ORB-12099 investigation — established cause, no persistence defect. The authoritative task history carries two `task_pilot_applied` events: 2026-09-11T02:37:46Z operation_id 298a69eb… wrote `unassessed -> hard` (the event Daniel supplied) and 2026-09-11T03:33:37Z operation_id ff156387… wrote `hard -> unassessed`, with `confidence: low` and evidence gaps (proc.spawn not advertised, review incomplete). The first write persisted; a later, separately audited pilot pass legitimately reported that it could not support a rating. This is a legitimate later change, not failed persistence, so there is no defect to repair in that flow. Why it recurs: a `no-diff-expected` auto-task legitimately has empty `context_files`, so `automatic_exclusion_reason` never excludes it from pilot discovery and every routine pass may reassess it — with the tag exemption this no longer withholds the task from admission. Deterministic coverage: `an_applied_assessment_is_durable_and_only_a_later_audited_pass_changes_it` applies a `host_operational` assessment to an auto-task-minted `no-diff-expected` review, reads `hard` back through a second `OrbitRuntime` opened on the same roots, runs an auto-task scheduler pass two hours later (skips on the open instance, complexity untouched), then applies a second `unassessed` assessment and asserts both audits remain readable in order.
6. Regression coverage breadth — PASS, see 1-5. `minted_no_diff_auto_task_is_prepared_without_selectors_then_admitted` was renamed to `minted_no_diff_auto_task_is_admitted_unassessed_and_still_assessable` and its pre-preparation assertion inverted: the minted task is now admissible before task-pilot sees it, and task-pilot may still assess it voluntarily.

## Validation
- `cargo test -p orbit-core` — PASSED (1399 lib + integration tests, 0 failed).
- `make ci-fast` — PASSED.
- `make ci-lint` — PASSED (workspace clippy, all targets, warnings denied). `cargo clippy -p orbit-core --all-targets` re-run clean after the final readability edits.
- `git diff --check` / `git status --short` — clean; only the seven declared files are modified, no untracked paths.

## Risks and notes
- The exemption is tag-only and case-exact; a task that merely carries `no-diff-needed` is not exempt (pinned by test).
- `crates/orbit-core/assets/activities/list_backlog_tasks.yaml` documents an `excluded.reason` enum that already omitted `unassessed_complexity` and `crew_not_allowed` before this change. That drift is pre-existing, output schemas are not enforced at runtime for deterministic actions, and no new reason value was introduced, so it was left alone.
- Tests exercise the real task/run stores on Linux; no OS-specific behavior is involved.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12118-6aa38784`
- Behind base: 0
- Ahead of base: 1