### PR TITLE
[qa-sweep] orbit run ship TASK-ID reports success when the named task is excluded, and no human-readable surface says why

### DIFF
--- a/crates/orbit-cli/src/command/run/format.rs
+++ b/crates/orbit-cli/src/command/run/format.rs
@@ -144,3 +144,62 @@ pub(crate) fn format_child_dispatch_lines(state: Option<&PipelineState>) -> Vec<
         })
         .collect()
 }
+
+/// Show backlog admission exclusions retained in the pipeline checkpoint.
+///
+/// The structured state remains the source of truth; this projection is only
+/// for the human-readable `orbit run show` view. Older or partially written
+/// checkpoints are ignored so inspection remains available when the optional
+/// diagnostic data is absent.
+pub(crate) fn format_backlog_exclusion_lines(state: Option<&PipelineState>) -> Vec<String> {
+    let Some(excluded) = state
+        .and_then(|state| state.pipeline.get("list_backlog"))
+        .and_then(|step| step.get("excluded"))
+        .and_then(serde_json::Value::as_array)
+    else {
+        return Vec::new();
+    };
+
+    let lines = excluded
+        .iter()
+        .filter_map(|entry| {
+            let task_id = entry.get("id").and_then(serde_json::Value::as_str)?;
+            let reason = entry
+                .get("reason")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unknown");
+            let crew = entry
+                .get("crew")
+                .and_then(serde_json::Value::as_str)
+                .map(|crew| format!(" crew={crew}"))
+                .unwrap_or_default();
+            let conflicts = entry
+                .get("conflicts")
+                .and_then(serde_json::Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(|conflict| {
+                    conflict
+                        .get("locking_task_id")
+                        .and_then(serde_json::Value::as_str)
+                })
+                .collect::<Vec<_>>();
+            let blocked_by = if conflicts.is_empty() {
+                String::new()
+            } else {
+                format!(" blocked-by={}", conflicts.join(","))
+            };
+            Some(format!(
+                "Excluded task {task_id}: {reason}{crew}{blocked_by}"
+            ))
+        })
+        .collect::<Vec<_>>();
+
+    if lines.is_empty() {
+        return Vec::new();
+    }
+
+    let mut output = vec![format!("Excluded backlog tasks ({}):", lines.len())];
+    output.extend(lines);
+    output
+}

--- a/crates/orbit-cli/src/command/run/show.rs
+++ b/crates/orbit-cli/src/command/run/show.rs
@@ -5,6 +5,7 @@ use serde_json::{Value, json};
 
 use crate::command::{Block, CommandOut, Execute, Payload};
 
+use super::format::format_backlog_exclusion_lines;
 use super::job::cli_job_run_to_json_with_activity_provenance;
 use super::steps::{
     RunDisplaySteps, RunStepRecord, StepSource, activity_provenance_lines, filtered_steps,
@@ -102,6 +103,11 @@ pub(crate) fn run_show_payload(
     }
     header.push_str(&live_provider_process_lines(&provider_processes));
     header.push_str(&agent_invocation_lines(&doc["run"]["agent_invocation"]));
+    let exclusion_lines = format_backlog_exclusion_lines(state.as_ref());
+    if !exclusion_lines.is_empty() {
+        header.push('\n');
+        header.push_str(&exclusion_lines.join("\n"));
+    }
     if steps_source == StepSource::Audit && !steps.is_empty() {
         header.push_str(&format!(
             "\n{} reconstructed from the run audit trail; the run record stores none",

--- a/crates/orbit-cli/src/command/run/tests/format.rs
+++ b/crates/orbit-cli/src/command/run/tests/format.rs
@@ -110,6 +110,52 @@ fn no_child_dispatches_prints_nothing() {
     assert!(format_child_dispatch_lines(None).is_empty());
 }
 
+#[test]
+fn backlog_exclusion_lines_name_tasks_and_reasons() {
+    let state = PipelineState::new(
+        "jrun-test".to_string(),
+        "task_auto_pipeline".to_string(),
+        json!({
+            "list_backlog": {
+                "excluded": [
+                    {
+                        "id": "ORB-1",
+                        "reason": "unassessed_complexity",
+                        "conflicts": [],
+                    },
+                    {
+                        "id": "ORB-2",
+                        "reason": "crew_not_allowed",
+                        "crew": "luna",
+                        "conflicts": [{"locking_task_id": "ORB-9"}],
+                    },
+                ],
+            },
+        }),
+    );
+
+    assert_eq!(
+        format_backlog_exclusion_lines(Some(&state)),
+        vec![
+            "Excluded backlog tasks (2):".to_string(),
+            "Excluded task ORB-1: unassessed_complexity".to_string(),
+            "Excluded task ORB-2: crew_not_allowed crew=luna blocked-by=ORB-9".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn absent_or_empty_backlog_exclusions_print_nothing() {
+    let state = PipelineState::new(
+        "jrun-test".to_string(),
+        "task_auto_pipeline".to_string(),
+        json!({"list_backlog": {"excluded": []}}),
+    );
+
+    assert!(format_backlog_exclusion_lines(Some(&state)).is_empty());
+    assert!(format_backlog_exclusion_lines(None).is_empty());
+}
+
 /// [ORB-11253] A retuned drain says so in `orbit run show`; an untouched one
 /// stays quiet, because its submitted input already answers the question.
 #[test]

--- a/crates/orbit-cli/src/command/run/tests/mod.rs
+++ b/crates/orbit-cli/src/command/run/tests/mod.rs
@@ -11,7 +11,7 @@ use chrono::Utc;
 use clap::{Parser, error::ErrorKind};
 use orbit_core::runtime::run_audit::RunAuditEvent;
 use orbit_core::{OrbitRuntime, V2AuditEventInsertParams};
-use orbit_types::workflow::{JobRun, JobRunState};
+use orbit_types::workflow::{JobRun, JobRunState, PipelineState};
 use serde_json::{Value, json};
 
 use crate::command::{Cli, CommandOutput, Commands, Execute};
@@ -568,6 +568,72 @@ fn parses_run_show_step() {
         }
         _ => panic!("expected show"),
     }
+}
+
+#[test]
+fn run_show_human_view_reports_backlog_exclusions() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    let workspace_id = runtime.workspace_id().expect("workspace id");
+    let now = Utc::now();
+    let run = JobRun {
+        run_id: "jrun-cli-exclusions".to_string(),
+        job_id: "task_auto_pipeline".to_string(),
+        attempt: 1,
+        state: JobRunState::Success,
+        scheduled_at: now,
+        started_at: Some(now),
+        finished_at: Some(now),
+        duration_ms: Some(1),
+        created_at: now,
+        pid: None,
+        pid_start_time: None,
+        input: None,
+        retry_source_run_id: None,
+        knowledge_metrics: None,
+        resolved_crew: None,
+        crew_model: None,
+        steps: Vec::new(),
+    };
+    runtime
+        .sqlite_store()
+        .expect("store")
+        .upsert_job_run_for_workspace(&workspace_id, &run, None)
+        .expect("insert run");
+
+    let state = PipelineState::new(
+        run.run_id.clone(),
+        run.job_id.clone(),
+        json!({
+            "list_backlog": {
+                "excluded": [{
+                    "id": "QAB-00003",
+                    "reason": "unassessed_complexity",
+                    "conflicts": [],
+                }],
+            },
+        }),
+    );
+    runtime
+        .write_run_state(&run.run_id, &state)
+        .expect("write pipeline state");
+
+    let output =
+        super::run_show_payload(&runtime, Some(&run.run_id), None).expect("show run payload");
+    let CommandOutput::Payload(payload) = output else {
+        panic!("show should produce a payload");
+    };
+    let (_, view) = payload.into_view();
+    let crate::output::payload::View::Blocks(blocks) = view else {
+        panic!("show keeps a human view");
+    };
+    let crate::output::payload::Block::Text(header) = &blocks[0] else {
+        panic!("show opens with prose");
+    };
+    assert!(header.contains("Excluded backlog tasks (1)"), "{header}");
+    assert!(
+        header.contains("Excluded task QAB-00003: unassessed_complexity"),
+        "{header}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-12133](https://orbit-cli.com/tasks/ORB-12133) — [qa-sweep] orbit run ship TASK-ID reports success when the named task is excluded, and no human-readable surface says why

### Description

## Summary

`orbit run ship <TASK_ID>` applies the same admission gate as automatic backlog
selection (`clears_complexity_gate` in
`crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs`, touched
by ORB-12118 / ea3355849). When the explicitly named task fails that gate it is
dropped from `list_backlog`, the pipeline runs to completion with zero bundles,
and the run ends `success`. Nothing the operator sees says the task was
excluded or why.

The exclusion record exists — `run show --format json` carries
`pipeline.list_backlog.excluded[].reason` — but no human-readable surface prints
it: `run ship` only echoes the submitted run id, the `run show` table shows step
names and counts, and `run events` shows a skipped gate step with a template
expression. `grep -rn "excluded" crates/orbit-cli/src` finds no rendering path
for it; only `orbit run readiness <TASK_ID>` reports the reason, and an operator
has to know to go there.

## Reproduction (disposable Orbit root under /tmp)

```sh
# QAB-00003 is a minted auto-task: status backlog, complexity unassessed, no
# no-diff-expected tag, so it does not clear the admission gate.
orbit task list          # QAB-00003 backlog unassessed [] [auto-task] QA plain probe
orbit run ship QAB-00003
#   Workflow: ship
#   Run ID: jrun-20260911-0549-t1
#   State: submitted
orbit run show jrun-20260911-0549-t1
#   State: success
#   0  list_backlog     success  1  -  -
#   1  validate_bundles success  0  -  -
#   2  dispatch         success  0  -  -
orbit run events jrun-20260911-0549-t1 | tail -2
#   require_gate_success step.skipped reason=when:{{ steps.validate_bundles.output.bundle_count }} != 0 => false
#   run.finished success

orbit run show jrun-20260911-0549-t1 --format json | jq .pipeline_state.pipeline.list_backlog.excluded
#   [{"conflicts": [], "id": "QAB-00003", "reason": "unassessed_complexity"}]   <- only here

orbit run readiness QAB-00003
#   QAB-00003: waiting (task_pilot_preparation_required)                        <- and here
```

Observed on 0.20.0 built from `fc4d42a22` (debug), Linux. The same silence
applies to every `BacklogTaskExclusionReason` on an explicit shipment
(`crew_not_allowed`, `context_lock_conflict`, `epic_child`, …), not only
`unassessed_complexity`.

## Why it matters

Automatic backlog selection is allowed to skip work silently — that is the
point of a drain. Explicit selection is an operator instruction about one named
task, and answering it with `State: success` and no shipment is a false
positive: the operator must diff the run's JSON against their intent to learn
nothing happened.

## Suggested direction

Either (a) render the exclusions on the human-readable `run show` output and in
the `run ship` submission summary when the run selected explicit task ids, or
(b) fail an explicit shipment whose named tasks are all excluded, naming each id
and reason (`orbit run readiness <ID>` already has the wording). (a) alone would
close the reporting gap; (b) additionally makes the exit status honest.

Validation impact: none — no test or prescribed validation command is blocked.
Production impact: an operator-visible false success on an explicit command; no
data loss.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a human-readable `orbit run show` section sourced from `pipeline.list_backlog.excluded`, naming each excluded task and reason.
- Included optional effective crew and lock-holder details when present; absent, empty, malformed, or older exclusion data remains non-fatal.
- Preserved the structured JSON projection and backlog admission behavior.
- Added formatter unit coverage and an end-to-end run-show human-view test.

Criteria mapping:
- Explicitly shipped tasks that are excluded now appear in the human-readable run inspection with their task ID and admission reason, addressing the reported false-success silence.
- All existing exclusion reason shapes remain renderable; crew and conflict metadata are included when available.

Validation:
- PASS: `cargo fmt --all -- --check`.
- PASS: `cargo test -p orbit-cli --bin orbit command::run::tests::format` (11 tests).
- PASS: `cargo test -p orbit-cli --bin orbit run_show_human_view_reports_backlog_exclusions` (1 test).
- PASS: `make ci-fast`; its compiler-cache namespace sub-check reported a bounded environment limitation (`bwrap: No permissions to create new namespace`) and was explicitly skipped by the guard, while the make target passed.
- PASS: `make ci-lint` (workspace clippy with warnings denied).
- PASS: `git diff --check`.
- PASS: final `git status --short`/diff review; four intended tracked files changed and no untracked task artifacts were created.

Assessment: The change is scoped to the run-show presentation boundary, keeps persisted state authoritative, and has both formatter and observable CLI-view regression coverage. Remaining risk is limited to terminal rendering differences not exercised by the Linux test environment.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12133-6aa39b55`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus