### PR TITLE
[code-review] tool enable/disable now refuses every registry-inactive builtin, stranding an already-disabled one and breaking its CLI wrapper with no recovery

### DIFF
--- a/crates/orbit-cli/src/command/tool/tests/enable.rs
+++ b/crates/orbit-cli/src/command/tool/tests/enable.rs
@@ -4,10 +4,11 @@ use orbit_core::OrbitRuntime;
 use super::super::disable::ToolDisableArgs;
 use super::super::enable::ToolEnableArgs;
 use crate::command::Execute;
+use crate::command::locks::LocksListArgs;
 
-/// A `register_inactive` builtin: availability is fixed at registration and
-/// is never read from the store's enabled flag [ORB-12122].
-const REGISTRY_INACTIVE_BUILTIN: &str = "orbit.task.reject";
+/// A `register_inactive` builtin: it is absent from the agent surface but can
+/// still be reached through administrative CLI paths.
+const REGISTRY_INACTIVE_BUILTIN: &str = "orbit.task.locks";
 
 #[test]
 fn tool_enable_refuses_a_registry_inactive_builtin_at_the_cli_boundary() {
@@ -37,17 +38,45 @@ fn tool_enable_refuses_a_registry_inactive_builtin_at_the_cli_boundary() {
 }
 
 #[test]
-fn tool_disable_refuses_a_registry_inactive_builtin_at_the_cli_boundary() {
+fn tool_disable_allows_a_registry_inactive_builtin_at_the_cli_boundary() {
     let runtime = OrbitRuntime::in_memory().expect("in-memory runtime");
 
-    let error = ToolDisableArgs {
+    ToolDisableArgs {
         name: REGISTRY_INACTIVE_BUILTIN.to_string(),
     }
     .execute(&runtime)
-    .expect_err("orbit tool disable must refuse a registry-inactive builtin");
+    .expect("orbit tool disable should persist the administrative state");
 
-    assert!(
-        matches!(error, OrbitError::InvalidInput(_)),
-        "unexpected error variant: {error:?}"
-    );
+    let disabled = runtime
+        .show_tool(REGISTRY_INACTIVE_BUILTIN)
+        .expect("show tool");
+    assert!(!disabled.active);
+    assert!(!disabled.enabled);
+}
+
+#[test]
+fn tool_enable_restores_a_stored_disabled_registry_inactive_builtin() {
+    let runtime = OrbitRuntime::in_memory().expect("in-memory runtime");
+
+    ToolDisableArgs {
+        name: REGISTRY_INACTIVE_BUILTIN.to_string(),
+    }
+    .execute(&runtime)
+    .expect("disable");
+
+    ToolEnableArgs {
+        name: REGISTRY_INACTIVE_BUILTIN.to_string(),
+    }
+    .execute(&runtime)
+    .expect("orbit tool enable should restore the stored state");
+
+    let enabled = runtime
+        .show_tool(REGISTRY_INACTIVE_BUILTIN)
+        .expect("show tool");
+    assert!(!enabled.active);
+    assert!(enabled.enabled);
+
+    LocksListArgs { json: true }
+        .execute(&runtime)
+        .expect("CLI lock wrapper should reach the restored inactive builtin");
 }

--- a/crates/orbit-core/src/adapter/command/registry.rs
+++ b/crates/orbit-core/src/adapter/command/registry.rs
@@ -262,16 +262,21 @@ impl OrbitRuntime {
             return Err(OrbitError::not_found(NotFoundKind::Tool, name.to_string()));
         }
 
+        let existing = self.stores().tools().get_tool(name)?;
         if !self.tool_registry().is_active(name) {
-            let verb = if enabled { "enable" } else { "disable" };
-            return Err(OrbitError::InvalidInput(format!(
-                "tool '{name}' is inactive on the agent tool surface; that availability is fixed \
-                 at registration, so {verb} would report success without changing whether the \
-                 tool can run"
-            )));
+            let changes_stored_state = existing
+                .as_ref()
+                .map_or(!enabled, |stored| stored.enabled != enabled);
+            if !changes_stored_state {
+                let state = if enabled { "enabled" } else { "disabled" };
+                let verb = if enabled { "enable" } else { "disable" };
+                return Err(OrbitError::InvalidInput(format!(
+                    "tool '{name}' is inactive on the agent tool surface and is already {state}; \
+                     `orbit tool {verb}` would be a no-op"
+                )));
+            }
         }
 
-        let existing = self.stores().tools().get_tool(name)?;
         if existing.is_none() {
             let schema = self
                 .tool_registry()

--- a/crates/orbit-core/src/adapter/command/tests/registry.rs
+++ b/crates/orbit-core/src/adapter/command/tests/registry.rs
@@ -1,10 +1,12 @@
 use orbit_common::OrbitError;
+use orbit_types::tool::StoredTool;
+use serde_json::json;
 
 use super::support::fresh_runtime;
 
-/// A `register_inactive` builtin: availability is fixed at registration and
-/// is never read from the store's enabled flag [ORB-12122].
-const REGISTRY_INACTIVE_BUILTIN: &str = "orbit.task.reject";
+/// A `register_inactive` builtin: it is absent from the agent surface but can
+/// still be reached through the administrative `run_tool` path.
+const REGISTRY_INACTIVE_BUILTIN: &str = "orbit.task.locks";
 
 #[test]
 fn enable_refuses_a_registry_inactive_builtin_instead_of_reporting_success() {
@@ -27,6 +29,11 @@ fn enable_refuses_a_registry_inactive_builtin_instead_of_reporting_success() {
             .to_string()
             .contains("inactive on the agent tool surface")
     );
+    assert!(
+        !error
+            .to_string()
+            .contains("without changing whether the tool can run")
+    );
 
     let after = runtime
         .show_tool(REGISTRY_INACTIVE_BUILTIN)
@@ -39,21 +46,60 @@ fn enable_refuses_a_registry_inactive_builtin_instead_of_reporting_success() {
 }
 
 #[test]
-fn disable_refuses_a_registry_inactive_builtin_the_same_way_as_enable() {
+fn disable_allows_a_registry_inactive_builtin_to_be_disabled() {
     let runtime = fresh_runtime();
 
-    let error = runtime
+    runtime
         .disable_tool(REGISTRY_INACTIVE_BUILTIN)
-        .expect_err("disable must refuse a registry-inactive builtin");
-    assert!(
-        matches!(error, OrbitError::InvalidInput(_)),
-        "unexpected error variant: {error:?}"
-    );
+        .expect("disable should persist the administrative state");
+
+    let tool = runtime
+        .show_tool(REGISTRY_INACTIVE_BUILTIN)
+        .expect("show tool");
+    assert!(!tool.active);
+    assert!(!tool.enabled);
+}
+
+#[test]
+fn enable_restores_a_stored_disabled_registry_inactive_builtin_for_run_tool() {
+    let runtime = fresh_runtime();
+    let schema = runtime
+        .show_tool(REGISTRY_INACTIVE_BUILTIN)
+        .expect("show tool");
+    runtime
+        .stores()
+        .tools()
+        .insert_tool(&StoredTool {
+            name: schema.name.clone(),
+            path: String::new(),
+            description: schema.description,
+            enabled: false,
+            builtin: schema.builtin,
+            parameters: schema.parameters,
+        })
+        .expect("seed disabled tool row");
+
+    runtime
+        .enable_tool(REGISTRY_INACTIVE_BUILTIN)
+        .expect("enable should restore a stored disabled tool");
+    let enabled = runtime
+        .show_tool(REGISTRY_INACTIVE_BUILTIN)
+        .expect("show tool");
+    assert!(!enabled.active);
+    assert!(enabled.enabled);
+
+    let error = runtime
+        .ensure_tool_agent_facing(REGISTRY_INACTIVE_BUILTIN)
+        .expect_err("inactive tool must remain unavailable to agents");
     assert!(
         error
             .to_string()
             .contains("inactive on the agent tool surface")
     );
+
+    runtime
+        .run_tool(REGISTRY_INACTIVE_BUILTIN, json!({}))
+        .expect("run_tool must reach the restored builtin");
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-12128](https://orbit-cli.com/tasks/ORB-12128) — [code-review] tool enable/disable now refuses every registry-inactive builtin, stranding an already-disabled one and breaking its CLI wrapper with no recovery

### Description

ORB-12122 added a guard to `set_tool_enabled_state` (`crates/orbit-core/src/adapter/command/registry.rs:260-272`) that refuses both `enable` and `disable` for any `register_inactive` builtin, on the stated grounds that "availability is fixed at registration, so {verb} would report success without changing whether the tool can run".

That premise is false for `disable`, and the guard is unconditional on the current stored state, producing two problems.

**1. The stored `enabled` flag does gate inactive tools.** `execute_registered_tool` calls `check_tool_enabled` for every caller (`crates/orbit-core/src/runtime/tool_exec.rs:42` and `:140-149`). Only `execute_tool_command_dispatch_with_session_context` adds `ensure_tool_agent_facing` (`crates/orbit-core/src/adapter/command/dispatch.rs:245`); the `run_tool` path does not (`crates/orbit-core/src/adapter/tool_execution.rs:12-38`). Several CLI subcommands drive registry-inactive builtins through `run_tool`:

- `crates/orbit-cli/src/command/locks.rs:72` -> `orbit.task.locks`
- `crates/orbit-cli/src/command/locks.rs:244` -> `orbit.task.locks.reserve`
- `crates/orbit-cli/src/command/locks.rs:356` -> `orbit.task.locks.release`

all registered inactive at `crates/orbit-tools/src/builtin/orbit/mod.rs:76-78`. So `orbit tool disable orbit.task.locks.reserve` previously did change whether the tool can run — it made `orbit locks reserve` fail with "tool ... is disabled".

**2. An already-disabled inactive builtin cannot be re-enabled.** The guard runs before the stored row is consulted, so on any host that disabled such a tool before this change, `orbit tool enable orbit.task.locks.reserve` is now refused, the stored `enabled = false` row persists, and `orbit locks reserve` stays broken. `remove_tool` refuses builtins as well (`crates/orbit-core/src/adapter/command/registry.rs:169-176`), so no CLI path clears the row — recovery requires editing SQLite by hand.

The new tests (`crates/orbit-core/src/adapter/command/tests/registry.rs`, `crates/orbit-cli/src/command/tool/tests/enable.rs`) only exercise a fresh runtime with no stored row, so neither problem is covered.

Suggested direction: keep the refusal for `enable` on a tool that has no stored row (the reported ORB-12122 symptom), but allow a state-changing call — at minimum always allow restoring `enabled = true` for a tool whose stored row says `false` — and correct the message so it does not claim a no-op for tools reachable through `run_tool`.

### Acceptance Criteria

- On a runtime where a registry-inactive builtin has a stored row with `enabled = false`, `orbit tool enable <name>` restores it and the tool's CLI wrapper (for example `orbit locks reserve`) runs again.
- The refusal message no longer asserts that the operation cannot change whether the tool runs, or the refusal is narrowed to the cases where that is true.
- A regression test covers a registry-inactive builtin that is already stored as disabled, and fails against the current unconditional guard.
- The original ORB-12122 symptom stays fixed: enabling a registry-inactive builtin never reports success while leaving it unreachable on the agent tool surface.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `set_tool_enabled_state` to read the persisted tool row before applying the inactive-surface guard. Inactive builtins may now be disabled (creating the stored false row) and re-enabled when that row is false; no-op requests still refuse with a state-specific message.
- Added core regression coverage for a pre-existing disabled inactive builtin, successful administrative `run_tool` execution after restoration, and continued agent-facing rejection.
- Added CLI-boundary coverage for disable→enable restoration and the `orbit task locks list` wrapper.

Acceptance criteria:
1. Passed — the core test seeds `orbit.task.locks` with `enabled = false`, enables it, and successfully executes it through `run_tool`; the CLI test also reaches the lock wrapper after restoration.
2. Passed — the no-op refusal now says the stored state is already enabled/disabled and the command would be a no-op; it no longer claims tool execution cannot change.
3. Passed — the core regression test directly seeds the disabled stored row, so it fails against the former unconditional guard.
4. Passed — restored inactive builtins remain inactive to agents via `ensure_tool_agent_facing`; fresh enable still refuses.

Validation:
- Passed: `cargo fmt --all -- --check`
- Passed: `cargo test -p orbit-core adapter::command::tests::registry -- --nocapture` (4 tests)
- Passed: `cargo test -p orbit-cli command::tool::tests::enable -- --nocapture` (3 tests)
- Passed: `make ci-fast`; its compiler-cache namespace probe was skipped because this host denied bubblewrap namespace creation (`No permissions to create new namespace`), while all remaining guardrails passed.
- Passed: `make ci-lint` (`cargo clippy --workspace --all-targets -- -D warnings`)
- Passed: `git diff --check`; final status contains only the three declared scoped files.

Assessment: The change is localized and preserves the distinction between registry inactivity (agent reachability) and stored enablement (administrative/CLI execution). No unrelated files or commits were created.

Remaining risk: the isolated compiler-cache namespace sub-check in `ci-fast` was not executable in this environment; no source-specific validation remains outstanding.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12128-6aa39d02`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus