### PR TITLE
Owner-wins cross-host task sync: import policy that overwrites only foreign-prefix bundles

### DIFF
--- a/crates/orbit-cli/src/command/task/import.rs
+++ b/crates/orbit-cli/src/command/task/import.rs
@@ -17,7 +17,8 @@ pub struct TaskImportArgs {
     /// workspace, registering it locally if unknown).
     #[arg(long = "task-workspace", value_name = "TASK_WORKSPACE")]
     pub task_workspace: Option<String>,
-    /// How to resolve an incoming task id that already exists locally.
+    /// How to resolve an incoming task id that already exists locally. Use
+    /// owner-wins for a repeatable cross-host sync of task mirrors.
     #[arg(long = "on-conflict", value_enum, default_value_t = ConflictArg::Renumber)]
     pub on_conflict: ConflictArg,
     /// Emit machine-readable JSON instead of a human summary.
@@ -34,6 +35,10 @@ pub enum ConflictArg {
     Skip,
     /// Abort the whole import on the first collision.
     Fail,
+    /// Trust the host that minted the id: replace a colliding task whose id
+    /// prefix is foreign, keep a colliding task under this host's prefix, and
+    /// never renumber. Safe to re-run.
+    OwnerWins,
 }
 
 impl From<ConflictArg> for ImportConflictPolicy {
@@ -42,6 +47,7 @@ impl From<ConflictArg> for ImportConflictPolicy {
             ConflictArg::Renumber => ImportConflictPolicy::Renumber,
             ConflictArg::Skip => ImportConflictPolicy::Skip,
             ConflictArg::Fail => ImportConflictPolicy::Fail,
+            ConflictArg::OwnerWins => ImportConflictPolicy::OwnerWins,
         }
     }
 }
@@ -52,6 +58,8 @@ fn action_label(action: ImportAction) -> &'static str {
         ImportAction::Renumbered => "renumbered",
         ImportAction::AlreadyPresent => "already-present",
         ImportAction::SkippedConflict => "skipped",
+        ImportAction::Updated => "updated",
+        ImportAction::SkippedLocalOwned => "skipped-local-owned",
     }
 }
 

--- a/crates/orbit-core/assets/skills/orbit/references/setup/maintenance.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/maintenance.md
@@ -159,6 +159,8 @@ For archive migration, `orbit task export --output <archive.tar.zst> --ids <id>,
 selects tasks (omitting IDs exports all). `orbit task import <archive.tar.zst>`
 defaults to renumbering collisions and rewriting references; choose
 `--on-conflict fail` or `skip` deliberately when appropriate. Inspect the returned
-ID mapping. Import is a different operation from publication's strict
+ID mapping. To keep a read-only mirror of another host's tasks in step, use
+`--on-conflict owner-wins`: it replaces only bundles whose task-ID prefix belongs
+to that host, never touches locally minted IDs, and is safe to re-run. Import is a different operation from publication's strict
 same-authority, identical-retry recovery; do not substitute it to bypass a
 publication ownership or divergence error.

--- a/crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs
+++ b/crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs
@@ -68,6 +68,7 @@ pub(crate) fn take_artifact_payload_reads() -> usize {
 /// a creation-only primitive and refuses to write into an existing bundle
 /// directory. Use narrower update helpers for later mutations.
 pub(crate) fn write_bundle_at(bundle_dir: &Path, bundle: &TaskBundleV2) -> Result<(), OrbitError> {
+    refuse_existing_bundle(bundle_dir)?;
     write_bundle_atomically(bundle_dir, bundle, None, publish_staged_bundle)
 }
 
@@ -78,12 +79,51 @@ pub(crate) fn write_bundle_with_artifacts_at(
     bundle: &TaskBundleV2,
     source_bundle_dir: &Path,
 ) -> Result<(), OrbitError> {
+    refuse_existing_bundle(bundle_dir)?;
     write_bundle_atomically(
         bundle_dir,
         bundle,
         Some(source_bundle_dir),
         publish_staged_bundle,
     )
+}
+
+/// Replace the bundle already published at `bundle_dir` with `bundle`.
+///
+/// Used by owner-wins task import, where the incoming copy comes from the
+/// task's owning host and supersedes the local mirror wholesale. The
+/// replacement is staged and verified exactly like a fresh write, so the
+/// destination only ever holds a complete bundle; `source_bundle_dir` supplies
+/// the artifact blobs the incoming manifest references.
+pub(crate) fn replace_bundle_at(
+    bundle_dir: &Path,
+    bundle: &TaskBundleV2,
+    source_bundle_dir: &Path,
+) -> Result<(), OrbitError> {
+    if !bundle_dir.is_dir() {
+        return Err(OrbitError::Store(format!(
+            "no task bundle to replace at {}",
+            bundle_dir.display()
+        )));
+    }
+    write_bundle_atomically(
+        bundle_dir,
+        bundle,
+        Some(source_bundle_dir),
+        publish_replacement_bundle,
+    )
+}
+
+/// Creation refuses to write into a bundle directory that already exists;
+/// superseding one is [`replace_bundle_at`]'s job.
+fn refuse_existing_bundle(bundle_dir: &Path) -> Result<(), OrbitError> {
+    if bundle_dir.exists() {
+        return Err(OrbitError::Store(format!(
+            "task bundle already exists at {}",
+            bundle_dir.display()
+        )));
+    }
+    Ok(())
 }
 
 fn write_bundle_atomically<F>(
@@ -95,12 +135,6 @@ fn write_bundle_atomically<F>(
 where
     F: FnOnce(&Path, &Path) -> std::io::Result<()>,
 {
-    if bundle_dir.exists() {
-        return Err(OrbitError::Store(format!(
-            "task bundle already exists at {}",
-            bundle_dir.display()
-        )));
-    }
     validate_bundle_dir_matches_task_id(bundle_dir, &bundle.envelope.id)?;
     validate_bundle(bundle)?;
     let staging_dir = create_staging_dir(bundle_dir)?;
@@ -175,20 +209,10 @@ fn create_staging_dir(bundle_dir: &Path) -> Result<PathBuf, OrbitError> {
         ))
     })?;
     fs::create_dir_all(parent).map_err(|error| OrbitError::from_write_io(parent, error))?;
-    let bundle_name = bundle_dir
-        .file_name()
-        .and_then(|name| name.to_str())
-        .ok_or_else(|| {
-            OrbitError::Store(format!("invalid task bundle path {}", bundle_dir.display()))
-        })?;
 
     for _ in 0..32 {
-        let sequence = STAGING_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let candidate = parent.join(format!(
-            ".{bundle_name}.{}.{}.staging",
-            std::process::id(),
-            sequence
-        ));
+        let candidate = scratch_sibling_path(bundle_dir, "staging")
+            .map_err(|error| OrbitError::from_write_io(bundle_dir, error))?;
         match fs::create_dir(&candidate) {
             Ok(()) => return Ok(candidate),
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
@@ -198,6 +222,31 @@ fn create_staging_dir(bundle_dir: &Path) -> Result<PathBuf, OrbitError> {
     Err(OrbitError::Store(format!(
         "could not allocate a staging directory for task bundle {}",
         bundle_dir.display()
+    )))
+}
+
+/// Build a unique hidden sibling path of `bundle_dir` for scratch use during
+/// publication (`.<bundle>.<pid>.<sequence>.<suffix>`). The process id and the
+/// process-wide counter keep two concurrent writers of the same bundle apart.
+fn scratch_sibling_path(bundle_dir: &Path, suffix: &str) -> std::io::Result<PathBuf> {
+    let invalid = |detail: &str| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("task bundle path {} {detail}", bundle_dir.display()),
+        )
+    };
+    let parent = bundle_dir
+        .parent()
+        .ok_or_else(|| invalid("has no parent directory"))?;
+    let bundle_name = bundle_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| invalid("has no UTF-8 file name"))?;
+
+    let sequence = STAGING_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+    Ok(parent.join(format!(
+        ".{bundle_name}.{}.{sequence}.{suffix}",
+        std::process::id()
     )))
 }
 
@@ -219,6 +268,25 @@ fn sync_path_parent(path: &Path) -> Result<(), OrbitError> {
 
 fn publish_staged_bundle(staging_dir: &Path, bundle_dir: &Path) -> std::io::Result<()> {
     fs::rename(staging_dir, bundle_dir)?;
+    sync_bundle_parent(bundle_dir)
+}
+
+/// Publish a staged bundle over an existing one. `rename` cannot overwrite a
+/// non-empty directory, so the superseded bundle is moved aside first and
+/// dropped only once the replacement is in place; a failed swap puts the
+/// original back, so the destination is never left empty.
+fn publish_replacement_bundle(staging_dir: &Path, bundle_dir: &Path) -> std::io::Result<()> {
+    let retired = scratch_sibling_path(bundle_dir, "retired")?;
+    fs::rename(bundle_dir, &retired)?;
+    if let Err(error) = fs::rename(staging_dir, bundle_dir) {
+        let _ = fs::rename(&retired, bundle_dir);
+        return Err(error);
+    }
+    sync_bundle_parent(bundle_dir)?;
+    fs::remove_dir_all(&retired)
+}
+
+fn sync_bundle_parent(bundle_dir: &Path) -> std::io::Result<()> {
     let parent = bundle_dir.parent().ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidInput,

--- a/crates/orbit-store/src/driver/file/task_bundle/mod.rs
+++ b/crates/orbit-store/src/driver/file/task_bundle/mod.rs
@@ -9,8 +9,8 @@ mod types;
 pub(crate) use bundle_io::{
     BundleWriteFault, PENDING_WRITE_FILE_NAME, PendingWriteGuard, append_jsonl_row,
     cleanup_partial_bundle_best_effort, fail_if_injected, publish_envelope, read_bundle_at,
-    read_bundle_lightweight_at, read_envelope_at, recover_pending_bundle_at, write_bundle_at,
-    write_bundle_with_artifacts_at,
+    read_bundle_lightweight_at, read_envelope_at, recover_pending_bundle_at, replace_bundle_at,
+    write_bundle_at, write_bundle_with_artifacts_at,
 };
 
 #[cfg(test)]

--- a/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
@@ -508,6 +508,22 @@ impl TaskRegistryStore {
         tx.commit().map_err(|e| OrbitError::Store(e.to_string()))
     }
 
+    /// The prefix this host mints under. Task authority follows the prefix, so
+    /// this is what separates a locally-owned task from a mirror of another
+    /// host's task.
+    pub fn local_task_prefix(&self) -> Result<String, OrbitError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+        conn.query_row(
+            "SELECT task_prefix FROM allocator_state WHERE authority = 'local'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| OrbitError::Store(e.to_string()))
+    }
+
     /// Prefixes recognized by the local registry: the active minting prefix
     /// plus every prefix already present in registered task bundles.
     pub fn known_task_prefixes(&self) -> Result<BTreeSet<String>, OrbitError> {

--- a/crates/orbit-store/src/workflow/task/mod.rs
+++ b/crates/orbit-store/src/workflow/task/mod.rs
@@ -24,6 +24,17 @@
 //!   so each run mints fresh ids. Import once; the printed `.idmap.json` records
 //!   what landed.
 //!
+//! # Owner-wins sync
+//! Task authority follows the id prefix: the host that minted `ORB-*` is the
+//! sole writer of those tasks, and any copy on a host that mints `DANI-*` is a
+//! read-only mirror. [`ImportConflictPolicy::OwnerWins`] makes import a
+//! repeatable sync of those mirrors — a colliding foreign-prefix id is replaced
+//! by the owner's bundle ([`ImportAction::Updated`]), a colliding local-prefix
+//! id is left alone ([`ImportAction::SkippedLocalOwned`]), and nothing is ever
+//! renumbered. Foreign relation targets therefore survive verbatim, no
+//! `.idmap.json` is written, and a second run of the same archive reports every
+//! task as already-present.
+//!
 //! # Artifact blobs
 //! Bundles carry a `artifacts/manifest.yaml` sidecar and the referenced blobs
 //! under `artifacts/files/**`. Export tars the entire canonical bundle tree, so
@@ -63,14 +74,16 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use orbit_common::OrbitError;
-use orbit_types::task::{TASK_ARTIFACT_SCHEMA_VERSION, validate_orb_task_id};
+use orbit_common::fs::io::with_exclusive_file_lock;
+use orbit_types::task::{TASK_ARTIFACT_SCHEMA_VERSION, task_id_prefix, validate_orb_task_id};
 use serde::{Deserialize, Serialize};
 
 use crate::driver::file::task_bundle::{
-    TaskBundleV2, read_bundle_at, write_bundle_at, write_bundle_with_artifacts_at,
+    TaskBundleV2, bundle_lock_target, read_bundle_at, replace_bundle_at, write_bundle_at,
+    write_bundle_with_artifacts_at,
 };
 use crate::driver::sqlite::task_registry::{
-    RegisterWorkspaceParams, TaskRegistryStore, parse_orb_task_number,
+    RegisterWorkspaceParams, TaskBundleBinding, TaskRegistryStore, parse_orb_task_number,
 };
 
 mod archive;
@@ -157,6 +170,12 @@ pub enum ImportConflictPolicy {
     Skip,
     /// Abort the whole import on the first collision.
     Fail,
+    /// Prefix authority: the host that minted a task id is its sole writer.
+    /// A colliding id under a *foreign* prefix is a stale mirror, so the
+    /// incoming bundle replaces it; a colliding id under the *local* prefix is
+    /// locally owned and is never touched. Nothing is ever renumbered, which
+    /// makes a repeated sync of the same archive a no-op.
+    OwnerWins,
 }
 
 /// What happened to a single task during import.
@@ -170,6 +189,11 @@ pub enum ImportAction {
     AlreadyPresent,
     /// Collided and `--on-conflict=skip` dropped it.
     SkippedConflict,
+    /// Owner-wins: a foreign-prefix mirror was replaced by the owner's copy.
+    Updated,
+    /// Owner-wins: the id is under the local prefix, so the local copy is
+    /// authoritative and the incoming one was dropped.
+    SkippedLocalOwned,
 }
 
 /// Per-task import record.
@@ -291,6 +315,13 @@ struct StagedBundle {
     staging_dir: PathBuf,
 }
 
+/// A colliding mirror whose owner is authoritative: the staged bundle replaces
+/// the local copy at the directory the registry already binds it to.
+struct MirrorReplacement {
+    staged: StagedBundle,
+    bundle_dir: PathBuf,
+}
+
 /// Resolved import target after workspace resolution.
 struct ImportTarget {
     workspace_id: String,
@@ -327,9 +358,14 @@ pub fn import_tasks(
     let staged = stage_bundles(staging.path(), &manifest)?;
     let target = resolve_target(registry, &manifest, target_workspace_id)?;
 
+    // The prefix this host mints under decides which colliding ids are mirrors
+    // of another host's tasks and which are locally owned.
+    let local_prefix = registry.local_task_prefix()?;
+
     // Classify each staged bundle against the current registry.
     let mut kept: Vec<StagedBundle> = Vec::new();
     let mut to_renumber: Vec<StagedBundle> = Vec::new();
+    let mut to_overwrite: Vec<MirrorReplacement> = Vec::new();
     let mut records: Vec<ImportedTask> = Vec::new();
     for staged in staged {
         match registry.find_task_binding(&staged.source_id)? {
@@ -362,6 +398,23 @@ pub fn import_tasks(
                         // source id still collides with the original local task
                         // (unchanged), so a second run mints another fresh id.
                         ImportConflictPolicy::Renumber => to_renumber.push(staged),
+                        ImportConflictPolicy::OwnerWins => {
+                            match owner_wins_verdict(
+                                &staged.source_id,
+                                &existing,
+                                &target.workspace_id,
+                                &local_prefix,
+                            )? {
+                                MirrorVerdict::LocalOwned => records.push(ImportedTask {
+                                    source_id: staged.source_id.clone(),
+                                    final_id: staged.source_id,
+                                    action: ImportAction::SkippedLocalOwned,
+                                }),
+                                MirrorVerdict::Replace(bundle_dir) => {
+                                    to_overwrite.push(MirrorReplacement { staged, bundle_dir })
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -369,7 +422,7 @@ pub fn import_tasks(
     }
 
     // Nothing new to write (all ids were free-and-identical, or all skipped).
-    if kept.is_empty() && to_renumber.is_empty() {
+    if kept.is_empty() && to_renumber.is_empty() && to_overwrite.is_empty() {
         return Ok(ImportOutcome {
             workspace_id: target.workspace_id,
             registered_workspace: false,
@@ -395,18 +448,21 @@ pub fn import_tasks(
     };
 
     // Reserve headroom so renumber allocations never collide with kept ids.
-    let kept_max = kept
-        .iter()
-        .filter_map(|staged| parse_orb_task_number(&staged.source_id))
-        .max();
-    let existing_max = registry.max_registered_task_number()?;
-    let floor = [kept_max, existing_max]
-        .into_iter()
-        .flatten()
-        .max()
-        .map(|value| value + 1)
-        .unwrap_or(0);
-    registry.bump_allocator_to_at_least(floor)?;
+    // Only renumbering mints, so no other policy moves the counter here.
+    if !to_renumber.is_empty() {
+        let kept_max = kept
+            .iter()
+            .filter_map(|staged| parse_orb_task_number(&staged.source_id))
+            .max();
+        let existing_max = registry.max_registered_task_number()?;
+        let floor = [kept_max, existing_max]
+            .into_iter()
+            .flatten()
+            .max()
+            .map(|value| value + 1)
+            .unwrap_or(0);
+        registry.bump_allocator_to_at_least(floor)?;
+    }
 
     // Allocate new ids for collisions (deterministic order by source id).
     to_renumber.sort_by(|a, b| a.source_id.cmp(&b.source_id));
@@ -416,7 +472,8 @@ pub fn import_tasks(
         id_remap.insert(staged.source_id.clone(), new_id);
     }
 
-    // Write kept + renumbered bundles, rewriting relation targets in the set.
+    // Write kept + renumbered bundles, rewriting relation targets in the set,
+    // then replace the mirrors their owner has changed.
     let write_result = (|| -> Result<Vec<u32>, OrbitError> {
         let mut landed_numbers = Vec::new();
         for staged in kept.iter().chain(to_renumber.iter()) {
@@ -443,13 +500,31 @@ pub fn import_tasks(
             guard.written_dirs.push(dir.clone());
             registry.register_task_bundle(&final_id, &target.workspace_id, &dir)?;
             guard.registered_ids.push(final_id.clone());
-            if let Some(number) = parse_orb_task_number(&final_id) {
+            if let Some(number) = local_task_number(&final_id, &local_prefix) {
                 landed_numbers.push(number);
             }
             records.push(ImportedTask {
                 source_id: staged.source_id.clone(),
                 final_id,
                 action,
+            });
+        }
+
+        // Owner-wins replacements land under their own (foreign) ids, so they
+        // are already registered and never touch the local allocator.
+        for replacement in &to_overwrite {
+            let staged = &replacement.staged;
+            // Readers and writers of this bundle coordinate on the same sibling
+            // lock file, which outlives the directory swap.
+            with_exclusive_file_lock(
+                &bundle_lock_target(&replacement.bundle_dir),
+                "task migration import",
+                || replace_bundle_at(&replacement.bundle_dir, &staged.bundle, &staged.staging_dir),
+            )?;
+            records.push(ImportedTask {
+                source_id: staged.source_id.clone(),
+                final_id: staged.source_id.clone(),
+                action: ImportAction::Updated,
             });
         }
         Ok(landed_numbers)
@@ -489,6 +564,45 @@ pub fn import_tasks(
         id_remap,
         id_map_path,
     })
+}
+
+/// What owner-wins does with one colliding id.
+enum MirrorVerdict {
+    /// The id is under the local prefix, so the local copy is authoritative.
+    LocalOwned,
+    /// The owner's copy supersedes the local mirror at this bundle directory.
+    Replace(PathBuf),
+}
+
+/// Decide a colliding id from its prefix alone: this host's own ids are never
+/// overwritten, and any other host's id is refreshed in place.
+fn owner_wins_verdict(
+    source_id: &str,
+    existing: &TaskBundleBinding,
+    target_workspace_id: &str,
+    local_prefix: &str,
+) -> Result<MirrorVerdict, OrbitError> {
+    if task_id_prefix(source_id) == Some(local_prefix) {
+        return Ok(MirrorVerdict::LocalOwned);
+    }
+    // Replacing in place keeps the mirror where the registry already binds it;
+    // moving a task between workspaces is a reconciliation this rule cannot
+    // decide from the id.
+    if existing.workspace_id != target_workspace_id {
+        return Err(OrbitError::InvalidInput(format!(
+            "task id '{source_id}' is registered to workspace '{}' locally but this archive lands in '{target_workspace_id}'; resolve the workspace before syncing",
+            existing.workspace_id
+        )));
+    }
+    Ok(MirrorVerdict::Replace(existing.canonical_path.clone()))
+}
+
+/// Numeric suffix of `task_id`, but only for ids this host mints. A mirror
+/// carries its owner's numbering, which must not advance the local allocator.
+fn local_task_number(task_id: &str, local_prefix: &str) -> Option<u32> {
+    (task_id_prefix(task_id) == Some(local_prefix))
+        .then(|| parse_orb_task_number(task_id))
+        .flatten()
 }
 
 fn read_manifest(staging: &Path) -> Result<TaskMigrationManifest, OrbitError> {
@@ -671,6 +785,12 @@ impl<'a> WriteGuard<'a> {
     /// first (they reference the dirs), then the bundle directories. Failures
     /// are logged, not propagated — the caller is already returning the original
     /// error.
+    ///
+    /// Owner-wins replacements are deliberately *not* undone: the bundle they
+    /// overwrote was a mirror, the copy now on disk is the owner's current one,
+    /// and restoring the stale mirror would be the wrong direction. Their index
+    /// rows can be left behind the bundle until the next successful sync (or
+    /// `orbit task reindex`) rebuilds them.
     fn rollback(&mut self) {
         for id in self.registered_ids.drain(..) {
             // workspace_id is not needed to look up the (global) binding, but the

--- a/crates/orbit-store/src/workflow/task/tests/mod.rs
+++ b/crates/orbit-store/src/workflow/task/tests/mod.rs
@@ -21,6 +21,7 @@ use crate::repository::task::v2_bundle::TaskBundleStoreV2;
 use super::*;
 
 mod inspect;
+mod owner_wins;
 mod publication;
 mod publish;
 mod restore;

--- a/crates/orbit-store/src/workflow/task/tests/owner_wins.rs
+++ b/crates/orbit-store/src/workflow/task/tests/owner_wins.rs
@@ -1,0 +1,345 @@
+//! Owner-wins import: the id prefix decides which colliding bundles a
+//! cross-host sync may overwrite. Here the importing host mints
+//! [`LOCAL_PREFIX`], so every `ORB-` id is a mirror of the peer's task and
+//! every `DANI-` id is locally owned.
+
+use std::path::Path;
+use std::slice;
+
+use tempfile::TempDir;
+
+use super::*;
+
+/// Prefix the importing host mints under.
+const LOCAL_PREFIX: &str = "DANI";
+
+/// Destination registry for a host that mints [`LOCAL_PREFIX`]. The prefix is
+/// adopted before anything is seeded, because a registry that has already
+/// allocated refuses to be renamed.
+fn open_mirror_registry(global: &Path) -> TaskRegistryStore {
+    let registry = open_registry(global);
+    registry
+        .set_task_prefix(LOCAL_PREFIX)
+        .expect("adopt the local prefix");
+    registry
+}
+
+/// Pack `bundles` into `archive` as the owning host would. Each call uses its
+/// own source root, so exporting a changed version of a task is just another
+/// call with different content under the same id.
+fn export_owner_archive(global: &Path, ws_id: &str, archive: &Path, bundles: &[TaskBundleV2]) {
+    let registry = open_registry(global);
+    let binding = bind(&registry, global, ws_id);
+    let store = bundle_store(&registry, &binding);
+    for bundle in bundles {
+        seed(&store, &registry, ws_id, bundle);
+    }
+    export_tasks(
+        &registry,
+        ws_id,
+        ExportSelection::All,
+        archive,
+        exported_at(),
+    )
+    .expect("export owner archive");
+}
+
+/// A `depends_on` edge: dependencies are persisted as `blocked_by` relations.
+fn blocked_by(target: &str) -> TaskRelation {
+    TaskRelation {
+        relation_type: TaskRelationType::BlockedBy,
+        target: target.to_string(),
+    }
+}
+
+/// The owning host moves a task on. Envelope status and event log advance
+/// together, because a bundle whose last event disagrees with its status does
+/// not validate.
+fn advanced_to(bundle: &TaskBundleV2, status: TaskStatus) -> TaskBundleV2 {
+    let mut moved = bundle.clone();
+    moved.envelope.status = status;
+    moved.events.push(TaskEventRowV2 {
+        schema_version: TASK_ARTIFACT_SCHEMA_VERSION,
+        event_id: "EV-0002".to_string(),
+        at: moved.envelope.updated_at,
+        by: "codex".to_string(),
+        event_type: "status_changed".to_string(),
+        note: None,
+        from_status: Some(bundle.envelope.status),
+        to_status: Some(status),
+    });
+    moved
+}
+
+fn landed_bundle(registry: &TaskRegistryStore, ws: &str, task_id: &str) -> TaskBundleV2 {
+    read_bundle_at(
+        &registry
+            .canonical_task_bundle_path(ws, task_id)
+            .expect("canonical path"),
+    )
+    .expect("read landed bundle")
+}
+
+fn id_map_path_for(archive: &Path) -> PathBuf {
+    let mut os = archive.as_os_str().to_owned();
+    os.push(".idmap.json");
+    PathBuf::from(os)
+}
+
+#[test]
+fn owner_wins_replaces_a_changed_foreign_mirror() {
+    let first_export = TempDir::new().unwrap();
+    let second_export = TempDir::new().unwrap();
+    let dst = TempDir::new().unwrap();
+    let ws = "orbit-owner-aaaaaa";
+
+    let mirrored = make_bundle("ORB-00000", "root task", Vec::new());
+    let archive = first_export.path().join("tasks.tar.zst");
+    export_owner_archive(
+        first_export.path(),
+        ws,
+        &archive,
+        slice::from_ref(&mirrored),
+    );
+
+    let registry = open_mirror_registry(dst.path());
+    bind(&registry, dst.path(), ws);
+    import_tasks(&registry, &archive, None, ImportConflictPolicy::OwnerWins).expect("first sync");
+
+    // The owner moved the task on, so the local mirror is now stale.
+    let mut owner_copy = advanced_to(&mirrored, TaskStatus::Review);
+    owner_copy.execution_summary = "landed on the owning host".to_string();
+    let refreshed = second_export.path().join("tasks.tar.zst");
+    export_owner_archive(
+        second_export.path(),
+        ws,
+        &refreshed,
+        slice::from_ref(&owner_copy),
+    );
+
+    let outcome =
+        import_tasks(&registry, &refreshed, None, ImportConflictPolicy::OwnerWins).expect("resync");
+
+    assert_eq!(outcome.tasks.len(), 1);
+    assert_eq!(outcome.tasks[0].action, ImportAction::Updated);
+    assert_eq!(outcome.tasks[0].final_id, "ORB-00000");
+    assert!(outcome.id_remap.is_empty(), "owner-wins never renumbers");
+    assert!(outcome.id_map_path.is_none());
+
+    assert_eq!(landed_bundle(&registry, ws, "ORB-00000"), owner_copy);
+    assert_eq!(
+        registry
+            .global_task_status_index()
+            .unwrap()
+            .get("ORB-00000"),
+        Some(&TaskStatus::Review),
+        "the index row follows the replaced bundle"
+    );
+    assert_eq!(
+        registry.tasks_for_workspace(ws).unwrap().len(),
+        1,
+        "the update reuses the mirror's id"
+    );
+    assert_eq!(
+        registry.allocator_next_number().unwrap(),
+        0,
+        "a foreign mirror never consumes a local id"
+    );
+}
+
+#[test]
+fn owner_wins_keeps_locally_owned_tasks() {
+    let src = TempDir::new().unwrap();
+    let dst = TempDir::new().unwrap();
+    let ws = "orbit-owner-bbbbbb";
+
+    // The peer's archive carries one of its own tasks plus a stale mirror of
+    // ours — that mirror must not come back at us.
+    let archive = src.path().join("tasks.tar.zst");
+    export_owner_archive(
+        src.path(),
+        ws,
+        &archive,
+        &[
+            make_bundle("ORB-00001", "peer-owned task", Vec::new()),
+            make_bundle("DANI-00007", "stale mirror of our task", Vec::new()),
+        ],
+    );
+
+    let registry = open_mirror_registry(dst.path());
+    let binding = bind(&registry, dst.path(), ws);
+    let store = bundle_store(&registry, &binding);
+    let local = make_bundle("DANI-00007", "local truth", Vec::new());
+    seed(&store, &registry, ws, &local);
+
+    let outcome =
+        import_tasks(&registry, &archive, None, ImportConflictPolicy::OwnerWins).expect("sync");
+
+    let ours = outcome
+        .tasks
+        .iter()
+        .find(|task| task.source_id == "DANI-00007")
+        .expect("record for the locally owned task");
+    assert_eq!(ours.action, ImportAction::SkippedLocalOwned);
+    assert_eq!(ours.final_id, "DANI-00007", "no fresh id is minted");
+    assert!(outcome.id_remap.is_empty());
+    assert!(outcome.id_map_path.is_none());
+    assert_eq!(landed_bundle(&registry, ws, "DANI-00007"), local);
+
+    let theirs = outcome
+        .tasks
+        .iter()
+        .find(|task| task.source_id == "ORB-00001")
+        .expect("record for the peer-owned task");
+    assert_eq!(theirs.action, ImportAction::Kept);
+    assert_eq!(
+        registry.tasks_for_workspace(ws).unwrap().len(),
+        2,
+        "one local task plus one new mirror"
+    );
+}
+
+#[test]
+fn owner_wins_second_run_changes_nothing() {
+    let first_export = TempDir::new().unwrap();
+    let second_export = TempDir::new().unwrap();
+    let dst = TempDir::new().unwrap();
+    let ws = "orbit-owner-cccccc";
+
+    let mirrored = make_bundle("ORB-00000", "root task", Vec::new());
+    let archive = first_export.path().join("tasks.tar.zst");
+    export_owner_archive(
+        first_export.path(),
+        ws,
+        &archive,
+        slice::from_ref(&mirrored),
+    );
+
+    let registry = open_mirror_registry(dst.path());
+    bind(&registry, dst.path(), ws);
+    import_tasks(&registry, &archive, None, ImportConflictPolicy::OwnerWins).expect("first sync");
+
+    let owner_copy = advanced_to(&mirrored, TaskStatus::Done);
+    let refreshed = second_export.path().join("tasks.tar.zst");
+    export_owner_archive(
+        second_export.path(),
+        ws,
+        &refreshed,
+        slice::from_ref(&owner_copy),
+    );
+
+    let updating =
+        import_tasks(&registry, &refreshed, None, ImportConflictPolicy::OwnerWins).expect("resync");
+    assert_eq!(updating.tasks[0].action, ImportAction::Updated);
+
+    let repeated = import_tasks(&registry, &refreshed, None, ImportConflictPolicy::OwnerWins)
+        .expect("repeat the same sync");
+    assert!(
+        repeated
+            .tasks
+            .iter()
+            .all(|task| task.action == ImportAction::AlreadyPresent),
+        "a settled mirror is already present: {:?}",
+        repeated.tasks
+    );
+    assert!(repeated.id_remap.is_empty());
+    assert!(repeated.id_map_path.is_none());
+    assert!(
+        !id_map_path_for(&refreshed).exists(),
+        "an idempotent sync writes no id map"
+    );
+
+    assert_eq!(landed_bundle(&registry, ws, "ORB-00000"), owner_copy);
+    assert_eq!(registry.tasks_for_workspace(ws).unwrap().len(), 1);
+    assert_eq!(registry.allocator_next_number().unwrap(), 0);
+}
+
+#[test]
+fn owner_wins_preserves_foreign_relation_targets() {
+    let first_export = TempDir::new().unwrap();
+    let second_export = TempDir::new().unwrap();
+    let dst = TempDir::new().unwrap();
+    let ws = "orbit-owner-dddddd";
+
+    let blocker = make_bundle("ORB-00000", "peer blocker", Vec::new());
+    let dependent = make_bundle("ORB-00001", "peer dependent", vec![blocked_by("ORB-00000")]);
+    let archive = first_export.path().join("tasks.tar.zst");
+    export_owner_archive(
+        first_export.path(),
+        ws,
+        &archive,
+        &[blocker.clone(), dependent.clone()],
+    );
+
+    let registry = open_mirror_registry(dst.path());
+    bind(&registry, dst.path(), ws);
+    import_tasks(&registry, &archive, None, ImportConflictPolicy::OwnerWins).expect("first sync");
+
+    // The owner advances the dependent while the dependency stands.
+    let owner_copy = advanced_to(&dependent, TaskStatus::InProgress);
+    let refreshed = second_export.path().join("tasks.tar.zst");
+    export_owner_archive(
+        second_export.path(),
+        ws,
+        &refreshed,
+        &[blocker, owner_copy.clone()],
+    );
+
+    let outcome =
+        import_tasks(&registry, &refreshed, None, ImportConflictPolicy::OwnerWins).expect("resync");
+    let updated = outcome
+        .tasks
+        .iter()
+        .find(|task| task.source_id == "ORB-00001")
+        .expect("record for the dependent");
+    assert_eq!(updated.action, ImportAction::Updated);
+
+    let landed = landed_bundle(&registry, ws, "ORB-00001");
+    assert_eq!(landed, owner_copy);
+    assert_eq!(
+        landed.envelope.relations,
+        vec![blocked_by("ORB-00000")],
+        "a foreign dependency target is kept verbatim"
+    );
+    assert_eq!(
+        registry
+            .indexed_relation_targets(ws, "ORB-00001", TaskRelationType::BlockedBy)
+            .unwrap(),
+        vec!["ORB-00000".to_string()],
+        "the rebuilt index keeps pointing at the owner's id"
+    );
+}
+
+#[test]
+fn owner_wins_refuses_to_move_a_mirror_between_workspaces() {
+    let src = TempDir::new().unwrap();
+    let dst = TempDir::new().unwrap();
+    let archive_ws = "orbit-owner-eeeeee";
+    let other_ws = "orbit-owner-ffffff";
+
+    let incoming = make_bundle("ORB-00002", "peer-owned task", Vec::new());
+    let archive = src.path().join("tasks.tar.zst");
+    export_owner_archive(src.path(), archive_ws, &archive, slice::from_ref(&incoming));
+
+    // The local mirror of the same id is bound to a different workspace.
+    let registry = open_mirror_registry(dst.path());
+    let other = bind(&registry, dst.path(), other_ws);
+    let store = bundle_store(&registry, &other);
+    let local = make_bundle("ORB-00002", "mirror in another workspace", Vec::new());
+    seed(&store, &registry, other_ws, &local);
+    bind(&registry, dst.path(), archive_ws);
+
+    let error = import_tasks(&registry, &archive, None, ImportConflictPolicy::OwnerWins)
+        .expect_err("a cross-workspace mirror needs reconciliation, not a silent move");
+    assert!(
+        format!("{error}").contains("resolve the workspace before syncing"),
+        "unexpected error: {error}"
+    );
+
+    assert_eq!(landed_bundle(&registry, other_ws, "ORB-00002"), local);
+    assert_eq!(
+        registry.tasks_for_workspace(archive_ws).unwrap().len(),
+        0,
+        "the refused import writes nothing"
+    );
+}

--- a/docs/design/task-migration/1_overview.md
+++ b/docs/design/task-migration/1_overview.md
@@ -56,6 +56,10 @@ machine a disjoint id range).
   hosts with different prefixes cannot collide, whatever their counters say.
 - **Owner** — the host whose prefix a task carries. Only the owner mutates the
   task; any copy elsewhere is a read-only mirror.
+- **Owner-wins** — the import policy that syncs those mirrors:
+  `--on-conflict=owner-wins` replaces a colliding foreign-prefix bundle with the
+  owner's copy, leaves a colliding local-prefix bundle alone, and never
+  renumbers.
 - **`id_start`** — a forward-only floor for the allocator. Predates prefixes
   (machine A took `0–9999`, machine B `10000+`); now redundant for collision
   avoidance and kept only as a harmless floor.
@@ -74,7 +78,7 @@ machine a disjoint id range).
 | Runtime facades | [crates/orbit-core/src/bootstrap/task_migration.rs](../../../crates/orbit-core/src/bootstrap/task_migration.rs) | [ORB-00034] |
 | CLI surfaces | [crates/orbit-cli/src/command/task/export.rs](../../../crates/orbit-cli/src/command/task/export.rs), [import.rs](../../../crates/orbit-cli/src/command/task/import.rs) | [ORB-00034] |
 | `[tasks] id_start` config | [crates/orbit-config/src/raw.rs](../../../crates/orbit-config/src/raw.rs) | [ORB-00034] |
-| Owner-wins sync (planned) | — | [ORB-12126] |
+| Owner-wins mirror sync | [crates/orbit-store/src/workflow/task/mod.rs](../../../crates/orbit-store/src/workflow/task/mod.rs) | [ORB-12126] |
 
 ## 4. The migration recipe
 
@@ -110,7 +114,9 @@ fresh ids. Import a renumber archive once; the printed `.idmap.json` is the
 record of what landed.
 
 `--on-conflict=skip` imports the non-colliding tasks and drops the rest;
-`--on-conflict=fail` aborts the whole import on the first collision.
+`--on-conflict=fail` aborts the whole import on the first collision;
+`--on-conflict=owner-wins` syncs mirrors from their owning host — see
+[§5](#5-multi-host-authority).
 
 ### Preventing future collisions
 
@@ -185,12 +191,24 @@ algorithm:
   [remote-access](../remote-access/1_overview.md)). A route that targets a
   specific host fails loudly when that host is down; it never falls back to the
   local prefix, because the operator chose which host runs the work.
-- **Mirrors are snapshots today.** Export/import is one-shot: a foreign task that
-  already landed and then changed on its owner is a *conflict* on re-import
-  (`renumber` duplicates it, `skip` drops the update, `fail` aborts). The
-  owner-wins import policy that turns this into a repeatable sync — overwrite
-  local bundles whose prefix is foreign, never touch local-prefix ones — is
-  tracked as [ORB-12126]; see [3_vision](./3_vision.md).
+- **Owner-wins import syncs the mirrors.** The other policies are one-shot: a
+  foreign task that already landed and then changed on its owner is a *conflict*
+  on re-import (`renumber` duplicates it, `skip` drops the update, `fail`
+  aborts). `--on-conflict=owner-wins` resolves it from the id alone — a
+  colliding foreign-prefix bundle is replaced by the owner's copy (reported
+  `updated`), a colliding local-prefix bundle is left untouched (reported
+  `skipped-local-owned`), and nothing is ever renumbered ([ORB-12126]).
+  Because it never mints, foreign relation targets survive verbatim, no
+  `.idmap.json` is written, and re-running the same archive reports every task
+  as `already-present` — so it is safe on a timer:
+
+  ```sh
+  orbit task import /tmp/peer-tasks.tar.zst --on-conflict=owner-wins
+  ```
+
+  Pull before push: a cross-host `depends_on` only resolves once its target's
+  mirror has landed. A failed run is re-runnable rather than rolled back —
+  replacements already applied stay, since the owner's copy is the newer one.
 
 The reasoning for choosing prefix ownership over a single authoritative host is
 in [4_decisions](./4_decisions.md).

--- a/docs/design/task-migration/3_vision.md
+++ b/docs/design/task-migration/3_vision.md
@@ -24,10 +24,10 @@ unless it cites a task.
 
 ## 1. Open Questions
 
-1. **Policy or command?** The core deliverable of [ORB-12126] is an import
-   policy — working name `--on-conflict owner-wins` — that overwrites a local
-   bundle only when the incoming task's prefix differs from the local
-   `task_prefix`, and never touches a local-prefix bundle. A convenience wrapper
+1. **Policy or command?** *Half-answered:* the import policy shipped as
+   `--on-conflict=owner-wins` ([ORB-12126]) — it replaces a local bundle only
+   when the incoming task's prefix differs from the local `task_prefix`, and
+   never touches a local-prefix bundle. A convenience wrapper
    (`orbit task sync <ssh-dest>`: export on the peer over SSH, import locally,
    then the reverse) can come later or not at all; scripts already compose the
    two halves. Should the wrapper exist in the binary, or stay a runbook?
@@ -49,10 +49,11 @@ unless it cites a task.
    [ORB-12126]. The global frictions store has the same two-writer shape; the
    docs corpus does not (it is git). Do frictions get the same prefix-ownership
    treatment, or a simpler append-only merge?
-6. **Idempotency proof.** Owner-wins must be a no-op on a second identical run
-   and must never write an `.idmap.json`. Is byte-identical bundle comparison
-   (today's `AlreadyPresent` test) sufficient, or does the manifest need a
-   per-task content hash so the comparison is cheap over SSH?
+6. **Idempotency proof.** *Answered for now:* the shipped policy reuses the
+   byte-identical bundle comparison, so a second identical run reports every
+   task `already-present` and writes no `.idmap.json`. Open only at scale: does
+   the manifest need a per-task content hash so the comparison is cheap over
+   SSH?
 
 ## 2. Prior Work
 

--- a/docs/design/task-migration/4_decisions.md
+++ b/docs/design/task-migration/4_decisions.md
@@ -38,9 +38,10 @@ write set so nothing ever needs merging.
 Authority follows the id's `task_prefix` ([ORB-10721]), not the machine. Any
 host may register any workspace and mint tasks in it under its own prefix. The
 host that minted a task is its sole writer; a copy on any other host is a
-read-only mirror. `import_tasks` will grow an owner-wins conflict policy that
-overwrites foreign-prefix bundles unconditionally and never overwrites
-local-prefix ones ([ORB-12126]); until it lands, mirrors are snapshots.
+read-only mirror. `import_tasks` carries the matching owner-wins conflict
+policy: it replaces foreign-prefix bundles with the owner's copy and never
+overwrites a local-prefix one ([ORB-12126]), which makes a repeated import a
+mirror sync rather than a collision.
 
 ### Consequences
 

--- a/plugin/skills/orbit/references/setup/maintenance.md
+++ b/plugin/skills/orbit/references/setup/maintenance.md
@@ -159,6 +159,8 @@ For archive migration, `orbit task export --output <archive.tar.zst> --ids <id>,
 selects tasks (omitting IDs exports all). `orbit task import <archive.tar.zst>`
 defaults to renumbering collisions and rewriting references; choose
 `--on-conflict fail` or `skip` deliberately when appropriate. Inspect the returned
-ID mapping. Import is a different operation from publication's strict
+ID mapping. To keep a read-only mirror of another host's tasks in step, use
+`--on-conflict owner-wins`: it replaces only bundles whose task-ID prefix belongs
+to that host, never touches locally minted IDs, and is safe to re-run. Import is a different operation from publication's strict
 same-authority, identical-retry recovery; do not substitute it to bypass a
 publication ownership or divergence error.


### PR DESCRIPTION
## Task

[ORB-12126](https://orbit-cli.com/tasks/ORB-12126) — Owner-wins cross-host task sync: import policy that overwrites only foreign-prefix bundles

### Description

Polaris CONVENTIONS now defines task authority per task_prefix (box mints ORB-*, mac mints DANI-*; the minting host is the sole writer; a task runs where it was minted; the other host holds a read-only mirror). The existing `orbit task export/import` is one-shot: in import_tasks (crates/orbit-store/src/workflow/task/mod.rs, find_task_binding branch) an incoming id that already exists locally is a no-op only when the bundle is byte-identical; if the owner changed the task (status, verdict, relations) the re-import is a conflict — `renumber` mints a duplicate, `skip` drops the update, `fail` aborts. So a periodic mac<->box sync corrupts or stalls on its second run.

Add an owner-wins import policy (working name: `--on-conflict owner-wins`, or a dedicated `orbit task sync`): for an incoming bundle whose task-id prefix != the local host's task_prefix (~/.orbit/host.toml), overwrite the local bundle unconditionally (the owner is authoritative) and rebuild its index row; for an incoming bundle whose prefix == the local prefix, never overwrite (the local copy is authoritative) — report it as skipped-local-owned. Must be idempotent across re-runs. Relations that target foreign-prefix ids must be preserved verbatim (no renumbering) so cross-host depends_on resolves once the mirror lands; the sync should pull before push. Network is mac->box only (mac accepts no inbound SSH), so the driver runs mac-side; `orbit task sync <ssh-dest>` may wrap export-over-ssh + local import, but the import policy is the core deliverable and may ship alone.

Out of scope: frictions store sync, docs corpus (already git), merging two writers of the same task (excluded by policy).

### Acceptance Criteria

- Re-importing an archive containing a foreign-prefix task that changed on its owner overwrites the local bundle and index row and reports action 'updated' (or equivalent), with no new id minted
- Importing an archive containing a local-prefix task that differs from the local copy leaves the local copy untouched and reports it as skipped (local-owned), never overwriting or renumbering
- Running the same owner-wins import twice in a row is a no-op on the second run (all records already-present); no .idmap.json is written
- A foreign-prefix task whose depends_on targets another foreign-prefix id keeps that target id verbatim after import
- Unit tests in crates/orbit-store/src/workflow/task/tests cover the four cases above; make ci passes
- The import CLI help and the polaris CONVENTIONS 'Task authority is per prefix' section reference the new policy name

## Execution Summary

<details>
<summary>Click to expand</summary>

Added the owner-wins import policy so `orbit task import` is a repeatable cross-host mirror sync instead of a one-shot migration.

## What changed

- `crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs`: new `replace_bundle_at` — stages and verifies the incoming bundle exactly like a fresh write, then swaps it over the existing directory (rename the old aside, rename the replacement in, drop the retired copy; a failed swap puts the original back). The existence precondition moved out of `write_bundle_atomically` into `refuse_existing_bundle`, so the creation wrappers keep their old behavior and the fault-injection test seam (`publish` closure) is unchanged. Staging/retired paths now share `scratch_sibling_path`.
- `crates/orbit-store/src/driver/sqlite/task_registry/store.rs`: `TaskRegistryStore::local_task_prefix()` reads the host's minting prefix from `allocator_state`.
- `crates/orbit-store/src/workflow/task/mod.rs`: `ImportConflictPolicy::OwnerWins` plus actions `Updated` / `SkippedLocalOwned`. On a non-identical collision, `owner_wins_verdict` decides from the id alone: local prefix ⇒ local copy stands; foreign prefix ⇒ the owner's bundle replaces the mirror in place, under the bundle's sibling write lock. Never renumbers, so `id_remap` stays empty, no `.idmap.json` is written, and relation targets are never rewritten. The allocator headroom bump is now taken only when something is actually renumbered, and only ids under the local prefix advance the counter (`local_task_number`) — a mirror carries its owner's numbering. A colliding id bound to a *different* local workspace is refused with a named error rather than silently relocated. Rollback deliberately does not undo replacements (the copy on disk is the owner's newer one); documented on `WriteGuard::rollback`.
- `crates/orbit-cli/src/command/task/import.rs`: `--on-conflict owner-wins`, with labels `updated` and `skipped-local-owned`.
- Docs: module doc, `docs/design/task-migration/{1_overview,3_vision,4_decisions}.md`, and the orbit skill maintenance reference (+ synced plugin mirror).

## Acceptance criteria

1. **Foreign-prefix update** — met. `owner_wins_replaces_a_changed_foreign_mirror` (host mints `DANI`, mirror is `ORB-00000`): action `Updated`, bundle equals the owner's copy, `global_task_status_index` shows the new status, task count unchanged, allocator still at 0 (no id minted).
2. **Local-prefix skip** — met. `owner_wins_keeps_locally_owned_tasks`: incoming `DANI-00007` differs from the local copy → `SkippedLocalOwned`, local bundle byte-identical to what was seeded, `id_remap` empty; the peer's own `ORB-00001` still lands.
3. **Second run is a no-op** — met. `owner_wins_second_run_changes_nothing`: run 2 updates, run 3 reports every task `AlreadyPresent`, `id_remap` empty, `<archive>.idmap.json` absent on disk.
4. **Foreign `depends_on` verbatim** — met. `owner_wins_preserves_foreign_relation_targets`: `ORB-00001` blocked_by `ORB-00000` keeps the target in the bundle and in the rebuilt `task_bundle_relations` rows after an owner-wins update.
5. **Tests + CI** — tests met: five tests in `crates/orbit-store/src/workflow/task/tests/owner_wins.rs` (the four above plus a cross-workspace refusal). `make ci` itself was not run locally — per AGENTS.md the full gate runs on the PR; the required pre-handoff gates and affected suites were run (below).
6. **CLI help + polaris CONVENTIONS** — half met. `orbit task import --help` now renders `owner-wins: Trust the host that minted the id: …` (verified against the built binary). The polaris CONVENTIONS edit could **not** be applied: everything outside this run's worktree is mounted read-only (`touch /home/…/knowledgebase/polaris/.write-probe` → `Read-only file system`; the directory is `drwxrwxr-x daniel daniel`, so it is the sandbox, not permissions). The exact replacement is attached to this task as `polaris-conventions-owner-wins.patch` — apply with `git apply` in the polaris checkout, then `orbit docs index`. Filed F2026-09-130 for the structural issue.

## Validation

- `make ci-fast` — passed (exit 0).
- `make ci-lint` — passed (exit 0; workspace clippy, all targets, warnings denied).
- `cargo test -p orbit-store -p orbit-cli -p orbit-core` — passed (exit 0; orbit-store lib 521 tests incl. the 5 new ones).
- `./target/debug/orbit task import --help` — renders the new `owner-wins` value and its help text.
- `git diff --check` clean; `git status --short` shows only the changed files plus the intended new `tests/owner_wins.rs`.
- `make ci` (full merge gate) — not run locally, by workspace policy; it runs on the PR.
- No end-to-end CLI import was exercised: that needs a disposable-HOME child process per the mutable-fixture rules, and the policy is tested at the store boundary that owns it. The CLI layer is a thin enum/label mapping, verified by compile plus rendered help.

## Risks / deviations

- A failed owner-wins run is re-runnable rather than rolled back: replacements already applied stay (the owner's copy is newer), and their index rows can lag the bundle until the next successful sync or `orbit task reindex`. Stated in `WriteGuard::rollback` and in 1_overview §5.
- The allocator no longer advances past foreign-prefix ids. This is the intended prefix-authority rule and changes nothing for a single-prefix (`ORB`-only) host, but it is a behavior change for the pre-existing policies too when importing a foreign-prefix archive.
- Scope additions beyond the listed `context_files`, all declared on the task: the bundle-IO replacement primitive and its module re-export, the registry prefix getter, the new test module, and the docs/skill files required to keep shipped descriptions of import behavior accurate.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12126-6aa39dfc`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus