### PR TITLE
[code-review] the GitShim child-process fixture passes vacuously when its hand-written test-name literal goes stale

### DIFF
--- a/crates/orbit-engine/src/activity_job/tests/workspace.rs
+++ b/crates/orbit-engine/src/activity_job/tests/workspace.rs
@@ -531,12 +531,19 @@ impl GitShim {
             .env("PATH", std::env::join_paths(paths).expect("shim PATH"))
             .output()
             .expect("isolated git shim test");
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
         assert!(
             output.status.success(),
             "git shim test failed:\n{}\n{}",
-            String::from_utf8_lossy(&output.stdout),
+            stdout,
             String::from_utf8_lossy(&output.stderr)
         );
+        // A libtest `--exact` filter that matches nothing still exits 0, which
+        // would let a stale `test` literal (e.g. after the enclosing test was
+        // renamed) make this fixture pass without ever running the child's
+        // assertions. Require the harness summary to confirm the one test we
+        // asked for actually ran.
+        assert_exactly_one_test_ran(&exact_test, &stdout);
 
         None
     }
@@ -561,4 +568,40 @@ fn which_git() -> PathBuf {
         .expect("locate git");
     assert!(output.status.success(), "git must be on PATH");
     PathBuf::from(String::from_utf8_lossy(&output.stdout).trim())
+}
+
+/// Fails unless the child's libtest summary reports exactly one test run.
+/// `--exact <filter>` exits 0 whether it matched one test or filtered out
+/// every test, so `output.status.success()` alone cannot tell a real run
+/// apart from a stale `exact_test` that no longer names any function.
+fn assert_exactly_one_test_ran(exact_test: &str, child_stdout: &str) {
+    let passed = child_stdout.lines().find_map(|line| {
+        let rest = line.strip_prefix("test result: ok. ")?;
+        let (count, _) = rest.split_once(" passed;")?;
+        count.parse::<usize>().ok()
+    });
+    assert_eq!(
+        passed,
+        Some(1),
+        "git shim child must run exactly one test ({exact_test}); got:\n{child_stdout}"
+    );
+}
+
+#[test]
+fn zero_matched_tests_are_rejected_instead_of_passing_silently() {
+    let stdout = "running 0 tests\n\n\
+        test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s\n";
+    let result =
+        std::panic::catch_unwind(|| assert_exactly_one_test_ran("module::renamed_away", stdout));
+    assert!(
+        result.is_err(),
+        "a filter that matched no tests must fail the git shim fixture, not pass silently"
+    );
+}
+
+#[test]
+fn one_matched_test_is_accepted() {
+    let stdout = "running 1 test\ntest module::real_test ... ok\n\n\
+        test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n";
+    assert_exactly_one_test_ran("module::real_test", stdout);
 }


### PR DESCRIPTION
## Task

[ORB-12130](https://orbit-cli.com/tasks/ORB-12130) — [code-review] the GitShim child-process fixture passes vacuously when its hand-written test-name literal goes stale

### Description

`GitShim::install` re-invokes the test binary for one exact test and asserts only on the child's exit status (`crates/orbit-engine/src/activity_job/tests/workspace.rs:488-541`):

```rust
let exact_test = format!("{module}::{test}");
...
let output = Command::new(std::env::current_exe()...)
    .args(["--exact", &exact_test, "--nocapture"])
    ...
assert!(output.status.success(), ...);
```

`module` comes from `module_path!()`, but `test` is a hand-written string literal that must match the enclosing function name — today `"capture_of_thousands_of_untracked_files_uses_a_constant_git_budget"` at `workspace.rs:284-287`. Nothing ties the two together.

When a libtest filter matches nothing it exits 0. Verified directly:

```
$ rustc --test t.rs -o t && ./t --exact does::not::exist --nocapture
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out
exit=0
```

So renaming or moving the test function makes the parent spawn a child that runs zero tests, see exit 0, and pass — while `invocation_count` and the constant-git-budget assertions never execute. The regression this test exists to catch is silently no longer covered, with a green run.

Suggested direction: have the parent require that exactly one test ran (parse the child's `1 passed` summary line, or pass a marker the child writes to the log path and assert the parent sees it), or derive the test name automatically instead of duplicating it as a literal.

### Acceptance Criteria

- Renaming the test function without updating the literal passed to `GitShim::install` makes the test fail rather than pass.
- The constant-git-budget assertions still run and still pass under `cargo test -p orbit-engine --lib` in the normal case.
- The fixture keeps the PATH isolation ORB-12123 introduced: no test mutates the parent process's PATH.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed the GitShim child-process fixture in crates/orbit-engine/src/activity_job/tests/workspace.rs so a stale test-name literal fails the fixture instead of passing vacuously.

Root cause: `GitShim::install` spawned the test binary filtered by `--exact <module>::<test>` and asserted only `output.status.success()`. libtest exits 0 when `--exact` matches zero tests, so if the enclosing test function is renamed without updating the hand-written `test` literal, the child runs 0 tests and the parent sees a clean exit — the constant-git-budget assertions silently never execute.

Fix: after the child exits successfully, `install` now also calls a new `assert_exactly_one_test_ran(exact_test, stdout)` that parses the libtest summary line (`test result: ok. N passed; ...`) and asserts `N == 1`. A filter that matches nothing (N == 0) now panics with a message naming the stale filter and the captured child stdout.

Verification:
- Added two unit tests for the new helper: `zero_matched_tests_are_rejected_instead_of_passing_silently` (asserts the helper panics on a captured "0 passed" summary) and `one_matched_test_is_accepted` (asserts it accepts a real "1 passed" summary).
- Regression demonstration: temporarily renamed `capture_of_thousands_of_untracked_files_uses_a_constant_git_budget` to `..._renamed` without updating the `GitShim::install` literal, ran it, confirmed it now fails with "git shim child must run exactly one test ... got: ... 0 passed ...", then restored the file from a backup copy (verified via `git diff` that no stray changes remained).
- `cargo test -p orbit-engine --lib activity_job::tests::workspace`: 10 passed, including `capture_of_thousands_of_untracked_files_uses_a_constant_git_budget` (constant-git-budget assertions still run and pass in the normal case).
- `cargo fmt -p orbit-engine -- --check`: clean.
- `make ci-fast`: passed (one unrelated environment-only skip, `test-compiler-cache-namespaces`, due to no non-privileged user namespaces in this sandbox — pre-existing, unrelated to this change).
- `make ci-lint` (workspace-wide clippy, warnings denied): passed.
- `git status --short` / `git diff --check`: only crates/orbit-engine/src/activity_job/tests/workspace.rs changed, no whitespace errors.

Acceptance criteria:
1. Renaming the test function without updating the `GitShim::install` literal now fails the fixture — demonstrated above and covered by `zero_matched_tests_are_rejected_instead_of_passing_silently`.
2. The constant-git-budget assertions still run and pass under `cargo test -p orbit-engine --lib` in the normal case — confirmed, all 10 tests in the module pass.
3. No PATH mutation was touched; the fixture still isolates the shim's PATH to the spawned child only (ORB-12123 behavior unchanged).

Scope: single file, matches the declared context_files selector. No task-scope expansion needed. Changes left uncommitted per workflow policy — pipeline owns commit/PR/merge.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12130-6aa39dde`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus