### PR TITLE
[qa-sweep] task export/import/reindex --workspace cannot name a task-registry workspace id, so the documented import recipe lands tasks the target host cannot read

### DIFF
--- a/crates/orbit-cli/src/command/task/export.rs
+++ b/crates/orbit-cli/src/command/task/export.rs
@@ -14,8 +14,8 @@ pub struct TaskExportArgs {
     #[arg(short = 'o', long = "output", value_name = "ARCHIVE")]
     pub output: PathBuf,
     /// Task-registry workspace id to export from (default: current workspace).
-    #[arg(long)]
-    pub workspace: Option<String>,
+    #[arg(long = "task-workspace", value_name = "TASK_WORKSPACE")]
+    pub task_workspace: Option<String>,
     /// Export only these task ids (comma-separated). Defaults to all tasks.
     #[arg(long, value_delimiter = ',', conflicts_with = "all")]
     pub ids: Vec<String>,
@@ -34,7 +34,8 @@ impl Execute for TaskExportArgs {
         } else {
             ExportSelection::Ids(self.ids)
         };
-        let outcome = runtime.export_tasks(self.workspace.as_deref(), selection, &self.output)?;
+        let outcome =
+            runtime.export_tasks(self.task_workspace.as_deref(), selection, &self.output)?;
 
         Ok(Payload::detail(
             json!({

--- a/crates/orbit-cli/src/command/task/import.rs
+++ b/crates/orbit-cli/src/command/task/import.rs
@@ -15,8 +15,8 @@ pub struct TaskImportArgs {
     pub archive: PathBuf,
     /// Target task-registry workspace id (default: the archive's source
     /// workspace, registering it locally if unknown).
-    #[arg(long)]
-    pub workspace: Option<String>,
+    #[arg(long = "task-workspace", value_name = "TASK_WORKSPACE")]
+    pub task_workspace: Option<String>,
     /// How to resolve an incoming task id that already exists locally.
     #[arg(long = "on-conflict", value_enum, default_value_t = ConflictArg::Renumber)]
     pub on_conflict: ConflictArg,
@@ -59,7 +59,7 @@ impl Execute for TaskImportArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
         let outcome = runtime.import_tasks(
             &self.archive,
-            self.workspace.as_deref(),
+            self.task_workspace.as_deref(),
             self.on_conflict.into(),
         )?;
 

--- a/crates/orbit-cli/src/command/task/reindex.rs
+++ b/crates/orbit-cli/src/command/task/reindex.rs
@@ -8,8 +8,8 @@ use crate::command::{CommandOut, Execute, Payload};
 #[derive(Args)]
 pub struct TaskReindexArgs {
     /// Task-registry workspace id to reindex (default: current workspace).
-    #[arg(long)]
-    pub workspace: Option<String>,
+    #[arg(long = "task-workspace", value_name = "TASK_WORKSPACE")]
+    pub task_workspace: Option<String>,
     /// Emit machine-readable JSON instead of a human summary.
     #[arg(long)]
     pub json: bool,
@@ -17,7 +17,7 @@ pub struct TaskReindexArgs {
 
 impl Execute for TaskReindexArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
-        let outcome = runtime.reindex_tasks(self.workspace.as_deref())?;
+        let outcome = runtime.reindex_tasks(self.task_workspace.as_deref())?;
 
         let doc = json!({
             "workspace_id": outcome.workspace_id,

--- a/crates/orbit-cli/src/command/task/tests/command.rs
+++ b/crates/orbit-cli/src/command/task/tests/command.rs
@@ -1,6 +1,7 @@
 use clap::{CommandFactory, Parser, error::ErrorKind};
 
-use crate::command::Cli;
+use crate::command::task::TaskSubcommand;
+use crate::command::{Cli, Commands};
 
 /// The trimmed `orbit task` surface has 11 subcommands. ORB-10428 returns lock
 /// administration here.
@@ -97,6 +98,47 @@ fn task_help_describes_update_status_transitions() {
     );
     assert!(!help.contains("proposed → archived"), "{help}");
     assert!(!help.contains("review → backlog"), "{help}");
+}
+
+#[test]
+fn task_migration_workspace_selector_is_distinct_from_global_workspace() {
+    let cli = Cli::try_parse_from([
+        "orbit",
+        "--workspace",
+        "catalog-workspace",
+        "task",
+        "import",
+        "tasks.tar.zst",
+        "--task-workspace",
+        "repo-abc123",
+    ])
+    .expect("task import should accept both workspace selectors");
+
+    assert_eq!(cli.workspace.as_deref(), Some("catalog-workspace"));
+    let Commands::Task(task) = cli.command else {
+        panic!("expected task command");
+    };
+    let TaskSubcommand::Import(args) = task.command else {
+        panic!("expected task import command");
+    };
+    assert_eq!(args.task_workspace.as_deref(), Some("repo-abc123"));
+
+    for (subcommand, args) in [
+        ("export", vec!["--output", "tasks.tar.zst"]),
+        ("reindex", Vec::new()),
+    ] {
+        let mut argv = vec![
+            "orbit",
+            "task",
+            subcommand,
+            "--task-workspace",
+            "repo-abc123",
+        ];
+        argv.extend(args);
+        Cli::try_parse_from(argv).unwrap_or_else(|error| {
+            panic!("task {subcommand} should accept --task-workspace: {error}")
+        });
+    }
 }
 
 #[test]

--- a/crates/orbit-core/src/bootstrap/task_migration.rs
+++ b/crates/orbit-core/src/bootstrap/task_migration.rs
@@ -32,7 +32,7 @@ impl OrbitRuntime {
     }
 
     /// Resolve the workspace id a migration command targets: an explicit
-    /// `--workspace <id>` (a task-registry workspace id like `orbit-8fb91e`) or,
+    /// `--task-workspace <id>` (a task-registry workspace id like `orbit-8fb91e`) or,
     /// when absent, the current workspace.
     fn resolve_migration_workspace(
         &self,

--- a/crates/orbit-store/src/workflow/task/mod.rs
+++ b/crates/orbit-store/src/workflow/task/mod.rs
@@ -48,7 +48,7 @@
 //!   <global>/tasks/workspaces/<ws-id>/ORB-XXXXX/artifacts/files/
 //!
 //! # 3. Re-index to validate the restored bundles end-to-end.
-//! orbit task reindex --workspace <ws-id>
+//! orbit task reindex --task-workspace <task-workspace-id>
 //! ```
 //!
 //! The manifest hashes are the source of truth — `orbit task reindex` reads
@@ -568,7 +568,7 @@ fn resolve_target(
     if let Some(requested) = target_workspace_id {
         let binding = registry.find_workspace_binding(requested)?.ok_or_else(|| {
             OrbitError::InvalidInput(format!(
-                "target workspace '{requested}' is not registered in the coordination registry; register it first or omit --workspace to register the source workspace"
+                "target workspace '{requested}' is not registered in the coordination registry; register it first or omit --task-workspace to register the source workspace"
             ))
         })?;
         return Ok(ImportTarget {

--- a/docs/design/task-migration/1_overview.md
+++ b/docs/design/task-migration/1_overview.md
@@ -81,21 +81,24 @@ machine a disjoint id range).
 Move a workspace's tasks from machine A to machine B:
 
 ```sh
-# On A — pack the workspace's tasks (omit --workspace to use the current one)
+# On A — pack the workspace's tasks (omit --task-workspace to use the current one)
 orbit task export --all -o tasks.tar.zst            # or --ids ORB-00001,ORB-00007
 
 # Move the archive
 scp tasks.tar.zst B:/tmp/
 
-# On B — import, renumbering any id that already exists locally
-orbit task import /tmp/tasks.tar.zst --on-conflict=renumber
+# On B — import into B's task-registry workspace, renumbering any id that already exists locally
+orbit task import /tmp/tasks.tar.zst \
+  --task-workspace <target-task-workspace-id> --on-conflict=renumber
 ```
 
 Import is transactional: it validates the manifest version and every bundle's
 integrity *before* touching state, so a corrupt or version-incompatible archive
-fails with no partial writes. It resolves the target workspace (the archive's
-source workspace if registered locally, else `--workspace <id>`, else it
-registers the source workspace id), keeps ids that are free, renumbers the rest,
+fails with no partial writes. `--task-workspace` selects the task-registry
+partition, whose id is the `workspace_id` in B's checkout `.orbit/config.yaml`;
+the checkout must already be registered locally. If omitted, import resolves the
+archive's source workspace if registered locally, otherwise it registers the
+source workspace id without a checkout. It keeps ids that are free, renumbers the rest,
 rebuilds the index rows from bundle YAML, and bumps the allocator past the highest
 landed id. When anything is
 renumbered, an `<archive>.idmap.json` old→new map is written and printed.
@@ -135,7 +138,7 @@ padding is a minimum display width, not an exhaustion boundary.
 If bundles were `rsync`'d or moved by hand, rebuild the index from disk:
 
 ```sh
-orbit task reindex --workspace <ws-id>   # default: the current workspace
+orbit task reindex --task-workspace <task-workspace-id>   # default: the current workspace
 ```
 
 Reindex treats the on-disk bundles as the source of truth: it registers any


### PR DESCRIPTION
## Task

[ORB-12134](https://orbit-cli.com/tasks/ORB-12134) — [qa-sweep] task export/import/reindex --workspace cannot name a task-registry workspace id, so the documented import recipe lands tasks the target host cannot read

### Description

## Summary

`orbit task export`, `orbit task import`, and `orbit task reindex` each declare
their own `--workspace` argument documented as a **task-registry** workspace id:

- export: `Task-registry workspace id to export from (default: current workspace)`
- import: `Target task-registry workspace id (default: the archive's source workspace, registering it locally if unknown)`
- reindex: `Task-registry workspace id to reindex (default: current workspace)`

Those fields are unreachable. `Cli::workspace` in
`crates/orbit-cli/src/command/mod.rs` is declared `#[arg(long, global = true)]`,
so the global workspace-*catalog* selector consumes the value and rejects
anything that is not a registered name, a `ws_*` catalog id, or an absolute
checkout path. A task-registry partition id — the `<slug>-<hash>` form minted by
`orbit-core/src/runtime/builder.rs` for every checkout without a catalog entry,
and the only id form a `task import` ever registers — is refused:

```sh
$ orbit task export  --workspace repof2-e3f7e0 -o /tmp/a.tar.zst
error: invalid input: unknown workspace selector 'repof2-e3f7e0'; pass a registered workspace name, a logical workspace ID, or an absolute local checkout path
$ orbit task reindex --workspace repof2-e3f7e0
error: (same)
$ orbit task import  /tmp/a.tar.zst --workspace repoh-db32db
error: (same)
```

It only appears to work in the external-root layout, where the catalog id and
the partition id happen to be the same string (`ws_repoe`).

## Consequence 1 — the documented migration recipe delivers unreadable tasks

`docs/design/task-migration/1_overview.md` §4 says: on B, run
`orbit task import /tmp/tasks.tar.zst --on-conflict=renumber`. With no
`--workspace`, import registers the *archive's source* workspace id locally,
with no checkout. The tasks land and are then invisible and unreadable:

```sh
# host B (prefix QBH), home-root layout
$ orbit task import /tmp/a2.tar.zst
imported into workspace 'repof2-e3f7e0'
  registered new workspace binding
  renumbered  QAG-00000 -> QBH-00001
$ orbit task list
QBH-00000  H local  proposed  medium  chore          # imported task absent
$ orbit task show QBH-00001
error: workspace error: task QBH-00001 is owned by workspace 'repof2' (repof2-e3f7e0), which has no readable local checkout on this machine; restore or re-register that checkout
$ orbit task show QAG-00000                          # same for the kept id
error: (same)
```

The remedy the docs offer — "else `--workspace <id>`" — is exactly the flag that
cannot be expressed on a home-root host, because the local target's id is
`repoh-db32db`.

That the intended flow is otherwise sound was confirmed on a host where the two
id spaces coincide:

```sh
$ orbit --root /tmp/qa/rootD task import /tmp/a2.tar.zst --workspace ws_repod
imported into workspace 'ws_repod'
  kept  QAG-00000
$ orbit --root /tmp/qa/rootD task show QAG-00000
ID: QAG-00000
Workspace: repoD (ws_repod)
Title: F2 task (updated on owner)
```

So the defect is purely the unreachable selector, not the import machinery.

## Consequence 2 — `task reindex` cannot be pointed at another partition

`task reindex` is the documented recovery for a lost/drifted
`~/.orbit/tasks/index.sqlite` (§"Recovering a drifted index"), and it works —
but only for the checkout you are standing in, because `--workspace` cannot name
another partition. A partition with no checkout (such as one created by
`task import`) cannot be reindexed at all. This compounds ORB-12131.

## Reproduction

Two hosts, both disposable under `/tmp`, `env -i PATH=… HOME=/tmp/qa/homeN`:

```sh
# host A: checkout with a repo-local .orbit, no workspace catalog entry
mkdir -p /tmp/qa/homeA /tmp/qa/repoF2/.orbit && git -C /tmp/qa/repoF2 init -q
orbitA init --non-interactive --host-name qag --task-prefix QAG
(cd /tmp/qa/repoF2 && orbitA task add --title "F2 task" --description f --complexity low)
(cd /tmp/qa/repoF2 && orbitA task export -o /tmp/qa/a.tar.zst)
#   exported 1 task(s) from workspace 'repof2-e3f7e0'

# host B
mkdir -p /tmp/qa/homeB /tmp/qa/repoH/.orbit && git -C /tmp/qa/repoH init -q
orbitB init --non-interactive --host-name qah --task-prefix QBH
(cd /tmp/qa/repoH && orbitB task import /tmp/qa/a.tar.zst)   # then the listings above
```

Observed on 0.20.0 built from `fc4d42a22` (debug), Linux. Related but distinct:
ORB-11772 (rejected) covered the same global-vs-subcommand `--workspace`
collision on `orbit search`.

## Scope

- `crates/orbit-cli/src/command/task/{export,import,reindex}.rs` — the local
  `--workspace` fields are dead and their help text is false. Either give them
  distinct names (`--task-workspace` / `--partition`) or teach the global
  selector to accept a task-registry partition id when the subcommand wants one.
- `crates/orbit-cli/src/command/mod.rs` — the `global = true` selector is what
  shadows them.
- `docs/design/task-migration/1_overview.md` §4 — the recipe needs the step that
  actually makes imported tasks readable on the target host, once a selector
  exists to express it.
- Worth deciding separately whether a bare `task import` should default to
  registering a checkout-less source workspace at all, given nothing on the
  target host can then read the tasks.

Validation impact: none — no test or prescribed validation command is blocked.
Production impact: yes; the documented cross-host task migration path completes
successfully and leaves the tasks unreadable on the destination.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Renamed the task-registry selectors on `task export`, `task import`, and `task reindex` to `--task-workspace`, leaving the global catalog `--workspace` selector available and unambiguous.
- Routed the renamed values through the three CLI handlers and updated the Core/store migration documentation and target-workspace error guidance.
- Updated the migration design recipe to target the destination checkout's `.orbit/config.yaml` `workspace_id`, preventing imports from defaulting to an unreadable source-only binding.
- Added parser coverage proving global `--workspace` and `--task-workspace` can be supplied together and that all three migration commands accept the renamed selector.
Assessment: The scoped CLI collision is fixed at the command boundary with a small compatible change; no change to runtime workspace resolution or migration engine behavior was necessary.
Criteria evidence:
- Acceptance criteria: none were explicitly recorded on the task; the described defect scope is satisfied by the selector rename, handler wiring, parser coverage, and documentation updates.
- Export/import/reindex selector reachability: help output and the focused parser test confirm `--task-workspace <TASK_WORKSPACE>` is distinct from global `--workspace <SELECTOR>` for all three commands.
- Cross-host migration guidance: the design recipe now requires the destination task-registry `workspace_id` and explains that omitting the selector registers the archive source without a checkout.
Validation:
- `cargo fmt --all -- --check`: passed.
- `cargo test -p orbit-cli --bin orbit command::task::tests`: passed, 56 tests.
- `target/debug/orbit task export --help`, `target/debug/orbit task import --help`, `target/debug/orbit task reindex --help`: passed; each shows `--task-workspace` separately from global `--workspace`.
- `make ci-fast`: passed; the internal compiler-cache namespace smoke check was skipped because bubblewrap cannot create a user namespace in this environment, while the guardrail target completed successfully.
- `make ci-lint`: passed, workspace all-target clippy with warnings denied.
- `git diff --check`: passed.
- `GIT_OPTIONAL_LOCKS=0 git status --short`: passed; only the seven task-scoped tracked files are modified.
- Initial `cargo test -p orbit-cli --lib command::task::tests`: not applicable/failed because `orbit-cli` has no library target; the correct binary-target command above passed.
Risks and deviations: Full `make ci` was not run per repository guidance; the two-host migration reproduction was not repeated because the bug is parser-level and the existing migration engine tests cover the underlying import path. Changes remain uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12134-6aa39b56`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus