### PR TITLE
[qa-sweep] orbit tool enable reports success for registry-inactive builtins but the tool stays unusable

### DIFF
--- a/crates/orbit-cli/src/command/tool/tests/enable.rs
+++ b/crates/orbit-cli/src/command/tool/tests/enable.rs
@@ -1,0 +1,53 @@
+use orbit_common::OrbitError;
+use orbit_core::OrbitRuntime;
+
+use super::super::disable::ToolDisableArgs;
+use super::super::enable::ToolEnableArgs;
+use crate::command::Execute;
+
+/// A `register_inactive` builtin: availability is fixed at registration and
+/// is never read from the store's enabled flag [ORB-12122].
+const REGISTRY_INACTIVE_BUILTIN: &str = "orbit.task.reject";
+
+#[test]
+fn tool_enable_refuses_a_registry_inactive_builtin_at_the_cli_boundary() {
+    let runtime = OrbitRuntime::in_memory().expect("in-memory runtime");
+
+    let error = ToolEnableArgs {
+        name: REGISTRY_INACTIVE_BUILTIN.to_string(),
+    }
+    .execute(&runtime)
+    .expect_err("orbit tool enable must refuse a registry-inactive builtin");
+
+    assert!(
+        matches!(error, OrbitError::InvalidInput(_)),
+        "unexpected error variant: {error:?}"
+    );
+    let message = error.to_string();
+    assert!(message.contains(REGISTRY_INACTIVE_BUILTIN));
+    assert!(message.contains("inactive on the agent tool surface"));
+
+    let tool = runtime
+        .show_tool(REGISTRY_INACTIVE_BUILTIN)
+        .expect("show tool");
+    assert!(
+        !tool.active,
+        "the tool must remain inactive after the refusal"
+    );
+}
+
+#[test]
+fn tool_disable_refuses_a_registry_inactive_builtin_at_the_cli_boundary() {
+    let runtime = OrbitRuntime::in_memory().expect("in-memory runtime");
+
+    let error = ToolDisableArgs {
+        name: REGISTRY_INACTIVE_BUILTIN.to_string(),
+    }
+    .execute(&runtime)
+    .expect_err("orbit tool disable must refuse a registry-inactive builtin");
+
+    assert!(
+        matches!(error, OrbitError::InvalidInput(_)),
+        "unexpected error variant: {error:?}"
+    );
+}

--- a/crates/orbit-cli/src/command/tool/tests/mod.rs
+++ b/crates/orbit-cli/src/command/tool/tests/mod.rs
@@ -1,1 +1,2 @@
+mod enable;
 mod run;

--- a/crates/orbit-core/src/adapter/command/registry.rs
+++ b/crates/orbit-core/src/adapter/command/registry.rs
@@ -251,7 +251,7 @@ impl OrbitRuntime {
         }
         if self.tool_registry().has(name) {
             return Err(OrbitError::Execution(format!(
-                "tool '{name}' is inactive on the agent tool surface; it is an admin/human-only operation — use the equivalent Orbit CLI or dashboard workflow"
+                "tool '{name}' is inactive on the agent tool surface; it is an admin/human-only operation not reachable by agents"
             )));
         }
         Err(OrbitError::not_found(NotFoundKind::Tool, name.to_string()))
@@ -260,6 +260,15 @@ impl OrbitRuntime {
     fn set_tool_enabled_state(&self, name: &str, enabled: bool) -> Result<(), OrbitError> {
         if !self.tool_registry().has(name) {
             return Err(OrbitError::not_found(NotFoundKind::Tool, name.to_string()));
+        }
+
+        if !self.tool_registry().is_active(name) {
+            let verb = if enabled { "enable" } else { "disable" };
+            return Err(OrbitError::InvalidInput(format!(
+                "tool '{name}' is inactive on the agent tool surface; that availability is fixed \
+                 at registration, so {verb} would report success without changing whether the \
+                 tool can run"
+            )));
         }
 
         let existing = self.stores().tools().get_tool(name)?;

--- a/crates/orbit-core/src/adapter/command/tests/mod.rs
+++ b/crates/orbit-core/src/adapter/command/tests/mod.rs
@@ -2,4 +2,5 @@
 
 mod dispatch;
 mod global_dispatch;
+mod registry;
 mod support;

--- a/crates/orbit-core/src/adapter/command/tests/registry.rs
+++ b/crates/orbit-core/src/adapter/command/tests/registry.rs
@@ -1,0 +1,73 @@
+use orbit_common::OrbitError;
+
+use super::support::fresh_runtime;
+
+/// A `register_inactive` builtin: availability is fixed at registration and
+/// is never read from the store's enabled flag [ORB-12122].
+const REGISTRY_INACTIVE_BUILTIN: &str = "orbit.task.reject";
+
+#[test]
+fn enable_refuses_a_registry_inactive_builtin_instead_of_reporting_success() {
+    let runtime = fresh_runtime();
+
+    let before = runtime
+        .show_tool(REGISTRY_INACTIVE_BUILTIN)
+        .expect("show tool");
+    assert!(!before.active);
+
+    let error = runtime
+        .enable_tool(REGISTRY_INACTIVE_BUILTIN)
+        .expect_err("enable must refuse a registry-inactive builtin");
+    assert!(
+        matches!(error, OrbitError::InvalidInput(_)),
+        "unexpected error variant: {error:?}"
+    );
+    assert!(
+        error
+            .to_string()
+            .contains("inactive on the agent tool surface")
+    );
+
+    let after = runtime
+        .show_tool(REGISTRY_INACTIVE_BUILTIN)
+        .expect("show tool");
+    assert!(!after.active);
+    assert_eq!(
+        before.enabled, after.enabled,
+        "enabled flag must be untouched"
+    );
+}
+
+#[test]
+fn disable_refuses_a_registry_inactive_builtin_the_same_way_as_enable() {
+    let runtime = fresh_runtime();
+
+    let error = runtime
+        .disable_tool(REGISTRY_INACTIVE_BUILTIN)
+        .expect_err("disable must refuse a registry-inactive builtin");
+    assert!(
+        matches!(error, OrbitError::InvalidInput(_)),
+        "unexpected error variant: {error:?}"
+    );
+    assert!(
+        error
+            .to_string()
+            .contains("inactive on the agent tool surface")
+    );
+}
+
+#[test]
+fn enable_and_disable_round_trip_for_an_active_builtin() {
+    let runtime = fresh_runtime();
+    const ACTIVE_BUILTIN: &str = "orbit.task.list";
+
+    runtime.disable_tool(ACTIVE_BUILTIN).expect("disable");
+    let disabled = runtime.show_tool(ACTIVE_BUILTIN).expect("show tool");
+    assert!(disabled.active);
+    assert!(!disabled.enabled);
+
+    runtime.enable_tool(ACTIVE_BUILTIN).expect("enable");
+    let enabled = runtime.show_tool(ACTIVE_BUILTIN).expect("show tool");
+    assert!(enabled.active);
+    assert!(enabled.enabled);
+}


### PR DESCRIPTION
## Task

[ORB-12122](https://orbit-cli.com/tasks/ORB-12122) — [qa-sweep] orbit tool enable reports success for registry-inactive builtins but the tool stays unusable

### Description

Admin-only builtins are registered with `ToolRegistry::register_inactive` (crates/orbit-tools/src/builtin/orbit/mod.rs), which is a compile-time property of the registry entry. `orbit tool enable` writes the *store's* enabled flag (`CommandRegistry::set_tool_enabled_state`, crates/orbit-core/src/adapter/command/registry.rs), and `ensure_tool_agent_facing` gates dispatch on `ToolRegistry::is_active`, which never consults that flag. The result is a command that always prints success and never has any effect.

Observed (orbit 0.20.0 built from fb7b8e5012cf004ae24993157ec6a6ed18f824e1; scratch root, HOME and all ORBIT_* authority cleared):

    $ orbit tool show orbit.task.locks.reserve | grep Status
    Status: inactive
    $ orbit tool enable orbit.task.locks.reserve
    Enabled tool 'orbit.task.locks.reserve'          <- exit 0
    $ orbit tool show orbit.task.locks.reserve | grep Status
    Status: inactive                                  <- unchanged
    $ orbit tool run orbit.task.locks.reserve --input '{"task_ids":["QAB-00000"]}'
    {"code":"execution_failed","error":"execution failed: tool 'orbit.task.locks.reserve' is inactive on the agent tool surface; it is an admin/human-only operation - use the equivalent Orbit CLI or dashboard workflow"}

The same false success applies to every `register_inactive` builtin (auto_task add/show/update/toggle, docs list/show/add/index/migrate, task delete/lint/reject, task locks + locks.reserve + locks.release, workspace_claim acquire/release/show, semantic install/uninstall, ...). Enable/disable does work correctly for active builtins, which is what makes the silent no-op confusing:

    $ orbit tool disable orbit.task.list && orbit tool show orbit.task.list | grep Status
    Status: disabled
    $ orbit tool run orbit.task.list --input '{}'
    {"code":"execution_failed","error":"... is disabled; enable it with: orbit tool enable orbit.task.list"}
    $ orbit tool enable orbit.task.list && orbit tool show orbit.task.list | grep Status
    Status: active

Second, smaller defect in the same area: the denial text directs the caller to "the equivalent Orbit CLI or dashboard workflow", but for the task-lock tools no such surface exists. There is no `orbit lock`/`orbit task locks` subcommand (`orbit --help` lists none), and the dashboard only exposes the read-only `GET /tasks/locks` projection (crates/orbit-web/src/api/mod.rs). So a caller following the advice has nowhere to go.

Practical consequence worth noting for triage: because `orbit.task.locks.reserve` is unreachable from every caller surface, the empty-task-surface refusal added for ORB-12114 (`EmptyTaskSurfacePolicy::Refuse`, crates/orbit-core/src/runtime/task/locks.rs) is not reachable in production - the only live caller, the v2 dispatch admission gate, passes `EmptyTaskSurfacePolicy::Admit`. That fix is exercised by unit tests only.

Suggested direction: make `orbit tool enable`/`disable` refuse a registry-inactive builtin with an explanation instead of reporting success, and either point the denial at a surface that exists or state plainly that the operation has no user-facing equivalent.

### Acceptance Criteria

- `orbit tool enable <registry-inactive builtin>` fails with an explanation instead of printing success, and `orbit tool disable` behaves consistently for the same class.
- `orbit tool enable`/`disable` still round-trip correctly for active builtins and external tools.
- The agent-surface denial message no longer directs callers to a CLI or dashboard workflow that does not exist for that tool.
- A test covers the inactive-builtin enable attempt at the CLI boundary.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed `orbit tool enable`/`disable` falsely reporting success for registry-inactive builtins, and softened the agent-surface denial message.

Root cause: `set_tool_enabled_state` (crates/orbit-core/src/adapter/command/registry.rs) only checked `ToolRegistry::has(name)` before writing the store's enabled flag, never `ToolRegistry::is_active(name)`. Since `is_active` (a compile-time property set by `register_inactive` at startup) is what actually gates dispatch via `ensure_tool_agent_facing`, toggling the store flag for one of these tools was a complete no-op that still reported success.

Changes:
- `set_tool_enabled_state`: added an early refusal — if the tool is registered but `!is_active`, return `OrbitError::InvalidInput` naming the tool and explaining availability is fixed at registration, instead of silently writing the flag. Applies identically to `enable_tool` and `disable_tool` (both call this one function), so the two behave consistently for this class.
- `ensure_tool_agent_facing`: reworded the denial from "...use the equivalent Orbit CLI or dashboard workflow" (false for tools like the task-lock reserve/release path, where the dashboard is read-only) to "...it is an admin/human-only operation not reachable by agents" — accurate for every `register_inactive` tool without asserting a redirect surface that may not exist.
- Enable/disable round-tripping for active builtins and external tools is unchanged (verified by test and existing coverage); the new early-return only fires when `is_active` is false.

Criteria mapping:
1. `enable`/`disable` on a registry-inactive builtin (tested against `orbit.task.reject`) now return an error instead of exit 0; tool `show_tool().active`/`.enabled` are unchanged by the attempt — covered by orbit-core unit tests and an orbit-cli CLI-boundary test.
2. Round-trip for an active builtin (`orbit.task.list`) verified by a new test (disable -> disabled, enable -> active/enabled again); external-tool path is unchanged code and covered by pre-existing behavior.
3. Denial message no longer references a CLI/dashboard workflow; verified by reading the new string and by the pre-existing `task_trimmed_surface.rs` assertion that never expected that clause.
4. New test `crates/orbit-cli/src/command/tool/tests/enable.rs::tool_enable_refuses_a_registry_inactive_builtin_at_the_cli_boundary` calls `ToolEnableArgs::execute` directly (CLI Execute boundary) and asserts the InvalidInput error and unchanged tool state.

New files (declared via context_files): crates/orbit-core/src/adapter/command/tests/registry.rs, crates/orbit-cli/src/command/tool/tests/enable.rs.

Validation:
- `cargo test -p orbit-core --lib` (targeted: `adapter::command::tests::registry::*`, `adapter::tool_host::tests::task_tools::*`) — passed.
- `cargo test -p orbit-cli --bins` (targeted: `command::tool::tests::enable::*`) — passed.
- `cargo test -p orbit-cli --test task_trimmed_surface` — passed (13/13), including the lock-tool admin-bypass tests unaffected by the message wording change.
- `make ci-fast` — passed.
- `make ci-lint` — passed (workspace-wide clippy, warnings denied).
- `git status --short` / `git diff --check` — clean, no stray artifacts.

No scope creep: did not attempt to give every `register_inactive` tool a real CLI/dashboard equivalent (out of scope per the task's "Suggested direction," which offered stating no-equivalent as an acceptable alternative). Left the practical-consequence note about `orbit.task.locks.reserve` reachability as-is; investigation during this task found `orbit task locks reserve/release` do exist as CLI subcommands reaching these tools via the admin `run_tool` bypass, so that inventory in the original report may be stale, but re-auditing it was outside this task's acceptance criteria.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12122-6aa38fd7`
- Behind base: 0
- Ahead of base: 1