### PR TITLE
[qa-sweep] GitShim mutates process-wide PATH, so `make test` / `cargo test -p orbit-engine --lib` fails nondeterministically

### DIFF
--- a/crates/orbit-engine/src/activity_job/tests/workspace.rs
+++ b/crates/orbit-engine/src/activity_job/tests/workspace.rs
@@ -3,7 +3,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::{Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
 use tempfile::{TempDir, tempdir};
@@ -12,7 +11,12 @@ use super::super::dispatcher::DispatchError;
 use super::super::workspace::fingerprint::{git_fingerprint, untracked_file_identity};
 use super::super::workspace::*;
 
-static GIT_SHIM_LOCK: Mutex<()> = Mutex::new(());
+/// Names the isolated child that owns the Git shim, so a future second user of
+/// the fixture cannot mistake another test's child process for its own.
+const GIT_SHIM_CHILD_ENV: &str = "ORBIT_TEST_GIT_SHIM_CHILD";
+
+/// Carries the shim's invocation log to that child.
+const GIT_SHIM_LOG_ENV: &str = "ORBIT_TEST_GIT_SHIM_LOG";
 
 #[test]
 fn resolve_subprocess_cwd_prefers_input_over_task_over_tool_ctx() {
@@ -277,13 +281,17 @@ fn fingerprint_identities_match_per_path_git_and_stay_stable() {
 
 #[test]
 fn capture_of_thousands_of_untracked_files_uses_a_constant_git_budget() {
+    let Some(shim) = GitShim::install(
+        module_path!(),
+        "capture_of_thousands_of_untracked_files_uses_a_constant_git_budget",
+    ) else {
+        return;
+    };
+
     let fixture = linked_worktree_fixture();
     write_untracked_tree(&fixture.assigned, 25);
     let pair = declared_pair(&fixture, "ORB-FINGERPRINT-BUDGET", "run-fingerprint-budget");
     let input = worktree_input(&fixture, "ORB-FINGERPRINT-BUDGET");
-
-    let _guard = lock_git_shim();
-    let shim = GitShim::install();
 
     let small_before = shim.invocation_count(&[&fixture.assigned, &fixture.primary]);
     WorktreeBoundaryGuard::capture(
@@ -462,20 +470,34 @@ fn domain_sha256(domain: &str, bytes: &[u8]) -> String {
     format!("sha256:{:x}", hasher.finalize())
 }
 
-fn lock_git_shim() -> MutexGuard<'static, ()> {
-    GIT_SHIM_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-}
-
+/// Child-side handle on the `git` shim installed for the isolated test
+/// process: the shim logs each invocation's cwd and arguments, then delegates
+/// to the real Git binary.
 struct GitShim {
     log_path: PathBuf,
-    previous_path: Option<std::ffi::OsString>,
-    _dir: TempDir,
 }
 
 impl GitShim {
-    fn install() -> Self {
+    /// Isolate the shim's PATH in a child test process. Prepending the shim
+    /// directory to this process's PATH would redirect `git` for every test
+    /// running concurrently in the same binary, and those tests then fail once
+    /// the shim's TempDir is removed.
+    ///
+    /// Returns the shim handle when this process is the isolated child; in the
+    /// parent it runs the child to completion and returns `None`.
+    fn install(module: &str, test: &str) -> Option<Self> {
+        let module = module
+            .strip_prefix(concat!(env!("CARGO_CRATE_NAME"), "::"))
+            .unwrap_or(module);
+        let exact_test = format!("{module}::{test}");
+
+        if std::env::var(GIT_SHIM_CHILD_ENV).ok().as_deref() == Some(&exact_test) {
+            let log_path = std::env::var_os(GIT_SHIM_LOG_ENV).expect("shim log path in child");
+            return Some(Self {
+                log_path: PathBuf::from(log_path),
+            });
+        }
+
         let dir = tempdir().expect("shim dir");
         let log_path = dir.path().join("git-invocations.log");
         fs::write(&log_path, "").expect("create shim log");
@@ -498,21 +520,25 @@ impl GitShim {
             fs::set_permissions(&script, permissions).expect("shim permissions");
         }
 
-        let previous_path = std::env::var_os("PATH");
-        let mut path = dir.path().as_os_str().to_os_string();
-        path.push(":");
-        if let Some(existing) = &previous_path {
-            path.push(existing);
-        }
-        // SAFETY: the matching Drop restores PATH, and GIT_SHIM_LOCK serializes
-        // the only test that mutates it.
-        unsafe { std::env::set_var("PATH", &path) };
+        let mut paths = vec![dir.path().to_path_buf()];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        let output = Command::new(std::env::current_exe().expect("test executable"))
+            .args(["--exact", &exact_test, "--nocapture"])
+            .env(GIT_SHIM_CHILD_ENV, &exact_test)
+            .env(GIT_SHIM_LOG_ENV, &log_path)
+            .env("PATH", std::env::join_paths(paths).expect("shim PATH"))
+            .output()
+            .expect("isolated git shim test");
+        assert!(
+            output.status.success(),
+            "git shim test failed:\n{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
 
-        Self {
-            log_path,
-            previous_path,
-            _dir: dir,
-        }
+        None
     }
 
     fn invocation_count(&self, roots: &[&Path]) -> usize {
@@ -525,18 +551,6 @@ impl GitShim {
                 })
             })
             .count()
-    }
-}
-
-impl Drop for GitShim {
-    fn drop(&mut self) {
-        // SAFETY: restores the PATH captured in GitShim::install.
-        unsafe {
-            match &self.previous_path {
-                Some(path) => std::env::set_var("PATH", path),
-                None => std::env::remove_var("PATH"),
-            }
-        }
     }
 }
 


### PR DESCRIPTION
## Task

[ORB-12123](https://orbit-cli.com/tasks/ORB-12123) — [qa-sweep] GitShim mutates process-wide PATH, so `make test` / `cargo test -p orbit-engine --lib` fails nondeterministically

### Description

Validation impact: `make test` (`cargo test --workspace`) cannot complete reliably. Production impact: none demonstrated - the defect is in the test harness, and the failing assertions are about test-fixture plumbing, not about shipped behavior.

Root cause. `GitShim::install` in crates/orbit-engine/src/activity_job/tests/workspace.rs writes a `git` shim into a `tempfile::tempdir()` and prepends that directory to the *process-wide* `PATH` with `unsafe { std::env::set_var("PATH", &path) }`, restoring it in `Drop`. Its SAFETY comment says "GIT_SHIM_LOCK serializes the only test that mutates it" - but that mutex only serializes other `GitShim` users. `cargo test` runs the whole `orbit-engine` lib suite as threads inside one process, so for the lifetime of the shim every other concurrently running test also sees the shim on `PATH`. When the shim's TempDir is dropped, any test that resolved `git` to it fails.

Observed failures (orbit 0.20.0 at fb7b8e5012cf004ae24993157ec6a6ed18f824e1, Linux 6.8.0-139-generic, 14 cores, git 2.43.0):

    $ cargo test -p orbit-engine --lib
    ---- executor::automation::vcs::commit::tests::already_landed::already_landed_accepts_captured_silent_validation_success stdout ----
    panicked at crates/orbit-engine/src/executor/automation/vcs/commit/tests/already_landed.rs:286:44:
    called `Result::unwrap()` on an `Err` value: Execution("git diff --name-only -z --relative HEAD -- failed in '/tmp/.tmpDxDNOR': /bin/sh: 0: cannot open /tmp/.tmprliLKO/git: No such file")
    test result: FAILED. 681 passed; 1 failed; 3 ignored

The `/bin/sh: 0: cannot open <tempdir>/git` form is the smoking gun: the kernel honored the shim's `#!/bin/sh` shebang, then `sh` could not open the script because the shim's TempDir had already been removed.

A second test fails the same way on other runs:

    ---- activity_job::cli_runner::tests::rebase_recovery::conflict_recovery_rejects_metadata_copy_redirection_and_poisoned_todo stdout ----
    panicked at crates/orbit-engine/src/activity_job/cli_runner/tests/rebase_recovery.rs:339:9:
    todo: cli invocation failed (permanent): conflict recovery requires an existing rebase matching the prepared branch, original HEAD and pinned target base

Reproduction and scope evidence (all from this checkout, this session):

    cargo test -p orbit-engine --lib                 -> FAILED, ok, FAILED, FAILED   (4 runs, 3 failures, 2 distinct tests)
    cargo test -p orbit-engine --lib -- --test-threads=1  -> ok, ok, ok               (3 runs, 682 passed each)
    cargo test -p orbit-engine --lib <single test name>   -> ok                        (both tests pass in isolation)
    cargo nextest run -p orbit-engine --lib          -> 682 passed, 682 passed         (2 runs)

Why CI is green. scripts/ci-guardrails.sh (and .github/workflows/ci.yml) run the suite with `cargo nextest run`, which executes each test in its own process, so a process-wide PATH mutation cannot reach another test. The `cargo test` fallback in that same script, and `make test`, are exposed. `make ci-fast` and `make ci-lint` both pass here.

Suggested direction: stop mutating the parent process's `PATH`. The neighbouring fixtures already solve this - `crates/orbit-engine/src/executor/automation/vcs/tests/mod.rs` and `.../vcs/commit/tests/git_ops.rs` re-exec the test binary as a child with `.env("PATH", ...)` precisely to avoid "process-global env races". Convert `GitShim` to the same child-process pattern, or thread an explicit git-program override through the code under test.

### Acceptance Criteria

- `cargo test -p orbit-engine --lib` passes repeatedly (at least 5 consecutive multi-threaded runs) on a multi-core Linux host.
- No orbit-engine test mutates the process-wide PATH; the git-shim fixture isolates PATH to a child process or passes the program path explicitly.
- The two observed tests (already_landed_accepts_captured_silent_validation_success and conflict_recovery_rejects_metadata_copy_redirection_and_poisoned_todo) still assert what they asserted before, unchanged in intent.
- `cargo nextest run -p orbit-engine --lib` still passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Converted the orbit-engine GitShim fixture from a process-wide PATH mutation to child-process isolation, matching the neighbouring with_fake_git / with_fake_gh fixtures.

Change (1 file, crates/orbit-engine/src/activity_job/tests/workspace.rs):
- GitShim::install(module, test) now writes the shim into a tempdir and re-execs the test binary with `--exact <module::test> --nocapture`, passing the shim dir on the child's PATH plus ORBIT_TEST_GIT_SHIM_CHILD (exact test name, the child marker) and ORBIT_TEST_GIT_SHIM_LOG (invocation-log path). In the child it returns Some(GitShim); in the parent it asserts child success and returns None so the parent body is skipped.
- Removed the unsafe std::env::set_var("PATH", ...) / Drop restore, the GIT_SHIM_LOCK mutex and lock_git_shim helper, and the now-unused previous_path/_dir fields and Mutex/MutexGuard imports. GitShim is now just { log_path }; invocation_count is unchanged.
- capture_of_thousands_of_untracked_files_uses_a_constant_git_budget opens with a let-else on GitShim::install; its fixture setup, capture calls and assertions are otherwise byte-identical.

Acceptance criteria:
1. `cargo test -p orbit-engine --lib` passes repeatedly: 6 consecutive multi-threaded runs on this 14-core Linux host, each 682 passed / 0 failed / 3 ignored (~15-19s each). PASS.
2. No orbit-engine test mutates process-wide PATH: `grep -rn 'env::set_var|env::remove_var' crates/orbit-engine/src` returns no PATH mutation (remaining hits are ORBIT_* vars in shell.rs, orchestrator.rs and spawn.rs, out of this task's scope). The shim now isolates PATH to the child. PASS.
3. The two observed tests are unchanged in intent: already_landed.rs and rebase_recovery.rs were not edited at all; the shim test's assertions are unchanged (only shim acquisition moved). PASS.
4. `cargo nextest run -p orbit-engine --lib`: 682 tests run, 682 passed, 3 skipped. PASS.

Validation commands: `cargo test -p orbit-engine --lib` x6 passed; `cargo nextest run -p orbit-engine --lib` passed; `make ci-fast` passed (exit 0; its test-compiler-cache-namespaces sub-check self-skips on this host because unprivileged user namespaces are disabled - pre-existing, unrelated); `make ci-lint` passed (exit 0). `make test` (full `cargo test --workspace`) was NOT run: it is not the per-task gate in this workspace, so the per-crate multi-threaded runs above are the evidence for the reported defect.

Harness-behaviour evidence: with a deliberately impossible assertion temporarily substituted in the shim test, `cargo test -p orbit-engine --lib capture_of_thousands` failed in both the child and the parent, confirming the child actually executes the test body (no vacuous pass) and that exactly one child is spawned (no re-exec recursion). The scratch edit was reverted before validation; final `git status --short` shows only the one intended modification and `git diff --check` is clean.

Risks/deviations: the shim test now costs one extra test-binary process (same cost as existing with_fake_git users). Under nextest the parent and child both run the binary, matching the established pattern. Windows behaviour is unchanged in kind (the `#!/bin/sh` shim was already effectively unix-only); only Linux was exercised.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12123-6aa38fd6`
- Behind base: 0
- Ahead of base: 1