### PR TITLE
[qa-sweep] orbit mcp init/remove never name the checkout they wrote, so registry-resolved writes land silently elsewhere

### DIFF
--- a/crates/orbit-cli/src/command/mcp/setup/args.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/args.rs
@@ -214,7 +214,12 @@ impl InitArgs {
             env_home_dir(),
             self.scope,
         )?;
-        print_action_summary(McpAction::Init(launch), &providers);
+        print_action_summary(
+            McpAction::Init(launch),
+            &providers,
+            &layout.repo_root,
+            layout.workspace_id.as_deref(),
+        );
         Ok(CommandOutput::Silent)
     }
 }
@@ -249,7 +254,12 @@ impl RemoveArgs {
             env_home_dir(),
             self.scope,
         )?;
-        print_action_summary(action, &providers);
+        print_action_summary(
+            action,
+            &providers,
+            &layout.repo_root,
+            layout.workspace_id.as_deref(),
+        );
         Ok(CommandOutput::Silent)
     }
 }

--- a/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
@@ -291,10 +291,32 @@ pub(super) fn auto_detected_providers(
     providers
 }
 
-pub(super) fn print_action_summary(action: McpAction<'_>, providers: &[McpProvider]) {
+/// Print which providers were touched and, crucially, where — resolution now
+/// goes through the workspace registry (ORB-12121) rather than always
+/// matching cwd, so the write can land in a linked worktree's primary
+/// checkout or in a `--root`-selected checkout the operator isn't standing
+/// in. Naming the path (and, when known, the bound `ws_*` id) turns that
+/// into an audit line instead of a silent no-op.
+pub(super) fn print_action_summary(
+    action: McpAction<'_>,
+    providers: &[McpProvider],
+    repo_root: &Path,
+    workspace_id: Option<&str>,
+) {
+    println!(
+        "{}",
+        format_action_summary(action, providers, repo_root, workspace_id)
+    );
+}
+
+pub(super) fn format_action_summary(
+    action: McpAction<'_>,
+    providers: &[McpProvider],
+    repo_root: &Path,
+    workspace_id: Option<&str>,
+) -> String {
     if providers.is_empty() {
-        println!("mcp {}: no providers selected", action.label());
-        return;
+        return format!("mcp {}: no providers selected", action.label());
     }
 
     let labels = providers
@@ -302,5 +324,19 @@ pub(super) fn print_action_summary(action: McpAction<'_>, providers: &[McpProvid
         .map(|provider| provider.label())
         .collect::<Vec<_>>()
         .join(", ");
-    println!("mcp {}: {}", action.label(), labels);
+    match workspace_id {
+        Some(id) => format!(
+            "mcp {}: {} -> {} ({})",
+            action.label(),
+            labels,
+            repo_root.display(),
+            id
+        ),
+        None => format!(
+            "mcp {}: {} -> {}",
+            action.label(),
+            labels,
+            repo_root.display()
+        ),
+    }
 }

--- a/crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs
@@ -1,7 +1,11 @@
+use std::path::Path;
+
 use tempfile::tempdir;
 
 use super::super::args::{McpAction, McpProvider, ProviderSelectionMode, ScopeArg};
-use super::super::dispatch::{auto_detected_providers, run_action, vscode_home_user_dir};
+use super::super::dispatch::{
+    auto_detected_providers, format_action_summary, run_action, vscode_home_user_dir,
+};
 use super::super::providers::ServerLaunch;
 
 #[test]
@@ -409,6 +413,39 @@ fn home_scope_without_home_dir_errors() {
         err,
         orbit_core::OrbitError::InvalidInput(message) if message.contains("HOME")
     ));
+}
+
+#[test]
+fn action_summary_names_the_resolved_checkout_and_workspace_id() {
+    let summary = format_action_summary(
+        McpAction::Init(ServerLaunch::default()),
+        &[McpProvider::Claude],
+        Path::new("/tmp/qa/repoA"),
+        Some("ws_repoa"),
+    );
+    assert_eq!(summary, "mcp init: claude -> /tmp/qa/repoA (ws_repoa)");
+}
+
+#[test]
+fn action_summary_omits_workspace_id_when_unregistered() {
+    let summary = format_action_summary(
+        McpAction::Remove,
+        &[McpProvider::Claude, McpProvider::Codex],
+        Path::new("/tmp/qa/repoA"),
+        None,
+    );
+    assert_eq!(summary, "mcp remove: claude, codex -> /tmp/qa/repoA");
+}
+
+#[test]
+fn action_summary_skips_path_when_no_providers_selected() {
+    let summary = format_action_summary(
+        McpAction::Init(ServerLaunch::default()),
+        &[],
+        Path::new("/tmp/qa/repoA"),
+        Some("ws_repoa"),
+    );
+    assert_eq!(summary, "mcp init: no providers selected");
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-12132](https://orbit-cli.com/tasks/ORB-12132) — [qa-sweep] orbit mcp init/remove never name the checkout they wrote, so registry-resolved writes land silently elsewhere

### Description

## Summary

ORB-12121 (8139b6ee6) made `orbit mcp init` / `orbit mcp remove` resolve the
target checkout through the workspace registry instead of walking up from the
current directory. That is the right fix, but it also means the destination is
now frequently **not** the directory the operator ran the command in — and the
success summary still prints only `mcp init: claude`, with no path.
`print_action_summary` in `crates/orbit-cli/src/command/mcp/setup/dispatch.rs`
renders the action and provider labels and nothing else.

Two resolution paths write outside cwd:

1. **Linked git worktree.** `find_checkout_by_path` does not know the worktree
   path, so `sole_checkout_for_root` resolves the root's single registered
   checkout and the config is written there.
2. **Any unrelated cwd with `--root`/`ORBIT_ROOT` naming a root that has exactly
   one registered checkout.** Same fallback; the command succeeds from, say,
   `/tmp`.

## Evidence (0.20.0 built from fc4d42a22, Linux)

```sh
# external-root layout: /tmp/qa/rootA is the Orbit root, /tmp/qa/repoA the only
# registered checkout (ws_repoa).

# (1) from a linked worktree of repoA
git -C /tmp/qa/repoA worktree add -q /tmp/qa/repoA-wt -b wt
cd /tmp/qa/repoA-wt && orbit --root /tmp/qa/rootA mcp init --claude
#   mcp init: claude
ls -a /tmp/qa/repoA-wt      # .  ..  .git          <- nothing written here
ls -l  /tmp/qa/repoA/.claude.json                   # <- written here instead

# (2) from an unrelated directory
rm -f /tmp/qa/repoA/.claude.json
cd /tmp && orbit --root /tmp/qa/rootA mcp init --claude
#   mcp init: claude
ls -l /tmp/qa/repoA/.claude.json                    # recreated in repoA
```

`orbit mcp remove` has the mirror-image problem: it reports `mcp remove: claude`
after deleting `.claude.json` and `.claude/` from a checkout the operator is not
standing in.

By contrast, the ambiguous case is handled well — with two checkouts sharing one
root, resolution refuses with a clear message naming `--root`. The gap is only
that the *unambiguous* remote write is silent.

## Suggested fix

Print the resolved checkout (and, for init, the bound `ws_*` id) in the action
summary, e.g.

```
mcp init: claude -> /tmp/qa/repoA (ws_repoa)
```

That also makes the linked-worktree behavior self-explanatory rather than
looking like a no-op, and gives `mcp remove` an audit line for a deletion that
happened somewhere else.

Validation impact: none. Production impact: no data loss, but an operator can
believe a client config was created (or deleted) in the directory they are in
when it was not; in a worktree the command looks like a silent no-op.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

## Change

`print_action_summary` in `crates/orbit-cli/src/command/mcp/setup/dispatch.rs` now takes the
resolved `repo_root: &Path` and `workspace_id: Option<&str>` (from `WorkspaceLayout`) and prints
them after the provider list, e.g.:

    mcp init: claude -> /tmp/qa/repoA (ws_repoa)
    mcp remove: claude -> /tmp/qa/repoA (ws_repoa)
    mcp remove: claude, codex -> /tmp/qa/repoA   (workspace_id unregistered)
    mcp init: no providers selected              (unchanged; no path when nothing was targeted)

The formatting logic was split into a pure, unit-testable `format_action_summary` helper (dispatch.rs
still owns the `println!`). Both call sites in `crates/orbit-cli/src/command/mcp/setup/args.rs`
(`InitArgs::execute_without_runtime`, `RemoveArgs::execute_without_runtime`) now pass
`&layout.repo_root` and `layout.workspace_id.as_deref()`. `init_auto_for_workspace` (the
`orbit workspace init --mcp` bootstrap path) was left untouched — it doesn't call
`print_action_summary` and already reports its own workspace context via a separate summary in
`command/workspace/init.rs`, which is out of this task's context_files.

## Acceptance criteria

None were listed on the task; the suggested fix in the description was treated as the spec:
"Print the resolved checkout (and, for init, the bound `ws_*` id) in the action summary." Both
`mcp init` and `mcp remove` now print the checkout path; the workspace id is shown for either
action whenever the registry knows it (simpler than gating it to init only, and equally useful as
an audit line for `remove`).

## Evidence

- Added 3 unit tests in `crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs` covering:
  resolved path + workspace id, path without a known workspace id, and the empty-provider-list
  case (no path printed).
- Manually reproduced the task's exact repro scenarios against the built binary
  (`target/debug/orbit`) in a scratch `/tmp` layout (external Orbit root + registered checkout),
  cleaned up afterward:
  - `mcp init --claude` from inside the registered checkout: `mcp init: claude -> <repo> (ws_repoa)`
  - `mcp init --claude` from a linked git worktree of that checkout (the ORB-12121 fallback path):
    same output, naming the primary checkout instead of the worktree — now self-explanatory instead
    of looking like a silent no-op.
  - `mcp remove --claude` from an unrelated directory (`/tmp`) with `--root` naming the sole
    registered checkout: `mcp remove: claude -> <repo> (ws_repoa)`.

## Validation

- `cargo build -p orbit-cli`: passed.
- `cargo test -p orbit-cli --bin orbit command::mcp`: passed (73 tests, including the 3 new ones).
- `cargo fmt -p orbit-cli`: applied (one line needed wrapping in args.rs); `cargo fmt --check` clean
  after.
- `cargo clippy -p orbit-cli --all-targets -- -D warnings`: passed, no warnings.
- `make ci-fast`: passed (fmt-check + guardrail scripts).
- `git diff --check` / `git status --short`: clean; only the three intended tracked files modified,
  no stray artifacts.
- `make ci-lint` (full workspace clippy) and `make ci` were not run locally, per workspace policy
  (ci-lint is paid once per task at review time; full `make ci` is the CI merge gate, not a per-task
  local check).

## Scope

Touched only `dispatch.rs`, `args.rs` (both originally in context_files), and the sibling test file
`tests/dispatch.rs` (added to context_files with rationale — mirrors the workspace's sibling-tests
convention for the changed function). No unrelated files changed, no new files created.

## Remaining risk

None identified. The change is additive to stdout formatting only; no behavior change to which
checkout is resolved or what gets written.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12132-6aa39b56`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus