### PR TITLE
[code-review] doctor deletes a populated task-store partition whenever the bound checkout is momentarily unreachable, destroying its task bundles

### DIFF
--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -426,18 +426,19 @@ fn doctor_check_task_reservations(runtime: &OrbitRuntime) -> WorkspaceDoctorResu
 /// partition directory is itself host-global.
 ///
 /// A partition is named for its *task-registry* workspace id, so the task
-/// registry is what claims it while the bound checkout's `orbit_dir` exists;
-/// a binding to a missing checkout is stale. The workspace catalog and the
-/// synthetic `--root` partition are the other claimants. Comparing the
-/// directory name against catalog `ws_*` ids alone reported every
-/// `<slug>-<hash>` partition — including live ones — as orphaned [ORB-12119].
+/// registry is what claims it while the bound checkout's `orbit_dir` exists.
+/// The workspace catalog and the synthetic `--root` partition are the other
+/// claimants. Comparing the directory name against catalog `ws_*` ids alone
+/// reported every `<slug>-<hash>` partition — including live ones — as
+/// orphaned [ORB-12119].
 ///
-/// An unknown populated partition gets its own non-destructive row: a lost or
-/// rebuilt registry leaves every other checkout's live partition looking
-/// exactly like abandoned residue, and the recovery for it is `orbit task
-/// reindex` in the owning checkout, not a deletion this check invites
-/// [ORB-12131]. A stale checkout binding is separately actionable because its
-/// missing `orbit_dir` proves the checkout is gone.
+/// Partitions that still hold task bundles are reported without inviting a
+/// deletion unless their checkout is confirmed gone. A lost or rebuilt
+/// registry leaves every other checkout's live partition looking like
+/// abandoned residue, and the recovery for that is `orbit task reindex` in the
+/// owning checkout [ORB-12131]; a checkout that merely failed to stat may be
+/// intact behind an unmounted volume or an unreadable parent directory, and
+/// the recovery is to restore access [ORB-12143].
 fn doctor_check_orphan_task_stores(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
     let global_root = runtime.global_root();
     let partitions = match task_store::inspect_task_store_partitions(&global_root) {
@@ -458,10 +459,51 @@ fn doctor_check_orphan_task_stores(runtime: &OrbitRuntime) -> WorkspaceDoctorRes
         }
     };
 
-    if partitions.removable.is_empty()
-        && partitions.stale.is_empty()
-        && partitions.unowned.is_empty()
-    {
+    // Each category gets its own clause, so one row can describe a host that
+    // has several at once, and its own remediation step in reporting order.
+    let mut clauses: Vec<String> = Vec::new();
+    let mut steps: Vec<String> = Vec::new();
+
+    if !partitions.unowned.is_empty() {
+        clauses.push(format!(
+            "{} task-store partition(s) hold task bundles that no workspace binding claims: {}",
+            partitions.unowned.len(),
+            describe_partitions(&partitions.unowned)
+        ));
+        steps.push(
+            "Run `orbit task reindex` from each checkout that owns those bundles to rebind them."
+                .to_string(),
+        );
+    }
+    if !partitions.unreachable.is_empty() {
+        clauses.push(format!(
+            "{} populated partition(s) whose bound checkout could not be reached: {}",
+            partitions.unreachable.len(),
+            describe_unreachable_partitions(&partitions.unreachable)
+        ));
+        steps.push(
+            "Restore access to the unreachable checkouts (remount the volume, repair directory \
+             permissions) and re-run `orbit doctor`; a populated partition is never deleted while \
+             its checkout cannot be stat-ed."
+                .to_string(),
+        );
+    }
+    if !partitions.stale.is_empty() {
+        clauses.push(format!(
+            "{} stale task-store partition(s) point at missing checkout directories: {}",
+            partitions.stale.len(),
+            describe_partitions(&partitions.stale)
+        ));
+    }
+    if !partitions.removable.is_empty() {
+        clauses.push(format!(
+            "{} orphaned empty task-store partition(s) (no workspace binding claims them): {}",
+            partitions.removable.len(),
+            describe_partitions(&partitions.removable)
+        ));
+    }
+
+    if clauses.is_empty() {
         return check(
             "orphan-task-stores",
             WorkspaceDoctorStatus::Ok,
@@ -472,80 +514,38 @@ fn doctor_check_orphan_task_stores(runtime: &OrbitRuntime) -> WorkspaceDoctorRes
         );
     }
 
-    // Unknown populated partitions decide the recovery guidance: their data is
-    // recoverable, so the operator must not be pointed at a repair that would
-    // delete it. A stale checkout binding is different evidence: the checkout
-    // is gone, so its partition is safe to remove after confirmation.
-    if !partitions.unowned.is_empty() {
-        let mut message = format!(
-            "{} task-store partition(s) hold task bundles that no workspace binding claims: {}",
-            partitions.unowned.len(),
-            describe_partitions(&partitions.unowned)
-        );
-        if !partitions.removable.is_empty() {
-            message.push_str(&format!(
-                "; {} empty unclaimed partition(s): {}",
-                partitions.removable.len(),
-                describe_partitions(&partitions.removable)
-            ));
-        }
-        if !partitions.stale.is_empty() {
-            message.push_str(&format!(
-                "; {} stale checkout-binding partition(s): {}",
-                partitions.stale.len(),
-                describe_partitions(&partitions.stale)
-            ));
-        }
-        let remediation = if partitions.stale.is_empty() {
-            "Run `orbit task reindex` from each checkout that owns these bundles to rebind them; \
-             `orbit doctor --fix-orphan-task-stores` never deletes a populated partition, so \
-             remove one by hand only after confirming its checkout is gone."
-                .to_string()
+    if !partitions.stale.is_empty() || !partitions.removable.is_empty() {
+        steps.push(if steps.is_empty() {
+            "Run `orbit doctor --fix-orphan-task-stores --confirm`.".to_string()
         } else {
-            "Run `orbit task reindex` from each checkout that owns the unknown bundles; \
-             then run `orbit doctor --fix-orphan-task-stores --confirm` to remove partitions \
-             whose checkout binding is stale."
+            "Then run `orbit doctor --fix-orphan-task-stores --confirm`, which removes only the \
+             empty partitions and the partitions whose checkout is confirmed gone."
                 .to_string()
-        };
-        return actionable_check(
-            "orphan-task-stores",
-            WorkspaceDoctorStatus::Warning,
-            message,
-            remediation,
-        );
-    }
-
-    if !partitions.stale.is_empty() {
-        let mut message = format!(
-            "{} stale task-store partition(s) point at missing checkout directories: {}",
-            partitions.stale.len(),
-            describe_partitions(&partitions.stale)
-        );
-        if !partitions.removable.is_empty() {
-            message.push_str(&format!(
-                "; {} empty unclaimed partition(s): {}",
-                partitions.removable.len(),
-                describe_partitions(&partitions.removable)
-            ));
-        }
-        return actionable_check(
-            "orphan-task-stores",
-            WorkspaceDoctorStatus::Warning,
-            message,
-            "Run `orbit doctor --fix-orphan-task-stores --confirm`.".to_string(),
-        );
+        });
     }
 
     actionable_check(
         "orphan-task-stores",
         WorkspaceDoctorStatus::Warning,
-        format!(
-            "{} orphaned empty task-store partition(s) (no workspace binding claims them): {}",
-            partitions.removable.len(),
-            describe_partitions(&partitions.removable)
-        ),
-        "Run `orbit doctor --fix-orphan-task-stores --confirm`.".to_string(),
+        clauses.join("; "),
+        steps.join(" "),
     )
+}
+
+/// Render partitions whose checkout could not be resolved, adding the
+/// filesystem failure that stopped the answer to the usual description.
+fn describe_unreachable_partitions(partitions: &[task_store::UnreachablePartition]) -> String {
+    partitions
+        .iter()
+        .map(|unreachable| {
+            format!(
+                "{} [{}]",
+                describe_partitions(std::slice::from_ref(&unreachable.partition)),
+                unreachable.reason
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Render unclaimed partitions for a diagnostic line: each one's workspace id,

--- a/crates/orbit-cmd/src/task_store.rs
+++ b/crates/orbit-cmd/src/task_store.rs
@@ -14,7 +14,7 @@
 //! task registry — not `workspaces.json` — decides which partition a checkout's
 //! task state lives in and which partitions are still claimed [ORB-12119].
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use orbit_common::OrbitError;
@@ -40,29 +40,45 @@ pub struct UnclaimedPartition {
     pub task_bundles: usize,
 }
 
+/// A populated partition whose bound checkout the filesystem could not answer
+/// for — neither present nor confirmed absent.
+#[derive(Debug, Clone)]
+pub struct UnreachablePartition {
+    /// The partition and the task data deleting it would cost.
+    pub partition: UnclaimedPartition,
+    /// The path that could not be resolved and what the filesystem said.
+    pub reason: String,
+}
+
 /// What a scan of `<global_root>/tasks/workspaces/` found.
 ///
-/// Unclaimed partitions are split into stale checkout bindings, empty residue,
-/// and populated partitions with no binding. A missing checkout binding is
-/// sufficient evidence for cleanup; an unknown populated partition remains
-/// recoverable with `orbit task reindex` [ORB-12131].
+/// Unclaimed partitions are split into confirmed-dead checkout bindings, empty
+/// residue, populated partitions with no binding, and populated partitions
+/// whose checkout could not be reached. Deleting task bundles requires
+/// evidence a transient filesystem condition cannot forge: a confirmed-absent
+/// checkout [ORB-12143]. Anything else populated stays recoverable with
+/// `orbit task reindex` [ORB-12131].
 #[derive(Debug, Clone)]
 pub struct TaskStorePartitions {
     /// Partition directories present on this host.
     pub scanned: usize,
     /// Unclaimed and empty of task bundles: nothing to lose by deleting them.
     pub removable: Vec<UnclaimedPartition>,
-    /// Partitions whose task-registry checkout binding points at a missing
-    /// orbit directory. The missing checkout is sufficient evidence to remove
-    /// the partition, including its bundles.
+    /// Partitions whose task-registry checkout binding points at an orbit
+    /// directory confirmed absent. That the checkout is gone is sufficient
+    /// evidence to remove the partition, including its bundles.
     pub stale: Vec<UnclaimedPartition>,
     /// Unclaimed but still holding task bundles, which `orbit task reindex`
     /// can rebind from the bundles themselves. Never deleted automatically.
     pub unowned: Vec<UnclaimedPartition>,
+    /// Populated partitions whose bound checkout could not be stat-ed — an
+    /// unmounted volume, an unsearchable parent, an offline share. Never
+    /// deleted automatically: the checkout may be intact behind the failure.
+    pub unreachable: Vec<UnreachablePartition>,
 }
 
-/// Classify every task-store partition on this host as claimed, removable, or
-/// unowned-but-populated.
+/// Classify every task-store partition on this host as claimed, removable,
+/// confirmed stale, unowned-but-populated, or unreachable.
 ///
 /// `None` means the directory has never been created (fresh host, no task ever
 /// committed) — nothing to diagnose rather than nothing orphaned.
@@ -72,17 +88,18 @@ pub fn inspect_task_store_partitions(
     let Some(partitions) = task_store_partitions(global_root)? else {
         return Ok(None);
     };
-    let (claimed, stale_bindings) = partition_claims(global_root)?;
+    let claims = partition_claims(global_root)?;
     let scanned = partitions.len();
 
     let mut removable = Vec::new();
     let mut stale = Vec::new();
     let mut unowned = Vec::new();
+    let mut unreachable = Vec::new();
     for path in partitions {
         let Some(id) = partition_id(&path).map(str::to_owned) else {
             continue;
         };
-        if claimed.contains(&id) {
+        if claims.claimed.contains(&id) {
             continue;
         }
 
@@ -90,12 +107,19 @@ pub fn inspect_task_store_partitions(
             task_bundles: count_task_bundles(&path),
             path,
         };
-        if stale_bindings.contains(&id) {
-            stale.push(partition);
-        } else if partition.task_bundles > 0 {
-            unowned.push(partition);
-        } else {
+        // An empty partition costs nothing to delete, so any binding that is
+        // not a live claim reclaims it; only bundles need stronger evidence.
+        if partition.task_bundles == 0 {
             removable.push(partition);
+        } else if claims.gone.contains(&id) {
+            stale.push(partition);
+        } else if let Some(reason) = claims.unreachable.get(&id) {
+            unreachable.push(UnreachablePartition {
+                partition,
+                reason: reason.clone(),
+            });
+        } else {
+            unowned.push(partition);
         }
     }
 
@@ -104,19 +128,24 @@ pub fn inspect_task_store_partitions(
         removable,
         stale,
         unowned,
+        unreachable,
     }))
 }
 
-/// Delete every stale-bound or empty unclaimed partition, retiring any
-/// registry rows that name it. Returns the removed partition paths.
+/// Delete every empty unclaimed partition and every partition whose bound
+/// checkout is confirmed gone, retiring any registry rows that name it.
+/// Returns the removed partition paths.
 ///
-/// A partition that still holds bundles is left alone however the registry
-/// answers: an unclaimed populated partition is exactly the state a lost or
-/// rebuilt `tasks/index.sqlite` produces for every checkout other than the one
-/// the command runs from, and deleting it would destroy task data that
-/// `orbit task reindex` can otherwise recover from the bundles [ORB-12131].
-/// Reclaiming a genuinely dead populated partition stays a deliberate manual
-/// step, or `orbit workspace teardown` while the checkout still exists.
+/// A partition that still holds bundles is deleted only on evidence a
+/// transient filesystem condition cannot forge. An unclaimed populated
+/// partition is exactly the state a lost or rebuilt `tasks/index.sqlite`
+/// produces for every checkout other than the one the command runs from, and
+/// deleting it would destroy task data that `orbit task reindex` can otherwise
+/// recover from the bundles [ORB-12131]. A populated partition whose checkout
+/// merely failed to stat — an unmounted volume, an unsearchable parent — is
+/// kept for the same reason: the checkout may still be there [ORB-12143].
+/// Reclaiming such a partition stays a deliberate manual step, or
+/// `orbit workspace teardown` while the checkout still exists.
 pub fn remove_unclaimed_task_stores(global_root: &Path) -> Result<Vec<PathBuf>, OrbitError> {
     let Some(partitions) = inspect_task_store_partitions(global_root)? else {
         return Ok(Vec::new());
@@ -190,40 +219,116 @@ pub fn partition_is_bound(global_root: &Path, workspace_id: &str) -> Result<bool
         .contains(workspace_id))
 }
 
-/// Every workspace id that claims a partition on this host, plus task-registry
-/// bindings whose checkout has disappeared. Live checkout bindings, workspace
-/// catalog ids, and the synthetic partition every `--root <data-dir>` write
-/// lands in are claims; a binding to a missing orbit directory is stale.
-fn partition_claims(
-    global_root: &Path,
-) -> Result<(BTreeSet<String>, BTreeSet<String>), OrbitError> {
+/// Who claims each partition on this host, and why the rest do not.
+struct PartitionClaims {
+    /// Live checkout bindings, workspace catalog ids, and the synthetic
+    /// partition every `--root <data-dir>` write lands in.
+    claimed: BTreeSet<String>,
+    /// Bindings whose checkout is confirmed absent.
+    gone: BTreeSet<String>,
+    /// Bindings whose checkout the filesystem could not answer for, mapped to
+    /// the failure that stopped the answer.
+    unreachable: BTreeMap<String, String>,
+}
+
+/// Resolve every partition claim, classifying each task-registry binding by
+/// what the filesystem says about the checkout it names.
+fn partition_claims(global_root: &Path) -> Result<PartitionClaims, OrbitError> {
     let tasks = open_task_registry(global_root)?;
-    let mut claimed = BTreeSet::new();
-    let mut stale_bindings = BTreeSet::new();
+    let mut claims = PartitionClaims {
+        claimed: BTreeSet::new(),
+        gone: BTreeSet::new(),
+        unreachable: BTreeMap::new(),
+    };
     for workspace_id in tasks.workspace_ids()? {
-        match tasks.find_workspace_checkout(&workspace_id)? {
-            Some(checkout) if checkout.orbit_dir.exists() => {
-                claimed.insert(workspace_id);
+        let Some(checkout) = tasks.find_workspace_checkout(&workspace_id)? else {
+            continue;
+        };
+        match checkout_evidence(&checkout.orbit_dir) {
+            CheckoutEvidence::Present => {
+                claims.claimed.insert(workspace_id);
             }
-            Some(_) => {
-                stale_bindings.insert(workspace_id);
+            CheckoutEvidence::Gone => {
+                claims.gone.insert(workspace_id);
             }
-            None => {}
+            CheckoutEvidence::Unreachable(reason) => {
+                claims.unreachable.insert(workspace_id, reason);
+            }
         }
     }
-    claimed.insert(UNBOUND_DATA_DIR_WORKSPACE_ID.to_string());
+    claims
+        .claimed
+        .insert(UNBOUND_DATA_DIR_WORKSPACE_ID.to_string());
 
     let registry_path = workspace_registry::registry_path_for(global_root);
     if registry_path.exists() {
         let registry = workspace_registry::load_registry_from(&registry_path)?;
-        claimed.extend(
+        claims.claimed.extend(
             registry
                 .workspaces
                 .into_iter()
                 .map(|workspace| workspace.id),
         );
     }
-    Ok((claimed, stale_bindings))
+    Ok(claims)
+}
+
+/// What the filesystem can testify about a bound checkout directory.
+enum CheckoutEvidence {
+    /// The bound `orbit_dir` is there: the binding is a live claim.
+    Present,
+    /// The bound `orbit_dir` is absent, and a directory we could actually read
+    /// said so: the checkout is gone.
+    Gone,
+    /// Neither answer was available, naming the path and the failure.
+    Unreachable(String),
+}
+
+/// Classify one bound checkout directory.
+///
+/// `Path::exists()` collapses every stat failure into "absent", which made an
+/// unmounted volume or an unsearchable parent directory indistinguishable from
+/// a deleted checkout — and the repair deletes task bundles on that evidence
+/// [ORB-12143]. Absence must therefore be positively confirmed rather than
+/// inferred from a failed stat.
+fn checkout_evidence(orbit_dir: &Path) -> CheckoutEvidence {
+    match std::fs::symlink_metadata(orbit_dir) {
+        Ok(_) => CheckoutEvidence::Present,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => confirm_absence(orbit_dir),
+        Err(error) => CheckoutEvidence::Unreachable(filesystem_failure(orbit_dir, &error)),
+    }
+}
+
+/// Confirm that an unstat-able `orbit_dir` is genuinely missing by walking up
+/// to the nearest ancestor that exists and listing it. Only a directory we can
+/// read can testify that the path beneath it is absent; a stat failure other
+/// than `NotFound` anywhere up the chain — `EACCES` from an unsearchable
+/// parent, `EIO`/`ENOTCONN` from a dropped mount — is not absence.
+fn confirm_absence(orbit_dir: &Path) -> CheckoutEvidence {
+    for ancestor in orbit_dir.ancestors().skip(1) {
+        match std::fs::symlink_metadata(ancestor) {
+            Ok(_) => {
+                return match std::fs::read_dir(ancestor) {
+                    Ok(_) => CheckoutEvidence::Gone,
+                    Err(error) => {
+                        CheckoutEvidence::Unreachable(filesystem_failure(ancestor, &error))
+                    }
+                };
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return CheckoutEvidence::Unreachable(filesystem_failure(ancestor, &error));
+            }
+        }
+    }
+    CheckoutEvidence::Unreachable(format!(
+        "{}: no readable ancestor directory could confirm it is absent",
+        orbit_dir.display()
+    ))
+}
+
+fn filesystem_failure(path: &Path, error: &std::io::Error) -> String {
+    format!("{}: {error}", path.display())
 }
 
 /// Open the task registry that names the partitions, rather than creating one

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -1163,3 +1163,57 @@ fn populated_unclaimed_partition_warns_toward_reindex_not_deletion() {
         "the repair must not delete task bundles"
     );
 }
+
+/// [ORB-12143] A populated partition whose bound checkout cannot be stat-ed —
+/// here because the checkout path resolves through a non-directory, as an
+/// unmounted volume or an unsearchable parent does — is reported with the
+/// filesystem failure and is never pointed at the deletion repair.
+#[test]
+fn unreachable_checkout_partition_is_reported_without_the_deletion_repair() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let global_root = temp.path().join("global");
+    let unreachable_root = temp.path().join("unreachable");
+    fs::create_dir_all(unreachable_root.join(".orbit")).expect("create checkout");
+
+    bind_task_partition(
+        &global_root,
+        "unreachable-a1b2c3",
+        "unreachable",
+        &unreachable_root,
+    );
+    write_task_bundle(&global_root, "unreachable-a1b2c3", "ORB-7");
+    fs::remove_dir_all(&unreachable_root).expect("remove checkout directory");
+    fs::write(&unreachable_root, b"not a directory").expect("write a file where the checkout was");
+
+    let results = runtime.doctor_workspace().expect("doctor");
+    let row = status_of(&results, "orphan-task-stores");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Warning, "{row:?}");
+    assert!(
+        row.message.contains("could not be reached")
+            && row.message.contains("unreachable-a1b2c3")
+            && row.message.contains("1 task bundle(s)"),
+        "message names the partition, its bundles, and why it was kept: {}",
+        row.message
+    );
+    let remediation = row
+        .remediation
+        .as_deref()
+        .expect("actionable row has remediation");
+    assert!(
+        !remediation.contains("--fix-orphan-task-stores --confirm"),
+        "remediation must not advertise the deletion repair: {remediation}"
+    );
+
+    assert_eq!(
+        runtime.remove_orphan_task_stores().expect("run the repair"),
+        0
+    );
+    assert!(
+        task_workspaces_dir(&global_root)
+            .join("unreachable-a1b2c3")
+            .join("ORB-7")
+            .is_dir(),
+        "the repair must not delete task bundles it cannot prove are abandoned"
+    );
+}

--- a/crates/orbit-cmd/src/tests/task_store.rs
+++ b/crates/orbit-cmd/src/tests/task_store.rs
@@ -235,3 +235,188 @@ fn an_unclaimed_partition_without_bundles_is_still_reclaimed() {
         "the bound checkout's partition must survive"
     );
 }
+
+/// Make `path` unsearchable and report whether the process is actually kept
+/// out. A test running as root reads a `0o000` directory regardless, and then
+/// has nothing to assert about a permission failure, so its caller skips.
+#[cfg(unix)]
+fn make_unsearchable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(0o000)).expect("drop directory modes");
+    fs::read_dir(path).is_err()
+}
+
+#[cfg(unix)]
+fn restore_search(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("restore directory modes");
+}
+
+/// [ORB-12143] A checkout behind an unsearchable parent directory — the shape
+/// an unmounted volume or a revoked mount permission takes — cannot be stat-ed,
+/// which `Path::exists()` reported as a deleted checkout. The repair then
+/// deleted the partition's task bundles, the only copy of that task data.
+#[cfg(unix)]
+#[test]
+fn an_unsearchable_parent_keeps_a_populated_partition() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let volume = temp.path().join("volume");
+    let repo_root = volume.join("proj");
+    fs::create_dir_all(&global_root).expect("create global root");
+    fs::create_dir_all(repo_root.join(".orbit")).expect("create checkout");
+
+    bind(&global_root, "proj-5b631f", "proj", &repo_root);
+    write_task_bundle(&global_root, "proj-5b631f", "ORB-1");
+
+    // Nothing to assert when the process searches the directory anyway.
+    if !make_unsearchable(&volume) {
+        restore_search(&volume);
+        return;
+    }
+    let partitions = inspect_task_store_partitions(&global_root).map(|scan| {
+        let scan = scan.expect("partitions directory exists");
+        (
+            scan.stale.len(),
+            scan.removable.len(),
+            scan.unreachable
+                .iter()
+                .map(|entry| (entry.partition.path.clone(), entry.reason.clone()))
+                .collect::<Vec<_>>(),
+        )
+    });
+    let removed = remove_unclaimed_task_stores(&global_root);
+    restore_search(&volume);
+
+    let (stale, removable, unreachable) = partitions.expect("inspect partitions");
+    assert_eq!(stale, 0, "an unreadable checkout is not a deleted checkout");
+    assert_eq!(removable, 0);
+    let (path, reason) = unreachable
+        .first()
+        .expect("the partition is reported as unreachable");
+    assert_eq!(
+        path,
+        &task_store_partition_path(&global_root, "proj-5b631f")
+    );
+    assert!(
+        reason.contains(&repo_root.join(".orbit").display().to_string())
+            || reason.contains(&repo_root.display().to_string()),
+        "the reason names the path that could not be resolved: {reason}"
+    );
+
+    assert!(
+        removed.expect("run the repair").is_empty(),
+        "no partition may be deleted while its checkout cannot be stat-ed"
+    );
+    assert!(
+        task_workspaces_dir(&global_root)
+            .join("proj-5b631f")
+            .join("ORB-1")
+            .is_dir(),
+        "the task bundle must survive the repair"
+    );
+    assert!(
+        partition_is_bound(&global_root, "proj-5b631f").expect("read bindings"),
+        "the binding of a reachable-again checkout must survive too"
+    );
+}
+
+/// [ORB-12143] Absence is the only stat answer that authorizes deleting
+/// bundles. Here the checkout path resolves through a non-directory (`ENOTDIR`),
+/// which is a failure to answer rather than a missing checkout.
+#[test]
+fn a_stat_failure_other_than_absence_keeps_a_populated_partition() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let repo_root = temp.path().join("proj");
+    fs::create_dir_all(&global_root).expect("create global root");
+    fs::create_dir_all(repo_root.join(".orbit")).expect("create checkout");
+
+    bind(&global_root, "proj-5b631f", "proj", &repo_root);
+    write_task_bundle(&global_root, "proj-5b631f", "ORB-1");
+
+    fs::remove_dir_all(&repo_root).expect("remove checkout directory");
+    fs::write(&repo_root, b"not a directory").expect("write a file where the checkout was");
+
+    let partitions = inspect_task_store_partitions(&global_root)
+        .expect("inspect partitions")
+        .expect("partitions directory exists");
+    assert!(partitions.stale.is_empty(), "{:?}", partitions.stale);
+    assert_eq!(partitions.unreachable.len(), 1, "{partitions:?}");
+
+    let removed = remove_unclaimed_task_stores(&global_root).expect("run the repair");
+    assert!(removed.is_empty(), "the repair removed {removed:?}");
+    assert!(
+        task_workspaces_dir(&global_root)
+            .join("proj-5b631f")
+            .join("ORB-1")
+            .is_dir()
+    );
+}
+
+/// [ORB-12143] A deleted checkout is still confirmed absent — the enclosing
+/// directory is readable and answers that the path is gone — so its partition
+/// and bundles are still reclaimed.
+#[test]
+fn a_confirmed_deleted_checkout_still_releases_its_populated_partition() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let repo_root = temp.path().join("volume").join("proj");
+    fs::create_dir_all(&global_root).expect("create global root");
+    fs::create_dir_all(repo_root.join(".orbit")).expect("create checkout");
+
+    bind(&global_root, "proj-5b631f", "proj", &repo_root);
+    write_task_bundle(&global_root, "proj-5b631f", "ORB-1");
+    fs::remove_dir_all(&repo_root).expect("delete checkout");
+
+    let partitions = inspect_task_store_partitions(&global_root)
+        .expect("inspect partitions")
+        .expect("partitions directory exists");
+    assert_eq!(
+        partitions
+            .stale
+            .iter()
+            .map(|partition| partition.path.clone())
+            .collect::<Vec<_>>(),
+        vec![task_store_partition_path(&global_root, "proj-5b631f")]
+    );
+    assert!(partitions.unreachable.is_empty(), "{partitions:?}");
+
+    let removed = remove_unclaimed_task_stores(&global_root).expect("run the repair");
+    assert_eq!(
+        removed,
+        vec![task_store_partition_path(&global_root, "proj-5b631f")]
+    );
+    assert!(!partition_is_bound(&global_root, "proj-5b631f").expect("read bindings"));
+}
+
+/// [ORB-12143] An unreachable checkout protects task bundles, not an empty
+/// partition directory: with no bundles to lose, a binding that is not a live
+/// claim still reclaims the directory.
+#[cfg(unix)]
+#[test]
+fn an_unreachable_checkout_still_reclaims_an_empty_partition() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let volume = temp.path().join("volume");
+    let repo_root = volume.join("proj");
+    fs::create_dir_all(&global_root).expect("create global root");
+    fs::create_dir_all(repo_root.join(".orbit")).expect("create checkout");
+
+    bind(&global_root, "proj-5b631f", "proj", &repo_root);
+    let partition = task_store_partition_path(&global_root, "proj-5b631f");
+    fs::create_dir_all(&partition).expect("create empty partition dir");
+
+    // Nothing to assert when the process searches the directory anyway.
+    if !make_unsearchable(&volume) {
+        restore_search(&volume);
+        return;
+    }
+    let removed = remove_unclaimed_task_stores(&global_root);
+    restore_search(&volume);
+
+    assert_eq!(removed.expect("run the repair"), vec![partition.clone()]);
+    assert!(!partition.exists());
+}

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -105,17 +105,27 @@ A partition directory is named for a **task-registry** workspace id
 (`workspace_bindings.workspace_id` in `~/.orbit/tasks/index.sqlite`), minted as `<slug>-<hash>`
 for a checkout that binds without an explicit id. That is a different id space from the workspace
 catalog's `ws_*` ids in `~/.orbit/workspaces.json`. A task-registry binding claims its partition
-only while the binding's recorded `orbit_dir` still exists on disk; a binding to a deleted checkout
-is stale and is reported as orphaned. Catalog `ws_*` ids and the synthetic `ws_unbound-data-dir`
-partition every `--root <data-dir>` write lands in remain claims, so they are never reported.
-`orphan-task-stores` names each orphaned workspace id, its partition path, and its task-bundle count.
+while the binding's recorded `orbit_dir` is present on disk. Catalog `ws_*` ids and the synthetic
+`ws_unbound-data-dir` partition every `--root <data-dir>` write lands in remain claims, so they are
+never reported. `orphan-task-stores` names each reported workspace id, its partition path, and its
+task-bundle count.
 
-An unclaimed partition that **still holds task bundles** and has no stale checkout binding is
-reported on its own terms and is never deleted by the repair. On disk it is indistinguishable from
-a live checkout's partition whose registry row was lost, and every `orbit` subcommand recreates an
-empty `~/.orbit/tasks/index.sqlite` before any check runs — so a lost or restored-without
-`index.sqlite` registry makes every checkout other than the one you are standing in look abandoned.
-That warning points at recovery instead:
+**Evidence rule for deleting task bundles.** A partition that holds task bundles is deleted by the
+repair only when its bound checkout is *confirmed gone*: `orbit_dir` stats as absent, and the
+nearest ancestor directory that does exist is readable and therefore able to testify that the path
+below it is missing. Any other filesystem answer — `EACCES` from an unsearchable parent, `EIO` or
+`ENOTCONN` from a dropped mount, a path that resolves through a non-directory — classifies the
+binding as **unreachable**: the checkout may be intact behind the failure, so the partition is
+retained, reported with the failing path and error, and never deleted by
+`--fix-orphan-task-stores`. A partition with **no task bundles** carries nothing to recover, so the
+older rule still applies to it: any binding that is not a live claim reclaims the directory.
+
+An unclaimed partition that **still holds task bundles** and has no checkout binding at all is
+likewise never deleted by the repair. On disk it is indistinguishable from a live checkout's
+partition whose registry row was lost, and every `orbit` subcommand recreates an empty
+`~/.orbit/tasks/index.sqlite` before any check runs — so a lost or restored-without `index.sqlite`
+registry makes every checkout other than the one you are standing in look abandoned. That warning
+points at recovery instead:
 
 ```sh
 cd <the checkout that owns the bundles>
@@ -123,26 +133,29 @@ orbit task reindex
 ```
 
 `orbit task reindex` rebuilds the registry rows for one partition from its bundle directories, so
-it must be run once per affected checkout. For a partition whose task-registry binding points at a
-missing `orbit_dir`, the stale binding is the evidence that the checkout is genuinely gone. The
-confirmed repair removes that partition, including its task bundles, and retires the stale registry
-rows:
+it must be run once per affected checkout.
+
+For an **unreachable** partition, restore access first — remount the volume, repair the directory
+permissions that hide the checkout — and re-run `orbit doctor`. A reachable checkout becomes a live
+claim again and the row clears itself; a checkout that is genuinely gone once its parent is
+readable becomes a confirmed-stale binding, which the repair can then remove.
+
+For a partition whose binding is confirmed stale, the missing `orbit_dir` is the evidence that the
+checkout is gone. The confirmed repair removes that partition, including its task bundles, and
+retires the stale registry rows — as it does for every empty unclaimed partition:
 
 ```sh
 orbit doctor --fix-orphan-task-stores --confirm
 ```
 
-Do not use that repair for an unknown populated partition; reindex it first.
-
-An unclaimed partition with **no task bundles** carries nothing to recover. Repair those with:
-
-```sh
-orbit doctor --fix-orphan-task-stores --confirm
-```
+Do not use that repair for an unknown or unreachable populated partition; reindex or restore it
+first. One residual limitation: a volume unmounted from a mountpoint that is itself still present
+and readable reports its checkout as absent, and the partition is then treated as confirmed stale.
+Remount before running the repair on a host with removable or network-mounted checkouts.
 
 The repair deletes partition directories, so it refuses to run without `--confirm`. It resolves the
-claims once, deletes empty partitions with no binding and partitions whose binding is stale, retires
-any registry rows naming them, and is idempotent: running it again after a partition is gone is a
+claims once, deletes empty unclaimed partitions and populated partitions whose checkout is
+confirmed gone, retires any registry rows naming them, and is idempotent: running it again after a partition is gone is a
 no-op.
 
 ### Repair retired activity backends


### PR DESCRIPTION
## Task

[ORB-12143](https://orbit-cli.com/tasks/ORB-12143) — [code-review] doctor deletes a populated task-store partition whenever the bound checkout is momentarily unreachable, destroying its task bundles

### Description

`orbit doctor --fix-orphan-task-stores --confirm` now deletes task-store partitions whose task-registry checkout binding is classified *stale*, and the only evidence for staleness is `checkout.orbit_dir.exists()` (`crates/orbit-cmd/src/task_store.rs:205-210`). `Path::exists()` answers `false` for every stat failure, not just a deleted checkout: an unmounted volume, an offline network share, or an unsearchable parent directory (EACCES) all look identical to a removed checkout. `remove_unclaimed_task_stores` then chains `partitions.stale` into the deletion loop (`crates/orbit-cmd/src/task_store.rs:127`), and `remove_partition` unbinds the workspace and `remove_dir_all`s the partition *including its task bundles* (`crates/orbit-cmd/src/task_store.rs:317-339`).

This reverses ORB-12131's invariant ("a populated partition is never deleted from the registry's answer alone") on evidence that a transient filesystem condition can forge. The bundles are the only copy of that task data: the checkout holds no tasks, so nothing can recover them.

## Reproduced on `b120228b4` (Linux, binary built from this worktree)

Disposable `HOME`/checkout under `/tmp`, every `INHERITED_AUTHORITY_ENV` variable cleared, routing verified with `orbit workspace show --format json` before any mutation.

```sh
# checkout /tmp/orbfx2/volume/proj auto-binds as partition proj-5b631f, 1 task bundle
chmod 000 /tmp/orbfx2/volume          # volume momentarily unreachable; the checkout is intact
orbit doctor
# orphan-task-stores warning  1 stale task-store partition(s) point at missing checkout
#   directories: proj-5b631f (.../workspaces/proj-5b631f, 1 task bundle(s))
#   | Action: Run `orbit doctor --fix-orphan-task-stores --confirm`.
orbit doctor --fix-orphan-task-stores --confirm
# Removed 1 empty orphaned task-store partition(s).
chmod 755 /tmp/orbfx2/volume          # volume back
cd /tmp/orbfx2/volume/proj && orbit task list
# no tasks matching the given filters
```

The partition directory and its bundle are gone; the checkout was never removed.

## Live host exposure

On dk-server-1 today, `workspace_checkout_bindings` holds bindings whose `orbit_dir` is absent and whose partitions are populated, none of them claimed by the `ws_*` workspace catalog — e.g. `bridge-c02d47` with 47 task bundles, `sextant-a0f00c` with 3. Before this change they were reported as populated-but-unclaimed and left alone; now a single `--fix-orphan-task-stores --confirm` deletes all of them.

## Suggested direction

Require evidence a transient condition cannot forge before deleting bundles: keep a populated partition non-destructive regardless of the binding (auto-delete only the empty stale ones), or distinguish "checkout directory is genuinely absent" from "stat failed" (`fs::symlink_metadata` error kind `NotFound` versus `PermissionDenied`/other) and additionally require the checkout's parent to be readable. See also the sibling finding about the repair's "empty" wording.

### Acceptance Criteria

- A populated task-store partition whose bound checkout is unreachable for a reason other than deletion (unmounted volume, EACCES on a parent) is not deleted by `orbit doctor --fix-orphan-task-stores --confirm`.
- A regression test covers the transient-unavailability case at the `inspect_task_store_partitions` / repair boundary and fails against the current classification.
- docs/runbooks/health-checks.md matches whatever evidence rule the fix adopts.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed the classification so `orbit doctor --fix-orphan-task-stores --confirm` cannot delete a populated task-store partition on evidence a transient filesystem condition forges.

## Change

- `crates/orbit-cmd/src/task_store.rs`: replaced `checkout.orbit_dir.exists()` with `checkout_evidence()`, a three-way classifier. `Present` when `symlink_metadata` succeeds. `Gone` only when the stat fails `NotFound` **and** `confirm_absence` finds the nearest existing ancestor and can `read_dir` it — only a directory we can actually read can testify that the path beneath it is missing. Every other outcome (EACCES from an unsearchable parent, EIO/ENOTCONN from a dropped mount, a path through a non-directory, an unreadable ancestor) is `Unreachable`, carrying the failing path and error. `partition_claims` now returns `PartitionClaims { claimed, gone, unreachable }`.
- `inspect_task_store_partitions` classifies by bundle count first: an **empty** partition keeps the old rule (any binding that is not a live claim reclaims it → `removable`); a **populated** partition is deletable only under `stale` (confirmed gone) and otherwise lands in the new `unreachable: Vec<UnreachablePartition>` (partition + reason) or `unowned`. `remove_unclaimed_task_stores` still chains only `stale` + `removable`, so an unreachable populated partition is never deleted and its binding is never retired.
- `crates/orbit-cmd/src/doctor.rs` (added to scope: the sole consumer of the classification; the new category needed a report line and the remediation could otherwise still advertise the deletion repair): the `orphan-task-stores` row is now composed of one clause plus one remediation step per category. Unreachable partitions are named with their filesystem failure and get a "restore access, then re-run doctor" step; `--fix-orphan-task-stores --confirm` is advertised only when a confirmed-stale or empty partition exists.
- `docs/runbooks/health-checks.md`: documents the evidence rule as adopted (confirmed-gone vs unreachable, empty partitions unchanged), the restore-access recovery, and the residual limitation that a volume unmounted from a still-present readable mountpoint still reads as absent.

## Acceptance criteria

1. *Populated partition behind an unreachable checkout is not deleted* — met. `an_unsearchable_parent_keeps_a_populated_partition` reproduces the task's `chmod 000` repro at the inspect/repair boundary: the partition is classified `unreachable` (not `stale`), `remove_unclaimed_task_stores` returns empty, the bundle and the binding survive. `a_stat_failure_other_than_absence_keeps_a_populated_partition` covers a non-permission stat failure (ENOTDIR) portably. `unreachable_checkout_partition_is_reported_without_the_deletion_repair` covers the doctor row and `remove_orphan_task_stores` (0 removed, bundle intact).
2. *Regression test fails against the current classification* — verified. With `checkout_evidence` temporarily reduced to the old `orbit_dir.exists()` rule, `an_unsearchable_parent_keeps_a_populated_partition` failed ("an unreadable checkout is not a deleted checkout", stale left 1 right 0), `a_stat_failure_other_than_absence_keeps_a_populated_partition` failed (partition classified stale), and `unreachable_checkout_partition_is_reported_without_the_deletion_repair` failed on the "stale … point at missing checkout directories" message. The temporary edit was reverted; the file now contains only the fix.
3. *Runbook matches the adopted rule* — met, see above. Two further tests pin the rules the fix must not break: `a_confirmed_deleted_checkout_still_releases_its_populated_partition` (deleted checkout is still confirmed absent, partition and binding still reclaimed) and `an_unreachable_checkout_still_reclaims_an_empty_partition` (zero-bundle partitions keep the existing stale-binding rule).

## Validation

- `make ci-fast` — passed (exit 0).
- `make ci-lint` — passed (exit 0, workspace clippy all-targets with warnings denied).
- `cargo test -p orbit-cmd` — passed: 148 passed, 0 failed, 1 ignored. An earlier run of the same suite failed only `update::tests::stage::rollback_replaces_a_running_executable_atomically` with `ExecutableFileBusy` (ETXTBSY) while launching a binary the build had just written; it passes on re-run and is unrelated to this change (no `update` code touched).
- `cargo fmt --all` applied.
- Not run: the end-to-end CLI repro from the task description. Workspace policy forbids bare mutable fixture commands from a managed worker shell, so the behavior is covered at the `inspect_task_store_partitions` / `remove_unclaimed_task_stores` boundary and at the doctor row instead. The unsearchable-parent tests are Unix-only and skip silently if the process can still search a `0o000` directory (running as root); the ENOTDIR test covers the same classification on every platform.

## Risks and deviations

- Reporting wording changed: a host with several categories now gets one clause per category joined with "; " instead of one category's message plus appendices. Existing doctor tests still pass unchanged.
- An empty partition whose binding is stale now reports under the "orphaned empty task-store partition(s)" clause rather than the stale clause; it is still deleted by the confirmed repair, as before.
- Residual limitation, documented in the runbook: a volume unmounted from a mountpoint that remains present and readable makes its checkout stat as absent, so such a partition is still classified confirmed-gone. Distinguishing that case needs mount-table evidence, which is outside this fix.
- The CLI's "Removed N empty orphaned task-store partition(s)." wording is still inaccurate for confirmed-stale populated partitions; that is the sibling finding named in the task description and was left out of scope.
- Files changed: crates/orbit-cmd/src/task_store.rs, crates/orbit-cmd/src/doctor.rs, crates/orbit-cmd/src/tests/task_store.rs, crates/orbit-cmd/src/tests/doctor.rs, docs/runbooks/health-checks.md. No untracked files; `git diff --check` clean; changes left uncommitted.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12143-6aa3b066`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus