### PR TITLE
orbit-search install test fixture accepts exactly one connection, so companion_install_streams_a_slow_one_mebibyte_download flakes under load

### DIFF
--- a/crates/orbit-search/src/commands/tests/install.rs
+++ b/crates/orbit-search/src/commands/tests/install.rs
@@ -119,13 +119,22 @@ fn companion_install_reports_a_dead_connection() {
 
 /// Serves `body` in 64 KiB chunks separated by `delay_between_chunks`, so the
 /// whole transfer takes far longer than any single quiet period.
+///
+/// The listener stays open and accepts in a loop (see
+/// [`accept_real_request`]) rather than a single `accept()`, because reqwest
+/// may open and drop a pre-flight/probe connection before the connection
+/// that actually carries the request (ORB-12141 / F2026-09-080): a
+/// single-accept fixture races that probe for the one accepted stream and,
+/// under concurrent load that widens the race window, loses it often enough
+/// to flake `cargo test` runs that share the host with other jobs.
 fn serve_throttled_response(body: Vec<u8>, delay_between_chunks: Duration) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind throttled HTTP server");
     let address = listener.local_addr().expect("throttled server address");
 
     thread::spawn(move || {
-        let (mut stream, _) = listener.accept().expect("accept companion download");
-        consume_request_head(&mut stream);
+        let Some(mut stream) = accept_real_request(&listener) else {
+            return;
+        };
         std::io::Write::write_all(
             &mut stream,
             format!(
@@ -150,6 +159,9 @@ fn serve_throttled_response(body: Vec<u8>, delay_between_chunks: Duration) -> St
 /// Serves response headers and one 64 KiB chunk of a body that promises one
 /// more byte, then holds the socket open without ever sending it. The client
 /// must therefore observe a stalled read rather than a premature EOF.
+///
+/// See [`serve_throttled_response`] for why this loops on accept rather than
+/// taking exactly one connection.
 fn serve_stalled_response() -> String {
     const DELIVERED_PREFIX: usize = 64 * 1024;
 
@@ -157,8 +169,9 @@ fn serve_stalled_response() -> String {
     let address = listener.local_addr().expect("stalled server address");
 
     thread::spawn(move || {
-        let (mut stream, _) = listener.accept().expect("accept companion download");
-        consume_request_head(&mut stream);
+        let Some(mut stream) = accept_real_request(&listener) else {
+            return;
+        };
         std::io::Write::write_all(
             &mut stream,
             format!(
@@ -179,21 +192,54 @@ fn serve_stalled_response() -> String {
     format!("http://{address}/companion")
 }
 
+/// Accepts connections until one sends a complete request head, then returns
+/// that stream. Connections that never complete a head — a dropped probe, a
+/// connect that the client abandons, one that idles past
+/// `PROBE_HEAD_TIMEOUT` — are discarded and the loop keeps accepting, so the
+/// fixture tolerates any number of non-request connections ahead of the real
+/// one. Returns `None` only if the listener itself errors out, which does not
+/// happen in these tests short of process teardown.
+fn accept_real_request(listener: &TcpListener) -> Option<TcpStream> {
+    for stream in listener.incoming() {
+        let mut stream = stream.ok()?;
+        if consume_request_head(&mut stream) {
+            return Some(stream);
+        }
+    }
+    None
+}
+
+/// Bounds how long [`accept_real_request`] waits for a single connection to
+/// send its request head before giving up on it and accepting the next one.
+/// Far below every assertion window in this module, so even a few discarded
+/// probes cannot push a test past its elapsed-time bounds.
+const PROBE_HEAD_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Reads and discards the request head so a fixture responds only after the
 /// client has finished sending its request. hyper rejects a response that
 /// overlaps the request it is still writing (`UnexpectedMessage`), which makes
 /// an eager fixture fail the exchange at random (ORB-11761).
-fn consume_request_head(stream: &mut TcpStream) {
+///
+/// Returns whether a complete head (`\r\n\r\n`) was received. A connection
+/// that closes early or sends nothing within `PROBE_HEAD_TIMEOUT` is treated
+/// as a probe, not an error, so the caller can move on to the next accepted
+/// connection instead of panicking.
+fn consume_request_head(stream: &mut TcpStream) -> bool {
+    stream
+        .set_read_timeout(Some(PROBE_HEAD_TIMEOUT))
+        .expect("set probe read timeout");
+
     let mut head = Vec::new();
     let mut byte = [0; 1];
 
     while !head.ends_with(b"\r\n\r\n") {
         match std::io::Read::read(stream, &mut byte) {
-            Ok(0) => break,
+            Ok(0) => return false,
             Ok(_) => head.push(byte[0]),
-            Err(error) => panic!("read companion request head: {error}"),
+            Err(_) => return false,
         }
     }
+    true
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-12141](https://orbit-cli.com/tasks/ORB-12141) — orbit-search install test fixture accepts exactly one connection, so companion_install_streams_a_slow_one_mebibyte_download flakes under load

### Description

## Observed

Friction F2026-09-080 (ORB-11705 validation, dk-server-1): `cargo test -p orbit-search --lib -- commands::tests::install` fails 4 of 5 runs at pristine HEAD with

```
Execution("failed to download companion: error sending request for url (http://127.0.0.1:<port>/companion)")
```

returned within ~1 s instead of the fixture's ~36 s throttled stream. The failure is load-sensitive (passes when the full crate runs alone), and it reproduces with the ORB-11705 diff excluded, so anyone validating an `orbit-search` change on a busy host may wrongly blame their own diff. This cost ~40 minutes of A/B attribution once already.

## Where

`crates/orbit-search/src/commands/tests/install.rs`:

- `serve_throttled_response` (line ~122) and `serve_stalled_response` (line ~150) bind a `TcpListener` and spawn a thread that calls `listener.accept()` **exactly once**, then serves that one stream and exits. Any additional connection attempt from the HTTP client — a pre-flight/probe connection, a retried connect after the first accept races with the client's connect timeout, or a connection the client drops before sending the request head — either consumes the single accept (leaving the real request with nobody listening) or is refused because the listener has been dropped with the thread.
- `companion_install_streams_a_slow_one_mebibyte_download_without_a_total_timeout` (line ~32) then asserts `elapsed > 35 s`, so the test is also a 36 s wall-clock test; that is by design (it proves there is no total deadline) and should be kept, but the fixture must not be the reason it fails.

## Wanted

Make the fixtures robust to the client's connection behaviour without weakening what the tests assert:

- keep the listener alive for the whole test and accept connections in a loop, serving the throttled/stalled response to whichever connection actually sends a request head (and cleanly closing any that do not);
- do not add retries or sleeps on the client side to paper over the race, and do not `#[ignore]` the test;
- if reqwest's connect behaviour (not the fixture) turns out to be the cause, document the finding in the test module and fix that instead.

### Acceptance Criteria

- `for i in $(seq 10); do cargo test -p orbit-search --lib -- commands::tests::install; done` passes 10/10 on dk-server-1 while at least two other cargo test runs are executing concurrently (reproduce the load condition from F2026-09-080).
- The throttled test still asserts elapsed > 35 s and the stalled test still asserts the client rejects the stalled read; neither assertion is weakened and no test is marked `#[ignore]`.
- Both fixtures accept in a loop for the lifetime of the test (or an equivalent mechanism) and the test module documents why the single-accept shape flaked.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Fix

`crates/orbit-search/src/commands/tests/install.rs`: `serve_throttled_response` and `serve_stalled_response` no longer take a single `listener.accept()`. Both now call a new `accept_real_request()` helper that keeps the `TcpListener` alive and accepts in a loop, discarding any connection that doesn't send a complete request head (a dropped probe/pre-flight connection, or one the client abandons) and serving the throttled/stalled response to whichever connection actually sends one.

`consume_request_head()` changed from `panic!`-on-read-error to returning `bool` (true only on a complete `\r\n\r\n` head), so an incomplete/aborted probe connection is a normal, handled case rather than a test panic. It also sets a `PROBE_HEAD_TIMEOUT` (5s) read timeout on each accepted connection so a probe that never closes and never sends data can't stall the accept loop past a few seconds — well under every elapsed-time assertion in the module (35s / 30s±3x), so it can't push either timed test outside its assertion window even if several probes stack up in one run.

Both fixtures now carry a doc comment explaining why they loop on accept instead of taking one connection (ORB-12141 / F2026-09-080: reqwest can open/drop a probe connection before the one that carries the real request; a single-accept fixture races that probe for the one accepted stream, and the race widens under concurrent host load).

## Acceptance criteria

1. **10/10 concurrent-load reproduction** — `for i in $(seq 10); do cargo test -p orbit-search --lib -- commands::tests::install; done` was run while two other `cargo test` suites (`-p orbit-core --lib`, `-p orbit-engine --lib`) looped concurrently in the background for the full duration, reproducing the load condition from F2026-09-080. Result: `FINAL pass=10 fail=0`, all 22 tests in the module passing every iteration, 0 failures.
2. **Assertions unweakened, no `#[ignore]`** — `companion_install_streams_a_slow_one_mebibyte_download_without_a_total_timeout` still asserts `elapsed > 35s`; `companion_download_bounds_a_stalled_response_after_partial_progress` still asserts the client rejects the stalled read (`elapsed >= COMPANION_STALLED_READ_TIMEOUT`, error contains "failed to read companion download"). Neither assertion was touched. No test in the module is `#[ignore]`d.
3. **Loop-accept + documentation** — both fixtures accept in a loop for the test's lifetime via `accept_real_request`, and the module documents (in doc comments on both fixtures and on `accept_real_request`) why the single-accept shape flaked and how the loop fixes it.

## Validation

- `cargo build -p orbit-search --lib --tests` — passed, clean build.
- `cargo test -p orbit-search --lib -- commands::tests::install` (single run, no induced load) — passed, 22/22.
- `for i in $(seq 10); do cargo test -p orbit-search --lib -- commands::tests::install; done` under concurrent load (two looped `cargo test` runs on other crates) — passed, 10/10, 0 failures.
- `make ci-fast` — passed.
- `cargo fmt -p orbit-search -- --check` — passed, no diff.
- `make ci-lint` (workspace-wide clippy, warnings denied) — passed, exit code 0, no warnings.
- `git status --short` / `git diff --check` — only `crates/orbit-search/src/commands/tests/install.rs` modified; no whitespace errors.

No deviations or remaining risk identified. Changes left uncommitted per workflow; no commit, push, or status transition performed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12141-6aa3ac19`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus