### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/auditability/specs/actor-identity.md
+++ b/docs/design/auditability/specs/actor-identity.md
@@ -2,13 +2,14 @@
 type: design
 summary: "Spec: Canonical Audit Actor Identity"
 tags: ["auditability"]
-last_validated: 2026-08-16
+last_validated: 2026-09-11
 ---
 
 # Spec: Canonical Audit Actor Identity
 
 `audit_events.role` is a single free-text label that conflates five unrelated kinds of
-value. Measured over a 30d window on the production audit database:
+value. Measured over a 30d window on the production audit database (as of 2026-08-16;
+not re-verified in this checkout):
 
 | kind | observed values |
 |---|---|
@@ -118,6 +119,6 @@ that is the grain the raw role aggregate already splits on.
 The role-grouped aggregate is retained: it is the raw, un-normalized view, and keeping
 both makes the normalization auditable rather than implicit.
 
-The dashboard summary emits `actor_split` beside `role_split`, and
+The dashboard summary emits `actor_split` beside `role_split`, and `orbit-web`'s
 `audit_event_to_json` exposes `actor`, `actor_kind`, `actor_vendor`, `actor_family`, and
 `actor_model` next to the untouched `role`.

--- a/docs/design/auditability/specs/self-reported-actor.md
+++ b/docs/design/auditability/specs/self-reported-actor.md
@@ -2,13 +2,14 @@
 type: design
 summary: "Spec: Self-Reported Actor Identity for Unauthenticated MCP Calls"
 tags: ["auditability"]
-last_validated: 2026-08-16
+last_validated: 2026-09-11
 ---
 
 # Spec: Self-Reported Actor Identity for Unauthenticated MCP Calls
 
 92.5% of MCP tool calls carry no actor identity. Over a 30d window on the production audit
-database, `subcommand = 'run-mcp'` splits 1373 `unverified` against 112 attributed
+database (as of 2026-08-16; not re-verified in this checkout), `subcommand = 'run-mcp'`
+splits 1373 `unverified` against 112 attributed
 (`agent` 64, `codex` 27, `claude-opus-5` 15, `sonnet` 4, `opus` 2).
 
 The cause is structural, not a bug in the trust check. `audit_role_label_for_entry_point`

--- a/docs/design/task-artifacts/3_vision.md
+++ b/docs/design/task-artifacts/3_vision.md
@@ -4,7 +4,7 @@ type: design
 title: "Task Artifacts — Vision"
 owner: codex
 last_updated: 2026-08-29
-last_validated: 2026-08-16
+last_validated: 2026-09-11
 status: Draft
 feature: task-artifacts
 doc_role: vision

--- a/docs/design/task-artifacts/4_decisions.md
+++ b/docs/design/task-artifacts/4_decisions.md
@@ -4,7 +4,7 @@ type: design
 title: "Task Artifacts — Decisions"
 owner: codex
 last_updated: 2026-08-11
-last_validated: 2026-08-16
+last_validated: 2026-09-11
 status: Draft
 feature: task-artifacts
 doc_role: decisions
@@ -102,6 +102,10 @@ Store lifecycle/history events in `events.jsonl`, task comments in `comments.jso
 - Audit readers can stream events without parsing the envelope.
 - Review prose can be stored as Markdown while thread metadata stays structured.
 - Cost: reads that need the complete task now load several files. Event-log corruption handling and partial-write recovery become part of the store contract.
+
+**Superseded 2026-09-11:** The current task-bundle contract treats legacy `review-threads/`
+directories as inert sidecars and the review-thread surface as retired; see [Retired Review-Thread Sidecars](./specs/task-bundle-v2.md#retired-review-thread-sidecars).
+This note preserves the historical decision above.
 
 
 ## Typed relations over scattered link fields

--- a/docs/design/task-artifacts/references/glossary.md
+++ b/docs/design/task-artifacts/references/glossary.md
@@ -2,7 +2,7 @@
 type: design
 summary: "Glossary: Task Artifacts"
 tags: ["task-artifacts"]
-last_validated: 2026-08-16
+last_validated: 2026-09-11
 ---
 
 # Glossary: Task Artifacts

--- a/docs/design/user-interface/1_overview.md
+++ b/docs/design/user-interface/1_overview.md
@@ -4,7 +4,7 @@ type: design
 title: "User Interface — Overview"
 owner: gemini
 last_updated: 2026-08-15
-last_validated: 2026-08-16
+last_validated: 2026-09-11
 status: Draft
 feature: user-interface
 doc_role: overview


### PR DESCRIPTION
## Task

[ORB-12137](https://orbit-cli.com/tasks/ORB-12137) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Batch selection:
- The in-scope Markdown inventory was ordered by real `last_validated` date with path tie-break. The six selected documents were the six context files, all at the oldest real date (2026-08-16): `docs/design/auditability/specs/actor-identity.md`, `docs/design/auditability/specs/self-reported-actor.md`, `docs/design/task-artifacts/3_vision.md`, `docs/design/task-artifacts/4_decisions.md`, `docs/design/task-artifacts/references/glossary.md`, and `docs/design/user-interface/1_overview.md`. Template `YYYY-MM-DD` placeholders were not treated as real dates. No selected document was frontmatter-less.

Changes and evidence:
- `docs/design/auditability/specs/actor-identity.md`: verified `CanonicalActor`, alias map/version, v16 migration/backfill, actor aggregate, and dashboard projection against `crates/orbit-types/src/telemetry/audit_actor.rs`, `crates/orbit-store/src/driver/sqlite/migration/mod.rs`, `crates/orbit-store/src/driver/sqlite/audit_event_store/mod.rs`, `crates/orbit-web/src/api/audit.rs`, and `crates/orbit-web/src/projections.rs`. Added `last_validated: 2026-09-11`, labeled the production-only measurement “as of 2026-08-16; not re-verified in this checkout,” and qualified canonical JSON as the `orbit-web` projection.
- `docs/design/auditability/specs/self-reported-actor.md`: verified the MCP trust boundary, initialize precedence/normalization, v17 schema, disjoint attribution SQL, CLI rendering/JSON, and dashboard summary against `crates/orbit-core/src/adapter/command/dispatch.rs`, `crates/orbit-engine/src/context/env.rs`, `crates/orbit-mcp/src/adapter/dispatch.rs`, `crates/orbit-types/src/telemetry/self_reported_actor.rs`, `crates/orbit-store/src/driver/sqlite/audit_event_store/mod.rs`, `crates/orbit-cli/src/command/audit/show.rs`, `crates/orbit-cli/src/command/audit/support.rs`, and `crates/orbit-web/src/api/audit.rs`. Added `last_validated: 2026-09-11` and labeled the production-only percentage/counts “as of 2026-08-16; not re-verified in this checkout.”
- `docs/design/task-artifacts/3_vision.md`: verified task-ID formatting/ceiling, canonical bundle location, no checkout projection, and retired review-thread wording against `crates/orbit-types/src/task/artifacts.rs`, `crates/orbit-store/src/repository/task/v2_bundle.rs`, `crates/orbit-store/src/driver/sqlite/task_registry/store.rs`, and `docs/design/task-artifacts/specs/task-bundle-v2.md`. Added `last_validated: 2026-09-11`.
- `docs/design/task-artifacts/4_decisions.md`: verified current v2 bundle paths, sidecars, JSONL, manifest, registry, relations, migration/version, and history-note claims against the task artifact/store sources and current task-bundle spec. Preserved the historical review-thread decision text and added a dated superseded note linking the normative “Retired Review-Thread Sidecars” section. Added `last_validated: 2026-09-11`.
- `docs/design/task-artifacts/references/glossary.md`: verified every listed path/term against `docs/design/task-artifacts/1_overview.md`, `2_design.md`, `4_decisions.md`, and the v2 task store/types. Added `last_validated: 2026-09-11`.
- `docs/design/user-interface/1_overview.md`: verified `orbit-web` ownership, assets/API paths, CLI adapter delegation, theme path, and embedded fonts against `crates/orbit-web/src/lib.rs`, `crates/orbit-web/src/api/`, `crates/orbit-cli/src/command/web.rs`, and `crates/orbit-web/assets/dashboard/dashboard.css`. Added `last_validated: 2026-09-11`.

Unverified or bounded claims:
- The two production-only audit measurements are not observable from this checkout. Their original numeric text was preserved; adjacent annotations explicitly mark the original date/status per the authorized task comment, so they are not presented as newly verified.
- No selected document was left wholly unchanged for uncertain classification. All six already had schema-compatible `type` and single-line `summary`; no frontmatter migration was needed. No new metadata field, sidecar, document, or section was introduced. The superseded review-thread note is an inline paragraph, not a new section.

Acceptance criteria:
- PASS: exact six-document oldest-real-date batch and stable path ordering.
- PASS: every stamped document has named code/source verification above.
- PASS with authorized refinement: unverifiable production claims remain historical and explicitly marked, not newly asserted.
- PASS: no prohibited or generated worktree paths changed.
- PASS: frontmatter-less documents are eligible by the existing tolerant inference contract; none were in this batch.
- PASS: no frontmatter migration was needed; existing `design` types and one-line summaries were already confident/schema-compatible.
- PASS: no uncertain document was stamped without verification; the two bounded claims are reported.
- PASS: no new metadata field, sidecar, or validation-marker system.
- PASS: no new document or section.
- PASS: no prose reflow or formatting-only churn.
- PASS: required `make ci-fast`.

Validation:
- PASS: `make ci-fast` (exit 0). The guardrail suite passed, including docs, history-note, dependency-direction, and plugin checks. Its compiler-cache namespace probe reported an environment limitation (“cannot create a mount namespace”); the probe is an allowed non-blocking skip and the overall required command passed.
- PASS: `git diff --check`.
- PASS: selected-link existence checks, including the normative review-thread link.
- PASS: scope check: exactly six tracked Markdown files changed; no `.orbit/adrs/`, `CHANGELOG.md`, `docs/changelogs/`, `docs/design/_archive/`, `.orbit/tasks/`, `.orbit/graph/`, or generated state changed.
- PASS: `GIT_OPTIONAL_LOCKS=0 git status --short`; only the six intended docs are modified.

Assessment: The bounded batch is complete and the documentation changes are minimal, source-backed, and honest about production evidence limits. Remaining risk is limited to the two historical production metrics, which require retained production evidence to remeasure.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12137-6aa3a850`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus