### PR TITLE
[code-review] orbit mcp init/remove refuse a shared Orbit root outright, so a multi-checkout --root layout can no longer register MCP at all

### DIFF
--- a/crates/orbit-cli/src/command/mcp/setup/workspace.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/workspace.rs
@@ -113,6 +113,10 @@ fn registered_checkout_paths(
     };
     let checkout = match explicit_root {
         Some(root) => sole_checkout_for_root(&registry, root)
+            .or_else(|| {
+                checkout_for_cwd(&registry, cwd)
+                    .filter(|checkout| paths_equivalent(&checkout.orbit_dir, root))
+            })
             .ok_or_else(|| explicit_root_resolution_error(&registry, root))?,
         None => {
             let Some(checkout) = checkout_for_cwd(&registry, cwd) else {
@@ -171,8 +175,9 @@ fn checkout_for_cwd<'a>(
 ///
 /// `--root` names a data directory, not a checkout, so it can only name a
 /// checkout when exactly one registered checkout keeps its state there. Several
-/// checkouts sharing one root stay ambiguous and resolution fails rather than
-/// writing into an arbitrary one.
+/// checkouts sharing one root are disambiguated by the current directory in
+/// `registered_checkout_paths`; an outside directory remains ambiguous rather
+/// than writing into an arbitrary checkout.
 fn sole_checkout_for_root<'a>(
     registry: &'a WorkspaceRegistry,
     root: &Path,

--- a/crates/orbit-cli/tests/mcp_setup_root.rs
+++ b/crates/orbit-cli/tests/mcp_setup_root.rs
@@ -285,6 +285,66 @@ fn explicit_root_outranks_a_different_registered_cwd_checkout() {
 }
 
 #[test]
+fn shared_root_mcp_setup_uses_cwd_checkout_for_init_and_remove() {
+    let fixture = SharedRootCheckoutPairFixture::init();
+    let root = fixture.orbit_root.to_str().expect("utf8 shared Orbit root");
+
+    let outside = fixture
+        .orbit(
+            &fixture.elsewhere,
+            &argv(&["--root", root, "mcp", "init", "--claude"]),
+        )
+        .failure();
+    let stderr = String::from_utf8_lossy(&outside.get_output().stderr);
+    assert!(
+        stderr.contains("does not identify exactly one registered checkout"),
+        "unexpected outside-checkout failure: {stderr}"
+    );
+    assert!(!fixture.checkout_a.join(".claude.json").exists());
+    assert!(!fixture.checkout_b.join(".claude.json").exists());
+
+    fixture
+        .orbit(
+            &fixture.checkout_a,
+            &argv(&["--root", root, "mcp", "init", "--claude"]),
+        )
+        .success();
+    assert_eq!(
+        generated_server_args(&fixture.checkout_a.join(".claude.json")),
+        vec!["mcp", "serve", "--workspace", "ws_alpha"]
+    );
+    assert!(!fixture.checkout_b.join(".claude.json").exists());
+
+    fixture
+        .orbit(
+            &fixture.checkout_b,
+            &argv(&["--root", root, "mcp", "init", "--claude"]),
+        )
+        .success();
+    assert_eq!(
+        generated_server_args(&fixture.checkout_b.join(".claude.json")),
+        vec!["mcp", "serve", "--workspace", "ws_beta"]
+    );
+
+    fixture
+        .orbit(
+            &fixture.checkout_a,
+            &argv(&["--root", root, "mcp", "remove", "--claude"]),
+        )
+        .success();
+    assert!(!fixture.checkout_a.join(".claude.json").exists());
+    assert!(fixture.checkout_b.join(".claude.json").exists());
+
+    fixture
+        .orbit(
+            &fixture.checkout_b,
+            &argv(&["--root", root, "mcp", "remove", "--claude"]),
+        )
+        .success();
+    assert!(!fixture.checkout_b.join(".claude.json").exists());
+}
+
+#[test]
 fn a_root_without_a_registered_checkout_refuses_instead_of_writing() {
     let fixture = ExternalRootFixture::init();
     let unrelated_root = fixture
@@ -341,6 +401,113 @@ fn an_unregistered_root_reports_the_root_and_registered_candidates() {
             && stderr.contains(fixture.checkout_b.to_str().expect("utf8 checkout B")),
         "failure must name candidate checkouts: {stderr}"
     );
+}
+
+struct SharedRootCheckoutPairFixture {
+    _temp: TempDir,
+    home: PathBuf,
+    orbit_root: PathBuf,
+    checkout_a: PathBuf,
+    checkout_b: PathBuf,
+    elsewhere: PathBuf,
+}
+
+impl SharedRootCheckoutPairFixture {
+    fn init() -> Self {
+        let temp = tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let orbit_root = temp.path().join("shared-root");
+        let checkout_a = temp.path().join("checkout-a");
+        let checkout_b = temp.path().join("checkout-b");
+        let elsewhere = temp.path().join("elsewhere");
+        for directory in [&home, &elsewhere] {
+            fs::create_dir_all(directory).expect("fixture directory");
+        }
+        init_git_repo(&checkout_a);
+        init_git_repo(&checkout_b);
+
+        let fixture = Self {
+            _temp: temp,
+            home,
+            orbit_root,
+            checkout_a,
+            checkout_b,
+            elsewhere,
+        };
+        let root = fixture.orbit_root.to_str().expect("utf8 shared Orbit root");
+        fixture
+            .orbit(
+                &fixture.checkout_a,
+                &argv(&[
+                    "--root",
+                    root,
+                    "init",
+                    "--non-interactive",
+                    "--host-name",
+                    "shared-root-host",
+                    "--task-prefix",
+                    "SHR",
+                ]),
+            )
+            .success();
+        fixture
+            .orbit(
+                &fixture.checkout_a,
+                &argv(&["--root", root, "workspace", "init", "--name", "alpha"]),
+            )
+            .success();
+        fixture
+            .orbit(
+                &fixture.checkout_b,
+                &argv(&["--root", root, "workspace", "init", "--name", "beta"]),
+            )
+            .success();
+        fixture.assert_shared_root_layout();
+        fixture
+    }
+
+    fn orbit(&self, cwd: &Path, args: &[String]) -> assert_cmd::assert::Assert {
+        let mut command = cargo_bin_cmd!("orbit");
+        test_env::clear_inherited_authority(|name| {
+            command.env_remove(name);
+        });
+        command
+            .current_dir(cwd)
+            .env("HOME", &self.home)
+            .env("USERPROFILE", &self.home)
+            .args(args)
+            .assert()
+    }
+
+    fn assert_shared_root_layout(&self) {
+        for (checkout, workspace_id) in [
+            (&self.checkout_a, "ws_alpha"),
+            (&self.checkout_b, "ws_beta"),
+        ] {
+            let assert = self
+                .orbit(
+                    checkout,
+                    &argv(&[
+                        "--root",
+                        self.orbit_root.to_str().expect("utf8 shared Orbit root"),
+                        "workspace",
+                        "show",
+                        "--format",
+                        "json",
+                    ]),
+                )
+                .success();
+            let shown: Value =
+                serde_json::from_slice(&assert.get_output().stdout).expect("workspace show json");
+            assert_eq!(shown["workspace"]["id"], workspace_id);
+            assert_eq!(shown["checkout"]["repo_root"], canonical_str(checkout));
+            assert_eq!(
+                shown["checkout"]["orbit_dir"],
+                canonical_str(&self.orbit_root)
+            );
+            assert!(!checkout.join(".orbit").exists());
+        }
+    }
 }
 
 struct RegisteredCheckoutPairFixture {


### PR DESCRIPTION
## Task

[ORB-12138](https://orbit-cli.com/tasks/ORB-12138) — [code-review] orbit mcp init/remove refuse a shared Orbit root outright, so a multi-checkout --root layout can no longer register MCP at all

### Description

## Summary

ORB-12129 (`b476273aa`) made an explicit `--root` / `ORBIT_ROOT` outrank the current
directory in `orbit mcp init` / `orbit mcp remove`. The new code no longer falls back
to the cwd at all when a root is given: `registered_checkout_paths`
(`crates/orbit-cli/src/command/mcp/setup/workspace.rs:106-128`) matches on
`explicit_root` first and, when `sole_checkout_for_root` finds anything other than
exactly one checkout, raises `explicit_root_resolution_error`
(`crates/orbit-cli/src/command/mcp/setup/workspace.rs:134-157`) instead of consulting
`checkout_for_cwd`.

`sole_checkout_for_root` (`crates/orbit-cli/src/command/mcp/setup/workspace.rs:176-187`)
matches a checkout by `checkout.orbit_dir == root`. In the shared-root layout every
checkout registered with `orbit --root <dir> workspace init` stores that same `<dir>`
as its `orbit_dir`, so as soon as a second workspace is registered against one root,
`sole_checkout_for_root` returns `None` for every invocation and both commands fail —
even when the operator is standing inside exactly one registered checkout.

That layout is first-class and tested elsewhere: `orbit workspace init` has a dedicated
`registered_shared_root` branch (`crates/orbit-cli/src/command/workspace/init.rs:198-205`,
`validate_shared_root_identity` at `:621`), and
`crates/orbit-cli/tests/shared_root_task_isolation.rs:14-53` registers `alpha` and `beta`
against one `--root`. Because such a checkout carries no repo-local `.orbit`, dropping
`--root` is not a workaround: resolution then falls to `walk_up_checkout_paths`
(`crates/orbit-cli/src/command/mcp/setup/workspace.rs:217-242`) and fails as well. MCP
registration is simply unavailable for that layout.

## Reproduction (disposable HOME under /tmp, inherited authority cleared)

```sh
orbit --root $FIX/shared-root init --non-interactive --host-name shared-host --task-prefix SHR
(cd $FIX/alpha && orbit --root $FIX/shared-root workspace init --name alpha)
(cd $FIX/beta  && orbit --root $FIX/shared-root workspace init --name beta)

(cd $FIX/alpha && orbit --root $FIX/shared-root workspace show --format json)
#   ws_alpha  repo_root=$FIX/alpha  orbit_dir=$FIX/shared-root   <- routing is unambiguous

(cd $FIX/alpha && orbit --root $FIX/shared-root mcp init --claude)
#   error: invalid input: explicit Orbit root '$FIX/shared-root' does not identify exactly
#   one registered checkout; candidate checkouts: $FIX/alpha (Orbit root $FIX/shared-root),
#   $FIX/beta (Orbit root $FIX/shared-root)
#   exit=1
```

Built from `b476273aa` (debug), Linux. Rebuilding the same fixture against `b476273aa^`
(the pre-ORB-12129 `workspace.rs`) instead prints
`mcp init: claude -> $FIX/alpha (ws_alpha)` and writes `$FIX/alpha/.claude.json` bound to
`ws_alpha`, so this is a regression introduced by that commit, not pre-existing behavior.

## Why it matters

ORB-12129's goal — an explicit root must not be overridden by the cwd — is right, but the
cwd is the legitimate *disambiguator* when one root hosts several checkouts, which is
exactly the state `--root` is designed to produce. The result is a loud but total loss of
`orbit mcp init` / `orbit mcp remove` for shared-root installations, with no flag that
recovers it.

## Suggested direction

Keep `--root` authoritative over the *data root*, then disambiguate the checkout within
that root by cwd: when `sole_checkout_for_root` is ambiguous, accept a `checkout_for_cwd`
match whose `orbit_dir` equals the explicit root, and only raise
`explicit_root_resolution_error` when the cwd is outside every checkout registered there.
That preserves the ORB-12129 test
`explicit_root_outranks_a_different_registered_cwd_checkout` (checkout A's cwd does not
live under root B) while restoring the shared-root case.


### Acceptance Criteria

- With two or more checkouts registered against one explicit Orbit root, `orbit --root <root> mcp init` run from inside one of them resolves that checkout and writes its MCP config, instead of failing with 'does not identify exactly one registered checkout'.
- An explicit root still outranks an unrelated registered cwd: running with `--root <root-of-B>` from inside checkout A keeps writing B's config, as ORB-12129 established.
- An explicit root that identifies no registered checkout, and an ambiguous root invoked from outside every checkout registered under it, still fail without writing.
- A regression test covers the shared-root layout for both `orbit mcp init` and `orbit mcp remove`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated explicit-root MCP checkout resolution to retain an exact single-checkout match first, then use the current directory only when it identifies a checkout registered under that same root.
- Added shared-root integration coverage for outside-checkout refusal, per-checkout `mcp init`, and selective `mcp remove` for both registered checkouts.

Acceptance criteria:
- Shared-root `mcp init` from inside a registered checkout passes and writes the config bound to that checkout; covered for both alpha and beta.
- Explicit root precedence over an unrelated cwd remains passing in `explicit_root_outranks_a_different_registered_cwd_checkout`.
- Unregistered explicit roots and ambiguous shared roots invoked outside registered checkouts fail without writing; covered by existing and new tests.
- Shared-root regression coverage exercises both `mcp init` and `mcp remove`, including preservation of the other checkout's config during removal.

Assessment: The change is localized to the resolver boundary and uses the existing path-equivalence and registry path-matching helpers. The focused fixture verifies observable config placement, workspace binding, failure behavior, and cleanup.

Validation:
- `cargo test -p orbit-cli --test mcp_setup_root` — passed, 7/7.
- `cargo fmt --all -- --check` — passed.
- `make ci-fast` — passed. The compiler-cache mount-namespace probe was skipped because this environment denied unprivileged bubblewrap namespaces; other guardrails passed.
- `make ci-lint` — passed, workspace clippy with warnings denied.
- `git diff --check` — passed.
- `GIT_OPTIONAL_LOCKS=0 git status --short` — two expected modified task-scoped files only.

Remaining risk: Validation ran on Linux; the namespace-specific probe was unavailable. The full `make ci` merge gate was not run because workspace guidance reserves it for PR CI.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12138-6aa3a851`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus