### PR TITLE
[code-review] the new mcp init/remove summary names the checkout even under --scope home, where nothing is written there

### DIFF
--- a/crates/orbit-cli/src/command/mcp/setup/args.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/args.rs
@@ -206,20 +206,23 @@ impl InitArgs {
         } else {
             ServerLaunch::local(false, layout.workspace_id.as_deref())
         };
+        let home_dir = env_home_dir();
         let providers = run_action(
             McpAction::Init(launch),
             &layout.repo_root,
             &layout.orbit_root,
             self.providers.resolve_mode()?,
-            env_home_dir(),
+            home_dir.clone(),
             self.scope,
         )?;
         print_action_summary(
             McpAction::Init(launch),
             &providers,
             &layout.repo_root,
+            home_dir.as_deref(),
+            self.scope,
             layout.workspace_id.as_deref(),
-        );
+        )?;
         Ok(CommandOutput::Silent)
     }
 }
@@ -246,20 +249,23 @@ impl RemoveArgs {
         } else {
             McpAction::Remove
         };
+        let home_dir = env_home_dir();
         let providers = run_action(
             action,
             &layout.repo_root,
             &layout.orbit_root,
             self.providers.resolve_mode()?,
-            env_home_dir(),
+            home_dir.clone(),
             self.scope,
         )?;
         print_action_summary(
             action,
             &providers,
             &layout.repo_root,
+            home_dir.as_deref(),
+            self.scope,
             layout.workspace_id.as_deref(),
-        );
+        )?;
         Ok(CommandOutput::Silent)
     }
 }

--- a/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
@@ -297,46 +297,83 @@ pub(super) fn auto_detected_providers(
 /// checkout or in a `--root`-selected checkout the operator isn't standing
 /// in. Naming the path (and, when known, the bound `ws_*` id) turns that
 /// into an audit line instead of a silent no-op.
+///
+/// Workspace scope writes land under `repo_root`, so naming it is accurate.
+/// Home scope (ORB-12139) writes under `home_dir` instead — each provider's
+/// `ConfigTarget::resolve` output is named there so the line still points at
+/// the file the run actually touched, not the unrelated checkout.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn print_action_summary(
     action: McpAction<'_>,
     providers: &[McpProvider],
     repo_root: &Path,
+    home_dir: Option<&Path>,
+    scope: ScopeArg,
     workspace_id: Option<&str>,
-) {
+) -> Result<(), OrbitError> {
     println!(
         "{}",
-        format_action_summary(action, providers, repo_root, workspace_id)
+        format_action_summary(action, providers, repo_root, home_dir, scope, workspace_id)?
     );
+    Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn format_action_summary(
     action: McpAction<'_>,
     providers: &[McpProvider],
     repo_root: &Path,
+    home_dir: Option<&Path>,
+    scope: ScopeArg,
     workspace_id: Option<&str>,
-) -> String {
+) -> Result<String, OrbitError> {
     if providers.is_empty() {
-        return format!("mcp {}: no providers selected", action.label());
+        return Ok(format!("mcp {}: no providers selected", action.label()));
     }
 
-    let labels = providers
-        .iter()
-        .map(|provider| provider.label())
-        .collect::<Vec<_>>()
-        .join(", ");
-    match workspace_id {
-        Some(id) => format!(
-            "mcp {}: {} -> {} ({})",
-            action.label(),
-            labels,
-            repo_root.display(),
-            id
-        ),
-        None => format!(
-            "mcp {}: {} -> {}",
-            action.label(),
-            labels,
-            repo_root.display()
-        ),
+    match scope {
+        ScopeArg::Workspace => {
+            let labels = providers
+                .iter()
+                .map(|provider| provider.label())
+                .collect::<Vec<_>>()
+                .join(", ");
+            Ok(match workspace_id {
+                Some(id) => format!(
+                    "mcp {}: {} -> {} ({})",
+                    action.label(),
+                    labels,
+                    repo_root.display(),
+                    id
+                ),
+                None => format!(
+                    "mcp {}: {} -> {}",
+                    action.label(),
+                    labels,
+                    repo_root.display()
+                ),
+            })
+        }
+        ScopeArg::Home => {
+            // `run_action` already succeeded with this scope, which requires
+            // `require_home_dir` to have resolved a home directory; resolving
+            // it again here for display should not hit the missing-HOME case,
+            // but the error is still propagated rather than assumed away.
+            let home = require_home_dir(home_dir)?;
+            let mut targets = Vec::with_capacity(providers.len());
+            for provider in providers {
+                let target = ConfigTarget::resolve(scope, provider, repo_root, Some(home))?;
+                targets.push(format!(
+                    "{} -> {}",
+                    provider.label(),
+                    target.mcp_path.display()
+                ));
+            }
+            let targets = targets.join(", ");
+            Ok(match workspace_id {
+                Some(id) => format!("mcp {}: {} (bound to {})", action.label(), targets, id),
+                None => format!("mcp {}: {}", action.label(), targets),
+            })
+        }
     }
 }

--- a/crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs
@@ -421,8 +421,11 @@ fn action_summary_names_the_resolved_checkout_and_workspace_id() {
         McpAction::Init(ServerLaunch::default()),
         &[McpProvider::Claude],
         Path::new("/tmp/qa/repoA"),
+        None,
+        ScopeArg::Workspace,
         Some("ws_repoa"),
-    );
+    )
+    .expect("workspace scope summary");
     assert_eq!(summary, "mcp init: claude -> /tmp/qa/repoA (ws_repoa)");
 }
 
@@ -433,7 +436,10 @@ fn action_summary_omits_workspace_id_when_unregistered() {
         &[McpProvider::Claude, McpProvider::Codex],
         Path::new("/tmp/qa/repoA"),
         None,
-    );
+        ScopeArg::Workspace,
+        None,
+    )
+    .expect("workspace scope summary");
     assert_eq!(summary, "mcp remove: claude, codex -> /tmp/qa/repoA");
 }
 
@@ -443,9 +449,55 @@ fn action_summary_skips_path_when_no_providers_selected() {
         McpAction::Init(ServerLaunch::default()),
         &[],
         Path::new("/tmp/qa/repoA"),
+        None,
+        ScopeArg::Workspace,
         Some("ws_repoa"),
-    );
+    )
+    .expect("empty provider summary");
     assert_eq!(summary, "mcp init: no providers selected");
+}
+
+#[test]
+fn action_summary_names_the_resolved_home_scope_file_and_workspace_id() {
+    let home = tempdir().expect("home tempdir");
+    let summary = format_action_summary(
+        McpAction::Init(ServerLaunch::default()),
+        &[McpProvider::Claude],
+        Path::new("/tmp/qa/repoA"),
+        Some(home.path()),
+        ScopeArg::Home,
+        Some("ws_wshome"),
+    )
+    .expect("home scope summary");
+    assert_eq!(
+        summary,
+        format!(
+            "mcp init: claude -> {} (bound to ws_wshome)",
+            home.path().join(".claude").join(".mcp.json").display()
+        )
+    );
+}
+
+#[test]
+fn action_summary_omits_workspace_id_for_home_scope_when_unregistered() {
+    let home = tempdir().expect("home tempdir");
+    let summary = format_action_summary(
+        McpAction::Remove,
+        &[McpProvider::Claude, McpProvider::Codex],
+        Path::new("/tmp/qa/repoA"),
+        Some(home.path()),
+        ScopeArg::Home,
+        None,
+    )
+    .expect("home scope summary");
+    assert_eq!(
+        summary,
+        format!(
+            "mcp remove: claude -> {}, codex -> {}",
+            home.path().join(".claude").join(".mcp.json").display(),
+            home.path().join(".codex").join("config.toml").display()
+        )
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-12139](https://orbit-cli.com/tasks/ORB-12139) — [code-review] the new mcp init/remove summary names the checkout even under --scope home, where nothing is written there

### Description

## Summary

ORB-12132 (`df0fa792d`) added a summary line to `orbit mcp init` / `orbit mcp remove` so
the operator can see where a registry-resolved write landed. The line always names
`layout.repo_root` (`crates/orbit-cli/src/command/mcp/setup/args.rs:217-222` and `:257-262`,
rendered by `format_action_summary` at
`crates/orbit-cli/src/command/mcp/setup/dispatch.rs:312-342`), but the actual write target
is chosen per provider by `ConfigTarget::resolve(scope, ...)`
(`crates/orbit-cli/src/command/mcp/setup/dispatch.rs:20`). With `--scope home` those files
land under `$HOME`, not under the repository — so the audit line names a path the command
did not touch.

## Reproduction (disposable HOME under /tmp, inherited authority cleared)

```sh
(cd $FIX/repo && orbit mcp init --claude --scope home)
#   mcp init: claude -> /tmp/.../repo (ws_wshome)

find $FIX -name '*.json' -not -path '*/.git/*'
#   /tmp/.../home/.claude/.mcp.json        <- what --scope home actually wrote
#   /tmp/.../home/.claude/settings.json
#   (nothing new under /tmp/.../repo)
```

Built from `b476273aa` (debug), Linux.

## Why it matters

The line exists precisely to stop an operator from having to guess which file changed.
Under home scope it points at the repository instead, which is the same class of
misdirection ORB-12132 set out to remove — smaller in blast radius, since the checkout
named is still the one the generated server binds to, but wrong as a record of the write.

## Suggested direction

Have `run_action` return the resolved config paths (or the scope) alongside the providers
and render that in the summary, e.g. `mcp init: claude -> ~/.claude/.mcp.json (bound to
ws_wshome)` for home scope, keeping the current repo-root form for workspace scope.
Extend the existing `format_action_summary` unit tests in
`crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs:418-449` with a home-scope case.


### Acceptance Criteria

- `orbit mcp init --scope home` and `orbit mcp remove --scope home` report a location that the run actually wrote to or removed from, not the repository root.
- The workspace-scope summary keeps naming the resolved checkout and, when known, its `ws_*` binding, as ORB-12132 established.
- A unit test covers the home-scope summary text alongside the existing workspace-scope cases.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed the `orbit mcp init`/`orbit mcp remove` summary line to name the location it actually wrote to under `--scope home`, instead of always naming `repo_root`.

## Changes

- `crates/orbit-cli/src/command/mcp/setup/dispatch.rs`: `format_action_summary`/`print_action_summary` now take `home_dir: Option<&Path>` and `scope: ScopeArg`. For `ScopeArg::Workspace` the output is unchanged (`mcp <action>: <providers> -> <repo_root> (<ws_id>)`). For `ScopeArg::Home` it re-resolves each provider's `ConfigTarget` (the same resolution `run_action` already used to write) and lists `<provider> -> <resolved mcp_path>`, e.g. `mcp init: claude -> /home/x/.claude/.mcp.json (bound to ws_wshome)`. Both functions now return `Result<_, OrbitError>` instead of assuming the home dir is present (avoids `expect()`/`unwrap()`, which `clippy::expect_used`/`unwrap_used` deny under `-D warnings`); the home-scope branch is unreachable in practice because `run_action` already validated the home dir for the same scope, but the error is propagated rather than assumed.
- `crates/orbit-cli/src/command/mcp/setup/args.rs`: `InitArgs`/`RemoveArgs::execute_without_runtime` capture `home_dir` once, pass it (and `self.scope`) into `print_action_summary`, and propagate its new `Result` with `?`.
- `crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs`: updated the three existing `format_action_summary` unit tests for the new signature/`Result`, and added two home-scope cases: one with a known `ws_*` id (single provider) and one without (multiple providers), asserting the exact resolved home path(s) appear in the summary.

`run_action`'s signature and return type (`Vec<McpProvider>`) are unchanged, so the ~15 other test files across `providers/tests/*.rs` that call it needed no changes.

## Acceptance criteria

1. "`orbit mcp init --scope home` / `remove --scope home` report a location that the run actually wrote to" — done. The home-scope branch now names each provider's resolved `mcp_path` (the same `ConfigTarget` value `run_action` wrote to), not `repo_root`.
2. "Workspace-scope summary keeps naming the resolved checkout and `ws_*` binding" — unchanged; covered by the pre-existing `action_summary_names_the_resolved_checkout_and_workspace_id` / `action_summary_omits_workspace_id_when_unregistered` tests (still passing, only updated for the new parameters).
3. "Unit test covers the home-scope summary text alongside workspace-scope cases" — added `action_summary_names_the_resolved_home_scope_file_and_workspace_id` and `action_summary_omits_workspace_id_for_home_scope_when_unregistered` in `tests/dispatch.rs`.

## Validation

- `cargo test -p orbit-cli mcp::setup --bins` — 59 passed, 0 failed.
- `cargo fmt -p orbit-cli -- --check` — passed (clean).
- `cargo clippy -p orbit-cli --all-targets -- -D warnings` — passed, 0 warnings.
- `make ci-fast` — passed.
- `git diff --check` — clean. `git status --short` shows only the 3 files listed above modified; no stray artifacts.
- `make ci-lint` (full workspace clippy) and `make ci` were not run, per workspace instructions reserving those for the merge gate / task-completion checkpoint rather than per-edit local runs; the crate-scoped clippy run above covers the same lint set for the changed crate.

No scope changes were needed beyond the four files already in `context_files` plus the sibling test file (already listed) and `args.rs` (already listed). No new files were created. Left uncommitted per pipeline ownership of commit/PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12139-6aa3a850`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus