### PR TITLE
[qa-sweep] orbit mcp init/remove ignore the workspace registry, so an external Orbit root writes MCP config to the root's parent directory

### DIFF
--- a/crates/orbit-cli/src/command/mcp/setup/args.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/args.rs
@@ -5,7 +5,7 @@ use orbit_core::OrbitError;
 
 use super::dispatch::{print_action_summary, run_action};
 use super::providers::ServerLaunch;
-use super::workspace::{env_home_dir, registered_workspace_id, resolve_workspace_layout};
+use super::workspace::{env_home_dir, resolve_workspace_layout};
 use crate::command::{CommandOut, CommandOutput};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
@@ -201,13 +201,10 @@ impl InitArgs {
         // Bare `orbit mcp init` keeps its pre-existing agent-only authority;
         // only the `orbit workspace init --mcp` bootstrap path (below, via
         // `init_auto_for_workspace`) selects operator authority.
-        let workspace_id = (!self.federated)
-            .then(|| registered_workspace_id(&layout.repo_root))
-            .flatten();
         let launch = if self.federated {
             ServerLaunch::Federated
         } else {
-            ServerLaunch::local(false, workspace_id.as_deref())
+            ServerLaunch::local(false, layout.workspace_id.as_deref())
         };
         let providers = run_action(
             McpAction::Init(launch),

--- a/crates/orbit-cli/src/command/mcp/setup/tests/workspace.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/tests/workspace.rs
@@ -13,8 +13,8 @@ fn resolve_workspace_layout_skips_global_home_orbit_during_walk_up() {
     std::fs::create_dir_all(&nested).expect("create nested cwd");
     let _env = EnvGuard::acquire().home(home.path());
 
-    let err =
-        resolve_workspace_layout_for_cwd(&nested).expect_err("walk-up to $HOME/.orbit should fail");
+    let err = resolve_workspace_layout_for_cwd(&nested, None)
+        .expect_err("walk-up to $HOME/.orbit should fail");
 
     assert!(matches!(
         err,

--- a/crates/orbit-cli/src/command/mcp/setup/workspace.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/workspace.rs
@@ -2,36 +2,182 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use orbit_cmd::registry_runtime::RegisteredRuntimeFactory;
+use orbit_cmd::registry_runtime::{RegisteredRuntimeFactory, global_root_for};
 use orbit_core::OrbitError;
 use orbit_registry::workspace_registry;
+use orbit_types::workspace::{WorkspaceCheckout, WorkspaceRegistry};
 
+/// Where an `orbit mcp init` / `orbit mcp remove` run writes, and what the
+/// generated server entry binds to.
 #[derive(Debug, Clone)]
 pub(super) struct WorkspaceLayout {
     pub(super) repo_root: PathBuf,
     pub(super) orbit_root: PathBuf,
+    /// Logical workspace ID (`ws_*`) this checkout is registered under, or
+    /// `None` when no registry on this machine knows it.
+    pub(super) workspace_id: Option<String>,
 }
 
 pub(super) fn resolve_workspace_layout(
     root_override: Option<&Path>,
 ) -> Result<WorkspaceLayout, OrbitError> {
-    if let Some(orbit_root) = root_override {
-        return Ok(WorkspaceLayout {
-            repo_root: orbit_root.parent().unwrap_or(orbit_root).to_path_buf(),
-            orbit_root: orbit_root.to_path_buf(),
-        });
-    }
-
     let cwd = env::current_dir().map_err(|err| OrbitError::Io(err.to_string()))?;
-    resolve_workspace_layout_for_cwd(&cwd)
+    resolve_workspace_layout_for_cwd(&cwd, root_override)
 }
 
-pub(super) fn resolve_workspace_layout_for_cwd(cwd: &Path) -> Result<WorkspaceLayout, OrbitError> {
+/// Resolve the checkout these MCP setup commands operate on.
+///
+/// The workspace registry answers first, because it is the only source that
+/// knows a checkout whose Orbit root lives outside the repository — the
+/// `orbit --root <dir> workspace init` layout, where neither the repository nor
+/// its ancestors contain a `.orbit` directory. The filesystem walk-up stays
+/// behind it for a checkout that carries its own `.orbit` without being
+/// registered on this machine.
+pub(super) fn resolve_workspace_layout_for_cwd(
+    cwd: &Path,
+    root_override: Option<&Path>,
+) -> Result<WorkspaceLayout, OrbitError> {
+    let explicit_root = explicit_orbit_root(cwd, root_override);
+    let explicit_root = explicit_root.as_deref();
+    let registry_root = registry_root(explicit_root);
+
+    let (repo_root, orbit_root) = match registry_root
+        .as_deref()
+        .and_then(|registry_root| registered_checkout_paths(registry_root, cwd, explicit_root))
+    {
+        Some(paths) => paths,
+        None => unregistered_checkout_paths(cwd, explicit_root)?,
+    };
+    let workspace_id = registry_root
+        .as_deref()
+        .and_then(|registry_root| registered_workspace_id(registry_root, &repo_root));
+
+    Ok(WorkspaceLayout {
+        repo_root,
+        orbit_root,
+        workspace_id,
+    })
+}
+
+/// The explicitly selected Orbit data root.
+///
+/// `--root` first, then the `ORBIT_ROOT` escape hatch, matching the precedence
+/// every other root-aware surface applies. Honoring the variable here is what
+/// keeps `ORBIT_ROOT=<root> orbit mcp init` pointed at the same workspace as
+/// `ORBIT_ROOT=<root> orbit task list`.
+fn explicit_orbit_root(cwd: &Path, root_override: Option<&Path>) -> Option<PathBuf> {
+    let root = match root_override {
+        Some(root) => root.to_path_buf(),
+        None => {
+            let value = env::var("ORBIT_ROOT").ok()?;
+            let value = value.trim();
+            if value.is_empty() {
+                return None;
+            }
+            PathBuf::from(value)
+        }
+    };
+    Some(if root.is_relative() {
+        cwd.join(root)
+    } else {
+        root
+    })
+}
+
+/// The Orbit data root whose workspace catalog describes this checkout.
+///
+/// An explicit root wins when it actually holds a catalog — that is the
+/// external-root layout, and a checkout it does not list must not be resolved
+/// out of the machine-global catalog behind the operator's back. A repo-local
+/// `.orbit` passed as `--root` holds no catalog of its own, so the machine's
+/// global root answers for it.
+fn registry_root(explicit_root: Option<&Path>) -> Option<PathBuf> {
+    if let Some(root) = explicit_root.filter(|root| has_registry(root)) {
+        return Some(root.to_path_buf());
+    }
+    global_root_for(None).ok().filter(|root| has_registry(root))
+}
+
+fn has_registry(global_root: &Path) -> bool {
+    workspace_registry::registry_path_for(global_root).is_file()
+}
+
+fn registered_checkout_paths(
+    registry_root: &Path,
+    cwd: &Path,
+    explicit_root: Option<&Path>,
+) -> Option<(PathBuf, PathBuf)> {
+    let registry = load_registry(registry_root)?;
+    let checkout = checkout_for_cwd(&registry, cwd)
+        .or_else(|| explicit_root.and_then(|root| sole_checkout_for_root(&registry, root)))?;
+    Some((checkout.repo_root.clone(), checkout.orbit_dir.clone()))
+}
+
+fn load_registry(global_root: &Path) -> Option<WorkspaceRegistry> {
+    workspace_registry::load_registry_from(&workspace_registry::registry_path_for(global_root)).ok()
+}
+
+fn checkout_for_cwd<'a>(
+    registry: &'a WorkspaceRegistry,
+    cwd: &Path,
+) -> Option<&'a WorkspaceCheckout> {
+    workspace_registry::find_checkout_by_path(registry, cwd).or_else(|| {
+        let canonical = fs::canonicalize(cwd).ok()?;
+        workspace_registry::find_checkout_by_path(registry, &canonical)
+    })
+}
+
+/// The checkout an explicit `--root` identifies on its own, used when the
+/// current directory is not inside a registered checkout.
+///
+/// `--root` names a data directory, not a checkout, so it can only name a
+/// checkout when exactly one registered checkout keeps its state there. Several
+/// checkouts sharing one root stay ambiguous and resolution fails rather than
+/// writing into an arbitrary one.
+fn sole_checkout_for_root<'a>(
+    registry: &'a WorkspaceRegistry,
+    root: &Path,
+) -> Option<&'a WorkspaceCheckout> {
+    let root = canonical_or_original(root);
+    let mut matching = registry
+        .checkouts
+        .iter()
+        .filter(|checkout| canonical_or_original(&checkout.orbit_dir) == root);
+    let first = matching.next()?;
+    matching.next().is_none().then_some(first)
+}
+
+/// Locate a checkout that no registry knows about.
+///
+/// An explicit `--root` is only usable here when it is a repo-local `.orbit`
+/// directory, whose parent is the checkout by construction. Any other
+/// unregistered root has no derivable checkout, and reporting that is the point
+/// — the alternative is a silent write into a directory that is neither the
+/// repository nor the Orbit root.
+fn unregistered_checkout_paths(
+    cwd: &Path,
+    root_override: Option<&Path>,
+) -> Result<(PathBuf, PathBuf), OrbitError> {
+    let Some(root) = root_override else {
+        return walk_up_checkout_paths(cwd);
+    };
+
+    let repo_root = root
+        .file_name()
+        .filter(|name| *name == ".orbit")
+        .and_then(|_| root.parent())
+        .ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "`--root {}` does not identify exactly one registered checkout; run this command from inside the checkout, or register it with `orbit workspace init` first",
+                root.display()
+            ))
+        })?;
+    Ok((repo_root.to_path_buf(), root.to_path_buf()))
+}
+
+fn walk_up_checkout_paths(cwd: &Path) -> Result<(PathBuf, PathBuf), OrbitError> {
     if cwd.file_name().is_some_and(|name| name == ".orbit") && cwd.is_dir() {
-        return Ok(WorkspaceLayout {
-            repo_root: cwd.parent().unwrap_or(cwd).to_path_buf(),
-            orbit_root: cwd.to_path_buf(),
-        });
+        return Ok((cwd.parent().unwrap_or(cwd).to_path_buf(), cwd.to_path_buf()));
     }
 
     // Skip the user's global $HOME/.orbit during ancestor walk-up. It is the
@@ -41,10 +187,7 @@ pub(super) fn resolve_workspace_layout_for_cwd(cwd: &Path) -> Result<WorkspaceLa
     for ancestor in cwd.ancestors() {
         let orbit_root = ancestor.join(".orbit");
         if orbit_root.is_dir() && !is_global_orbit_dir(&orbit_root) {
-            return Ok(WorkspaceLayout {
-                repo_root: ancestor.to_path_buf(),
-                orbit_root,
-            });
+            return Ok((ancestor.to_path_buf(), orbit_root));
         }
         if home
             .as_deref()
@@ -59,8 +202,8 @@ pub(super) fn resolve_workspace_layout_for_cwd(cwd: &Path) -> Result<WorkspaceLa
     ))
 }
 
-/// The logical workspace ID this checkout is registered under on this machine,
-/// or `None` when the machine registry does not know it.
+/// The logical workspace ID this checkout is registered under in `global_root`,
+/// or `None` when that registry does not know it.
 ///
 /// This is what a generated integration binds its MCP server to. The logical
 /// `ws_*` ID is used rather than the checkout path so a linked worktree — whose
@@ -71,10 +214,9 @@ pub(super) fn resolve_workspace_layout_for_cwd(cwd: &Path) -> Result<WorkspaceLa
 /// An unregistered checkout is not an error here: the generated server simply
 /// stays unbound, exactly as it was before a binding existed, and every
 /// workspace-scoped call supplies its own selector.
-pub(super) fn registered_workspace_id(repo_root: &Path) -> Option<String> {
-    let global_root = workspace_registry::global_orbit_dir().ok()?;
+fn registered_workspace_id(global_root: &Path, repo_root: &Path) -> Option<String> {
     let selector = repo_root.to_str()?;
-    RegisteredRuntimeFactory::resolve_workspace_selector(&global_root, selector)
+    RegisteredRuntimeFactory::resolve_workspace_selector(global_root, selector)
         .ok()
         .map(|selected| selected.workspace.id)
 }
@@ -87,12 +229,11 @@ fn is_global_orbit_dir(candidate: &Path) -> bool {
 }
 
 fn paths_equivalent(left: &Path, right: &Path) -> bool {
-    if left == right {
-        return true;
-    }
-    let left = fs::canonicalize(left).unwrap_or_else(|_| left.to_path_buf());
-    let right = fs::canonicalize(right).unwrap_or_else(|_| right.to_path_buf());
-    left == right
+    left == right || canonical_or_original(left) == canonical_or_original(right)
+}
+
+fn canonical_or_original(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 pub(super) fn env_home_dir() -> Option<PathBuf> {

--- a/crates/orbit-cli/tests/mcp_setup_root.rs
+++ b/crates/orbit-cli/tests/mcp_setup_root.rs
@@ -1,0 +1,330 @@
+//! `orbit mcp init` / `orbit mcp remove` against an external Orbit data root.
+//!
+//! `orbit --root <dir> workspace init` registers a checkout whose Orbit root
+//! lives outside the repository, so nothing under the checkout marks it as an
+//! Orbit workspace. Only the workspace registry in that root knows the pair,
+//! and these tests pin that both setup commands resolve the checkout through
+//! it: the client config lands in the repository, carries the registered
+//! `ws_*` binding, and is removed again — while a root that names no single
+//! registered checkout refuses instead of writing somewhere else (ORB-12121).
+
+#![allow(missing_docs)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command as StdCommand;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
+use serde_json::Value;
+use tempfile::{TempDir, tempdir};
+
+/// One machine with an external Orbit root and a single checkout registered
+/// against it.
+struct ExternalRootFixture {
+    _temp: TempDir,
+    home: PathBuf,
+    orbit_root: PathBuf,
+    checkout: PathBuf,
+    elsewhere: PathBuf,
+}
+
+impl ExternalRootFixture {
+    fn init() -> Self {
+        let temp = tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        // Deliberately nested, so a write to the root's parent is visible.
+        let orbit_root = temp.path().join("orbit-data").join("root");
+        let checkout = temp.path().join("checkout");
+        let elsewhere = temp.path().join("elsewhere");
+        for directory in [&home, &elsewhere] {
+            fs::create_dir_all(directory).expect("fixture directory");
+        }
+        init_git_repo(&checkout);
+
+        let fixture = Self {
+            _temp: temp,
+            home,
+            orbit_root,
+            checkout,
+            elsewhere,
+        };
+        fixture
+            .orbit(
+                &fixture.checkout,
+                &fixture.rooted(&[
+                    "init",
+                    "--non-interactive",
+                    "--host-name",
+                    "external-root-host",
+                    "--task-prefix",
+                    "EXR",
+                ]),
+            )
+            .success();
+        fixture
+            .orbit(
+                &fixture.checkout,
+                &fixture.rooted(&["workspace", "init", "--name", "wsname"]),
+            )
+            .success();
+        fixture.assert_external_root_layout();
+        fixture
+    }
+
+    /// Confirm the setup produced the layout these tests are about: the
+    /// registry in `orbit_root` binds the checkout, and the checkout itself
+    /// carries no `.orbit` for a filesystem walk-up to find.
+    fn assert_external_root_layout(&self) {
+        let assert = self
+            .orbit(
+                &self.checkout,
+                &self.rooted(&["workspace", "show", "--format", "json"]),
+            )
+            .success();
+        let shown: Value =
+            serde_json::from_slice(&assert.get_output().stdout).expect("workspace show json");
+        assert_eq!(shown["workspace"]["id"], "ws_wsname");
+        assert_eq!(
+            shown["checkout"]["repo_root"],
+            canonical_str(&self.checkout)
+        );
+        assert_eq!(
+            shown["checkout"]["orbit_dir"],
+            canonical_str(&self.orbit_root)
+        );
+        assert!(!self.checkout.join(".orbit").exists());
+    }
+
+    /// Prefix `args` with the explicit data-root selector this layout requires.
+    fn rooted(&self, args: &[&str]) -> Vec<String> {
+        let mut rooted = vec![
+            "--root".to_string(),
+            self.orbit_root
+                .to_str()
+                .expect("utf8 orbit root")
+                .to_string(),
+        ];
+        rooted.extend(argv(args));
+        rooted
+    }
+
+    fn orbit(&self, cwd: &Path, args: &[String]) -> assert_cmd::assert::Assert {
+        self.orbit_with_env(cwd, args, &[])
+    }
+
+    fn orbit_with_env(
+        &self,
+        cwd: &Path,
+        args: &[String],
+        env: &[(&str, &Path)],
+    ) -> assert_cmd::assert::Assert {
+        let mut command = cargo_bin_cmd!("orbit");
+        test_env::clear_inherited_authority(|name| {
+            command.env_remove(name);
+        });
+        command
+            .current_dir(cwd)
+            .env("HOME", &self.home)
+            .env("USERPROFILE", &self.home)
+            .args(args);
+        for (name, value) in env {
+            command.env(name, value);
+        }
+        command.assert()
+    }
+
+    fn claude_config(&self) -> PathBuf {
+        self.checkout.join(".claude.json")
+    }
+
+    fn claude_settings(&self) -> PathBuf {
+        self.checkout.join(".claude").join("settings.json")
+    }
+
+    /// Every directory that a mis-resolved run has historically written into.
+    fn assert_no_client_config_outside_the_checkout(&self) {
+        let root_parent = self.orbit_root.parent().expect("orbit root parent");
+        for directory in [&self.orbit_root, root_parent, &self.elsewhere, &self.home] {
+            for entry in [".claude.json", ".claude"] {
+                let stray = directory.join(entry);
+                assert!(
+                    !stray.exists(),
+                    "MCP client config written outside the checkout: {}",
+                    stray.display()
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn mcp_init_binds_an_external_root_checkout_and_remove_reverses_it() {
+    let fixture = ExternalRootFixture::init();
+
+    fixture
+        .orbit(
+            &fixture.checkout,
+            &fixture.rooted(&["mcp", "init", "--claude"]),
+        )
+        .success();
+
+    assert_eq!(
+        generated_server_args(&fixture.claude_config()),
+        vec!["mcp", "serve", "--workspace", "ws_wsname"],
+        "the generated server must carry the registered workspace binding"
+    );
+    assert!(fixture.claude_settings().is_file());
+    fixture.assert_no_client_config_outside_the_checkout();
+
+    fixture
+        .orbit(
+            &fixture.checkout,
+            &fixture.rooted(&["mcp", "remove", "--claude"]),
+        )
+        .success();
+
+    assert!(!fixture.claude_config().exists());
+    assert!(!fixture.checkout.join(".claude").exists());
+}
+
+#[test]
+fn mcp_init_resolves_the_registered_checkout_from_an_unrelated_directory() {
+    let fixture = ExternalRootFixture::init();
+
+    fixture
+        .orbit(
+            &fixture.elsewhere,
+            &fixture.rooted(&["mcp", "init", "--claude"]),
+        )
+        .success();
+
+    assert_eq!(
+        generated_server_args(&fixture.claude_config()),
+        vec!["mcp", "serve", "--workspace", "ws_wsname"]
+    );
+    fixture.assert_no_client_config_outside_the_checkout();
+
+    fixture
+        .orbit(
+            &fixture.elsewhere,
+            &fixture.rooted(&["mcp", "remove", "--claude"]),
+        )
+        .success();
+
+    assert!(!fixture.claude_config().exists());
+    assert!(!fixture.checkout.join(".claude").exists());
+}
+
+#[test]
+fn orbit_root_env_selects_the_same_checkout_as_the_root_flag() {
+    let fixture = ExternalRootFixture::init();
+    let env = [("ORBIT_ROOT", fixture.orbit_root.as_path())];
+
+    fixture
+        .orbit_with_env(&fixture.checkout, &argv(&["mcp", "init", "--claude"]), &env)
+        .success();
+
+    assert_eq!(
+        generated_server_args(&fixture.claude_config()),
+        vec!["mcp", "serve", "--workspace", "ws_wsname"]
+    );
+    fixture.assert_no_client_config_outside_the_checkout();
+
+    fixture
+        .orbit_with_env(
+            &fixture.checkout,
+            &argv(&["mcp", "remove", "--claude"]),
+            &env,
+        )
+        .success();
+
+    assert!(!fixture.claude_config().exists());
+}
+
+#[test]
+fn a_root_without_a_registered_checkout_refuses_instead_of_writing() {
+    let fixture = ExternalRootFixture::init();
+    let unrelated_root = fixture
+        .orbit_root
+        .parent()
+        .expect("orbit root parent")
+        .join("unregistered");
+    fs::create_dir_all(&unrelated_root).expect("create unregistered root");
+
+    let assert = fixture
+        .orbit(
+            &fixture.elsewhere,
+            &argv(&[
+                "--root",
+                unrelated_root.to_str().expect("utf8 root"),
+                "mcp",
+                "init",
+                "--claude",
+            ]),
+        )
+        .failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("does not identify exactly one registered checkout"),
+        "unexpected failure message: {stderr}"
+    );
+
+    assert!(!unrelated_root.join(".claude.json").exists());
+    fixture.assert_no_client_config_outside_the_checkout();
+    assert!(!fixture.claude_config().exists());
+}
+
+fn argv(args: &[&str]) -> Vec<String> {
+    args.iter().map(|arg| (*arg).to_string()).collect()
+}
+
+fn canonical_str(path: &Path) -> String {
+    fs::canonicalize(path)
+        .expect("canonicalize fixture path")
+        .to_str()
+        .expect("utf8 fixture path")
+        .to_string()
+}
+
+fn generated_server_args(config_path: &Path) -> Vec<String> {
+    let config: Value = serde_json::from_str(
+        &fs::read_to_string(config_path).expect("read generated client config"),
+    )
+    .expect("parse generated client config");
+    config["mcpServers"]["orbit"]["args"]
+        .as_array()
+        .expect("generated args array")
+        .iter()
+        .map(|value| value.as_str().expect("arg is a string").to_string())
+        .collect()
+}
+
+fn init_git_repo(repo: &Path) {
+    fs::create_dir_all(repo).expect("create repo");
+    run_git(repo, &["init", "--initial-branch", "main"]);
+    run_git(repo, &["config", "user.name", "Orbit Test"]);
+    run_git(repo, &["config", "user.email", "orbit-test@example.com"]);
+    run_git(repo, &["config", "commit.gpgsign", "false"]);
+    fs::write(repo.join("README.md"), "# repo\n").expect("write readme");
+    run_git(repo, &["add", "README.md"]);
+    run_git(repo, &["commit", "-m", "initial"]);
+}
+
+fn run_git(cwd: &Path, args: &[&str]) {
+    let output = StdCommand::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git -C {} {} failed\nstdout:\n{}\nstderr:\n{}",
+        cwd.display(),
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/website/src/content/docs/how-to/mcp-integration.md
+++ b/website/src/content/docs/how-to/mcp-integration.md
@@ -33,6 +33,17 @@ orbit mcp init --grok
 
 **Grok Build** uses the native `.grok/config.toml` format (similar to how Claude Code can use a config file). `orbit mcp init --grok` will create or update `.grok/config.toml` in your workspace root (or `~/.grok/config.toml` for global).
 
+### Workspaces with an external Orbit root
+
+`orbit --root <dir> workspace init` registers a checkout whose Orbit data root
+lives outside the repository, so nothing inside the checkout marks it as a
+workspace. Select that root on the setup commands too — `orbit --root <dir> mcp
+init --claude`, or `ORBIT_ROOT=<dir>` in the environment — and Orbit resolves
+the registered checkout from that root's catalog: the client config is written
+into the repository and bound to its `ws_*` workspace, and `orbit mcp remove`
+takes it back out. Without a root selector there is no catalog to consult, and
+both commands refuse rather than writing the config elsewhere.
+
 ## Register the federated mux
 
 Federated MCP presents one namespace over this machine's workspaces plus any


### PR DESCRIPTION
## Task

[ORB-12121](https://orbit-cli.com/tasks/ORB-12121) — [qa-sweep] orbit mcp init/remove ignore the workspace registry, so an external Orbit root writes MCP config to the root's parent directory

### Description

`orbit mcp init` and `orbit mcp remove` resolve the target checkout with `resolve_workspace_layout` (crates/orbit-cli/src/command/mcp/setup/workspace.rs), which only knows two shapes: `--root <dir>` means "<dir> is a repo-local .orbit, so the repo root is its parent", otherwise walk cwd's ancestors for a non-global `.orbit` directory. Neither consults the workspace registry, which already records this checkout's `repo_root`. When a workspace is registered against an Orbit root that is not a checkout-local `.orbit` (the `orbit --root <dir> workspace init` layout), both branches are wrong.

Symptom A - the supported layout is reported as uninitialized. From inside the registered checkout, `orbit mcp init --claude` fails with `current directory is not inside an initialized Orbit workspace; run 'orbit workspace init' first or pass '--root <path/to/.orbit>'`. `orbit workspace init` has already succeeded and `orbit workspace show` resolves the checkout, so the remediation the error prints is a loop.

Symptom B - the documented workaround writes to an unrelated directory, silently. `orbit --root <orbit-root> mcp init --claude` prints `mcp init: claude` and exit 0, but writes `.claude.json` and `.claude/settings.json` into the *parent* of the Orbit root, not into the checkout. The generated server entry is also unbound: `registered_workspace_id()` is called with that parent path, finds no registration, and omits the `--workspace ws_*` argument the working path emits. So the operator gets a success message, no file where they expected one, and a degraded server definition in a directory that has nothing to do with either the repo or the Orbit root.

Reproduction (orbit 0.20.0 built from fb7b8e5012cf004ae24993157ec6a6ed18f824e1; HOME and all ORBIT_* authority cleared per orbit_common::test_env::INHERITED_AUTHORITY_ENV):

    export HOME=/tmp/scratch/home
    orbit --root /tmp/scratch/orbit-data/root init --non-interactive --host-name qb --task-prefix QBX
    mkdir -p /tmp/scratch/checkout && cd /tmp/scratch/checkout && git init -b main . && git commit --allow-empty -m init
    orbit --root /tmp/scratch/orbit-data/root workspace init --name wsname
    #   id: ws_wsname   root: /tmp/scratch/checkout   orbit_dir: /tmp/scratch/orbit-data/root

    orbit mcp init --claude
    #   error: invalid input: current directory is not inside an initialized Orbit workspace;
    #          run `orbit workspace init` first or pass `--root <path/to/.orbit>`

    orbit --root /tmp/scratch/orbit-data/root mcp init --claude
    #   mcp init: claude        (exit 0)
    ls -a /tmp/scratch/checkout          # .git README.md  -- nothing written
    ls -a /tmp/scratch/orbit-data        # .claude  .claude.json  root
    cat /tmp/scratch/orbit-data/.claude.json
    #   {"mcpServers":{"orbit":{"args":["mcp","serve"],"command":"orbit"}}}   <- no --workspace binding

Contrast with the checkout-local layout, which behaves correctly: `orbit workspace init` with the default home root creates `<checkout>/.orbit`, and `orbit mcp init --claude` then writes `<checkout>/.claude.json` with `["mcp","serve","--workspace","ws_repo2"]`. `orbit mcp remove --claude` cleans both files and the now-empty `.claude/` directory (ORB-12115 behaves as intended there).

Suggested direction: resolve the checkout through the workspace registry (the same resolution `orbit workspace show` uses) before falling back to the ancestor walk, and treat the global `--root` as the Orbit data root it is documented to be rather than as `<repo>/.orbit`. At minimum, refuse rather than write when the derived repo root is not a registered checkout, so a silent write to an unrelated directory is impossible.

### Acceptance Criteria

- From a checkout registered against an external Orbit root, `orbit mcp init --claude` succeeds and writes the client config into that checkout.
- `orbit mcp init` never writes MCP client configuration into a directory that is not the resolved checkout; an unresolvable target fails instead of reporting success.
- A generated server entry carries the registered `--workspace ws_*` binding in every layout where the checkout is registered.
- `orbit mcp remove` removes exactly what the matching `orbit mcp init` wrote, in the same layouts.
- A regression test covers the external-Orbit-root layout for both init and remove.

## Execution Summary

<details>
<summary>Click to expand</summary>

Registry-first checkout resolution for `orbit mcp init` / `orbit mcp remove`.

## Change

`crates/orbit-cli/src/command/mcp/setup/workspace.rs` — `resolve_workspace_layout` no longer treats `--root <dir>` as "<dir> is `<repo>/.orbit`". It now:
- picks one authoritative catalog: the explicitly selected data root (`--root`, else the `ORBIT_ROOT` escape hatch every other root-aware surface honors) when it holds `workspaces.json`, otherwise this machine's global root;
- resolves the checkout from cwd against that catalog (`find_checkout_by_path`, canonicalized retry), and when cwd is outside every registered checkout, accepts an explicit root only when exactly one registered checkout stores its state there;
- derives the generated server's `--workspace ws_*` binding from the same root (`registered_workspace_id` is now root-parameterized instead of always reading `~/.orbit`), so `WorkspaceLayout` carries `workspace_id`;
- falls back to the previous ancestor walk-up only for an unregistered repo-local `.orbit`; an explicit root that is not itself a `.orbit` directory and names no single registered checkout now fails with `` `--root <path>` does not identify exactly one registered checkout … `` instead of writing into the root's parent.

`args.rs` consumes `layout.workspace_id` (the separate `registered_workspace_id` call is gone; `--federated` still emits an unbound federated entry). `dispatch.rs` was read but needed no change.

Docs: `website/src/content/docs/how-to/mcp-integration.md` gains a short "Workspaces with an external Orbit root" subsection stating that the root must be selected with `--root`/`ORBIT_ROOT` and that the commands refuse rather than writing elsewhere.

New file `crates/orbit-cli/tests/mcp_setup_root.rs` (4 tests, declared in `context_files`): the fixture builds the `orbit --root <dir> workspace init` layout with a disposable HOME, clears `INHERITED_AUTHORITY_ENV`, and verifies routing with read-only `workspace show --format json` (canonicalized `repo_root`/`orbit_dir`) before any assertion. All four fail against HEAD (ea33558) and pass with the fix.

## Acceptance criteria

1. **External-root checkout: `orbit mcp init --claude` succeeds and writes into the checkout** — met when the run selects that root, i.e. `orbit --root <dir> mcp init --claude` or `ORBIT_ROOT=<dir> orbit mcp init --claude` (covered by `mcp_init_binds_an_external_root_checkout_and_remove_reverses_it` and `orbit_root_env_selects_the_same_checkout_as_the_root_flag`). **Deviation:** with neither selector the command still refuses. Verified on this machine that nothing records an external root — `orbit init --root X` writes no pointer into `$HOME/.orbit`, which holds only `state/`; the checkout has no `.orbit`; so no catalog on the machine can map that cwd to the workspace. Every Orbit command shares this (bare `orbit task list` there resolves nothing and seeds a fresh `<checkout>/.orbit` instead). Making the bare form succeed would require a new root-discovery mechanism, which is outside this bug; criterion 2 requires refusing in exactly that situation.
2. **Never writes outside the resolved checkout; unresolvable target fails** — met. `assert_no_client_config_outside_the_checkout` asserts no `.claude.json` / `.claude` in the Orbit root, its parent, the unrelated cwd, or HOME, on every success path; `a_root_without_a_registered_checkout_refuses_instead_of_writing` pins the non-zero exit, the message, and that nothing was written.
3. **Generated entry carries the registered `ws_*` binding in every registered layout** — met. All three external-root tests assert `["mcp","serve","--workspace","ws_wsname"]`; the checkout-local layout keeps its binding (manually re-verified from the checkout, a subdirectory, and `--root <checkout>/.orbit` from an unrelated cwd: `ws_localws` in each).
4. **`remove` reverses exactly what `init` wrote, in the same layouts** — met. Each test's remove step asserts `.claude.json` and the `.claude/` directory are gone; the checkout-local layout was re-checked manually (ORB-12115 behavior unchanged).
5. **Regression test for the external-root layout, init and remove** — met by the new integration test file.

## Validation

Passed:
- `cargo test -p orbit-cli --test mcp_setup_root` — 4 passed (and 4 failed on reverted sources, confirming regression detection).
- `cargo test -p orbit-cli` — full crate suite green (512 unit + every integration target, including `mcp_roundtrip`, `workspace_selector`, `worktree_resolution`, `shared_root_task_isolation`, `ambient_authority_isolation`).
- `make ci-fast` — exit 0 (one guard self-skips: `test-compiler-cache-namespaces`, no user namespaces on this host).
- `make ci-lint` — exit 0.
- Manual CLI reproduction of the task's scenario with the rebuilt binary (isolated HOME, authority env cleared): external root via `--root` and via `ORBIT_ROOT`, from inside the checkout and from an unrelated cwd; checkout-local layout; two checkouts sharing one external root.

Not run: `make ci` (CI-owned merge gate), and any non-Linux check — all evidence here is Linux-only, though no platform-specific code paths were touched.

## Risks / notes

- Precedence change: when an explicit root holds a catalog, that catalog is authoritative and the machine-global one is not consulted for the checkout. A cwd inside a home-registered checkout combined with `--root <other-catalog>` now resolves through the explicit root (or fails) rather than silently using the home registry.
- Ambiguity policy: several checkouts sharing one external root resolve only from inside one of them; from an unrelated cwd the command refuses instead of picking one.
- Registry reads stay in the existing `command/mcp/setup/workspace.rs` adapter, which already performed them; no new cross-crate dependency edge (`orbit-cli` already depends on `orbit-cmd`, `orbit-registry`, `orbit-types`).
- Working tree left uncommitted; `git diff --check` clean; no stray build or scratch artifacts (all reproduction scratch lived under `/tmp`, outside the worktree).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12121-6aa38f23`
- Behind base: 0
- Ahead of base: 1