### PR TITLE
Prepare v0.21.0 release after the overnight repair and QA gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.21.0
+
+### Breaking Changes
+
+- **Layout-v3 checkout task projections removed**: `.orbit/tasks` symlink projections and projection fields are removed in favor of canonical storage; stop older binaries before running layout migration v3 to prevent recreating obsolete links. ([ORB-11994], [ORB-12078])
+- **Worktree GC activity schema updated**: custom `worktree_gc` invocations and automations must supply `target_run_id` instead of `run_id` for single-run scoping. ([ORB-11998])
+- **Public config path Result API**: `OrbitRuntime::config_path` now returns `Result<PathBuf, OrbitError>` instead of an infallible `PathBuf`; callers must handle config validation errors. ([ORB-12023])
+- **Linux runtime sandbox requires descriptor mounts**: Linux runtime write sandboxes now require Bubblewrap `--bind-fd` support; environments lacking descriptor-binding cannot mount writable runtime roots. ([ORB-12042], [ORB-12063])
+- **Task-pilot admission contract enforced**: automatic and explicit implementation admission now withhold unassessed tasks until complexity is evaluated, while `no-diff-expected` tasks are exempt. ([ORB-11991], [ORB-12053], [ORB-12118])
+- **Task complexity required on update**: human and agent `task.update` surfaces now reject `complexity: unassessed` with the create-time validation error; only automated system pipelines may assign unassessed status. ([ORB-12116])
+- **Strict new-file delivery declarations**: task delivery now enforces explicit new-file intent declarations and rejects unknown untracked paths before index mutation; declare new files via `file:` selectors. ([ORB-12050])
+
+### Highlights
+
+- **Read-only observational Orbit modes**: SQLite databases can be safely observed without write locks even when uncheckpointed WAL frames exist, and workspaces can start without requiring semantic indexing. ([ORB-12090], [ORB-12092], [ORB-12093])
+- **Rust path-validation and descriptor hardening**: file inspection and sandbox directory creation hold file descriptors through verification and mount operations, closing race conditions across runtime roots. ([ORB-12048], [ORB-12051], [ORB-12054], [ORB-12065])
+- **Task-pilot automated repair assessment**: code-scanning tasks are minted without speculative selectors, while task-pilot evaluates repair complexity and persists modification targets atomically before implementation. ([ORB-11991], [ORB-12118])
+- **CLI and MCP surface reliability**: fixes across tool execution, workspace filtering, MCP caller authorization, routine naming, credential redaction, and CLI output consistency improve agent ergonomics. ([ORB-12104], [ORB-12106], [ORB-12108], [ORB-12113])
+- **End-to-end full-QA coverage**: comprehensive QA verification suites, deterministic process fixtures, and browser capability evidence retention ensure stability across supported platforms. ([ORB-12010], [ORB-12047], [ORB-12062], [ORB-12085], [ORB-12086])
+
 ## 0.20.0
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,7 +2094,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbit-agent"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-automation"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cli"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cmd"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "flate2",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-common"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-config"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "orbit-common",
  "orbit-types",
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-core"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-engine"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-exec"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "libc",
  "orbit-common",
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-mcp"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-policy"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-registry"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "hostname",
@@ -2346,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-search"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-store"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-tools"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-types"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2427,7 +2427,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-web"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 license = "MIT"
 # MSRV [ORB-10010]: edition 2024 requires >= 1.85; the highest `rust-version`

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbit-tools/cli",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "mcpName": "io.github.constellation-works/orbit",
   "description": "npm proxy for the Orbit CLI. Downloads the matching native binary from GitHub Releases on install and forwards all invocations.",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface, skills, and orchestration subagents to Claude Code.",
   "author": {
     "name": "constellation-works",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP task and knowledge surface plus workflow skills to Codex.",
   "author": {
     "name": "constellation-works",
@@ -20,7 +20,7 @@
   "mcpServers": {
     "orbit": {
       "command": "npx",
-      "args": ["-y", "@orbit-tools/cli@0.20.0", "mcp", "serve"]
+      "args": ["-y", "@orbit-tools/cli@0.21.0", "mcp", "serve"]
     }
   },
   "interface": {

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "orbit": {
       "command": "npx",
-      "args": ["-y", "@orbit-tools/cli@0.20.0", "mcp", "serve"]
+      "args": ["-y", "@orbit-tools/cli@0.21.0", "mcp", "serve"]
     }
   }
 }

--- a/plugin/mcp.json
+++ b/plugin/mcp.json
@@ -4,7 +4,7 @@
     "orbit": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@orbit-tools/cli@0.20.0", "mcp", "serve"]
+      "args": ["-y", "@orbit-tools/cli@0.21.0", "mcp", "serve"]
     }
   }
 }

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "orbit",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface and shared workflow skills to compatible clients.",
   "author": {
     "name": "constellation-works",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/constellation-works/orbit",
     "source": "github"
   },
-  "version": "0.20.0",
+  "version": "0.21.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@orbit-tools/cli",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Task

[ORB-12073](https://orbit-cli.com/tasks/ORB-12073) — Prepare v0.21.0 release after the overnight repair and QA gates

### Description

Prepare the release candidate on a dedicated branch from agent-main after the overnight repairs and QA gates are complete. Daniel explicitly authorized tonight's breaking version bump, validated delivery to agent-main, and the operator's later annotated tag/push. Website deployment, npm publication, and promotion to main remain Daniel-owned.

Use RELEASING.md and docs/runbooks/release.md as the current procedure. The verified previous release is v0.20.0. Version 0.21.0 is appropriate for the pre-1.0 breaking release.

Release range (pinned 2026-09-10 22:42 PT): v0.20.0..fc4d42a22f0a5cc4635abca9b0b807abaa9149b2 (origin/agent-main tip, "docs: task authority is per prefix, not per host [ORB-12126] (#1927)"), 198 commits. ORB-12028 contains the release survey through 1fe3b8da4289fdffed86db7b1b9659ffab2a0916; the remaining 66-commit delta 1fe3b8da..fc4d42a22 must be surveyed by this task and folded into the changelog. If agent-main has advanced past fc4d42a22 when the candidate branch is cut, extend the survey to the actual tip and record the final SHA in the execution summary.

Delta since the ORB-12028 survey (1fe3b8da..fc4d42a22), grouped:
- Layout-v3 follow-through: removal of workspace .orbit/tasks symlink projections (ORB-11994), README/ARCHITECTURE cleanup (ORB-12078), config show phantom task-store path (ORB-12079), read-only MCP mutation diagnostics aligned to canonical layout (ORB-12094, ORB-12097), workspace teardown leaving the task store behind + doctor orphan-task-store check (ORB-12109, ORB-12119), nested-workspace init regression (ORB-12067), task authority per prefix docs (ORB-12126).
- Read-only/observational Orbit modes: SQLite WAL read without writes (ORB-12090), keep read-only observations current on WAL commits (ORB-12092), startup without optional semantic index (ORB-12093).
- Sandbox/path-validation hardening: proven Rust path-validation model activated (ORB-12048), remaining descriptor-read CodeQL flows (ORB-12051), runtime config root validation (ORB-12023), runtime sandbox dir + SQLite grants (ORB-12042), bubblewrap authority fd remap (ORB-12063), O_NONBLOCK on no-follow reads (ORB-12054), FIFO lock-holder regression (ORB-12065), docs config race-safe read boundary (ORB-12030), unused LinuxRuntimeWriteAuthority import (ORB-12095).
- Task-pilot / admission contract: assess automated repair complexity + modification targets (ORB-11991), unassessed-complexity admission gate (ORB-12053), reject unassessed complexity on task.update surfaces (ORB-12116), exempt no-diff-expected tasks (ORB-12118), active drain candidate-pool limit (ORB-12044).
- Delivery/ship pipeline: prevent delivery from committing untracked files (ORB-12050), ship gate hardcoded auto_push in local mode (ORB-12102), step_failure_recovery rewriting git remote config (ORB-12103), sibling top-level job run IDs (ORB-12111).
- CLI/MCP surface fixes from the 2026-09-10 QA sweep: global --workspace ignored by tool run (ORB-12106), sweep --workspace ignored (ORB-12108), task.show stray artifacts on non-matching workspace filter (ORB-12104), mcp-callers.toml single-caller deny (ORB-12105), mcp init/remove ignoring workspace registry (ORB-12121), tool enable false success on registry-inactive (ORB-12122), GitShim PATH mutation breaking make test (ORB-12123), CLI output shape consistency across audit/search/run show (ORB-12113), task update --priority + empty lock reservation (ORB-12114), init seeding global root before --task-prefix validation (ORB-12112), seeded routine names from checkout dir (ORB-12107), mcp remove leaving empty .claude dir (ORB-12115), credential redaction in hyphenated words (ORB-12084).
- QA/CI: qa-full-sweep auto-task (ORB-12010), full-QA sign-off requires behavioral coverage (ORB-12047), remaining full-QA CLI gaps + hosted macOS evidence (ORB-12062), restored core CI coverage (ORB-12056), red CI fix (ORB-12068), deterministic/fenced process fixtures (ORB-12085, ORB-12086, ORB-12087), browser capability evidence retention (ORB-12077).
- Website/docs/chores: website UX refresh (ORB-12011), Routines/Auto-Tasks concept + changelog page (#1919), orbit-cli.com deploy workflow removed (ORB-12096), doc-duties validation (ORB-12045, ORB-12055), worktree_gc age floor lowered to 1h, stray evidence files removed (ORB-12049), several auto-commits.

Explicitly explain layout-v3 removal of checkout task projections and old-binary upgrade handling, worktree_gc activity run_id→target_run_id, task-pilot assessment contract changes (including the new unassessed-complexity rejection on task.update and the no-diff-expected exemption), and public config Result API changes. Include the Linux descriptor-mount prerequisite, the read-only/observational mode behavior, and validated operational improvements where user-visible. Preserve released changelog history; do not archive the 0.x line.

This leaf prepares and validates the source/version/changelog PR only. It must not tag, push tags, create a release, publish npm, deploy a website, or merge to main. Root will independently verify QA, exact merged source, immutable tag availability, and the release workflow afterward. No external publishing credentials are required for preparation.

### Acceptance Criteria

- All prescribed version-bearing source, lockfile, npm, server metadata, and plugin manifests/pins consistently identify0.21.0; release-check and mirror checks pass.
- Changelog covers the verified full range sincev0.20.0, including explicit breaking changes and upgrade guidance; no historical sections are rewritten or archived.
- make release-check, scripts/sync-plugin-skills.sh --check, scripts/smoke-plugin-install.sh, scripts/smoke-npm-install.sh --dry-run-version-assertion, make ci-fast, and make ci-lint pass with evidence tied to the prepared commit; report exact limitations rather than treating missing external publication as pre-release failure.
- The task-scoped PR targets agent-main and the execution summary records exact source/version, release survey delta, validation results, and operator handoff. No tag/release/main merge/website deployment/npm publication occurs in this leaf.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Exact source and version:
- Previous release baseline: v0.20.0 (commit 66a6179b539e0e80ae837f06a3b86d4735104202)
- Target version: 0.21.0
- Base commit: fc4d42a22f0a5cc4635abca9b0b807abaa9149b2 (origin/agent-main tip, 198 commits since v0.20.0)

Release survey delta:
- Full range covers 198 commits across v0.20.0..fc4d42a22f0a5cc4635abca9b0b807abaa9149b2.
- Folds in the ORB-12028 survey (v0.20.0..1fe3b8da, 132 commits) and the 66-commit delta (1fe3b8da..fc4d42a22), including layout-v3 follow-through, read-only/observational modes, sandbox/path hardening, task-pilot/admission contract, delivery pipeline safeguards, CLI/MCP fixes, full-QA suites, and UX/docs updates.

Changes:
- Cargo.toml: bumped workspace.package version from 0.20.0 to 0.21.0.
- Cargo.lock: refreshed 17 Orbit workspace member versions to 0.21.0 via cargo update --workspace --offline without third-party dependency drift.
- npm/package.json: bumped version from 0.20.0 to 0.21.0.
- server.json: bumped top-level version and packages[0].version from 0.20.0 to 0.21.0.
- plugin/.claude-plugin/plugin.json: bumped version from 0.20.0 to 0.21.0.
- plugin/.codex-plugin/plugin.json: bumped version and MCP args pin to 0.21.0 / @orbit-tools/cli@0.21.0.
- plugin/plugin.json: bumped version from 0.20.0 to 0.21.0.
- plugin/.mcp.json and plugin/mcp.json: bumped MCP args pins to @orbit-tools/cli@0.21.0.
- CHANGELOG.md: drafted and inserted ## 0.21.0 section with 7 breaking changes (layout-v3 checkout task projections removal, worktree_gc target_run_id rename, public config Result API, Linux bwrap --bind-fd prerequisite, task-pilot admission contract, task complexity requirement on update, strict new-file delivery declarations) and 5 highlights (read-only SQLite WAL observation mode, Rust path-validation/descriptor hardening, task-pilot automated repair assessment, CLI/MCP surface reliability, end-to-end full-QA coverage). Preserved existing changelog history without archiving.

Acceptance criteria mapping:
1. All prescribed version-bearing files and manifests consistently identify 0.21.0; mirror checks pass: PASSED. All 10 context files updated and consistent.
2. Changelog covers verified full range since v0.20.0 with explicit breaking changes and upgrade guidance, no history rewritten/archived: PASSED.
3. make release-check, scripts/sync-plugin-skills.sh --check, scripts/smoke-plugin-install.sh, scripts/smoke-npm-install.sh --dry-run-version-assertion, make ci-fast, and make ci-lint pass with evidence tied to prepared commit; reported exact pre-release limitations: PASSED.
4. Leaf prepares source/version/changelog PR targeting agent-main; no tag, release, publication, or deployment in this leaf: PASSED.

Validation:
- PASSED: scripts/sync-plugin-skills.sh --check (clean committed mirror match).
- PASSED: scripts/smoke-plugin-install.sh (Claude Code / Codex scratch installs verify MCP and skill assets; Cursor local symlink and Agent Plugins 1.0 contract validated).
- PASSED: scripts/smoke-npm-install.sh --dry-run-version-assertion (asserts mismatched tag versions fail).
- PASSED: make ci-fast (fast guardrails, fmt-check, security, pubkey, installer, asset sync, and plugin validation passed; unprivileged mount namespace probe skipped due to container limits).
- PASSED: make ci-lint (full workspace-wide clippy --all-targets -D warnings, 0 warnings, 0 errors in 1m 58s).
- PASSED: make release-check local verification (all 6 local sources agree on 0.21.0 and launch pins match @orbit-tools/cli@0.21.0). Pre-release limitation: gh release list reports latest published tag v0.20.0 and npm registry is unreachable/unpublished, as expected before release per docs/runbooks/release.md §4.
- PASSED: git diff --check (clean).
- PASSED: git status --short (exactly the 10 declared tracked context files modified, 0 untracked files).
- NOT RUN: make ci (full CI suite reserved for pipeline merge gate per workspace policy).
- NOT RUN: live npm publish, git tag, git push, github release, website deployment (explicitly human/operator-owned per runbook).

Operator handoff:
- Changes are left uncommitted for pipeline delivery to agent-main.
- Post-merge, operator cuts and pushes annotated tag v0.21.0, monitors .github/workflows/release.yml, manually publishes npm @orbit-tools/cli@0.21.0, files Cursor marketplace follow-up, promotes agent-main -> main, and back-merges main -> agent-main.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12073-6aa3961f`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra