### PR TITLE
[qa-sweep] doctor's missing-task-registry guard never fires, so --fix-orphan-task-stores still deletes live task bundles

### DIFF
--- a/crates/orbit-cli/src/command/doctor.rs
+++ b/crates/orbit-cli/src/command/doctor.rs
@@ -34,11 +34,11 @@ pub struct DoctorCommand {
     #[arg(long)]
     pub fix_retired_activity_backends: bool,
 
-    /// Delete task-store partitions that no workspace binding on this host claims. Requires --confirm.
+    /// Delete empty task-store partitions that no workspace binding on this host claims. Partitions that still hold task bundles are never deleted. Requires --confirm.
     #[arg(long)]
     pub fix_orphan_task_stores: bool,
 
-    /// Confirm a destructive repair. Required by --fix-orphan-task-stores, which deletes task bundles.
+    /// Confirm a destructive repair. Required by --fix-orphan-task-stores, which deletes partition directories.
     #[arg(long)]
     pub confirm: bool,
 }
@@ -112,16 +112,16 @@ impl Execute for DoctorCommand {
         if self.fix_orphan_task_stores {
             if !self.confirm {
                 return Err(orbit_core::OrbitError::InvalidInput(
-                    "--fix-orphan-task-stores deletes task bundles. Pass --confirm to proceed."
+                    "--fix-orphan-task-stores deletes task-store partition directories. Pass --confirm to proceed."
                         .to_string(),
                 ));
             }
             let removed = runtime.remove_orphan_task_stores()?;
-            eprintln!("Removed {removed} orphaned task-store partition(s).");
+            eprintln!("Removed {removed} empty orphaned task-store partition(s).");
             results.push(WorkspaceDoctorResult {
                 check_name: "fix-orphan-task-stores".to_string(),
                 status: WorkspaceDoctorStatus::Ok,
-                message: format!("Removed {removed} orphaned task-store partition(s)."),
+                message: format!("Removed {removed} empty orphaned task-store partition(s)."),
                 remediation: None,
             });
         }

--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -130,7 +130,8 @@ pub trait DoctorCommands {
     /// Delete task-store partitions under `<global_root>/tasks/workspaces/`
     /// whose workspace id is no longer present in the registry — left behind
     /// by a `workspace teardown` run on an older binary, or by removing a
-    /// checkout without running teardown [ORB-12109].
+    /// checkout without running teardown [ORB-12109]. Partitions that still
+    /// hold task bundles are reported but never deleted [ORB-12131].
     fn remove_orphan_task_stores(&self) -> Result<usize, OrbitError>;
 
     /// Cheap store write probe for health endpoints: open the store and
@@ -429,6 +430,12 @@ fn doctor_check_task_reservations(runtime: &OrbitRuntime) -> WorkspaceDoctorResu
 /// `--root` partition are the other claimants. Comparing the directory name
 /// against catalog `ws_*` ids alone reported every `<slug>-<hash>` partition —
 /// including live ones — as orphaned [ORB-12119].
+///
+/// An unclaimed partition that still holds task bundles gets its own
+/// non-destructive row: a lost or rebuilt registry leaves every other
+/// checkout's live partition looking exactly like abandoned residue, and the
+/// recovery for it is `orbit task reindex` in the owning checkout, not a
+/// deletion this check invites [ORB-12131].
 fn doctor_check_orphan_task_stores(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
     let global_root = runtime.global_root();
     let partitions = match task_store::inspect_task_store_partitions(&global_root) {
@@ -449,7 +456,7 @@ fn doctor_check_orphan_task_stores(runtime: &OrbitRuntime) -> WorkspaceDoctorRes
         }
     };
 
-    if partitions.unclaimed.is_empty() {
+    if partitions.removable.is_empty() && partitions.unowned.is_empty() {
         return check(
             "orphan-task-stores",
             WorkspaceDoctorStatus::Ok,
@@ -460,40 +467,60 @@ fn doctor_check_orphan_task_stores(runtime: &OrbitRuntime) -> WorkspaceDoctorRes
         );
     }
 
-    let orphans = partitions
-        .unclaimed
-        .iter()
-        .map(|path| {
-            format!(
-                "{} ({}, {} task bundle(s))",
-                task_store::partition_id(path).unwrap_or("<unnamed>"),
-                path.display(),
-                count_task_bundles(path)
-            )
-        })
-        .collect::<Vec<_>>();
+    // Populated partitions decide the row: their data is recoverable, so the
+    // operator must not be pointed at a repair that would delete it, even when
+    // empty residue is present too and would be safe to reclaim.
+    if !partitions.unowned.is_empty() {
+        let mut message = format!(
+            "{} task-store partition(s) hold task bundles that no workspace binding claims: {}",
+            partitions.unowned.len(),
+            describe_partitions(&partitions.unowned)
+        );
+        if !partitions.removable.is_empty() {
+            message.push_str(&format!(
+                "; {} empty unclaimed partition(s): {}",
+                partitions.removable.len(),
+                describe_partitions(&partitions.removable)
+            ));
+        }
+        return actionable_check(
+            "orphan-task-stores",
+            WorkspaceDoctorStatus::Warning,
+            message,
+            "Run `orbit task reindex` from each checkout that owns these bundles to rebind them; \
+             `orbit doctor --fix-orphan-task-stores` never deletes a populated partition, so \
+             remove one by hand only after confirming its checkout is gone."
+                .to_string(),
+        );
+    }
 
     actionable_check(
         "orphan-task-stores",
         WorkspaceDoctorStatus::Warning,
         format!(
-            "{} orphaned task-store partition(s) (no workspace binding claims them): {}",
-            orphans.len(),
-            orphans.join("; ")
+            "{} orphaned empty task-store partition(s) (no workspace binding claims them): {}",
+            partitions.removable.len(),
+            describe_partitions(&partitions.removable)
         ),
         "Run `orbit doctor --fix-orphan-task-stores --confirm`.".to_string(),
     )
 }
 
-/// Task bundles directly under one workspace's task-store partition — each
-/// is a subdirectory named for its task id.
-fn count_task_bundles(partition: &Path) -> usize {
-    std::fs::read_dir(partition)
-        .into_iter()
-        .flatten()
-        .flatten()
-        .filter(|entry| entry.path().is_dir())
-        .count()
+/// Render unclaimed partitions for a diagnostic line: each one's workspace id,
+/// its path on disk, and how much task data deleting it would cost.
+fn describe_partitions(partitions: &[task_store::UnclaimedPartition]) -> String {
+    partitions
+        .iter()
+        .map(|partition| {
+            format!(
+                "{} ({}, {} task bundle(s))",
+                task_store::partition_id(&partition.path).unwrap_or("<unnamed>"),
+                partition.path.display(),
+                partition.task_bundles
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
 }
 
 /// Delete one dead-holder lock only after acquiring its advisory lock. A

--- a/crates/orbit-cmd/src/task_store.rs
+++ b/crates/orbit-cmd/src/task_store.rs
@@ -22,6 +22,7 @@ use orbit_core::runtime::UNBOUND_DATA_DIR_WORKSPACE_ID;
 use orbit_registry::workspace_registry;
 pub use orbit_store::maintenance::task_registry::task_workspaces_dir;
 use orbit_store::maintenance::task_registry::{TaskRegistryStore, task_registry_path};
+use orbit_types::task::is_valid_orb_task_id;
 
 /// Path to one workspace's task-store partition under
 /// `<global_root>/tasks/workspaces/<workspace_id>/`.
@@ -29,16 +30,35 @@ pub fn task_store_partition_path(global_root: &Path, workspace_id: &str) -> Path
     task_workspaces_dir(global_root).join(workspace_id)
 }
 
+/// One partition directory that no registry claims, with the amount of task
+/// data it still holds.
+#[derive(Debug, Clone)]
+pub struct UnclaimedPartition {
+    /// The partition directory itself.
+    pub path: PathBuf,
+    /// Task bundles directly inside it — each a directory named for a task id.
+    pub task_bundles: usize,
+}
+
 /// What a scan of `<global_root>/tasks/workspaces/` found.
+///
+/// Unclaimed partitions are split by whether they still hold task bundles,
+/// because on disk a partition abandoned by `workspace teardown` and a live
+/// partition whose registry row was lost are the same thing. Only the empty
+/// ones can be deleted from that evidence alone [ORB-12131].
 #[derive(Debug, Clone)]
 pub struct TaskStorePartitions {
     /// Partition directories present on this host.
     pub scanned: usize,
-    /// Those that no registry claims.
-    pub unclaimed: Vec<PathBuf>,
+    /// Unclaimed and empty of task bundles: nothing to lose by deleting them.
+    pub removable: Vec<UnclaimedPartition>,
+    /// Unclaimed but still holding task bundles, which `orbit task reindex`
+    /// can rebind from the bundles themselves. Never deleted automatically.
+    pub unowned: Vec<UnclaimedPartition>,
 }
 
-/// Classify every task-store partition on this host as claimed or orphaned.
+/// Classify every task-store partition on this host as claimed, removable, or
+/// unowned-but-populated.
 ///
 /// `None` means the directory has never been created (fresh host, no task ever
 /// committed) — nothing to diagnose rather than nothing orphaned.
@@ -50,29 +70,46 @@ pub fn inspect_task_store_partitions(
     };
     let claimed = claimed_partition_ids(global_root)?;
     let scanned = partitions.len();
-    let unclaimed = partitions
+
+    let (unowned, removable) = partitions
         .into_iter()
         .filter(|path| !path_is_claimed(path, &claimed))
-        .collect();
-    Ok(Some(TaskStorePartitions { scanned, unclaimed }))
+        .map(|path| UnclaimedPartition {
+            task_bundles: count_task_bundles(&path),
+            path,
+        })
+        .partition(|partition| partition.task_bundles > 0);
+
+    Ok(Some(TaskStorePartitions {
+        scanned,
+        removable,
+        unowned,
+    }))
 }
 
-/// Delete every partition no registry claims, retiring any registry rows that
-/// name it. Returns the removed partition paths.
+/// Delete every unclaimed partition that holds no task bundles, retiring any
+/// registry rows that name it. Returns the removed partition paths.
+///
+/// A partition that still holds bundles is left alone however the registry
+/// answers: an unclaimed populated partition is exactly the state a lost or
+/// rebuilt `tasks/index.sqlite` produces for every checkout other than the one
+/// the command runs from, and deleting it would destroy task data that
+/// `orbit task reindex` can otherwise recover from the bundles [ORB-12131].
+/// Reclaiming a genuinely dead populated partition stays a deliberate manual
+/// step, or `orbit workspace teardown` while the checkout still exists.
 pub fn remove_unclaimed_task_stores(global_root: &Path) -> Result<Vec<PathBuf>, OrbitError> {
     let Some(partitions) = inspect_task_store_partitions(global_root)? else {
         return Ok(Vec::new());
     };
-    let unclaimed = partitions.unclaimed;
     let tasks = open_task_registry(global_root)?;
 
     let mut removed = Vec::new();
-    for path in unclaimed {
-        let Some(workspace_id) = partition_id(&path) else {
+    for partition in partitions.removable {
+        let Some(workspace_id) = partition_id(&partition.path) else {
             continue;
         };
         if remove_partition(&tasks, global_root, workspace_id)? {
-            removed.push(path);
+            removed.push(partition.path);
         }
     }
     Ok(removed)
@@ -155,9 +192,16 @@ fn claimed_partition_ids(global_root: &Path) -> Result<BTreeSet<String>, OrbitEr
     Ok(claimed)
 }
 
-/// Open the task registry that names the partitions, refusing to answer
-/// ownership questions when it is absent: without it every live partition
-/// would look unclaimed, and the caller's next step is deletion.
+/// Open the task registry that names the partitions, rather than creating one
+/// as a side effect of asking who owns a directory. An absent registry answers
+/// "nothing is claimed" for every partition on the host, so report it instead.
+///
+/// This only catches a caller that reaches the registry before any runtime has
+/// built it. Every `orbit` subcommand bootstraps the global root first, which
+/// recreates an empty `tasks/index.sqlite`, so a registry lost since the last
+/// command is indistinguishable here from a legitimately empty one; refusing
+/// to delete populated partitions is what protects that case
+/// ([`remove_unclaimed_task_stores`]) [ORB-12131].
 fn open_task_registry(global_root: &Path) -> Result<TaskRegistryStore, OrbitError> {
     let path = task_registry_path(global_root);
     if !path.exists() {
@@ -195,6 +239,23 @@ fn task_store_partitions(global_root: &Path) -> Result<Option<Vec<PathBuf>>, Orb
 /// Workspace id a partition directory is named for.
 pub fn partition_id(partition: &Path) -> Option<&str> {
     partition.file_name().and_then(|name| name.to_str())
+}
+
+/// Task bundles directly under one partition: subdirectories named for a task
+/// id, counting a `<task-id>.deleted` tombstone as data the way
+/// `orbit task reindex` does when it rebuilds the index from these directories.
+fn count_task_bundles(partition: &Path) -> usize {
+    std::fs::read_dir(partition)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter(|entry| entry.path().is_dir())
+        .filter(|entry| {
+            entry.file_name().to_str().is_some_and(|name| {
+                is_valid_orb_task_id(name.strip_suffix(".deleted").unwrap_or(name))
+            })
+        })
+        .count()
 }
 
 fn path_is_claimed(partition: &Path, claimed: &BTreeSet<String>) -> bool {

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -107,6 +107,13 @@ fn write_task_bundle(global_root: &Path, workspace_id: &str, task_id: &str) {
     fs::write(bundle.join("task.yaml"), b"id: dummy\n").expect("write bundle file");
 }
 
+/// A partition directory emptied of its bundles, as `workspace teardown` on an
+/// older binary left it behind.
+fn write_empty_partition(global_root: &Path, workspace_id: &str) {
+    fs::create_dir_all(task_workspaces_dir(global_root).join(workspace_id))
+        .expect("create empty partition dir");
+}
+
 #[test]
 fn healthy_fresh_workspace_has_no_failures() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
@@ -940,7 +947,8 @@ fn registered_task_store_partition_is_not_an_orphan() {
 /// [ORB-12109] A task-store partition whose workspace id no longer resolves
 /// in the registry — left behind by `workspace teardown` on an older binary,
 /// or by deleting a checkout without running teardown — is named with its
-/// path and an exact repair command.
+/// path and an exact repair command. Emptied of bundles, it carries nothing to
+/// recover, so the repair is the right next step [ORB-12131].
 #[test]
 fn orphan_task_store_partition_is_reported_with_path_and_remediation() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -948,8 +956,7 @@ fn orphan_task_store_partition_is_reported_with_path_and_remediation() {
     let global_root = temp.path().join("global");
     write_registered_workspace(&global_root, "ws_registered", "registered");
     write_task_bundle(&global_root, "ws_registered", "ORB-1");
-    write_task_bundle(&global_root, "ws_orphan", "ORB-2");
-    write_task_bundle(&global_root, "ws_orphan", "ORB-3");
+    write_empty_partition(&global_root, "ws_orphan");
 
     let results = runtime.doctor_workspace().expect("doctor");
     let row = status_of(&results, "orphan-task-stores");
@@ -965,7 +972,7 @@ fn orphan_task_store_partition_is_reported_with_path_and_remediation() {
         "message names the orphaned partition path: {}",
         row.message
     );
-    assert!(row.message.contains("2 task bundle(s)"), "{}", row.message);
+    assert!(row.message.contains("0 task bundle(s)"), "{}", row.message);
     assert!(
         !row.message.contains("ws_registered"),
         "registered partition must not be reported: {}",
@@ -1020,7 +1027,7 @@ fn fix_orphan_task_stores_keeps_every_claimed_partition() {
     write_task_bundle(&global_root, "drifted-a1b2c3", "ORB-2");
     // Every `--root <data-dir>` write lands here, and no registry ever records it.
     write_task_bundle(&global_root, "ws_unbound-data-dir", "ORB-3");
-    write_task_bundle(&global_root, "ws_orphan", "ORB-4");
+    write_empty_partition(&global_root, "ws_orphan");
 
     let removed = runtime
         .remove_orphan_task_stores()
@@ -1054,7 +1061,7 @@ fn fix_orphan_task_stores_removes_only_the_unregistered_partition() {
     let global_root = temp.path().join("global");
     write_registered_workspace(&global_root, "ws_registered", "registered");
     write_task_bundle(&global_root, "ws_registered", "ORB-1");
-    write_task_bundle(&global_root, "ws_orphan", "ORB-2");
+    write_empty_partition(&global_root, "ws_orphan");
 
     let removed = runtime
         .remove_orphan_task_stores()
@@ -1072,5 +1079,49 @@ fn fix_orphan_task_stores_removes_only_the_unregistered_partition() {
         status_of(&results, "orphan-task-stores").status,
         WorkspaceDoctorStatus::Ok,
         "{results:?}"
+    );
+}
+
+/// [ORB-12131] A partition that still holds task bundles is reported without
+/// pointing the operator at the deletion repair: the same picture is what a
+/// lost `tasks/index.sqlite` paints for every live checkout, and `orbit task
+/// reindex` restores those bundles.
+#[test]
+fn populated_unclaimed_partition_warns_toward_reindex_not_deletion() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let populated = task_workspaces_dir(&runtime.global_root())
+        .join("elsewhere-d4e5f6")
+        .join("ORB-77");
+    fs::create_dir_all(&populated).expect("create task bundle in an unclaimed partition");
+
+    let row = status_of(
+        &runtime.doctor_workspace().expect("doctor"),
+        "orphan-task-stores",
+    )
+    .clone();
+    assert_eq!(row.status, WorkspaceDoctorStatus::Warning, "{row:?}");
+    assert!(
+        row.message.contains("elsewhere-d4e5f6") && row.message.contains("1 task bundle(s)"),
+        "message names the partition and its bundles: {}",
+        row.message
+    );
+    let remediation = row.remediation.expect("actionable row has remediation");
+    assert!(
+        remediation.contains("orbit task reindex"),
+        "remediation points at recovery: {remediation}"
+    );
+    assert!(
+        !remediation.contains("--fix-orphan-task-stores --confirm"),
+        "remediation must not advertise the deletion repair: {remediation}"
+    );
+
+    assert_eq!(
+        runtime.remove_orphan_task_stores().expect("run the repair"),
+        0
+    );
+    assert!(
+        populated.is_dir(),
+        "the repair must not delete task bundles"
     );
 }

--- a/crates/orbit-cmd/src/tests/task_store.rs
+++ b/crates/orbit-cmd/src/tests/task_store.rs
@@ -9,7 +9,8 @@ use orbit_store::maintenance::task_registry::{
 };
 
 use crate::task_store::{
-    bound_partition_id, partition_is_bound, remove_checkout_task_stores, task_store_partition_path,
+    bound_partition_id, inspect_task_store_partitions, partition_is_bound,
+    remove_checkout_task_stores, remove_unclaimed_task_stores, task_store_partition_path,
 };
 
 fn bind(global_root: &Path, workspace_id: &str, slug: &str, repo_root: &Path) {
@@ -25,6 +26,24 @@ fn bind(global_root: &Path, workspace_id: &str, slug: &str, repo_root: &Path) {
             repo_fingerprint: None,
         })
         .expect("bind task-registry workspace");
+}
+
+/// Delete the task registry the way a corrupted restore or a manual rebuild
+/// does, leaving every partition directory in place.
+fn lose_task_registry(global_root: &Path) {
+    let registry = task_registry_path(global_root);
+    let name = registry
+        .file_name()
+        .expect("task registry path names a file")
+        .to_owned();
+    for suffix in ["", "-wal", "-shm"] {
+        let mut sidecar = name.clone();
+        sidecar.push(suffix);
+        let path = registry.with_file_name(sidecar);
+        if path.exists() {
+            fs::remove_file(&path).expect("remove task registry file");
+        }
+    }
 }
 
 fn write_task_bundle(global_root: &Path, workspace_id: &str, task_id: &str) {
@@ -129,4 +148,90 @@ fn removing_a_checkout_deletes_an_unbound_catalog_named_partition() {
         vec![task_store_partition_path(&global_root, "ws_legacy")]
     );
     assert!(!task_workspaces_dir(&global_root).join("ws_legacy").exists());
+}
+
+/// [ORB-12131] A lost `tasks/index.sqlite` is recreated empty by the next
+/// runtime bootstrap, which rebinds only the checkout the command runs from.
+/// Every other checkout's live partition then looks unclaimed, so the repair
+/// must leave those bundles for `orbit task reindex` instead of deleting them.
+#[test]
+fn losing_the_task_registry_leaves_populated_partitions_for_reindex() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let here = temp.path().join("here");
+    let elsewhere = temp.path().join("elsewhere");
+    fs::create_dir_all(&global_root).expect("create global root");
+    fs::create_dir_all(here.join(".orbit")).expect("create local checkout");
+    fs::create_dir_all(elsewhere.join(".orbit")).expect("create remote checkout");
+
+    bind(&global_root, "here-a1b2c3", "here", &here);
+    write_task_bundle(&global_root, "here-a1b2c3", "ORB-1");
+    bind(&global_root, "elsewhere-d4e5f6", "elsewhere", &elsewhere);
+    write_task_bundle(&global_root, "elsewhere-d4e5f6", "ORB-2");
+
+    lose_task_registry(&global_root);
+    // The bootstrap that recreates the registry rebinds only this checkout.
+    bind(&global_root, "here-a1b2c3", "here", &here);
+
+    let partitions = inspect_task_store_partitions(&global_root)
+        .expect("inspect partitions")
+        .expect("partitions directory exists");
+    assert_eq!(partitions.scanned, 2);
+    assert!(
+        partitions.removable.is_empty(),
+        "no populated partition may be offered for deletion: {:?}",
+        partitions.removable
+    );
+    assert_eq!(
+        partitions
+            .unowned
+            .iter()
+            .map(|partition| partition.path.clone())
+            .collect::<Vec<_>>(),
+        vec![task_store_partition_path(&global_root, "elsewhere-d4e5f6")]
+    );
+
+    let removed = remove_unclaimed_task_stores(&global_root).expect("run the repair");
+    assert!(removed.is_empty(), "the repair removed {removed:?}");
+    assert!(
+        task_workspaces_dir(&global_root)
+            .join("elsewhere-d4e5f6")
+            .join("ORB-2")
+            .is_dir(),
+        "the unclaimed checkout's task bundle must survive the repair"
+    );
+}
+
+/// Residue with no task bundles carries nothing `orbit task reindex` could
+/// restore, so the repair still reclaims it [ORB-12109].
+#[test]
+fn an_unclaimed_partition_without_bundles_is_still_reclaimed() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let repo_root = temp.path().join("repo");
+    fs::create_dir_all(&global_root).expect("create global root");
+    fs::create_dir_all(repo_root.join(".orbit")).expect("create checkout");
+
+    bind(&global_root, "repo-a1b2c3", "repo", &repo_root);
+    write_task_bundle(&global_root, "repo-a1b2c3", "ORB-1");
+    // Teardown on an older binary retired the bindings and removed the bundles
+    // but left the directory behind, along with a stray lock file.
+    let residue = task_store_partition_path(&global_root, "gone-f6e5d4");
+    fs::create_dir_all(&residue).expect("create residue partition");
+    fs::write(residue.join("bundle.lock"), b"").expect("write residue lock file");
+
+    let partitions = inspect_task_store_partitions(&global_root)
+        .expect("inspect partitions")
+        .expect("partitions directory exists");
+    assert!(partitions.unowned.is_empty(), "{:?}", partitions.unowned);
+
+    let removed = remove_unclaimed_task_stores(&global_root).expect("run the repair");
+    assert_eq!(removed, vec![residue.clone()]);
+    assert!(!residue.exists());
+    assert!(
+        task_workspaces_dir(&global_root)
+            .join("repo-a1b2c3")
+            .is_dir(),
+        "the bound checkout's partition must survive"
+    );
 }

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -108,17 +108,32 @@ catalog's `ws_*` ids in `~/.orbit/workspaces.json`, so a partition is orphaned o
 registry claims it; the synthetic `ws_unbound-data-dir` partition every `--root <data-dir>` write
 lands in is never reported. `orphan-task-stores` exists for partitions a prior teardown on an
 older binary left behind, or a checkout removed without running teardown at all: each warning
-names the orphaned workspace id, its partition path, and its task-bundle count. Repair with:
+names the orphaned workspace id, its partition path, and its task-bundle count.
+
+An unclaimed partition that **still holds task bundles** is reported on its own terms and is never
+deleted by the repair. On disk it is indistinguishable from a live checkout's partition whose
+registry row was lost, and every `orbit` subcommand recreates an empty `~/.orbit/tasks/index.sqlite`
+before any check runs — so a lost or restored-without-`index.sqlite` registry makes every checkout
+other than the one you are standing in look abandoned. That warning points at recovery instead:
+
+```sh
+cd <the checkout that owns the bundles>
+orbit task reindex
+```
+
+`orbit task reindex` rebuilds the registry rows for one partition from its bundle directories, so
+it must be run once per affected checkout. Only after confirming a checkout is genuinely gone
+should you delete its populated partition directory by hand.
+
+An unclaimed partition with **no task bundles** carries nothing to recover. Repair those with:
 
 ```sh
 orbit doctor --fix-orphan-task-stores --confirm
 ```
 
-The repair deletes task bundles, so it refuses to run without `--confirm`. It resolves the claims
-once, deletes only the partitions no binding names, retires any registry rows naming them, and is
-idempotent: running it again after a partition is gone is a no-op. When the task registry itself
-is missing, the check warns and the repair refuses rather than treating every live partition as
-unclaimed.
+The repair deletes partition directories, so it refuses to run without `--confirm`. It resolves the
+claims once, deletes only the empty partitions no binding names, retires any registry rows naming
+them, and is idempotent: running it again after a partition is gone is a no-op.
 
 ### Repair retired activity backends
 


### PR DESCRIPTION
## Task

[ORB-12131](https://orbit-cli.com/tasks/ORB-12131) — [qa-sweep] doctor's missing-task-registry guard never fires, so --fix-orphan-task-stores still deletes live task bundles

### Description

## Summary

`orbit doctor`'s `orphan-task-stores` check classifies a task-store partition as
orphaned when neither the task registry (`<root>/tasks/index.sqlite`) nor the
workspace catalog (`<root>/workspaces.json`) claims it. ORB-12119 (2fdc4634b)
added a guard for the dangerous case — if the task registry is absent, every
live partition looks unclaimed and the repair would delete it — and
`docs/runbooks/health-checks.md` now documents that guard:

> When the task registry itself is missing, the check warns and the repair
> refuses rather than treating every live partition as unclaimed.

The guard is ineffective in the real CLI. `orbit_cmd::task_store::open_task_registry`
tests `task_registry_path(global_root).exists()`, but by the time any `orbit`
subcommand reaches that code the runtime has already opened the global root and
**recreated an empty `tasks/index.sqlite`** with a fresh schema. The file always
exists, the guard never triggers, and the check instead reports every partition
that the newly-empty registry does not know as orphaned — telling the operator,
with an `Action:` line, to run a command that permanently deletes those task
bundles.

A checkout is affected whenever its partition id lives only in the task registry
— i.e. a partition named `<slug>-<hash>`, minted by
`orbit-core/src/runtime/builder.rs` for any checkout that has no `ws_*` entry in
`workspaces.json`. On this host 15 of 25 partitions are of that shape
(`polaris-68dcd0`, `orbit-5c61b3`, `constellation-25cebd`, …).

## Impact

Permanent loss of task bundles (task.yaml, description, plan, comments, events,
artifacts) for every checkout other than the one the operator happens to run
`doctor` from. The checkout you run from is rescued only incidentally: the
runtime re-binds it on startup and deterministically re-mints the same
`<slug>-<hash>` id, so its own partition is claimed again. Every other
checkout's partition is deleted.

Not a regression from ORB-12119 — the pre-ORB-12119 code deleted these
partitions unconditionally — but the guard that change advertises, and that the
runbook promises, does not exist in practice.

## Reproduction (fully disposable, /tmp only)

```sh
# 1. Two checkouts with a repo-local .orbit but no workspace catalog entry,
#    so each binds under a task-registry-minted <slug>-<hash> partition id.
mkdir -p /tmp/qa/home /tmp/qa/repoF/.orbit /tmp/qa/repoG/.orbit
for r in repoF repoG; do git -C /tmp/qa/$r init -q; \
  git -C /tmp/qa/$r -c user.email=q@q -c user.name=q commit -q --allow-empty -m init; done
ORB() { env -i PATH=/usr/bin:/bin HOME=/tmp/qa/home /path/to/orbit "$@"; }
ORB init --non-interactive --host-name qag --task-prefix QAG
(cd /tmp/qa/repoF && ORB task add --title "F task" --description f  --complexity low)  # QAG-00000
(cd /tmp/qa/repoG && ORB task add --title "G task" --description g  --complexity low)  # QAG-00001
ls /tmp/qa/home/.orbit/tasks/workspaces/   # repof-e3f7e0  repog-52592d
(cd /tmp/qa/repoF && ORB doctor | grep orphan)
#   orphan-task-stores ok  2 task-store partition(s) scanned, all claimed by a workspace binding

# 2. Lose the task registry (corruption, a restore that missed it, a manual
#    rebuild). Nothing else changes.
rm -f /tmp/qa/home/.orbit/tasks/index.sqlite*

# 3. Doctor recreates an empty index.sqlite, so the "missing registry" guard
#    never runs:
(cd /tmp/qa/repoF && ORB doctor | grep orphan)
#   orphan-task-stores warning  1 orphaned task-store partition(s) (no workspace
#   binding claims them): repog-52592d (…/repog-52592d, 1 task bundle(s))
#   | Action: Run `orbit doctor --fix-orphan-task-stores --confirm`.

(cd /tmp/qa/repoF && ORB doctor --fix-orphan-task-stores --confirm | grep Removed)
#   Removed 1 orphaned task-store partition(s).
(cd /tmp/qa/repoG && ORB task list)
#   no tasks matching the given filters      <-- QAG-00001 is gone
ls /tmp/qa/home/.orbit/tasks/workspaces/   # repof-e3f7e0 only
```

Observed on 0.20.0 built from `fc4d42a22` (debug), Linux. A second run against a
copy of this host's real `~/.orbit/tasks/index.sqlite` plus its 25 partition
directories reproduced the same classification at host scale: with the registry
in place all 25 were reported claimed; with `index.sqlite` moved aside, 18 were
reported orphaned and `--fix … --confirm` deleted all 18.

## Scope

- `crates/orbit-cmd/src/task_store.rs` — `open_task_registry` guards on file
  existence, which the runtime has already satisfied. An emptied-and-recreated
  registry is indistinguishable from a legitimately empty one at that call site;
  the signal has to come from somewhere the runtime bootstrap has not already
  overwritten (for example: refuse when the registry has zero
  `workspace_bindings` rows but partitions exist, or resolve each partition's
  owner from the partition's own bundles/checkout evidence before deleting).
- `crates/orbit-cmd/src/doctor.rs` — the warning's `Action:` line advertises the
  destructive repair in exactly the state where it destroys live data.
- `docs/runbooks/health-checks.md` — the "check warns and the repair refuses"
  sentence describes behavior that does not happen; fix it with the code.
- Consider whether the check should downgrade to a non-actionable warning when a
  partition holds task bundles whose `task.yaml` names a workspace the operator
  can still see.

Validation impact: none — no test or prescribed validation command is blocked.
Production impact: yes, unrecoverable deletion of user task data.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

## Outcome

`orbit doctor --fix-orphan-task-stores --confirm` can no longer delete recoverable task
bundles. The repair now deletes only unclaimed partitions that hold **no** task bundles;
a populated unclaimed partition gets its own non-destructive warning pointing at
`orbit task reindex`.

## Why this shape, not the one the report suggested

The report proposed "refuse when the registry has zero `workspace_bindings` rows but
partitions exist". That cannot work: the same bootstrap that recreates the empty
`tasks/index.sqlite` also rebinds the checkout the command runs from, so a freshly
wiped registry always has exactly one binding row, never zero. Verified end-to-end —
in the reproduction, `repof-dafe3a` is reported claimed while `repog-665f27` is reported
unclaimed, so a row-count guard would never fire.

It also proposed resolving each partition's owner from its own bundles. There is no such
evidence: `task.yaml` records no `repo_root`, `workspace_path`, or workspace id (confirmed
against real bundles on this host).

With no local evidence distinguishing a teardown leftover from a live partition whose
registry row was lost, the only sound rule is to refuse to auto-delete data that
`orbit task reindex` can restore. Reclaiming disk from a genuinely dead populated
partition is now a deliberate manual step; permanent loss of user task data is not a
price worth paying for that convenience.

## Changes

- `crates/orbit-cmd/src/task_store.rs` — `TaskStorePartitions` now splits unclaimed
  partitions into `removable` (no bundles) and `unowned` (holds bundles), via a new
  `UnclaimedPartition { path, task_bundles }`. Bundle counting moved here from
  `doctor.rs` and tightened to match `orbit task reindex`'s enumeration: subdirectories
  whose name (minus a `.deleted` tombstone suffix) is a valid task id.
  `remove_unclaimed_task_stores` iterates `removable` only.
  `open_task_registry`'s existence check is kept (it stops a caller creating a registry
  as a side effect of an ownership question) but its doc comment no longer claims a
  protection it cannot provide.
- `crates/orbit-cmd/src/doctor.rs` — `orphan-task-stores` emits a recovery `Action:`
  (`orbit task reindex` per owning checkout) whenever any populated unclaimed partition
  is present, naming empty residue in the same message without advertising deletion for
  it; the deletion `Action:` is reached only when every unclaimed partition is empty.
  Rendering extracted to `describe_partitions`.
- `crates/orbit-cli/src/command/doctor.rs` — `--fix-orphan-task-stores` help,
  `--confirm` refusal message, and repair summary corrected; all three claimed the
  repair deletes task bundles. `--confirm` is retained (it still removes directories).
- `docs/runbooks/health-checks.md` — the false "when the task registry itself is missing,
  the check warns and the repair refuses" sentence is replaced with the behavior that
  ships, including why (bootstrap recreates `index.sqlite` before any check runs) and the
  per-checkout `orbit task reindex` recovery.

`ARCHITECTURE.md` untouched: no new crate edge (`orbit-cmd` already depends on
`orbit-types`).

## Scope additions

Appended to `context_files`, each needed to satisfy the deliverable:
`crates/orbit-cli/src/command/doctor.rs` (its help/refusal/summary text asserted the
removed behavior), `crates/orbit-cmd/src/tests/task_store.rs` and
`crates/orbit-cmd/src/tests/doctor.rs` (regression coverage; three existing doctor tests
encoded the old contract and were re-pointed at empty residue partitions, which is the
case the repair still handles).

## Criteria

The task carries no explicit acceptance criteria; it is checked against its Summary,
Impact, Reproduction, and Scope sections.

1. **The advertised guard now exists in practice** — met, by a different and effective
   mechanism. Verified end-to-end (below): after `rm -f ~/.orbit/tasks/index.sqlite*`,
   `--fix-orphan-task-stores --confirm` removes 0 partitions and the other checkout's
   bundle survives.
2. **The `Action:` line no longer advertises a destructive repair in the state where it
   destroys live data** — met. The populated-partition row's remediation contains
   `orbit task reindex` and does not contain `--fix-orphan-task-stores --confirm`.
3. **Runbook matches behavior** — met; the false sentence is replaced and the new text
   was written from the observed output.
4. **"Consider downgrading to a non-actionable warning when a partition holds bundles"**
   — adopted in substance: `Warning` status is kept (the condition is real and needs
   attention) but its action is recovery, not deletion, and the repair refuses the
   partition regardless of what the operator types.
5. **ORB-12109's original purpose preserved** — met. An unclaimed partition with no
   bundles is still reported with the exact repair command and still reclaimed;
   `fix_orphan_task_stores_keeps_every_claimed_partition` and
   `fix_orphan_task_stores_removes_only_the_unregistered_partition` still pass.

## Validation

Required workspace gates (run at final HEAD state of the tree):

- `make ci-fast` — **passed** (exit 0). One pre-existing environment skip inside it:
  `test-compiler-cache-namespaces: skip: cannot create a mount namespace (bwrap: No
  permissions to create new namespace…)`. Unrelated to this change.
- `make ci-lint` — **passed** (exit 0, warnings denied, workspace-wide all-targets).
- `cargo test -p orbit-cmd` — **passed**, 142 passed / 0 failed / 1 ignored.
- `cargo test -p orbit-cli --bins` — **passed**, 514 passed / 0 failed.
- `cargo test -p orbit-cli doctor` / `teardown` (integration targets) — **passed**.
- `make ci` — **not run**; it is the CI merge gate, not a per-task local command.

New automated coverage:

- `orbit-cmd` `tests::task_store::losing_the_task_registry_leaves_populated_partitions_for_reindex`
  — reproduces the reported state at the owning boundary (bind two checkouts, write a
  bundle in each, delete `index.sqlite*`, rebind only one) and asserts the repair removes
  nothing and the other checkout's bundle survives.
- `orbit-cmd` `tests::task_store::an_unclaimed_partition_without_bundles_is_still_reclaimed`
  — empty residue (including a stray non-bundle file) is still deleted.
- `orbit-cmd` `tests::doctor::populated_unclaimed_partition_warns_toward_reindex_not_deletion`
  — row wording, remediation content, and `remove_orphan_task_stores() == 0`.

End-to-end reproduction against a debug `orbit` built from this tree, Linux, using a
disposable `HOME` (`env -i PATH=/usr/bin:/bin HOME=/tmp/orb12131qa/home`, fixture and
checkouts entirely under `/tmp`, routing confirmed via `orbit workspace show --format json`
reporting `orbit_root` under the disposable checkout before any mutation):

```
# baseline, registry intact
orphan-task-stores  ok  2 task-store partition(s) scanned, all claimed by a workspace binding

# rm -f $HOME/.orbit/tasks/index.sqlite*
orphan-task-stores  warning  1 task-store partition(s) hold task bundles that no workspace
  binding claims: repog-665f27 (…/repog-665f27, 1 task bundle(s))
  | Action: Run `orbit task reindex` from each checkout that owns these bundles to rebind
    them; `orbit doctor --fix-orphan-task-stores` never deletes a populated partition, so
    remove one by hand only after confirming its checkout is gone.

$ orbit doctor --fix-orphan-task-stores --confirm
  Removed 0 empty orphaned task-store partition(s).          # previously: "Removed 1", data gone

# the recommended recovery, run in repoG
$ orbit task reindex
  reindexed workspace 'repog-665f27': 1 bundle(s), 0 stale binding(s) dropped
$ orbit task list
  QAG-00001  G task  proposed  medium  chore
$ orbit doctor            # from repoF
  orphan-task-stores  ok  2 task-store partition(s) scanned, all claimed by a workspace binding

# empty residue still reclaimed
$ mkdir $HOME/.orbit/tasks/workspaces/gone-abc123 && orbit doctor
  orphan-task-stores  warning  1 orphaned empty task-store partition(s) … (0 task bundle(s))
  | Action: Run `orbit doctor --fix-orphan-task-stores --confirm`.
$ orbit doctor --fix-orphan-task-stores --confirm
  Removed 1 empty orphaned task-store partition(s).
$ orbit doctor --fix-orphan-task-stores
  error: invalid input: --fix-orphan-task-stores deletes task-store partition directories.
         Pass --confirm to proceed.
```

The disposable fixture was removed after the run; `git status --short` shows only the six
modified tracked files and `git diff --check` is clean.

Environment note: all checks ran on Linux (the affected environment for the report). No
macOS or Windows verification was performed; the changed logic is filesystem-generic
(`read_dir` + directory-name matching) but this has not been demonstrated on those
platforms.

## Risks and deviations

- **Behavior change beyond a pure bug fix.** `--fix-orphan-task-stores` no longer reclaims
  a populated partition left behind by a genuine teardown on an older binary; the operator
  must delete it by hand. This is deliberate — see "Why this shape" — and is stated in the
  runbook, the flag help, and the refusal message.
- **Partial-loss registries are still not fully protected.** If a registry is restored from
  an older backup that legitimately knows most partitions, a live partition missing from it
  is still merely *reported*, never deleted — so no data is lost — but the operator sees a
  warning whose cause is ambiguous between "teardown residue" and "stale restore". Naming
  the partition and its bundle count is the disambiguating evidence available on disk.
- **A partition holding only non-bundle files is treated as empty** and can be reclaimed.
  That is intentional (`an_unclaimed_partition_without_bundles_is_still_reclaimed` fixes it
  as behavior): anything other than a task-id-named bundle directory is not task data that
  `orbit task reindex` could rebuild.

Friction filed: `F2026-09-129` — existence guards on `~/.orbit` global-root artifacts never
fire because the runtime bootstrap creates them first, and the row-count variant fails for
the same reason.

Changes left uncommitted for the pipeline.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12131-6aa39b56`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus