### PR TITLE
[code-review] owner-wins sync wedges permanently if a mirror's bundle directory is missing: every later run fails and lands nothing

### DIFF
--- a/crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs
+++ b/crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs
@@ -88,24 +88,20 @@ pub(crate) fn write_bundle_with_artifacts_at(
     )
 }
 
-/// Replace the bundle already published at `bundle_dir` with `bundle`.
+/// Replace the bundle published at `bundle_dir` with `bundle`.
 ///
 /// Used by owner-wins task import, where the incoming copy comes from the
 /// task's owning host and supersedes the local mirror wholesale. The
 /// replacement is staged and verified exactly like a fresh write, so the
-/// destination only ever holds a complete bundle; `source_bundle_dir` supplies
-/// the artifact blobs the incoming manifest references.
+/// destination only ever holds a complete bundle. A missing canonical path is
+/// recreated because its registry binding still identifies the owner-wins
+/// mirror. `source_bundle_dir` supplies the artifact blobs the incoming
+/// manifest references.
 pub(crate) fn replace_bundle_at(
     bundle_dir: &Path,
     bundle: &TaskBundleV2,
     source_bundle_dir: &Path,
 ) -> Result<(), OrbitError> {
-    if !bundle_dir.is_dir() {
-        return Err(OrbitError::Store(format!(
-            "no task bundle to replace at {}",
-            bundle_dir.display()
-        )));
-    }
     write_bundle_atomically(
         bundle_dir,
         bundle,
@@ -271,19 +267,66 @@ fn publish_staged_bundle(staging_dir: &Path, bundle_dir: &Path) -> std::io::Resu
     sync_bundle_parent(bundle_dir)
 }
 
-/// Publish a staged bundle over an existing one. `rename` cannot overwrite a
-/// non-empty directory, so the superseded bundle is moved aside first and
-/// dropped only once the replacement is in place; a failed swap puts the
-/// original back, so the destination is never left empty.
+/// Publish a staged bundle over an existing one, or recreate a missing one.
+/// `rename` cannot overwrite a non-empty directory, so the superseded bundle
+/// is moved aside first and dropped only once the replacement is in place; a
+/// failed swap puts the original back, so the destination is never left empty.
 fn publish_replacement_bundle(staging_dir: &Path, bundle_dir: &Path) -> std::io::Result<()> {
-    let retired = scratch_sibling_path(bundle_dir, "retired")?;
-    fs::rename(bundle_dir, &retired)?;
+    let retired = if bundle_dir.exists() {
+        let retired = scratch_sibling_path(bundle_dir, "retired")?;
+        fs::rename(bundle_dir, &retired)?;
+        Some(retired)
+    } else {
+        None
+    };
+
     if let Err(error) = fs::rename(staging_dir, bundle_dir) {
-        let _ = fs::rename(&retired, bundle_dir);
+        if let Some(retired) = &retired {
+            let _ = fs::rename(retired, bundle_dir);
+        }
         return Err(error);
     }
     sync_bundle_parent(bundle_dir)?;
-    fs::remove_dir_all(&retired)
+
+    for retired in retired_bundle_paths(bundle_dir)? {
+        fs::remove_dir_all(retired)?;
+    }
+    Ok(())
+}
+
+/// Find interrupted replacement directories for `bundle_dir`.
+///
+/// These siblings are deliberately ignored while resolving a bundle. Once a
+/// replacement has been published and synced, they are safe to remove: the
+/// canonical path now contains the complete owner copy.
+fn retired_bundle_paths(bundle_dir: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let parent = bundle_dir.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("no parent dir for {}", bundle_dir.display()),
+        )
+    })?;
+    let bundle_name = bundle_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("no UTF-8 file name for {}", bundle_dir.display()),
+            )
+        })?;
+    let prefix = format!(".{bundle_name}.");
+
+    let mut retired = Vec::new();
+    for entry in parent.read_dir()? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with(&prefix) && name.ends_with(".retired") && entry.file_type()?.is_dir() {
+            retired.push(entry.path());
+        }
+    }
+    Ok(retired)
 }
 
 fn sync_bundle_parent(bundle_dir: &Path) -> std::io::Result<()> {

--- a/crates/orbit-store/src/workflow/task/tests/owner_wins.rs
+++ b/crates/orbit-store/src/workflow/task/tests/owner_wins.rs
@@ -3,6 +3,7 @@
 //! [`LOCAL_PREFIX`], so every `ORB-` id is a mirror of the peer's task and
 //! every `DANI-` id is locally owned.
 
+use std::fs;
 use std::path::Path;
 use std::slice;
 
@@ -252,6 +253,115 @@ fn owner_wins_second_run_changes_nothing() {
     assert_eq!(landed_bundle(&registry, ws, "ORB-00000"), owner_copy);
     assert_eq!(registry.tasks_for_workspace(ws).unwrap().len(), 1);
     assert_eq!(registry.allocator_next_number().unwrap(), 0);
+}
+
+#[test]
+fn owner_wins_recreates_a_missing_bound_mirror_and_is_rerunnable() {
+    let first_export = TempDir::new().unwrap();
+    let second_export = TempDir::new().unwrap();
+    let dst = TempDir::new().unwrap();
+    let ws = "orbit-owner-fefefe";
+
+    let mirrored = make_bundle("ORB-00000", "root task", Vec::new());
+    let first_archive = first_export.path().join("tasks.tar.zst");
+    export_owner_archive(
+        first_export.path(),
+        ws,
+        &first_archive,
+        slice::from_ref(&mirrored),
+    );
+
+    let registry = open_mirror_registry(dst.path());
+    bind(&registry, dst.path(), ws);
+    import_tasks(
+        &registry,
+        &first_archive,
+        None,
+        ImportConflictPolicy::OwnerWins,
+    )
+    .expect("first sync");
+
+    let canonical = registry
+        .canonical_task_bundle_path(ws, "ORB-00000")
+        .expect("canonical path");
+    let retired = canonical
+        .parent()
+        .expect("bundle parent")
+        .join(".ORB-00000.9999.0.retired");
+    fs::rename(&canonical, &retired).expect("simulate an interrupted replacement");
+    assert!(!canonical.exists());
+    assert!(retired.is_dir());
+
+    let refreshed = advanced_to(&mirrored, TaskStatus::Review);
+    let second_archive = second_export.path().join("tasks.tar.zst");
+    export_owner_archive(
+        second_export.path(),
+        ws,
+        &second_archive,
+        &[
+            refreshed.clone(),
+            make_bundle("ORB-00003", "new peer task", Vec::new()),
+        ],
+    );
+
+    let repaired = import_tasks(
+        &registry,
+        &second_archive,
+        None,
+        ImportConflictPolicy::OwnerWins,
+    )
+    .expect("owner-wins repairs the missing mirror and lands the rest");
+    assert_eq!(repaired.tasks.len(), 2);
+    assert_eq!(
+        repaired
+            .tasks
+            .iter()
+            .find(|task| task.source_id == "ORB-00000")
+            .expect("record for the repaired mirror")
+            .action,
+        ImportAction::Updated
+    );
+    assert_eq!(
+        repaired
+            .tasks
+            .iter()
+            .find(|task| task.source_id == "ORB-00003")
+            .expect("record for the new mirror")
+            .action,
+        ImportAction::Kept
+    );
+    assert_eq!(landed_bundle(&registry, ws, "ORB-00000"), refreshed);
+    assert_eq!(
+        landed_bundle(&registry, ws, "ORB-00003").envelope.id,
+        "ORB-00003"
+    );
+    assert!(
+        !retired.exists(),
+        "successful replacement cleans retired siblings"
+    );
+    assert_eq!(
+        registry
+            .global_task_status_index()
+            .unwrap()
+            .get("ORB-00000"),
+        Some(&TaskStatus::Review),
+        "rebuilding the index sees the recreated canonical path"
+    );
+
+    let repeated = import_tasks(
+        &registry,
+        &second_archive,
+        None,
+        ImportConflictPolicy::OwnerWins,
+    )
+    .expect("the repaired owner-wins import is rerunnable");
+    assert!(
+        repeated
+            .tasks
+            .iter()
+            .all(|task| task.action == ImportAction::AlreadyPresent)
+    );
+    assert_eq!(registry.tasks_for_workspace(ws).unwrap().len(), 2);
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-12146](https://orbit-cli.com/tasks/ORB-12146) — [code-review] owner-wins sync wedges permanently if a mirror's bundle directory is missing: every later run fails and lands nothing

### Description

`replace_bundle_at` refuses outright when the destination directory is absent (`crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs:98-105`), and `import_tasks` propagates that error out of the whole write phase (`crates/orbit-store/src/workflow/task/mod.rs:513-527`), rolling back every other task the same archive would have landed. So a *single* mirror whose bundle directory is gone while its registry binding survives makes every subsequent `--on-conflict=owner-wins` run of that workspace fail — including the ones that only needed to add unrelated new tasks.

The new replacement path creates that state itself: `publish_replacement_bundle` (`bundle_io/mod.rs:272-290`) renames the live bundle aside to a hidden `.<id>.<pid>.<n>.retired` sibling and only then renames the staged copy into place. A process killed between the two renames leaves the canonical directory missing, the binding intact, and the only local copy inside a hidden directory nothing ever cleans up. `orbit task delete`'s documented crash roll-forward window and hand-copied/rsync'd bundles reach the same state.

This contradicts the behavior `docs/design/task-migration/1_overview.md:194-211` advertises for the policy — "safe on a timer", "A failed run is re-runnable rather than rolled back" — and the error names neither the cause nor the recovery.

## Reproduced on `b120228b4` (Linux, binary built from this worktree)

Two disposable `/tmp` hosts (peer mints `ORB`, mirror mints `DANI`), inherited authority cleared, routing verified with `orbit workspace show --format json` before any mutation. After a healthy owner-wins sync, the interrupted-replacement state was staged by moving the mirror's bundle directory to the same hidden name the publisher uses:

```
$ mv .../workspaces/ws_peerws/ORB-00000 .../workspaces/ws_peerws/.ORB-00000.9999.0.retired
$ orbit task import /tmp/orbfxP/sync3.tar.zst --on-conflict owner-wins
error: store error: no task bundle to replace at .../workspaces/ws_peerws/ORB-00000
$ ls .../workspaces/ws_peerws          # ORB-00003 from the same archive did not land
ORB-00001  ORB-00002
$ orbit task import /tmp/orbfxP/sync3.tar.zst --on-conflict owner-wins   # not re-runnable
error: store error: no task bundle to replace at .../workspaces/ws_peerws/ORB-00000
$ orbit task reindex --task-workspace ws_peerws
reindexed workspace 'ws_peerws': 2 bundle(s), 1 stale binding(s) dropped
$ orbit task import /tmp/orbfxP/sync3.tar.zst --on-conflict owner-wins   # only now recovers
  kept  ORB-00000
  kept  ORB-00003
```

## Suggested direction

Treat a bound-but-missing mirror as a bundle to (re)create rather than a hard failure — the owner's copy is authoritative either way — or, at minimum, keep the rest of the archive landing and report the affected id with the `orbit task reindex` recovery in the error. Also consider recovering a leftover `.retired` sibling on the next run so the interrupted replacement is rolled forward instead of leaked.

### Acceptance Criteria

- An owner-wins import whose local mirror directory is missing while its binding survives either restores that bundle or completes the rest of the archive, instead of failing the whole run.
- Re-running the same owner-wins archive after such a failure succeeds without a manual `orbit task reindex`.
- A regression test covers the bound-but-missing mirror at the `import_tasks` boundary.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `replace_bundle_at`/replacement publication so owner-wins imports recreate a missing canonical bundle directory when its registry binding survives.
- Retired siblings are ignored for resolution and removed only after the replacement is published and the parent directory is synced; failed staged renames still restore the prior canonical directory when one exists.
- Added `owner_wins_recreates_a_missing_bound_mirror_and_is_rerunnable` at the `import_tasks` workflow boundary. It preserves the binding while moving the canonical directory to a `.retired` sibling, imports the changed mirror plus an unrelated task, verifies index rebuild and cleanup, then repeats the identical archive without reindex.

Acceptance criteria:
- Missing bound mirror no longer aborts the import: the regression proves `ORB-00000` is restored and unrelated `ORB-00003` lands in the same owner-wins run.
- The identical second owner-wins import succeeds and reports `AlreadyPresent` for both tasks without `orbit task reindex`.
- Regression coverage is present at `crates/orbit-store/src/workflow/task/tests/owner_wins.rs` and drives `import_tasks` directly.

Validation:
- PASSED — `cargo test -p orbit-store owner_wins -- --nocapture` (6 passed, 0 failed).
- PASSED — `cargo fmt --all -- --check`.
- PASSED — `make ci-fast`; its guardrails completed successfully. The compiler-cache namespace subcheck was explicitly skipped because this environment cannot create an unprivileged `bwrap` mount namespace; this is environment coverage, not a task failure.
- PASSED — `make ci-lint` (`cargo clippy --workspace --all-targets -- -D warnings`).
- PASSED — `git diff --check` and final `GIT_OPTIONAL_LOCKS=0 git status --short`; only the two scoped tracked files are modified and no untracked artifacts remain.

Assessment: The repair is localized at the bundle publication boundary, retains atomic staging and existing rollback behavior, and validates the owner-wins import/index/rerun contract at its owning workflow boundary.

Remaining risks / deviations: The full `make ci` merge gate was not run, per workspace guidance to leave it to CI; the fast guardrail namespace subcheck remains unexercised due host kernel permissions.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12146-6aa3b066`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus