### PR TITLE
[code-review] doctor's orphan-task-store check compares task-registry partition ids against workspace-registry ids, so --fix-orphan-task-stores deletes the live task store

### DIFF
--- a/crates/orbit-cli/src/command/doctor.rs
+++ b/crates/orbit-cli/src/command/doctor.rs
@@ -34,9 +34,13 @@ pub struct DoctorCommand {
     #[arg(long)]
     pub fix_retired_activity_backends: bool,
 
-    /// Delete task-store partitions whose workspace is no longer registered on this host.
+    /// Delete task-store partitions that no workspace binding on this host claims. Requires --confirm.
     #[arg(long)]
     pub fix_orphan_task_stores: bool,
+
+    /// Confirm a destructive repair. Required by --fix-orphan-task-stores, which deletes task bundles.
+    #[arg(long)]
+    pub confirm: bool,
 }
 
 impl Execute for DoctorCommand {
@@ -106,6 +110,12 @@ impl Execute for DoctorCommand {
             });
         }
         if self.fix_orphan_task_stores {
+            if !self.confirm {
+                return Err(orbit_core::OrbitError::InvalidInput(
+                    "--fix-orphan-task-stores deletes task bundles. Pass --confirm to proceed."
+                        .to_string(),
+                ));
+            }
             let removed = runtime.remove_orphan_task_stores()?;
             eprintln!("Removed {removed} orphaned task-store partition(s).");
             results.push(WorkspaceDoctorResult {

--- a/crates/orbit-cli/src/command/tests/doctor.rs
+++ b/crates/orbit-cli/src/command/tests/doctor.rs
@@ -52,6 +52,7 @@ fn failing_workspace_renders_diagnostics_and_exits_nonzero() {
         fix_stale_artifacts: false,
         fix_retired_activity_backends: false,
         fix_orphan_task_stores: false,
+        confirm: false,
     }
     .execute(&runtime)
     .expect("doctor should render a failing report");
@@ -93,6 +94,7 @@ fn warning_only_workspace_keeps_zero_exit_and_structured_rows() {
         fix_stale_artifacts: false,
         fix_retired_activity_backends: false,
         fix_orphan_task_stores: false,
+        confirm: false,
     }
     .execute(&runtime)
     .expect("doctor should render a warning report");
@@ -131,6 +133,7 @@ fn fix_stale_locks_records_repair_count_in_payload_doc() {
         fix_stale_artifacts: false,
         fix_retired_activity_backends: false,
         fix_orphan_task_stores: false,
+        confirm: false,
     }
     .execute(&runtime)
     .expect("doctor should run repairs and render report");

--- a/crates/orbit-cli/src/command/workspace/teardown.rs
+++ b/crates/orbit-cli/src/command/workspace/teardown.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use orbit_cmd::{remove_task_store_partition, task_store_partition_path};
+use orbit_cmd::remove_checkout_task_stores;
 use orbit_core::{OrbitError, OrbitRuntime};
 use orbit_registry::workspace_registry;
 
@@ -53,6 +53,7 @@ impl Execute for WorkspaceTeardownArgs {
         // 1. Deregister from workspace registry (before deleting .orbit/)
         let global_root = runtime.global_root();
         let registry_path = workspace_registry::registry_path_for(&global_root);
+        let mut catalog_workspace_id = None;
         if registry_path.exists() {
             let mut registry = workspace_registry::load_registry_from(&registry_path)?;
             let checkout = registry.checkouts.iter().find(|checkout| {
@@ -67,17 +68,21 @@ impl Execute for WorkspaceTeardownArgs {
                     "deregistered workspace '{}' from registry",
                     ws.name
                 ));
-
-                if remove_task_store_partition(&global_root, &ws_id)? {
-                    removed.push(format!(
-                        "deleted task store {}",
-                        task_store_partition_path(&global_root, &ws_id).display()
-                    ));
-                }
+                catalog_workspace_id = Some(ws_id);
             }
         }
 
-        // 2. Remove legacy repo-local skill symlinks from .agents/skills/ and .claude/skills/
+        // 2. Delete the task-store partition this checkout's task state is
+        //    bound to. The catalog id above is not that partition's name
+        //    unless the two id spaces happen to coincide, so the task registry
+        //    resolves it and retires its bindings [ORB-12119].
+        for partition in
+            remove_checkout_task_stores(&global_root, &orbit_dir, catalog_workspace_id.as_deref())?
+        {
+            removed.push(format!("deleted task store {}", partition.display()));
+        }
+
+        // 3. Remove legacy repo-local skill symlinks from .agents/skills/ and .claude/skills/
         for dir_name in &[".agents", ".claude"] {
             let skills_dir = repo_root.join(dir_name).join("skills");
             if skills_dir.is_dir() {
@@ -97,13 +102,13 @@ impl Execute for WorkspaceTeardownArgs {
             }
         }
 
-        // 3. Delete .orbit/ directory
+        // 4. Delete .orbit/ directory
         if orbit_dir.is_dir() {
             std::fs::remove_dir_all(&orbit_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
             removed.push(format!("deleted {}", orbit_dir.display()));
         }
 
-        // 4. Print summary
+        // 5. Print summary
         println!("teardown complete:");
         for item in &removed {
             println!("  - {item}");

--- a/crates/orbit-cli/src/command/workspace/tests/teardown.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/teardown.rs
@@ -1,12 +1,16 @@
 //! [ORB-12109] `workspace teardown` must not leave the deregistered
 //! workspace's global task-store partition behind, and `orbit doctor` must
 //! flag it if it ever does.
+//!
+//! [ORB-12119] The partition to delete is the one the *task registry* binds to
+//! the checkout, not the one named for its workspace-catalog id, and its
+//! registry bindings must be retired with it.
 
 use std::path::Path;
 
 use chrono::Utc;
 use orbit_cmd::DoctorCommands;
-use orbit_cmd::task_store::task_workspaces_dir;
+use orbit_cmd::task_store::{bound_partition_id, partition_is_bound, task_workspaces_dir};
 use orbit_core::{OrbitError, OrbitRuntime};
 use orbit_registry::workspace_registry;
 use orbit_types::workspace::{Workspace, WorkspaceCheckout, WorkspaceStatus};
@@ -56,7 +60,7 @@ fn register(global_root: &Path, workspace_id: &str, repo_root: &Path, orbit_dir:
 }
 
 #[test]
-fn teardown_deletes_the_task_store_partition_and_doctor_confirms_no_orphan_remains() {
+fn teardown_deletes_the_bound_task_store_partition_and_retires_its_bindings() {
     let temp = tempfile::tempdir().expect("tempdir");
     let global_root = temp.path().join("global");
     let repo_root = temp.path().join("repo");
@@ -79,28 +83,60 @@ fn teardown_deletes_the_task_store_partition_and_doctor_confirms_no_orphan_remai
     write_task_bundle(&global_root, "ws_survivor", "ORB-1");
 
     register(&global_root, "ws_teardown", &repo_root, &orbit_dir);
-    write_task_bundle(&global_root, "ws_teardown", "ORB-2");
-    write_task_bundle(&global_root, "ws_teardown", "ORB-3");
-    let partition = task_workspaces_dir(&global_root).join("ws_teardown");
+    let runtime = OrbitRuntime::from_roots(&global_root, &orbit_dir).expect("build runtime");
+
+    // Opening the runtime bound this checkout in the task registry. That
+    // binding — not the catalog's `ws_teardown` — names the partition its task
+    // state lives in.
+    let bound = bound_partition_id(&global_root, &orbit_dir)
+        .expect("read checkout binding")
+        .expect("checkout is bound");
+    assert_ne!(
+        bound, "ws_teardown",
+        "fixture must exercise the two distinct id spaces"
+    );
+    write_task_bundle(&global_root, &bound, "ORB-2");
+    write_task_bundle(&global_root, &bound, "ORB-3");
+    // A partition named for the catalog id, as an older binary would have left it.
+    write_task_bundle(&global_root, "ws_teardown", "ORB-4");
+
+    let bound_partition = task_workspaces_dir(&global_root).join(&bound);
     assert!(
-        partition.is_dir(),
+        bound_partition.is_dir(),
         "fixture task store must exist before teardown"
     );
 
-    let runtime = OrbitRuntime::from_roots(&global_root, &orbit_dir).expect("build runtime");
     WorkspaceTeardownArgs { confirm: true }
         .execute(&runtime)
         .expect("teardown");
 
     assert!(
-        !partition.exists(),
-        "teardown must delete the torn-down workspace's task store"
+        !bound_partition.exists(),
+        "teardown must delete the partition this checkout's task state is bound to"
+    );
+    assert!(
+        !task_workspaces_dir(&global_root)
+            .join("ws_teardown")
+            .exists(),
+        "teardown must also delete a partition left under its catalog id"
     );
     assert!(
         task_workspaces_dir(&global_root)
             .join("ws_survivor")
             .exists(),
         "teardown must not touch another workspace's task store"
+    );
+
+    // No binding may survive pointing at a deleted bundle directory.
+    assert!(
+        !partition_is_bound(&global_root, &bound).expect("read workspace bindings"),
+        "teardown must retire the task-registry binding for the deleted partition"
+    );
+    assert!(
+        bound_partition_id(&global_root, &orbit_dir)
+            .expect("read checkout binding")
+            .is_none(),
+        "teardown must retire the checkout binding for the deleted orbit dir"
     );
 
     let registry = workspace_registry::load_registry_from(&workspace_registry::registry_path_for(
@@ -113,7 +149,7 @@ fn teardown_deletes_the_task_store_partition_and_doctor_confirms_no_orphan_remai
     );
 
     // Doctor, run right after teardown, must report no orphaned task-store
-    // partitions — the torn-down partition is gone, and the survivor's is
+    // partitions — the torn-down partitions are gone, and the survivor's is
     // still registered.
     let results = runtime.doctor_workspace().expect("doctor after teardown");
     let row = results

--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -24,12 +24,11 @@ use fs2::FileExt;
 use orbit_common::OrbitError;
 use orbit_core::OrbitRuntime;
 use orbit_core::application::artifact_health::{ArtifactFinding, RetiredActivityBackendRepair};
-use orbit_registry::workspace_registry;
 use orbit_store::maintenance::migration::SUPPORTED_SCHEMA_VERSION;
 use orbit_types::workspace::WorkspacePaths;
 use serde::Serialize;
 
-use crate::task_store::task_workspaces_dir;
+use crate::task_store;
 
 /// Outcome of one workspace doctor check.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -179,28 +178,8 @@ impl DoctorCommands for OrbitRuntime {
     }
 
     fn remove_orphan_task_stores(&self) -> Result<usize, OrbitError> {
-        let global_root = self.global_root();
-        let workspaces_dir = task_workspaces_dir(&global_root);
-        let Some(entries) = read_task_workspaces_dir(&workspaces_dir)? else {
-            return Ok(0);
-        };
-        let registry = workspace_registry::load_registry_from(
-            &workspace_registry::registry_path_for(&global_root),
-        )?;
-
-        let mut removed = 0;
-        for path in entries {
-            let Some(ws_id) = path.file_name().and_then(|name| name.to_str()) else {
-                continue;
-            };
-            if workspace_registry::find_workspace_by_id(&registry, ws_id).is_some() {
-                continue;
-            }
-            if crate::task_store::remove_task_store_partition(&global_root, ws_id)? {
-                removed += 1;
-            }
-        }
-        Ok(removed)
+        let removed = crate::task_store::remove_unclaimed_task_stores(&self.global_root())?;
+        Ok(removed.len())
     }
 
     fn remove_retired_graph_state(&self) -> Result<usize, OrbitError> {
@@ -440,15 +419,20 @@ fn doctor_check_task_reservations(runtime: &OrbitRuntime) -> WorkspaceDoctorResu
 }
 
 /// Task-store partitions under `<global_root>/tasks/workspaces/<ws_id>/`
-/// whose workspace id is absent from the registry — orphaned by a
-/// `workspace teardown` run on an older binary, or by deleting a checkout
-/// without running teardown [ORB-12109]. Scoped to the whole host, not just
-/// this workspace, because the partition directory is itself host-global.
+/// that no registry claims — left behind by a `workspace teardown` run on an
+/// older binary, or by deleting a checkout without running teardown
+/// [ORB-12109]. Scoped to the whole host, not just this workspace, because the
+/// partition directory is itself host-global.
+///
+/// A partition is named for its *task-registry* workspace id, so the task
+/// registry is what claims it; the workspace catalog and the synthetic
+/// `--root` partition are the other claimants. Comparing the directory name
+/// against catalog `ws_*` ids alone reported every `<slug>-<hash>` partition —
+/// including live ones — as orphaned [ORB-12119].
 fn doctor_check_orphan_task_stores(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
     let global_root = runtime.global_root();
-    let workspaces_dir = task_workspaces_dir(&global_root);
-    let entries = match read_task_workspaces_dir(&workspaces_dir) {
-        Ok(Some(entries)) => entries,
+    let partitions = match task_store::inspect_task_store_partitions(&global_root) {
+        Ok(Some(partitions)) => partitions,
         Ok(None) => {
             return check(
                 "orphan-task-stores",
@@ -460,82 +444,45 @@ fn doctor_check_orphan_task_stores(runtime: &OrbitRuntime) -> WorkspaceDoctorRes
             return check(
                 "orphan-task-stores",
                 WorkspaceDoctorStatus::Warning,
-                format!("cannot scan {}: {error}", workspaces_dir.display()),
+                format!("cannot resolve task-store partition owners: {error}"),
             );
         }
     };
 
-    let registry = match workspace_registry::load_registry_from(
-        &workspace_registry::registry_path_for(&global_root),
-    ) {
-        Ok(registry) => registry,
-        Err(error) => {
-            return check(
-                "orphan-task-stores",
-                WorkspaceDoctorStatus::Warning,
-                format!("cannot read workspace registry: {error}"),
-            );
-        }
-    };
-
-    let mut orphans = Vec::new();
-    for path in &entries {
-        let Some(ws_id) = path.file_name().and_then(|name| name.to_str()) else {
-            continue;
-        };
-        if workspace_registry::find_workspace_by_id(&registry, ws_id).is_some() {
-            continue;
-        }
-        orphans.push(format!(
-            "{ws_id} ({}, {} task bundle(s))",
-            path.display(),
-            count_task_bundles(path)
-        ));
-    }
-
-    if orphans.is_empty() {
+    if partitions.unclaimed.is_empty() {
         return check(
             "orphan-task-stores",
             WorkspaceDoctorStatus::Ok,
             format!(
-                "{} task-store partition(s) scanned, all registered",
-                entries.len()
+                "{} task-store partition(s) scanned, all claimed by a workspace binding",
+                partitions.scanned
             ),
         );
     }
+
+    let orphans = partitions
+        .unclaimed
+        .iter()
+        .map(|path| {
+            format!(
+                "{} ({}, {} task bundle(s))",
+                task_store::partition_id(path).unwrap_or("<unnamed>"),
+                path.display(),
+                count_task_bundles(path)
+            )
+        })
+        .collect::<Vec<_>>();
 
     actionable_check(
         "orphan-task-stores",
         WorkspaceDoctorStatus::Warning,
         format!(
-            "{} orphaned task-store partition(s) (workspace no longer registered on this host): {}",
+            "{} orphaned task-store partition(s) (no workspace binding claims them): {}",
             orphans.len(),
             orphans.join("; ")
         ),
-        "Run `orbit doctor --fix-orphan-task-stores`.".to_string(),
+        "Run `orbit doctor --fix-orphan-task-stores --confirm`.".to_string(),
     )
-}
-
-/// Immediate subdirectories of `<global_root>/tasks/workspaces/`, one per
-/// workspace partition. `None` when the directory has never been created
-/// (fresh host, no task ever committed).
-fn read_task_workspaces_dir(workspaces_dir: &Path) -> Result<Option<Vec<PathBuf>>, OrbitError> {
-    let entries = match std::fs::read_dir(workspaces_dir) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => {
-            return Err(OrbitError::Io(format!(
-                "read {}: {error}",
-                workspaces_dir.display()
-            )));
-        }
-    };
-    let paths = entries
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|path| path.is_dir())
-        .collect();
-    Ok(Some(paths))
 }
 
 /// Task bundles directly under one workspace's task-store partition — each

--- a/crates/orbit-cmd/src/lib.rs
+++ b/crates/orbit-cmd/src/lib.rs
@@ -39,7 +39,10 @@ pub use activity_v2::{ActivityV2Commands, V2ActivityRunResult};
 pub use diagnostics::DiagnosticsCommands;
 pub use doctor::{DoctorCommands, WorkspaceDoctorResult, WorkspaceDoctorStatus};
 pub use migrate::{MigrateCommands, MigrateStatus, migrate_dry_run_at};
-pub use task_store::{remove_task_store_partition, task_store_partition_path};
+pub use task_store::{
+    TaskStorePartitions, bound_partition_id, inspect_task_store_partitions,
+    remove_checkout_task_stores, remove_unclaimed_task_stores, task_store_partition_path,
+};
 
 /// One-stop import for every runtime extension trait this crate defines.
 pub mod prelude {

--- a/crates/orbit-cmd/src/task_store.rs
+++ b/crates/orbit-cmd/src/task_store.rs
@@ -1,16 +1,27 @@
-//! Task-store partition paths, shared by `workspace teardown` and `doctor`'s
-//! orphan-partition check/fix [ORB-12109].
+//! Task-store partition paths and ownership, shared by `workspace teardown`
+//! and `doctor`'s orphan-partition check/fix [ORB-12109].
 //!
 //! `orbit-store` owns the per-workspace bundle layout
 //! (`<global_root>/tasks/workspaces/<workspace_id>/`) but knows nothing
 //! about the workspace registry; this module is the composition seam that
 //! lets a caller resolve or remove one workspace's partition without
 //! reaching around `orbit-store` from `orbit-cli`.
+//!
+//! The partition directory name is a *task-registry* workspace id
+//! (`workspace_bindings.workspace_id` in `<global_root>/tasks/index.sqlite`),
+//! which is minted as `<slug>-<hash>` whenever a checkout binds without an
+//! explicit id. It is not the workspace catalog's `ws_*` id space, so the
+//! task registry — not `workspaces.json` — decides which partition a checkout's
+//! task state lives in and which partitions are still claimed [ORB-12119].
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use orbit_common::OrbitError;
+use orbit_core::runtime::UNBOUND_DATA_DIR_WORKSPACE_ID;
+use orbit_registry::workspace_registry;
 pub use orbit_store::maintenance::task_registry::task_workspaces_dir;
+use orbit_store::maintenance::task_registry::{TaskRegistryStore, task_registry_path};
 
 /// Path to one workspace's task-store partition under
 /// `<global_root>/tasks/workspaces/<workspace_id>/`.
@@ -18,12 +29,214 @@ pub fn task_store_partition_path(global_root: &Path, workspace_id: &str) -> Path
     task_workspaces_dir(global_root).join(workspace_id)
 }
 
-/// Delete one workspace's task-store partition if present. Returns whether
-/// anything was removed.
-pub fn remove_task_store_partition(
+/// What a scan of `<global_root>/tasks/workspaces/` found.
+#[derive(Debug, Clone)]
+pub struct TaskStorePartitions {
+    /// Partition directories present on this host.
+    pub scanned: usize,
+    /// Those that no registry claims.
+    pub unclaimed: Vec<PathBuf>,
+}
+
+/// Classify every task-store partition on this host as claimed or orphaned.
+///
+/// `None` means the directory has never been created (fresh host, no task ever
+/// committed) — nothing to diagnose rather than nothing orphaned.
+pub fn inspect_task_store_partitions(
+    global_root: &Path,
+) -> Result<Option<TaskStorePartitions>, OrbitError> {
+    let Some(partitions) = task_store_partitions(global_root)? else {
+        return Ok(None);
+    };
+    let claimed = claimed_partition_ids(global_root)?;
+    let scanned = partitions.len();
+    let unclaimed = partitions
+        .into_iter()
+        .filter(|path| !path_is_claimed(path, &claimed))
+        .collect();
+    Ok(Some(TaskStorePartitions { scanned, unclaimed }))
+}
+
+/// Delete every partition no registry claims, retiring any registry rows that
+/// name it. Returns the removed partition paths.
+pub fn remove_unclaimed_task_stores(global_root: &Path) -> Result<Vec<PathBuf>, OrbitError> {
+    let Some(partitions) = inspect_task_store_partitions(global_root)? else {
+        return Ok(Vec::new());
+    };
+    let unclaimed = partitions.unclaimed;
+    let tasks = open_task_registry(global_root)?;
+
+    let mut removed = Vec::new();
+    for path in unclaimed {
+        let Some(workspace_id) = partition_id(&path) else {
+            continue;
+        };
+        if remove_partition(&tasks, global_root, workspace_id)? {
+            removed.push(path);
+        }
+    }
+    Ok(removed)
+}
+
+/// Delete the task-store partitions a torn-down checkout leaves behind:
+/// the partition its task state is actually bound to, plus a partition named
+/// for its workspace-catalog id when one exists and no other checkout is bound
+/// to it. Returns the removed partition paths.
+///
+/// The second case only arises for a checkout whose catalog id and bound
+/// partition id coincide, or for a partition left over from before the two id
+/// spaces were told apart; a partition another checkout still binds is never
+/// this checkout's to delete.
+pub fn remove_checkout_task_stores(
+    global_root: &Path,
+    orbit_dir: &Path,
+    catalog_workspace_id: Option<&str>,
+) -> Result<Vec<PathBuf>, OrbitError> {
+    let tasks = open_task_registry(global_root)?;
+    let mut targets: Vec<String> = Vec::new();
+
+    if let Some(bound) = tasks.find_checkout_by_orbit_dir(orbit_dir)? {
+        targets.push(bound.workspace_id);
+    }
+    if let Some(catalog_id) = catalog_workspace_id
+        && !targets.iter().any(|id| id == catalog_id)
+        && !bound_to_another_checkout(&tasks, catalog_id, orbit_dir)?
+    {
+        targets.push(catalog_id.to_string());
+    }
+
+    let mut removed = Vec::new();
+    for workspace_id in targets {
+        if remove_partition(&tasks, global_root, &workspace_id)? {
+            removed.push(task_store_partition_path(global_root, &workspace_id));
+        }
+    }
+    Ok(removed)
+}
+
+/// Partition the checkout at `orbit_dir` binds its task state to, when it is
+/// bound — the directory a caller must look in to find that checkout's task
+/// bundles, whatever the workspace catalog calls the same checkout.
+pub fn bound_partition_id(
+    global_root: &Path,
+    orbit_dir: &Path,
+) -> Result<Option<String>, OrbitError> {
+    Ok(open_task_registry(global_root)?
+        .find_checkout_by_orbit_dir(orbit_dir)?
+        .map(|binding| binding.workspace_id))
+}
+
+/// Whether the task registry still binds `workspace_id` as a partition.
+pub fn partition_is_bound(global_root: &Path, workspace_id: &str) -> Result<bool, OrbitError> {
+    Ok(open_task_registry(global_root)?
+        .workspace_ids()?
+        .contains(workspace_id))
+}
+
+/// Every workspace id that still claims a partition on this host: the task
+/// registry's own bindings, the workspace catalog's ids, and the synthetic
+/// partition every `--root <data-dir>` write lands in, which by construction
+/// appears in neither registry.
+fn claimed_partition_ids(global_root: &Path) -> Result<BTreeSet<String>, OrbitError> {
+    let tasks = open_task_registry(global_root)?;
+    let mut claimed = tasks.workspace_ids()?;
+    claimed.insert(UNBOUND_DATA_DIR_WORKSPACE_ID.to_string());
+
+    let registry_path = workspace_registry::registry_path_for(global_root);
+    if registry_path.exists() {
+        let registry = workspace_registry::load_registry_from(&registry_path)?;
+        claimed.extend(
+            registry
+                .workspaces
+                .into_iter()
+                .map(|workspace| workspace.id),
+        );
+    }
+    Ok(claimed)
+}
+
+/// Open the task registry that names the partitions, refusing to answer
+/// ownership questions when it is absent: without it every live partition
+/// would look unclaimed, and the caller's next step is deletion.
+fn open_task_registry(global_root: &Path) -> Result<TaskRegistryStore, OrbitError> {
+    let path = task_registry_path(global_root);
+    if !path.exists() {
+        return Err(OrbitError::Io(format!(
+            "task registry {} is missing, so no task-store partition's owner can be resolved",
+            path.display()
+        )));
+    }
+    TaskRegistryStore::open(&path)
+}
+
+/// Immediate subdirectories of `<global_root>/tasks/workspaces/`, one per
+/// partition. `None` when the directory has never been created.
+fn task_store_partitions(global_root: &Path) -> Result<Option<Vec<PathBuf>>, OrbitError> {
+    let workspaces_dir = task_workspaces_dir(global_root);
+    let entries = match std::fs::read_dir(&workspaces_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(OrbitError::Io(format!(
+                "read {}: {error}",
+                workspaces_dir.display()
+            )));
+        }
+    };
+    Ok(Some(
+        entries
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.is_dir())
+            .collect(),
+    ))
+}
+
+/// Workspace id a partition directory is named for.
+pub fn partition_id(partition: &Path) -> Option<&str> {
+    partition.file_name().and_then(|name| name.to_str())
+}
+
+fn path_is_claimed(partition: &Path, claimed: &BTreeSet<String>) -> bool {
+    partition_id(partition).is_some_and(|id| claimed.contains(id))
+}
+
+/// Whether `workspace_id`'s partition holds *another* checkout's task state,
+/// and so is not this checkout's to delete. The registry normalizes the paths
+/// it stores, so the comparison canonicalizes too.
+fn bound_to_another_checkout(
+    tasks: &TaskRegistryStore,
+    workspace_id: &str,
+    orbit_dir: &Path,
+) -> Result<bool, OrbitError> {
+    let binding = match tasks.find_workspace_checkout(workspace_id) {
+        Ok(binding) => binding,
+        // Not a well-formed workspace id, so no binding can name it.
+        Err(OrbitError::InvalidInput(_)) => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    let canonical = std::fs::canonicalize(orbit_dir).unwrap_or_else(|_| orbit_dir.to_path_buf());
+    Ok(binding.is_some_and(|binding| binding.orbit_dir != canonical))
+}
+
+/// Retire one partition's registry bindings, then delete its directory —
+/// bindings first, so an interrupted removal leaves recoverable bundles rather
+/// than a binding pointing at a directory that is gone. Returns whether a
+/// partition directory was deleted; bindings are retired either way, including
+/// for a workspace that never wrote a bundle.
+fn remove_partition(
+    tasks: &TaskRegistryStore,
     global_root: &Path,
     workspace_id: &str,
 ) -> Result<bool, OrbitError> {
+    // A directory name that is not a well-formed workspace id can hold no
+    // bindings; its directory is still this function's to remove.
+    if let Err(error) = tasks.unbind_workspace(workspace_id)
+        && !matches!(error, OrbitError::InvalidInput(_))
+    {
+        return Err(error);
+    }
+
     let path = task_store_partition_path(global_root, workspace_id);
     if !path.is_dir() {
         return Ok(false);

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -6,7 +6,9 @@ use std::path::Path;
 use chrono::Utc;
 use fs2::FileExt;
 use orbit_registry::workspace_registry;
-use orbit_store::maintenance::task_registry::task_workspaces_dir;
+use orbit_store::maintenance::task_registry::{
+    BindWorkspaceParams, TaskRegistryStore, task_registry_path, task_workspaces_dir,
+};
 use orbit_types::workflow::{JobRun, JobRunState};
 use orbit_types::workspace::{Workspace, WorkspaceStatus};
 use sha2::{Digest, Sha256};
@@ -77,6 +79,24 @@ fn write_registered_workspace(global_root: &Path, workspace_id: &str, name: &str
     )
     .expect("register workspace");
     workspace_registry::save_registry_to(&registry, &registry_path).expect("save registry");
+}
+
+/// Bind a checkout in the *task* registry — the id space the partition
+/// directories are named after, which a `<slug>-<hash>` id inhabits and the
+/// workspace catalog's `ws_*` ids do not [ORB-12119].
+fn bind_task_partition(global_root: &Path, workspace_id: &str, slug: &str, repo_root: &Path) {
+    let tasks =
+        TaskRegistryStore::open(&task_registry_path(global_root)).expect("open task registry");
+    tasks
+        .bind_workspace(BindWorkspaceParams {
+            workspace_id: Some(workspace_id.to_string()),
+            slug: slug.to_string(),
+            repo_root: repo_root.to_path_buf(),
+            workspace_path: repo_root.to_path_buf(),
+            orbit_dir: repo_root.join(".orbit"),
+            repo_fingerprint: None,
+        })
+        .expect("bind task-registry workspace");
 }
 
 fn write_task_bundle(global_root: &Path, workspace_id: &str, task_id: &str) {
@@ -953,7 +973,74 @@ fn orphan_task_store_partition_is_reported_with_path_and_remediation() {
     );
     assert_eq!(
         row.remediation.as_deref(),
-        Some("Run `orbit doctor --fix-orphan-task-stores`.")
+        Some("Run `orbit doctor --fix-orphan-task-stores --confirm`.")
+    );
+}
+
+/// [ORB-12119] A partition bound in the task registry under a derived
+/// `<slug>-<hash>` id is live task state, even though that id is absent from
+/// the workspace catalog, which knows the same checkout as `ws_*`. Comparing
+/// partition names against catalog ids alone flagged every such partition —
+/// the host's real task stores — as orphaned.
+#[test]
+fn task_registry_bound_partition_is_not_an_orphan() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let global_root = temp.path().join("global");
+    let drifted_root = temp.path().join("drifted");
+    fs::create_dir_all(drifted_root.join(".orbit")).expect("create drifted checkout");
+
+    write_registered_workspace(&global_root, "ws_drifted", "drifted");
+    bind_task_partition(&global_root, "drifted-a1b2c3", "drifted", &drifted_root);
+    write_task_bundle(&global_root, "drifted-a1b2c3", "ORB-1");
+
+    let results = runtime.doctor_workspace().expect("doctor");
+    let row = status_of(&results, "orphan-task-stores");
+    assert_eq!(
+        row.status,
+        WorkspaceDoctorStatus::Ok,
+        "a bound partition is live task state: {row:?}"
+    );
+}
+
+/// [ORB-12119] The fix deletes only partitions no registry claims: a
+/// task-registry binding, a workspace-catalog entry, and the synthetic
+/// `--root` data-dir partition each keep their bundles.
+#[test]
+fn fix_orphan_task_stores_keeps_every_claimed_partition() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let global_root = temp.path().join("global");
+    let drifted_root = temp.path().join("drifted");
+    fs::create_dir_all(drifted_root.join(".orbit")).expect("create drifted checkout");
+
+    write_registered_workspace(&global_root, "ws_registered", "registered");
+    write_task_bundle(&global_root, "ws_registered", "ORB-1");
+    bind_task_partition(&global_root, "drifted-a1b2c3", "drifted", &drifted_root);
+    write_task_bundle(&global_root, "drifted-a1b2c3", "ORB-2");
+    // Every `--root <data-dir>` write lands here, and no registry ever records it.
+    write_task_bundle(&global_root, "ws_unbound-data-dir", "ORB-3");
+    write_task_bundle(&global_root, "ws_orphan", "ORB-4");
+
+    let removed = runtime
+        .remove_orphan_task_stores()
+        .expect("remove orphan task stores");
+    assert_eq!(removed, 1, "only the unclaimed partition is removed");
+
+    let partitions = task_workspaces_dir(&global_root);
+    assert!(!partitions.join("ws_orphan").exists());
+    for claimed in ["ws_registered", "drifted-a1b2c3", "ws_unbound-data-dir"] {
+        assert!(
+            partitions.join(claimed).is_dir(),
+            "claimed partition '{claimed}' must survive the fix"
+        );
+    }
+
+    let results = runtime.doctor_workspace().expect("doctor after fix");
+    assert_eq!(
+        status_of(&results, "orphan-task-stores").status,
+        WorkspaceDoctorStatus::Ok,
+        "{results:?}"
     );
 }
 

--- a/crates/orbit-cmd/src/tests/mod.rs
+++ b/crates/orbit-cmd/src/tests/mod.rs
@@ -7,4 +7,5 @@ mod migrate;
 mod registry_routines;
 mod registry_runtime;
 mod task_owner;
+mod task_store;
 mod workspace_catalog;

--- a/crates/orbit-cmd/src/tests/task_store.rs
+++ b/crates/orbit-cmd/src/tests/task_store.rs
@@ -1,0 +1,132 @@
+//! Sibling tests for `task_store.rs` — which partition a checkout's task state
+//! lives in, and what removing one retires [ORB-12119].
+
+use std::fs;
+use std::path::Path;
+
+use orbit_store::maintenance::task_registry::{
+    BindWorkspaceParams, TaskRegistryStore, task_registry_path, task_workspaces_dir,
+};
+
+use crate::task_store::{
+    bound_partition_id, partition_is_bound, remove_checkout_task_stores, task_store_partition_path,
+};
+
+fn bind(global_root: &Path, workspace_id: &str, slug: &str, repo_root: &Path) {
+    let tasks =
+        TaskRegistryStore::open(&task_registry_path(global_root)).expect("open task registry");
+    tasks
+        .bind_workspace(BindWorkspaceParams {
+            workspace_id: Some(workspace_id.to_string()),
+            slug: slug.to_string(),
+            repo_root: repo_root.to_path_buf(),
+            workspace_path: repo_root.to_path_buf(),
+            orbit_dir: repo_root.join(".orbit"),
+            repo_fingerprint: None,
+        })
+        .expect("bind task-registry workspace");
+}
+
+fn write_task_bundle(global_root: &Path, workspace_id: &str, task_id: &str) {
+    let bundle = task_workspaces_dir(global_root)
+        .join(workspace_id)
+        .join(task_id);
+    fs::create_dir_all(&bundle).expect("create task bundle dir");
+    fs::write(bundle.join("task.yaml"), b"id: dummy\n").expect("write bundle file");
+}
+
+/// A checkout bound under a derived `<slug>-<hash>` id keeps its task state
+/// there, not under the `ws_*` id the workspace catalog knows it by. Removing
+/// the checkout's task stores must follow the binding and retire it.
+#[test]
+fn removing_a_checkout_deletes_the_bound_partition_and_retires_its_bindings() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let repo_root = temp.path().join("repo");
+    let orbit_dir = repo_root.join(".orbit");
+    fs::create_dir_all(&global_root).expect("create global root");
+    fs::create_dir_all(&orbit_dir).expect("create checkout");
+
+    bind(&global_root, "repo-a1b2c3", "repo", &repo_root);
+    write_task_bundle(&global_root, "repo-a1b2c3", "ORB-1");
+    // An unrelated checkout's partition, which this removal must not touch.
+    let other_root = temp.path().join("other");
+    fs::create_dir_all(other_root.join(".orbit")).expect("create other checkout");
+    bind(&global_root, "other-d4e5f6", "other", &other_root);
+    write_task_bundle(&global_root, "other-d4e5f6", "ORB-2");
+
+    assert_eq!(
+        bound_partition_id(&global_root, &orbit_dir).expect("resolve bound partition"),
+        Some("repo-a1b2c3".to_string())
+    );
+
+    let removed = remove_checkout_task_stores(&global_root, &orbit_dir, Some("ws_repo"))
+        .expect("remove checkout task stores");
+    assert_eq!(
+        removed,
+        vec![task_store_partition_path(&global_root, "repo-a1b2c3")]
+    );
+    assert!(
+        !task_workspaces_dir(&global_root)
+            .join("repo-a1b2c3")
+            .exists()
+    );
+    assert!(
+        !partition_is_bound(&global_root, "repo-a1b2c3").expect("read bindings"),
+        "no binding may survive pointing at the deleted bundle directory"
+    );
+
+    assert!(
+        task_workspaces_dir(&global_root)
+            .join("other-d4e5f6")
+            .is_dir(),
+        "an unrelated checkout's partition must survive"
+    );
+    assert!(partition_is_bound(&global_root, "other-d4e5f6").expect("read bindings"));
+}
+
+/// A partition named for the removed checkout's catalog id, but bound to a
+/// different checkout, holds that checkout's live tasks.
+#[test]
+fn removing_a_checkout_leaves_a_catalog_named_partition_another_checkout_binds() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let repo_root = temp.path().join("repo");
+    let orbit_dir = repo_root.join(".orbit");
+    let other_root = temp.path().join("other");
+    fs::create_dir_all(&global_root).expect("create global root");
+    fs::create_dir_all(&orbit_dir).expect("create checkout");
+    fs::create_dir_all(other_root.join(".orbit")).expect("create other checkout");
+
+    bind(&global_root, "ws_shared", "other", &other_root);
+    write_task_bundle(&global_root, "ws_shared", "ORB-1");
+
+    let removed = remove_checkout_task_stores(&global_root, &orbit_dir, Some("ws_shared"))
+        .expect("remove checkout task stores");
+    assert!(removed.is_empty(), "nothing of this checkout's to remove");
+    assert!(task_workspaces_dir(&global_root).join("ws_shared").is_dir());
+    assert!(partition_is_bound(&global_root, "ws_shared").expect("read bindings"));
+}
+
+/// A checkout with no task-registry binding still leaves a partition named for
+/// its catalog id, as an older binary wrote it.
+#[test]
+fn removing_a_checkout_deletes_an_unbound_catalog_named_partition() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let orbit_dir = temp.path().join("repo").join(".orbit");
+    fs::create_dir_all(&global_root).expect("create global root");
+    fs::create_dir_all(&orbit_dir).expect("create checkout");
+
+    // Open the registry once so the fixture has one, as any real host does.
+    TaskRegistryStore::open(&task_registry_path(&global_root)).expect("open task registry");
+    write_task_bundle(&global_root, "ws_legacy", "ORB-1");
+
+    let removed = remove_checkout_task_stores(&global_root, &orbit_dir, Some("ws_legacy"))
+        .expect("remove checkout task stores");
+    assert_eq!(
+        removed,
+        vec![task_store_partition_path(&global_root, "ws_legacy")]
+    );
+    assert!(!task_workspaces_dir(&global_root).join("ws_legacy").exists());
+}

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -35,7 +35,12 @@ use crate::skill_catalog::SkillCatalog;
 /// Job-run partition used when an explicit `--root` data directory is opened
 /// without a selected checkout. Never written to `config.yaml` and never
 /// inserted as a `workspace_checkout_bindings` row.
-const UNBOUND_DATA_DIR_WORKSPACE_ID: &str = "ws_unbound-data-dir";
+///
+/// Public because it is the one partition id no registry ever claims: host
+/// maintenance that decides whether a task-store partition is orphaned must
+/// recognize it rather than delete the tasks every `--root` write lands in
+/// [ORB-12119].
+pub const UNBOUND_DATA_DIR_WORKSPACE_ID: &str = "ws_unbound-data-dir";
 
 /// Runtime builder. Global root provides activities, jobs, executors, policies,
 /// config, global skills, and SQLite. Shared root provides existing workspace

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -66,6 +66,9 @@ pub use resolve::{
 // `pub` for the runtime-less `orbit migrate --dry-run` inspection that moved
 // to `orbit-cmd` [ORB-10016].
 pub use resolve::{is_global_orbit_root, resolve_global_root, try_resolve_initialized_roots};
+// `pub` for host task-store maintenance in `orbit-cmd`, which must recognize
+// the one partition id no registry claims [ORB-12119].
+pub use builder::UNBOUND_DATA_DIR_WORKSPACE_ID;
 pub use run_input::managed_workspace_selector_from_env;
 pub(crate) use task::{failed_run_error_context, is_workflow_failure_state};
 

--- a/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
@@ -1247,6 +1247,75 @@ impl TaskRegistryStore {
         &self.workspaces_dir
     }
 
+    /// Every logical workspace id the registry binds.
+    ///
+    /// This is the id space the on-disk partitions under
+    /// `<global>/tasks/workspaces/` are named after, so a caller deciding
+    /// whether a partition directory is still claimed asks here rather than
+    /// inferring an owner from the workspace catalog, whose `ws_*` ids are a
+    /// different namespace [ORB-12119].
+    pub fn workspace_ids(&self) -> Result<BTreeSet<String>, OrbitError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+        let mut stmt = conn
+            .prepare("SELECT workspace_id FROM workspace_bindings")
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        rows.collect::<Result<BTreeSet<_>, _>>()
+            .map_err(|e| OrbitError::Store(e.to_string()))
+    }
+
+    /// Retire one workspace's registry rows: its checkout binding, every task
+    /// bundle bound to it, and the logical workspace itself. Returns whether a
+    /// binding existed.
+    ///
+    /// Paired with deleting the workspace's bundle partition, so that no
+    /// binding survives pointing at a directory that is gone [ORB-12119]. The
+    /// dependent rows are deleted explicitly rather than left to
+    /// `ON DELETE CASCADE`, which a connection without `foreign_keys=ON` would
+    /// silently skip.
+    pub fn unbind_workspace(&self, workspace_id: &str) -> Result<bool, OrbitError> {
+        let workspace_id = validate_workspace_id(workspace_id)?;
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        for statement in [
+            // Relations are retired from both ends, like `unregister_task_bundle`:
+            // an edge another workspace points at these tasks would otherwise
+            // outlive them.
+            "DELETE FROM task_bundle_relations
+             WHERE workspace_id = ?1
+                OR target_task_id IN (
+                    SELECT task_id FROM task_bundle_bindings WHERE workspace_id = ?1
+                )",
+            "DELETE FROM task_bundle_tags WHERE workspace_id = ?1",
+            "DELETE FROM task_bundle_index WHERE workspace_id = ?1",
+            "DELETE FROM task_bundle_bindings WHERE workspace_id = ?1",
+            "DELETE FROM workspace_checkout_bindings WHERE workspace_id = ?1",
+        ] {
+            tx.execute(statement, [&workspace_id])
+                .map_err(|e| OrbitError::Store(e.to_string()))?;
+        }
+        let deleted = tx
+            .execute(
+                "DELETE FROM workspace_bindings WHERE workspace_id = ?1",
+                [&workspace_id],
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        tx.commit().map_err(|e| OrbitError::Store(e.to_string()))?;
+        Ok(deleted > 0)
+    }
+
     /// Look up a logical workspace by id. Public wrapper over the internal query
     /// so migration tooling can resolve a target workspace without opening the
     /// SQLite connection directly.

--- a/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
@@ -1841,3 +1841,142 @@ fn bump_allocator_never_lowers() {
     store.bump_allocator_to_at_least(900).expect("bump high");
     assert_eq!(store.allocator_next_number().expect("read"), 900);
 }
+
+#[test]
+fn workspace_ids_lists_every_bound_partition() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let workspace = bind(&store, temp.path());
+    store
+        .register_workspace(RegisterWorkspaceParams {
+            workspace_id: "ws_remote".into(),
+            slug: "remote".into(),
+            repo_fingerprint: None,
+        })
+        .expect("register logical workspace");
+
+    let ids = store.workspace_ids().expect("list workspace ids");
+    assert!(ids.contains(&workspace.workspace_id));
+    assert!(ids.contains("ws_remote"));
+}
+
+/// Deleting a workspace's bundle partition on disk is paired with retiring its
+/// registry rows, so no binding survives naming a directory that is gone
+/// [ORB-12119].
+#[test]
+fn unbind_workspace_retires_the_checkout_and_its_task_bundles() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let workspace = bind(&store, temp.path());
+    let bundle_dir = create_canonical_bundle(&store, &workspace, "ORB-00000");
+    store
+        .register_task_bundle("ORB-00000", &workspace.workspace_id, &bundle_dir)
+        .expect("register bundle");
+    store
+        .replace_task_index(
+            &workspace.workspace_id,
+            &envelope(
+                "ORB-00000",
+                TaskStatus::Backlog,
+                vec!["v2".into()],
+                Vec::new(),
+            ),
+        )
+        .expect("index task");
+
+    assert!(
+        store
+            .unbind_workspace(&workspace.workspace_id)
+            .expect("unbind workspace")
+    );
+
+    assert!(
+        store
+            .find_workspace_binding(&workspace.workspace_id)
+            .expect("read workspace binding")
+            .is_none()
+    );
+    assert!(
+        store
+            .find_checkout_by_orbit_dir(&workspace.orbit_dir)
+            .expect("read checkout binding")
+            .is_none()
+    );
+    assert!(
+        store
+            .find_task_binding("ORB-00000")
+            .expect("read task binding")
+            .is_none(),
+        "a task binding must not outlive its partition"
+    );
+    assert!(
+        !store
+            .unbind_workspace(&workspace.workspace_id)
+            .expect("second unbind is a no-op"),
+        "unbinding an unknown workspace reports that nothing was retired"
+    );
+}
+
+/// A relation another workspace points at the retired workspace's tasks must
+/// not outlive the partition those tasks lived in [ORB-12119].
+#[test]
+fn unbind_workspace_retires_relations_pointing_into_it() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let retired = bind(&store, temp.path());
+
+    let other_root = temp.path().join("other");
+    let other_orbit_dir = other_root.join(".orbit");
+    fs::create_dir_all(&other_orbit_dir).expect("create other orbit dir");
+    let other = store
+        .bind_workspace(BindWorkspaceParams {
+            workspace_id: Some("other-654321".into()),
+            slug: "Other".into(),
+            repo_root: other_root.clone(),
+            workspace_path: other_root,
+            orbit_dir: other_orbit_dir,
+            repo_fingerprint: None,
+        })
+        .expect("bind other workspace");
+
+    for (workspace_id, task_id) in [
+        (&retired.workspace_id, "ORB-00000"),
+        (&other.workspace_id, "ORB-00001"),
+    ] {
+        let bundle_dir = store
+            .canonical_task_bundle_path(workspace_id, task_id)
+            .expect("canonical bundle path");
+        fs::create_dir_all(&bundle_dir).expect("create bundle");
+        store
+            .register_task_bundle(task_id, workspace_id, &bundle_dir)
+            .expect("register bundle");
+    }
+    store
+        .replace_task_index(
+            &other.workspace_id,
+            &envelope(
+                "ORB-00001",
+                TaskStatus::Backlog,
+                Vec::new(),
+                vec![TaskRelation {
+                    relation_type: TaskRelationType::BlockedBy,
+                    target: "ORB-00000".into(),
+                }],
+            ),
+        )
+        .expect("index the pointing task");
+
+    store
+        .unbind_workspace(&retired.workspace_id)
+        .expect("unbind workspace");
+
+    let conn = store.conn.lock().expect("lock registry");
+    let remaining: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM task_bundle_relations WHERE target_task_id = ?1",
+            ["ORB-00000"],
+            |row| row.get(0),
+        )
+        .expect("count relations");
+    assert_eq!(remaining, 0, "no edge may point into a retired partition");
+}

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -28,7 +28,7 @@ Every check degrades to a row rather than aborting unless the store itself canno
 | `job-runs` | orphaned `pending` or `running` runs with no live worker process |
 | `task-reservations` | active reservations whose owner run or terminal task association proves the reservation stale |
 | `task-relations` | unresolved relation/dependency targets that would block a task-index rebuild |
-| `orphan-task-stores` | task-store partitions (`~/.orbit/tasks/workspaces/<ws_id>/`) whose workspace is no longer registered on this host |
+| `orphan-task-stores` | task-store partitions (`~/.orbit/tasks/workspaces/<ws_id>/`) that no workspace binding on this host claims |
 | `artifacts-*` | skills, jobs, activities, auto-tasks, and routines on disk: stale, deprecated, residual, catalog-invalid, or a previously reconciled shipped default that is missing |
 
 Example:
@@ -46,7 +46,7 @@ $ orbit doctor
 │ job-runs         ok        no orphaned job runs                                              │
 │ task-reservations ok       no conclusively stale active task reservations                    │
 │ task-relations   ok        no unresolved relation/dependency targets                        │
-│ orphan-task-stores ok      2 task-store partition(s) scanned, all registered                │
+│ orphan-task-stores ok      2 task-store partition(s) scanned, all claimed …                 │
 0 failure(s), 1 warning(s).
 ```
 
@@ -98,18 +98,27 @@ individual flag; neither command upgrades the binary or pulls a remote repositor
 ### Reclaim orphaned task stores
 
 `orbit workspace teardown --confirm` deregisters the workspace and deletes both the checkout's
-`.orbit/` and its global task-store partition
-(`~/.orbit/tasks/workspaces/<ws_id>/`) in one step. `orphan-task-stores` exists for partitions a
-prior teardown on an older binary left behind, or a checkout removed without running teardown at
-all: each warning names the orphaned workspace id, its partition path, and its task-bundle
-count. Repair with:
+`.orbit/` and the global task-store partition its task state is bound to, retiring that
+partition's rows in `~/.orbit/tasks/index.sqlite` in the same step.
+
+A partition directory is named for a **task-registry** workspace id
+(`workspace_bindings.workspace_id` in `~/.orbit/tasks/index.sqlite`), minted as `<slug>-<hash>`
+for a checkout that binds without an explicit id. That is a different id space from the workspace
+catalog's `ws_*` ids in `~/.orbit/workspaces.json`, so a partition is orphaned only when neither
+registry claims it; the synthetic `ws_unbound-data-dir` partition every `--root <data-dir>` write
+lands in is never reported. `orphan-task-stores` exists for partitions a prior teardown on an
+older binary left behind, or a checkout removed without running teardown at all: each warning
+names the orphaned workspace id, its partition path, and its task-bundle count. Repair with:
 
 ```sh
-orbit doctor --fix-orphan-task-stores
+orbit doctor --fix-orphan-task-stores --confirm
 ```
 
-The repair loads the registry once, then deletes only the partitions it finds with no matching
-workspace id; it is idempotent, and running it again after a partition is gone is a no-op.
+The repair deletes task bundles, so it refuses to run without `--confirm`. It resolves the claims
+once, deletes only the partitions no binding names, retires any registry rows naming them, and is
+idempotent: running it again after a partition is gone is a no-op. When the task registry itself
+is missing, the check warns and the repair refuses rather than treating every live partition as
+unclaimed.
 
 ### Repair retired activity backends
 


### PR DESCRIPTION
## Task

[ORB-12119](https://orbit-cli.com/tasks/ORB-12119) — [code-review] doctor's orphan-task-store check compares task-registry partition ids against workspace-registry ids, so --fix-orphan-task-stores deletes the live task store

### Description

Found by the ORB-12099 code-review sweep over `420f3702f..fb7b8e501`, in the ORB-12109 delivery (`48773f492`, PR #1911).

## Defect

`doctor_check_orphan_task_stores` and `remove_orphan_task_stores` treat a directory under `<global_root>/tasks/workspaces/<id>/` as orphaned when `<id>` is absent from the **workspace registry** (`workspaces.json` → `Workspace.id`):

- `crates/orbit-cmd/src/doctor.rs:486` — `workspace_registry::find_workspace_by_id(&registry, ws_id).is_some()` is the only "registered" test in the warning path.
- `crates/orbit-cmd/src/doctor.rs:196` — the same test in the `--fix` path, followed by `remove_task_store_partition` → `std::fs::remove_dir_all`.
- `crates/orbit-cmd/src/task_store.rs:25-35` — the removal itself, an unconditional recursive delete of the partition.
- `crates/orbit-cli/src/command/doctor.rs:108-116` — the `--fix-orphan-task-stores` flag; no confirmation beyond the flag.

But the partition directory name is the **task-registry** `workspace_id` (`workspace_bindings.workspace_id` in `<global_root>/tasks/index.sqlite`), minted in `orbit-store` as `<slug>-<hash>` whenever `bind_workspace` is asked for a binding without an explicit id (`crates/orbit-core/src/runtime/builder.rs:292`, `rebind_candidate_workspace_id`). That identifier space is *not* the workspace-registry `ws_*` id space, and `builder.rs:274-286` documents that a checkout whose `config.yaml` identity drifted "still keeps its task state under the bound id".

Consequence: the host's real, live partitions are reported as orphans, and the remediation the warning prints deletes them.

## Evidence on this host (read-only inspection, 2026-09-11)

`~/.orbit/tasks/workspaces/` vs `~/.orbit/workspaces.json` `workspaces[].id`:

```
ORPHAN  orbit-5c61b3        2159 bundles   <- the live Orbit task store (contains ORB-12099)
ORPHAN  polaris-68dcd0       121 bundles
ORPHAN  bridge-c02d47         47 bundles
ORPHAN  orrery-66f9a9         46 bundles
ORPHAN  constellation-25cebd  44 bundles
ORPHAN  daniel-e9c542         44 bundles
ORPHAN  principia-29ed35      28 bundles
ORPHAN  server-e7c6c5         22 bundles
... (18 of 22 partitions flagged)
ok      ws_orbit              14 bundles
ok      ws_orbit-graph        20 bundles
ok      ws_orbit-research      3 bundles
ok      ws_parallax            2 bundles
```

`workspace_bindings` in `~/.orbit/tasks/index.sqlite` confirms `('orbit-5c61b3', 'orbit', 'git@github.com:danieljhkim/orbit.git', …)` is the bound partition for this checkout, while `workspaces.json` registers the workspace as `ws_orbit`. So:

1. Plain `orbit doctor` now emits a `Warning` naming 18 live partitions as "workspace no longer registered on this host" with remediation "Run `orbit doctor --fix-orphan-task-stores`".
2. An operator who follows that remediation deletes `~/.orbit/tasks/workspaces/orbit-5c61b3` — 2159 task bundles, i.e. Orbit's entire task history on this machine. The `tasks/index.sqlite` bindings survive, so every task ID then resolves to a missing bundle.

A synthetic, never-registered id is also affected by construction: `UNBOUND_DATA_DIR_WORKSPACE_ID` (`crates/orbit-core/src/runtime/builder.rs:38`, `:87`, `:258`) is the partition every `--root <data-dir>` write lands in (see the `ws_unbound-data-dir` assertions at `crates/orbit-cli/tests/mcp_roundtrip.rs:5115-5125`), and it is never written to `workspaces.json`.

## Second symptom, same root cause

`orbit workspace teardown --confirm` deletes `task_store_partition_path(&global_root, &ws_id)` where `ws_id` is the **workspace-registry** checkout id (`crates/orbit-cli/src/command/workspace/teardown.rs:66-77`). For this host that is `ws_orbit`, not the bound `orbit-5c61b3`, so teardown still leaves the real partition behind — the ORB-12109 symptom it was meant to fix — while deleting a differently-bound partition that may hold real tasks. Teardown also leaves the `workspace_bindings` / `task_bundle_bindings` rows in `tasks/index.sqlite` pointing at the deleted directory.

## Suggested direction

Resolve the partition id through the task registry (`TaskRegistryStore::find_checkout_by_orbit_dir` / `workspace_bindings`) instead of the workspace registry, and treat a partition as orphaned only when no task-registry binding *and* no workspace-registry entry claims it — excluding the synthetic unbound-data-dir partition. Whatever removal path survives should also retire the corresponding registry rows, and the destructive fix deserves the same `--confirm` treatment teardown has.

### Acceptance Criteria

- `orbit doctor` reports no orphaned task-store partition for a checkout whose task-registry `workspace_id` differs from its workspace-registry `ws_*` id, proven by a test that binds a partition under a `<slug>-<hash>` id and registers the workspace under a `ws_*` id.
- `orbit doctor --fix-orphan-task-stores` leaves every partition that any task-registry binding (or the synthetic unbound-data-dir partition) claims, and deletes only partitions no registry claims.
- `orbit workspace teardown --confirm` removes the partition the torn-down checkout's task state actually lives in, verified by asserting the bundle directory resolved through the task registry is gone.
- Whatever partition removal path remains also retires the matching `tasks/index.sqlite` bindings, so no binding survives pointing at a deleted bundle directory.

## Execution Summary

<details>
<summary>Click to expand</summary>

Partition ownership now resolves through the task registry, not the workspace catalog.

## Changes

- `crates/orbit-store/.../task_registry/store.rs`: added `TaskRegistryStore::workspace_ids()` (every id `workspace_bindings` holds) and `unbind_workspace()` (one transaction retiring relations from both ends, tags, index, task-bundle bindings, the checkout binding, and the logical workspace).
- `crates/orbit-core/src/runtime/{builder,mod}.rs`: `UNBOUND_DATA_DIR_WORKSPACE_ID` is now `pub` and re-exported from `orbit_core::runtime`, so host maintenance can recognize the synthetic `--root` partition instead of deleting it.
- `crates/orbit-cmd/src/task_store.rs`: rewritten as the partition-ownership seam — `inspect_task_store_partitions` (scanned + unclaimed), `remove_unclaimed_task_stores`, `remove_checkout_task_stores`, `bound_partition_id`, `partition_is_bound`. A partition is claimed when a task-registry binding, a workspace-catalog entry, or the unbound-data-dir id names it. Every removal retires registry rows *before* deleting the directory, and a missing `tasks/index.sqlite` is an error (fail closed) rather than "everything is unclaimed".
- `crates/orbit-cmd/src/doctor.rs`: check and `--fix` both delegate to that module; the dead local directory scanner was deleted.
- `crates/orbit-cli/src/command/doctor.rs`: `--fix-orphan-task-stores` now requires a new `--confirm` flag (it deletes task bundles); help text updated.
- `crates/orbit-cli/src/command/workspace/teardown.rs`: deletes the partition the task registry binds to this checkout, plus a catalog-id-named partition when no other checkout binds it, and retires the bindings with it.
- `docs/runbooks/health-checks.md`: check table, sample row, and the "Reclaim orphaned task stores" section describe the two id spaces, the `--confirm` requirement, and the fail-closed behavior.

## Criteria → evidence

1. *No orphan for a drifted checkout* — `orbit-cmd` `tests::doctor::task_registry_bound_partition_is_not_an_orphan` binds `drifted-a1b2c3` in the task registry while the catalog registers `ws_drifted`; the row is `Ok`. Fault-injected (claims computed without task-registry ids) the test FAILS, so it detects the original defect.
2. *Fix keeps every claimed partition* — `tests::doctor::fix_orphan_task_stores_keeps_every_claimed_partition`: catalog-claimed, task-registry-bound, and `ws_unbound-data-dir` partitions all survive; only `ws_orphan` is deleted (removed == 1). The pre-existing `fix_orphan_task_stores_removes_only_the_unregistered_partition` still passes.
3. *Teardown removes the bound partition* — `orbit-cli` `command::workspace::tests::teardown::teardown_deletes_the_bound_task_store_partition_and_retires_its_bindings` resolves the partition through the task registry (asserting it differs from the catalog id `ws_teardown`), writes bundles there, and asserts the directory is gone after teardown; the survivor workspace's partition is untouched. Fault-injected (teardown resolving the wrong orbit dir) the test FAILS.
4. *Bindings retired with the directory* — same test asserts no binding names the deleted partition and no checkout binding survives for the deleted orbit dir; `orbit-cmd` `tests::task_store::removing_a_checkout_deletes_the_bound_partition_and_retires_its_bindings` and orbit-store `unbind_workspace_retires_the_checkout_and_its_task_bundles` / `unbind_workspace_retires_relations_pointing_into_it` cover the row-level behavior.

Additional safety coverage: `removing_a_checkout_leaves_a_catalog_named_partition_another_checkout_binds` (a catalog-named partition bound to a different checkout is never deleted) and `removing_a_checkout_deletes_an_unbound_catalog_named_partition` (the ORB-12109 legacy leftover is still cleaned).

## Validation

- `make ci-fast` — passed.
- `make ci-lint` — passed (no warnings).
- `cargo test -p orbit-store --lib` — 516 passed.
- `cargo test -p orbit-cmd --lib` — 139 passed.
- `cargo test -p orbit-cli --bin orbit` — 512 passed.
- `cargo test -p orbit-core --lib` — 1393 passed.
- `cargo test -p orbit-cli --test worktree_resolution doctor` — 1 passed.
- Full `make ci` — not run (workspace policy: CI is the merge gate). Other crates' integration suites not run; nothing outside these crates references the changed APIs (`rg` over the workspace).

## Risks / deviations

- `--fix-orphan-task-stores` now requires `--confirm`: a behavior change on a flag shipped in ORB-12109, taken from the task's suggested direction. Any script using the bare flag must add `--confirm`; the warning's remediation string and the runbook already print the new form.
- Verified only on Linux; behavior is filesystem- and SQLite-generic, but the removal paths were not exercised on macOS or Windows.
- `orbit doctor` now opens `tasks/index.sqlite` read-side on every run to resolve claims; an unreadable registry degrades to a `Warning` row and the fix refuses, rather than deleting.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12119-6aa38add`
- Behind base: 0
- Ahead of base: 1