### PR TITLE
[code-review] orbit mcp init/remove let the current directory outrank an explicit --root, silently writing MCP config into the wrong checkout

### DIFF
--- a/crates/orbit-cli/src/command/mcp/setup/workspace.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/workspace.rs
@@ -27,12 +27,11 @@ pub(super) fn resolve_workspace_layout(
 
 /// Resolve the checkout these MCP setup commands operate on.
 ///
-/// The workspace registry answers first, because it is the only source that
-/// knows a checkout whose Orbit root lives outside the repository — the
-/// `orbit --root <dir> workspace init` layout, where neither the repository nor
-/// its ancestors contain a `.orbit` directory. The filesystem walk-up stays
-/// behind it for a checkout that carries its own `.orbit` without being
-/// registered on this machine.
+/// An explicit `--root` or `ORBIT_ROOT` answers first, matching the precedence
+/// used by the other root-aware surfaces. When no root is selected, the
+/// workspace registry identifies relocated checkouts before filesystem
+/// walk-up, because it is the only source that knows a checkout whose Orbit
+/// root lives outside the repository.
 pub(super) fn resolve_workspace_layout_for_cwd(
     cwd: &Path,
     root_override: Option<&Path>,
@@ -41,10 +40,12 @@ pub(super) fn resolve_workspace_layout_for_cwd(
     let explicit_root = explicit_root.as_deref();
     let registry_root = registry_root(explicit_root);
 
-    let (repo_root, orbit_root) = match registry_root
+    let registered_paths = registry_root
         .as_deref()
-        .and_then(|registry_root| registered_checkout_paths(registry_root, cwd, explicit_root))
-    {
+        .map(|registry_root| registered_checkout_paths(registry_root, cwd, explicit_root))
+        .transpose()?
+        .flatten();
+    let (repo_root, orbit_root) = match registered_paths {
         Some(paths) => paths,
         None => unregistered_checkout_paths(cwd, explicit_root)?,
     };
@@ -106,15 +107,53 @@ fn registered_checkout_paths(
     registry_root: &Path,
     cwd: &Path,
     explicit_root: Option<&Path>,
-) -> Option<(PathBuf, PathBuf)> {
-    let registry = load_registry(registry_root)?;
-    let checkout = checkout_for_cwd(&registry, cwd)
-        .or_else(|| explicit_root.and_then(|root| sole_checkout_for_root(&registry, root)))?;
-    Some((checkout.repo_root.clone(), checkout.orbit_dir.clone()))
+) -> Result<Option<(PathBuf, PathBuf)>, OrbitError> {
+    let Some(registry) = load_registry(registry_root) else {
+        return Ok(None);
+    };
+    let checkout = match explicit_root {
+        Some(root) => sole_checkout_for_root(&registry, root)
+            .ok_or_else(|| explicit_root_resolution_error(&registry, root))?,
+        None => {
+            let Some(checkout) = checkout_for_cwd(&registry, cwd) else {
+                return Ok(None);
+            };
+            checkout
+        }
+    };
+    Ok(Some((
+        checkout.repo_root.clone(),
+        checkout.orbit_dir.clone(),
+    )))
 }
 
 fn load_registry(global_root: &Path) -> Option<WorkspaceRegistry> {
     workspace_registry::load_registry_from(&workspace_registry::registry_path_for(global_root)).ok()
+}
+
+fn explicit_root_resolution_error(registry: &WorkspaceRegistry, root: &Path) -> OrbitError {
+    let candidates = registry
+        .checkouts
+        .iter()
+        .map(|checkout| {
+            format!(
+                "{} (Orbit root {})",
+                checkout.repo_root.display(),
+                checkout.orbit_dir.display()
+            )
+        })
+        .collect::<Vec<_>>();
+    let candidates = if candidates.is_empty() {
+        "none".to_string()
+    } else {
+        candidates.join(", ")
+    };
+
+    OrbitError::InvalidInput(format!(
+        "explicit Orbit root '{}' does not identify exactly one registered checkout; candidate checkouts: {}",
+        root.display(),
+        candidates
+    ))
 }
 
 fn checkout_for_cwd<'a>(

--- a/crates/orbit-cli/tests/mcp_setup_root.rs
+++ b/crates/orbit-cli/tests/mcp_setup_root.rs
@@ -244,6 +244,47 @@ fn orbit_root_env_selects_the_same_checkout_as_the_root_flag() {
 }
 
 #[test]
+fn explicit_root_outranks_a_different_registered_cwd_checkout() {
+    let fixture = RegisteredCheckoutPairFixture::init();
+    let root = fixture
+        .checkout_b
+        .join(".orbit")
+        .canonicalize()
+        .expect("canonicalize B Orbit root");
+
+    fixture
+        .orbit(
+            &fixture.checkout_a,
+            &argv(&[
+                "--root",
+                root.to_str().expect("utf8 B Orbit root"),
+                "mcp",
+                "init",
+                "--claude",
+            ]),
+        )
+        .success();
+
+    assert!(!fixture.checkout_a.join(".claude.json").exists());
+    assert_eq!(
+        generated_server_args(&fixture.checkout_b.join(".claude.json")),
+        vec!["mcp", "serve", "--workspace", "ws_beta"]
+    );
+
+    let env = [("ORBIT_ROOT", root.as_path())];
+    fixture
+        .orbit_with_env(
+            &fixture.checkout_a,
+            &argv(&["mcp", "remove", "--claude"]),
+            &env,
+        )
+        .success();
+
+    assert!(!fixture.checkout_a.join(".claude.json").exists());
+    assert!(!fixture.checkout_b.join(".claude.json").exists());
+}
+
+#[test]
 fn a_root_without_a_registered_checkout_refuses_instead_of_writing() {
     let fixture = ExternalRootFixture::init();
     let unrelated_root = fixture
@@ -270,10 +311,122 @@ fn a_root_without_a_registered_checkout_refuses_instead_of_writing() {
         stderr.contains("does not identify exactly one registered checkout"),
         "unexpected failure message: {stderr}"
     );
-
     assert!(!unrelated_root.join(".claude.json").exists());
     fixture.assert_no_client_config_outside_the_checkout();
     assert!(!fixture.claude_config().exists());
+}
+
+#[test]
+fn an_unregistered_root_reports_the_root_and_registered_candidates() {
+    let fixture = RegisteredCheckoutPairFixture::init();
+    let root = fixture.checkout_a.join("not-registered");
+    let assert = fixture.orbit(
+        &fixture.checkout_a,
+        &argv(&[
+            "--root",
+            root.to_str().expect("utf8 unregistered root"),
+            "mcp",
+            "init",
+            "--claude",
+        ]),
+    );
+    let stderr = String::from_utf8_lossy(&assert.failure().get_output().stderr).to_string();
+
+    assert!(
+        stderr.contains(root.to_str().expect("utf8 unregistered root")),
+        "failure must name the explicit root: {stderr}"
+    );
+    assert!(
+        stderr.contains(fixture.checkout_a.to_str().expect("utf8 checkout A"))
+            && stderr.contains(fixture.checkout_b.to_str().expect("utf8 checkout B")),
+        "failure must name candidate checkouts: {stderr}"
+    );
+}
+
+struct RegisteredCheckoutPairFixture {
+    _temp: TempDir,
+    home: PathBuf,
+    checkout_a: PathBuf,
+    checkout_b: PathBuf,
+}
+
+impl RegisteredCheckoutPairFixture {
+    fn init() -> Self {
+        let temp = tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let checkout_a = temp.path().join("checkout-a");
+        let checkout_b = temp.path().join("checkout-b");
+        fs::create_dir_all(&home).expect("fixture home");
+        init_git_repo(&checkout_a);
+        init_git_repo(&checkout_b);
+
+        let fixture = Self {
+            _temp: temp,
+            home,
+            checkout_a,
+            checkout_b,
+        };
+        fixture
+            .orbit(
+                &fixture.checkout_a,
+                &argv(&[
+                    "init",
+                    "--non-interactive",
+                    "--host-name",
+                    "local-root-host",
+                    "--task-prefix",
+                    "LCL",
+                ]),
+            )
+            .success();
+        fixture
+            .orbit(
+                &fixture.checkout_a,
+                &argv(&["workspace", "init", "--name", "alpha"]),
+            )
+            .success();
+        fixture
+            .orbit(
+                &fixture.checkout_b,
+                &argv(&["workspace", "init", "--name", "beta"]),
+            )
+            .success();
+        fixture
+    }
+
+    fn orbit(&self, cwd: &Path, args: &[String]) -> assert_cmd::assert::Assert {
+        let mut command = cargo_bin_cmd!("orbit");
+        test_env::clear_inherited_authority(|name| {
+            command.env_remove(name);
+        });
+        command
+            .current_dir(cwd)
+            .env("HOME", &self.home)
+            .env("USERPROFILE", &self.home)
+            .args(args)
+            .assert()
+    }
+
+    fn orbit_with_env(
+        &self,
+        cwd: &Path,
+        args: &[String],
+        env: &[(&str, &Path)],
+    ) -> assert_cmd::assert::Assert {
+        let mut command = cargo_bin_cmd!("orbit");
+        test_env::clear_inherited_authority(|name| {
+            command.env_remove(name);
+        });
+        command
+            .current_dir(cwd)
+            .env("HOME", &self.home)
+            .env("USERPROFILE", &self.home)
+            .args(args);
+        for (name, value) in env {
+            command.env(name, value);
+        }
+        command.assert()
+    }
 }
 
 fn argv(args: &[&str]) -> Vec<String> {


### PR DESCRIPTION
## Task

[ORB-12129](https://orbit-cli.com/tasks/ORB-12129) — [code-review] orbit mcp init/remove let the current directory outrank an explicit --root, silently writing MCP config into the wrong checkout

### Description

`resolve_workspace_layout_for_cwd` resolves the target checkout through `registered_checkout_paths` (`crates/orbit-cli/src/command/mcp/setup/workspace.rs:44-50` and `:105-114`), which tries `checkout_for_cwd` first and only falls back to the explicitly selected root:

```rust
let checkout = checkout_for_cwd(&registry, cwd)
    .or_else(|| explicit_root.and_then(|root| sole_checkout_for_root(&registry, root)))?;
```

`checkout_for_cwd` -> `workspace_registry::find_checkout_by_path` is a path-prefix match (`crates/orbit-registry/src/workspace_registry/catalog.rs:463-482`), so it matches from anywhere *inside* a registered checkout.

Failure case: checkouts A and B are both registered in `~/.orbit/workspaces.json`. From inside A, run `orbit --root /path/to/B/.orbit mcp init --claude`. `registry_root` resolves to the global root (a repo-local `.orbit` holds no catalog, `workspace.rs:92-103`), `checkout_for_cwd` matches A, and the `--root` selector is never consulted. The client config is written into A and the generated server is bound to A's `ws_*` id; the operator gets a success summary naming A's paths. The same applies to `orbit mcp remove`, which then removes the entry from A. Before 8139b6ee6 an explicit `--root` was used directly (`repo_root = root.parent()`), so this is a behaviour change in the ORB-12121 rewrite.

Every other Orbit surface gives an explicit root precedence over discovery: `resolve_roots` applies `--root` first, then `ORBIT_ROOT`, and only then worktree/registry/walk-up (`crates/orbit-core/src/runtime/resolve.rs:139-166`). The MCP setup path is the one surface that inverts it, and it does so silently rather than reporting an ambiguity.

The new integration tests (`crates/orbit-cli/tests/mcp_setup_root.rs:192-274`) only run from the registered checkout itself or from an unregistered directory, so this case is uncovered. The doc comment at `workspace.rs:130-136` states the cwd-first ordering deliberately, so fixing this is a decision about precedence, not just a patch.

Suggested direction: when an explicit root is supplied, resolve from it first and fall back to cwd only when it identifies no checkout — or fail loudly when the cwd checkout and the `--root` checkout disagree.

### Acceptance Criteria

- Running `orbit --root <B-data-root> mcp init` from inside a different registered checkout A targets B (the checkout registered under the explicit root) and never writes A's client config; explicit `--root` / `ORBIT_ROOT` takes precedence over cwd discovery, matching `resolve_roots` in `crates/orbit-core/src/runtime/resolve.rs`.
- If the explicit root resolves to more than one registered checkout, or to none, the command fails with a message naming the root and the candidate checkouts instead of silently falling back to cwd.
- The same precedence applies to `orbit mcp remove`.
- The doc comment at `crates/orbit-cli/src/command/mcp/setup/workspace.rs` (currently stating cwd-first ordering) is updated to state root-first ordering.
- An integration test in `crates/orbit-cli/tests/mcp_setup_root.rs` covers cwd inside registered checkout A with an explicit root selecting B, asserts B's config is written and A's is untouched, and fails against the current cwd-first ordering.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated MCP workspace resolution so explicit --root / ORBIT_ROOT selects the registered checkout before cwd discovery, matching the root precedence in orbit-core.
- Added fail-closed diagnostics for explicit roots that identify zero or multiple registered checkouts, including the selected root and registered candidate checkout paths.
- Updated the resolver documentation and added two-checkout integration coverage proving init targets B from cwd A, remove follows ORBIT_ROOT to B, A remains untouched, and invalid roots report candidates.

Acceptance criteria:
- Explicit-root init from registered checkout A targets registered checkout B and leaves A's client config untouched: passed by explicit_root_outranks_a_different_registered_cwd_checkout.
- Ambiguous/unmatched explicit roots fail with the root and candidate checkouts: passed by resolver error handling and an_unregistered_root_reports_the_root_and_registered_candidates.
- mcp remove uses the same explicit-root precedence: passed by the ORBIT_ROOT remove half of the cross-checkout integration test.
- Root-first documentation: passed; workspace.rs now documents --root / ORBIT_ROOT before registry/cwd discovery.
- Regression test coverage: passed; crates/orbit-cli/tests/mcp_setup_root.rs contains the cross-checkout init/remove test.

Validation:
- cargo fmt --all -- --check: passed.
- cargo test -p orbit-cli --test mcp_setup_root: passed, 6 tests.
- cargo clippy -p orbit-cli --test mcp_setup_root -- -D warnings: passed.
- make ci-fast: passed; compiler-cache namespace probe was skipped because bwrap cannot create a mount namespace in this environment.
- make ci-lint: passed.
- git diff --check: passed.
- git status --short: two intended modified tracked files; changes left uncommitted for the pipeline.

Assessment: The change is scoped to MCP workspace selection and its integration tests. No remaining task-specific risks or deviations.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12129-6aa39d62`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus