### PR TITLE
[code-review] doctor's orphan-task-store check treats a stale task-registry binding as a claim, so it never reports the leftovers it exists for

### DIFF
--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -420,22 +420,24 @@ fn doctor_check_task_reservations(runtime: &OrbitRuntime) -> WorkspaceDoctorResu
 }
 
 /// Task-store partitions under `<global_root>/tasks/workspaces/<ws_id>/`
-/// that no registry claims — left behind by a `workspace teardown` run on an
-/// older binary, or by deleting a checkout without running teardown
+/// that no live registry claim covers — left behind by a `workspace teardown`
+/// run on an older binary, or by deleting a checkout without running teardown
 /// [ORB-12109]. Scoped to the whole host, not just this workspace, because the
 /// partition directory is itself host-global.
 ///
 /// A partition is named for its *task-registry* workspace id, so the task
-/// registry is what claims it; the workspace catalog and the synthetic
-/// `--root` partition are the other claimants. Comparing the directory name
-/// against catalog `ws_*` ids alone reported every `<slug>-<hash>` partition —
-/// including live ones — as orphaned [ORB-12119].
+/// registry is what claims it while the bound checkout's `orbit_dir` exists;
+/// a binding to a missing checkout is stale. The workspace catalog and the
+/// synthetic `--root` partition are the other claimants. Comparing the
+/// directory name against catalog `ws_*` ids alone reported every
+/// `<slug>-<hash>` partition — including live ones — as orphaned [ORB-12119].
 ///
-/// An unclaimed partition that still holds task bundles gets its own
-/// non-destructive row: a lost or rebuilt registry leaves every other
-/// checkout's live partition looking exactly like abandoned residue, and the
-/// recovery for it is `orbit task reindex` in the owning checkout, not a
-/// deletion this check invites [ORB-12131].
+/// An unknown populated partition gets its own non-destructive row: a lost or
+/// rebuilt registry leaves every other checkout's live partition looking
+/// exactly like abandoned residue, and the recovery for it is `orbit task
+/// reindex` in the owning checkout, not a deletion this check invites
+/// [ORB-12131]. A stale checkout binding is separately actionable because its
+/// missing `orbit_dir` proves the checkout is gone.
 fn doctor_check_orphan_task_stores(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
     let global_root = runtime.global_root();
     let partitions = match task_store::inspect_task_store_partitions(&global_root) {
@@ -456,7 +458,10 @@ fn doctor_check_orphan_task_stores(runtime: &OrbitRuntime) -> WorkspaceDoctorRes
         }
     };
 
-    if partitions.removable.is_empty() && partitions.unowned.is_empty() {
+    if partitions.removable.is_empty()
+        && partitions.stale.is_empty()
+        && partitions.unowned.is_empty()
+    {
         return check(
             "orphan-task-stores",
             WorkspaceDoctorStatus::Ok,
@@ -467,9 +472,10 @@ fn doctor_check_orphan_task_stores(runtime: &OrbitRuntime) -> WorkspaceDoctorRes
         );
     }
 
-    // Populated partitions decide the row: their data is recoverable, so the
-    // operator must not be pointed at a repair that would delete it, even when
-    // empty residue is present too and would be safe to reclaim.
+    // Unknown populated partitions decide the recovery guidance: their data is
+    // recoverable, so the operator must not be pointed at a repair that would
+    // delete it. A stale checkout binding is different evidence: the checkout
+    // is gone, so its partition is safe to remove after confirmation.
     if !partitions.unowned.is_empty() {
         let mut message = format!(
             "{} task-store partition(s) hold task bundles that no workspace binding claims: {}",
@@ -483,14 +489,50 @@ fn doctor_check_orphan_task_stores(runtime: &OrbitRuntime) -> WorkspaceDoctorRes
                 describe_partitions(&partitions.removable)
             ));
         }
+        if !partitions.stale.is_empty() {
+            message.push_str(&format!(
+                "; {} stale checkout-binding partition(s): {}",
+                partitions.stale.len(),
+                describe_partitions(&partitions.stale)
+            ));
+        }
+        let remediation = if partitions.stale.is_empty() {
+            "Run `orbit task reindex` from each checkout that owns these bundles to rebind them; \
+             `orbit doctor --fix-orphan-task-stores` never deletes a populated partition, so \
+             remove one by hand only after confirming its checkout is gone."
+                .to_string()
+        } else {
+            "Run `orbit task reindex` from each checkout that owns the unknown bundles; \
+             then run `orbit doctor --fix-orphan-task-stores --confirm` to remove partitions \
+             whose checkout binding is stale."
+                .to_string()
+        };
         return actionable_check(
             "orphan-task-stores",
             WorkspaceDoctorStatus::Warning,
             message,
-            "Run `orbit task reindex` from each checkout that owns these bundles to rebind them; \
-             `orbit doctor --fix-orphan-task-stores` never deletes a populated partition, so \
-             remove one by hand only after confirming its checkout is gone."
-                .to_string(),
+            remediation,
+        );
+    }
+
+    if !partitions.stale.is_empty() {
+        let mut message = format!(
+            "{} stale task-store partition(s) point at missing checkout directories: {}",
+            partitions.stale.len(),
+            describe_partitions(&partitions.stale)
+        );
+        if !partitions.removable.is_empty() {
+            message.push_str(&format!(
+                "; {} empty unclaimed partition(s): {}",
+                partitions.removable.len(),
+                describe_partitions(&partitions.removable)
+            ));
+        }
+        return actionable_check(
+            "orphan-task-stores",
+            WorkspaceDoctorStatus::Warning,
+            message,
+            "Run `orbit doctor --fix-orphan-task-stores --confirm`.".to_string(),
         );
     }
 

--- a/crates/orbit-cmd/src/task_store.rs
+++ b/crates/orbit-cmd/src/task_store.rs
@@ -42,16 +42,20 @@ pub struct UnclaimedPartition {
 
 /// What a scan of `<global_root>/tasks/workspaces/` found.
 ///
-/// Unclaimed partitions are split by whether they still hold task bundles,
-/// because on disk a partition abandoned by `workspace teardown` and a live
-/// partition whose registry row was lost are the same thing. Only the empty
-/// ones can be deleted from that evidence alone [ORB-12131].
+/// Unclaimed partitions are split into stale checkout bindings, empty residue,
+/// and populated partitions with no binding. A missing checkout binding is
+/// sufficient evidence for cleanup; an unknown populated partition remains
+/// recoverable with `orbit task reindex` [ORB-12131].
 #[derive(Debug, Clone)]
 pub struct TaskStorePartitions {
     /// Partition directories present on this host.
     pub scanned: usize,
     /// Unclaimed and empty of task bundles: nothing to lose by deleting them.
     pub removable: Vec<UnclaimedPartition>,
+    /// Partitions whose task-registry checkout binding points at a missing
+    /// orbit directory. The missing checkout is sufficient evidence to remove
+    /// the partition, including its bundles.
+    pub stale: Vec<UnclaimedPartition>,
     /// Unclaimed but still holding task bundles, which `orbit task reindex`
     /// can rebind from the bundles themselves. Never deleted automatically.
     pub unowned: Vec<UnclaimedPartition>,
@@ -68,26 +72,42 @@ pub fn inspect_task_store_partitions(
     let Some(partitions) = task_store_partitions(global_root)? else {
         return Ok(None);
     };
-    let claimed = claimed_partition_ids(global_root)?;
+    let (claimed, stale_bindings) = partition_claims(global_root)?;
     let scanned = partitions.len();
 
-    let (unowned, removable) = partitions
-        .into_iter()
-        .filter(|path| !path_is_claimed(path, &claimed))
-        .map(|path| UnclaimedPartition {
+    let mut removable = Vec::new();
+    let mut stale = Vec::new();
+    let mut unowned = Vec::new();
+    for path in partitions {
+        let Some(id) = partition_id(&path).map(str::to_owned) else {
+            continue;
+        };
+        if claimed.contains(&id) {
+            continue;
+        }
+
+        let partition = UnclaimedPartition {
             task_bundles: count_task_bundles(&path),
             path,
-        })
-        .partition(|partition| partition.task_bundles > 0);
+        };
+        if stale_bindings.contains(&id) {
+            stale.push(partition);
+        } else if partition.task_bundles > 0 {
+            unowned.push(partition);
+        } else {
+            removable.push(partition);
+        }
+    }
 
     Ok(Some(TaskStorePartitions {
         scanned,
         removable,
+        stale,
         unowned,
     }))
 }
 
-/// Delete every unclaimed partition that holds no task bundles, retiring any
+/// Delete every stale-bound or empty unclaimed partition, retiring any
 /// registry rows that name it. Returns the removed partition paths.
 ///
 /// A partition that still holds bundles is left alone however the registry
@@ -104,7 +124,7 @@ pub fn remove_unclaimed_task_stores(global_root: &Path) -> Result<Vec<PathBuf>, 
     let tasks = open_task_registry(global_root)?;
 
     let mut removed = Vec::new();
-    for partition in partitions.removable {
+    for partition in partitions.stale.into_iter().chain(partitions.removable) {
         let Some(workspace_id) = partition_id(&partition.path) else {
             continue;
         };
@@ -170,13 +190,27 @@ pub fn partition_is_bound(global_root: &Path, workspace_id: &str) -> Result<bool
         .contains(workspace_id))
 }
 
-/// Every workspace id that still claims a partition on this host: the task
-/// registry's own bindings, the workspace catalog's ids, and the synthetic
-/// partition every `--root <data-dir>` write lands in, which by construction
-/// appears in neither registry.
-fn claimed_partition_ids(global_root: &Path) -> Result<BTreeSet<String>, OrbitError> {
+/// Every workspace id that claims a partition on this host, plus task-registry
+/// bindings whose checkout has disappeared. Live checkout bindings, workspace
+/// catalog ids, and the synthetic partition every `--root <data-dir>` write
+/// lands in are claims; a binding to a missing orbit directory is stale.
+fn partition_claims(
+    global_root: &Path,
+) -> Result<(BTreeSet<String>, BTreeSet<String>), OrbitError> {
     let tasks = open_task_registry(global_root)?;
-    let mut claimed = tasks.workspace_ids()?;
+    let mut claimed = BTreeSet::new();
+    let mut stale_bindings = BTreeSet::new();
+    for workspace_id in tasks.workspace_ids()? {
+        match tasks.find_workspace_checkout(&workspace_id)? {
+            Some(checkout) if checkout.orbit_dir.exists() => {
+                claimed.insert(workspace_id);
+            }
+            Some(_) => {
+                stale_bindings.insert(workspace_id);
+            }
+            None => {}
+        }
+    }
     claimed.insert(UNBOUND_DATA_DIR_WORKSPACE_ID.to_string());
 
     let registry_path = workspace_registry::registry_path_for(global_root);
@@ -189,7 +223,7 @@ fn claimed_partition_ids(global_root: &Path) -> Result<BTreeSet<String>, OrbitEr
                 .map(|workspace| workspace.id),
         );
     }
-    Ok(claimed)
+    Ok((claimed, stale_bindings))
 }
 
 /// Open the task registry that names the partitions, rather than creating one
@@ -256,10 +290,6 @@ fn count_task_bundles(partition: &Path) -> usize {
             })
         })
         .count()
-}
-
-fn path_is_claimed(partition: &Path, claimed: &BTreeSet<String>) -> bool {
-    partition_id(partition).is_some_and(|id| claimed.contains(id))
 }
 
 /// Whether `workspace_id`'s partition holds *another* checkout's task state,

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -21,6 +21,7 @@ use crate::doctor::{
     DoctorCommands, WorkspaceDoctorResult, WorkspaceDoctorStatus, collect_lock_files,
     disk_space_check, process_is_alive,
 };
+use crate::task_store::partition_is_bound;
 
 fn status_of<'a>(results: &'a [WorkspaceDoctorResult], name: &str) -> &'a WorkspaceDoctorResult {
     results
@@ -1008,6 +1009,43 @@ fn task_registry_bound_partition_is_not_an_orphan() {
         WorkspaceDoctorStatus::Ok,
         "a bound partition is live task state: {row:?}"
     );
+}
+
+/// A task-registry binding to a deleted checkout is stale rather than a live
+/// claim. Doctor reports it, and the confirmed repair removes its partition
+/// and the binding's task data.
+#[test]
+fn stale_task_registry_binding_is_reported_and_removed() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let global_root = temp.path().join("global");
+    let deleted_root = temp.path().join("deleted");
+    fs::create_dir_all(deleted_root.join(".orbit")).expect("create deleted checkout");
+
+    bind_task_partition(&global_root, "deleted-a1b2c3", "deleted", &deleted_root);
+    write_task_bundle(&global_root, "deleted-a1b2c3", "ORB-2");
+    fs::remove_dir_all(&deleted_root).expect("delete checkout");
+
+    let results = runtime.doctor_workspace().expect("doctor");
+    let row = status_of(&results, "orphan-task-stores");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Warning, "{row:?}");
+    assert!(row.message.contains("deleted-a1b2c3"), "{}", row.message);
+    assert!(row.message.contains("1 task bundle(s)"), "{}", row.message);
+    assert_eq!(
+        row.remediation.as_deref(),
+        Some("Run `orbit doctor --fix-orphan-task-stores --confirm`.")
+    );
+
+    let removed = runtime
+        .remove_orphan_task_stores()
+        .expect("remove stale orphan task store");
+    assert_eq!(removed, 1);
+    assert!(
+        !task_workspaces_dir(&global_root)
+            .join("deleted-a1b2c3")
+            .exists()
+    );
+    assert!(!partition_is_bound(&global_root, "deleted-a1b2c3").expect("read binding"));
 }
 
 /// [ORB-12119] The fix deletes only partitions no registry claims: a

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -104,17 +104,18 @@ partition's rows in `~/.orbit/tasks/index.sqlite` in the same step.
 A partition directory is named for a **task-registry** workspace id
 (`workspace_bindings.workspace_id` in `~/.orbit/tasks/index.sqlite`), minted as `<slug>-<hash>`
 for a checkout that binds without an explicit id. That is a different id space from the workspace
-catalog's `ws_*` ids in `~/.orbit/workspaces.json`, so a partition is orphaned only when neither
-registry claims it; the synthetic `ws_unbound-data-dir` partition every `--root <data-dir>` write
-lands in is never reported. `orphan-task-stores` exists for partitions a prior teardown on an
-older binary left behind, or a checkout removed without running teardown at all: each warning
-names the orphaned workspace id, its partition path, and its task-bundle count.
+catalog's `ws_*` ids in `~/.orbit/workspaces.json`. A task-registry binding claims its partition
+only while the binding's recorded `orbit_dir` still exists on disk; a binding to a deleted checkout
+is stale and is reported as orphaned. Catalog `ws_*` ids and the synthetic `ws_unbound-data-dir`
+partition every `--root <data-dir>` write lands in remain claims, so they are never reported.
+`orphan-task-stores` names each orphaned workspace id, its partition path, and its task-bundle count.
 
-An unclaimed partition that **still holds task bundles** is reported on its own terms and is never
-deleted by the repair. On disk it is indistinguishable from a live checkout's partition whose
-registry row was lost, and every `orbit` subcommand recreates an empty `~/.orbit/tasks/index.sqlite`
-before any check runs — so a lost or restored-without-`index.sqlite` registry makes every checkout
-other than the one you are standing in look abandoned. That warning points at recovery instead:
+An unclaimed partition that **still holds task bundles** and has no stale checkout binding is
+reported on its own terms and is never deleted by the repair. On disk it is indistinguishable from
+a live checkout's partition whose registry row was lost, and every `orbit` subcommand recreates an
+empty `~/.orbit/tasks/index.sqlite` before any check runs — so a lost or restored-without
+`index.sqlite` registry makes every checkout other than the one you are standing in look abandoned.
+That warning points at recovery instead:
 
 ```sh
 cd <the checkout that owns the bundles>
@@ -122,8 +123,16 @@ orbit task reindex
 ```
 
 `orbit task reindex` rebuilds the registry rows for one partition from its bundle directories, so
-it must be run once per affected checkout. Only after confirming a checkout is genuinely gone
-should you delete its populated partition directory by hand.
+it must be run once per affected checkout. For a partition whose task-registry binding points at a
+missing `orbit_dir`, the stale binding is the evidence that the checkout is genuinely gone. The
+confirmed repair removes that partition, including its task bundles, and retires the stale registry
+rows:
+
+```sh
+orbit doctor --fix-orphan-task-stores --confirm
+```
+
+Do not use that repair for an unknown populated partition; reindex it first.
 
 An unclaimed partition with **no task bundles** carries nothing to recover. Repair those with:
 
@@ -132,8 +141,9 @@ orbit doctor --fix-orphan-task-stores --confirm
 ```
 
 The repair deletes partition directories, so it refuses to run without `--confirm`. It resolves the
-claims once, deletes only the empty partitions no binding names, retires any registry rows naming
-them, and is idempotent: running it again after a partition is gone is a no-op.
+claims once, deletes empty partitions with no binding and partitions whose binding is stale, retires
+any registry rows naming them, and is idempotent: running it again after a partition is gone is a
+no-op.
 
 ### Repair retired activity backends
 


### PR DESCRIPTION
## Task

[ORB-12127](https://orbit-cli.com/tasks/ORB-12127) — [code-review] doctor's orphan-task-store check treats a stale task-registry binding as a claim, so it never reports the leftovers it exists for

### Description

`doctor_check_orphan_task_stores` / `--fix-orphan-task-stores` decide "claimed" from `claimed_partition_ids` (`crates/orbit-cmd/src/task_store.rs:140-156`), which unions three sets: every `workspace_bindings.workspace_id` in `~/.orbit/tasks/index.sqlite` (`TaskRegistryStore::workspace_ids`, `crates/orbit-store/src/driver/sqlite/task_registry/store.rs:1257-1277`), the synthetic `ws_unbound-data-dir` id, and every `ws_*` id in `workspaces.json`.

The task-registry row is never removed when a checkout goes away. The only `DELETE FROM workspace_bindings` in the codebase is the new `unbind_workspace` (`store.rs:1288-1315`), reached only from `remove_partition` in the removal path itself (`crates/orbit-cmd/src/task_store.rs:216-248`). Nothing deletes those rows when a checkout is `rm -rf`'d, and the pre-ORB-12119 `workspace teardown` deleted the *catalog*-id partition without touching the task registry (`crates/orbit-cli/src/command/workspace/teardown.rs`, before 2fdc4634b).

So the two scenarios the check is documented to exist for both keep a live `workspace_bindings` row and are now permanently classified as claimed:

1. a partition a prior `workspace teardown` on an older binary left behind, and
2. a checkout deleted without running teardown at all.

After ORB-12119 the check reports a partition only when its directory name is in neither registry — in practice only bundles rsync'd/copied in by hand, or a partially failed removal. `orbit doctor` reports `orphan-task-stores ok` while the bundles and their `task_bundle_*` index rows accumulate, and `docs/runbooks/health-checks.md:100-113` still advertises exactly the two cases above as what the check finds.

The over-correction is understandable — ORB-12119 fixed the opposite failure, where live partitions were reported and deleted — but a binding whose `workspace_checkout_bindings.orbit_dir` no longer exists on disk is evidence of an orphan, not of a claim. `crates/orbit-cmd/src/tests/doctor.rs:983-1043` only covers bindings whose checkout directory still exists, so nothing fails today.

Suggested direction: treat a task-registry binding as a claim only when its `workspace_checkout_bindings.orbit_dir` still exists (or when no checkout row exists but the logical workspace is in `workspaces.json`), and add a regression test for the deleted-checkout case.

### Acceptance Criteria

- A task-store partition whose only claim is a `workspace_bindings` row for a checkout whose `orbit_dir` no longer exists on disk is reported by `orbit doctor`'s `orphan-task-stores` check and removed by `--fix-orphan-task-stores --confirm`.
- A partition bound to a checkout that still exists on disk, a partition named for a registered `ws_*` catalog id, and the synthetic `ws_unbound-data-dir` partition all remain unreported and undeleted.
- A regression test covers the deleted-checkout-with-stale-binding case and fails against the current claim rule.
- `docs/runbooks/health-checks.md` describes the claim rule that the code actually applies.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Task-store claim classification now treats a task-registry binding as live only while its recorded orbit_dir exists; stale bindings are reported separately and removed by the confirmed orphan-store repair, including their bundles and registry rows.
- Doctor output distinguishes stale-bound partitions from unknown populated partitions, preserving the reindex-only safety path for the latter.
- Added a regression test for a deleted checkout with a stale binding and task bundle; existing live-binding, registered-catalog, synthetic-partition, and unknown-populated coverage remains passing.
- Updated docs/runbooks/health-checks.md to describe the filesystem-aware claim rule and repair behavior.

Acceptance criteria:
- Deleted-checkout stale binding is reported with its partition and bundle count, and the repair removes the partition and binding: verified by stale_task_registry_binding_is_reported_and_removed.
- Live task-registry binding, registered ws_* catalog partition, and ws_unbound-data-dir remain unreported and undeleted: verified by existing doctor tests, including task_registry_bound_partition_is_not_an_orphan and fix_orphan_task_stores_keeps_every_claimed_partition.
- Regression test covers the deleted-checkout stale-binding case and would fail under the prior claim rule: verified by the focused test suite.
- Runbook documents the implemented claim rule: verified by final diff review.

Validation:
- PASSED: cargo test -p orbit-cmd --lib doctor (32 passed).
- PASSED: cargo test -p orbit-cli teardown (2 passed).
- PASSED: cargo fmt --all -- --check.
- PASSED: make ci-fast; its compiler-cache namespace probe was skipped because the environment denied unprivileged bubblewrap namespaces, while the remaining guardrails passed.
- PASSED: make ci-lint.
- PASSED: git diff --check.
- PASSED: GIT_OPTIONAL_LOCKS=0 git status --short; only the four scoped files are modified.
- An initial multi-filter cargo test command was rejected by cargo argument parsing; the corrected focused command passed.

Assessment: The change keeps the existing conservative recovery behavior for unknown populated partitions while using an explicit stale checkout binding as the ownership evidence required for cleanup. No remaining task-scoped risks identified.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12127-6aa39ff2`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus