### PR TITLE
Auto-task SkipIfOpen dedupe counts a 'someday' instance as open, silently blocking every later mint of that auto-task

### DIFF
--- a/crates/orbit-automation/src/auto_tasks/scheduler.rs
+++ b/crates/orbit-automation/src/auto_tasks/scheduler.rs
@@ -28,7 +28,12 @@ pub trait AutoTaskDispatch {
 
     fn state_dir(&self) -> PathBuf;
 
-    fn has_open_instance(&self, definition: &AutoTaskDefinition) -> Result<bool, OrbitError>;
+    /// The id of a still-open instance of `definition`'s prior mints, if any.
+    /// `None` means `SkipIfOpen` dedupe should let the current fire proceed.
+    fn has_open_instance(
+        &self,
+        definition: &AutoTaskDefinition,
+    ) -> Result<Option<String>, OrbitError>;
 
     fn mint_task(&self, definition: &AutoTaskDefinition) -> Result<String, OrbitError>;
 }
@@ -47,6 +52,8 @@ pub struct AutoTaskFireReport {
     pub slot: Option<String>,
     /// Task minted by a fire.
     pub task_id: Option<String>,
+    /// The still-open task id that caused a `dedupe_open` skip.
+    pub blocking_task_id: Option<String>,
     pub automation: Option<orbit_types::workflow::automation::AutomationDiagnostic>,
 }
 
@@ -96,6 +103,7 @@ pub fn run_auto_task_scheduler_at(
                     reason: Some(format!("error: {error}")),
                     slot: None,
                     task_id: None,
+                    blocking_task_id: None,
                     automation: None,
                 }
             });
@@ -132,6 +140,7 @@ fn fire_definition(
             reason: Some(diagnostic.reason.clone()),
             slot: None,
             task_id,
+            blocking_task_id: None,
             automation: Some(diagnostic),
         });
     }
@@ -171,10 +180,11 @@ fn dry_run_definition(
         AutoTaskDueDecision::NotDue => Ok(skipped(definition, "not_due")),
         AutoTaskDueDecision::Fire { slot } => {
             if definition.dedupe == DedupePolicy::SkipIfOpen
-                && host.has_open_instance(definition)?
+                && let Some(blocking_task_id) = host.has_open_instance(definition)?
             {
                 return Ok(AutoTaskFireReport {
                     slot: Some(slot),
+                    blocking_task_id: Some(blocking_task_id),
                     ..skipped(definition, "dedupe_open")
                 });
             }
@@ -222,10 +232,11 @@ fn fire_locked(
         AutoTaskDueDecision::NotDue => Ok(skipped(definition, "not_due")),
         AutoTaskDueDecision::Fire { slot } => {
             if definition.dedupe == DedupePolicy::SkipIfOpen
-                && host.has_open_instance(definition)?
+                && let Some(blocking_task_id) = host.has_open_instance(definition)?
             {
                 return Ok(AutoTaskFireReport {
                     slot: Some(slot),
+                    blocking_task_id: Some(blocking_task_id),
                     ..skipped(definition, "dedupe_open")
                 });
             }
@@ -258,6 +269,7 @@ fn recover_pending(
                 )),
                 slot: Some(pending.slot),
                 task_id: Some(task_id),
+                blocking_task_id: None,
                 automation: None,
             })),
             Err(error) => Ok(Some(AutoTaskFireReport {
@@ -268,6 +280,7 @@ fn recover_pending(
                 )),
                 slot: Some(pending.slot),
                 task_id: Some(task_id),
+                blocking_task_id: None,
                 automation: None,
             })),
         };
@@ -313,6 +326,7 @@ fn fire_slot(
                 reason: Some(format!("mint failed; slot not consumed: {error}")),
                 slot: Some(slot),
                 task_id: None,
+                blocking_task_id: None,
                 automation: None,
             });
         }
@@ -338,6 +352,7 @@ fn fire_slot(
             reason: None,
             slot: Some(slot),
             task_id: Some(task),
+            blocking_task_id: None,
             automation: None,
         }),
         Err(error) => {
@@ -364,6 +379,7 @@ fn fire_slot(
                 )),
                 slot: Some(slot),
                 task_id: Some(task),
+                blocking_task_id: None,
                 automation: None,
             })
         }
@@ -416,6 +432,7 @@ fn skipped(definition: &AutoTaskDefinition, reason: &str) -> AutoTaskFireReport 
         reason: Some(reason.to_string()),
         slot: None,
         task_id: None,
+        blocking_task_id: None,
         automation: None,
     }
 }
@@ -427,6 +444,7 @@ fn action(definition: &AutoTaskDefinition, action: &'static str) -> AutoTaskFire
         reason: None,
         slot: None,
         task_id: None,
+        blocking_task_id: None,
         automation: None,
     }
 }

--- a/crates/orbit-automation/src/auto_tasks/tests/scheduler.rs
+++ b/crates/orbit-automation/src/auto_tasks/tests/scheduler.rs
@@ -25,7 +25,7 @@ struct TestDispatch {
     minted: AtomicUsize,
     mint_ids: Mutex<Vec<String>>,
     mint_should_fail: AtomicBool,
-    open_instance: AtomicBool,
+    open_instance: Mutex<Option<String>>,
 }
 
 impl TestDispatch {
@@ -36,8 +36,12 @@ impl TestDispatch {
             minted: AtomicUsize::new(0),
             mint_ids: Mutex::new(Vec::new()),
             mint_should_fail: AtomicBool::new(false),
-            open_instance: AtomicBool::new(false),
+            open_instance: Mutex::new(None),
         }
+    }
+
+    fn set_open_instance(&self, blocking_task_id: &str) {
+        *self.open_instance.lock().expect("open_instance") = Some(blocking_task_id.to_string());
     }
 }
 
@@ -59,8 +63,11 @@ impl AutoTaskDispatch for TestDispatch {
         self.state_dir.clone()
     }
 
-    fn has_open_instance(&self, _definition: &AutoTaskDefinition) -> Result<bool, OrbitError> {
-        Ok(self.open_instance.load(Ordering::SeqCst))
+    fn has_open_instance(
+        &self,
+        _definition: &AutoTaskDefinition,
+    ) -> Result<Option<String>, OrbitError> {
+        Ok(self.open_instance.lock().expect("open_instance").clone())
     }
 
     fn mint_task(&self, _definition: &AutoTaskDefinition) -> Result<String, OrbitError> {
@@ -382,7 +389,7 @@ fn skip_if_open_does_not_claim_or_mint() {
     let state_dir = root.path().join("state");
     write_interval_definition(&definition_root, "chore", "skip_if_open");
     let dispatch = TestDispatch::new(definition_root, state_dir);
-    dispatch.open_instance.store(true, Ordering::SeqCst);
+    dispatch.set_open_instance("ORB-90001");
     let t0 = at(2026, 1, 1, 0, 0);
     upsert_cursor(
         &cursor_state_path(&dispatch.state_dir),
@@ -399,6 +406,10 @@ fn skip_if_open_does_not_claim_or_mint() {
     .expect("pass");
     assert_eq!(outcome.reports[0].action, "skipped");
     assert_eq!(outcome.reports[0].reason.as_deref(), Some("dedupe_open"));
+    assert_eq!(
+        outcome.reports[0].blocking_task_id.as_deref(),
+        Some("ORB-90001")
+    );
     assert_eq!(dispatch.minted.load(Ordering::SeqCst), 0);
     let state = load_cursor_state(&cursor_state_path(&dispatch.state_dir)).expect("load");
     assert!(state.definitions["chore"].last_slot.is_none());
@@ -508,7 +519,7 @@ fn skip_if_open_dry_run_reports_dedupe_without_writing() {
     let state_dir = root.path().join("state");
     write_interval_definition(&definition_root, "chore", "skip_if_open");
     let dispatch = TestDispatch::new(definition_root, state_dir);
-    dispatch.open_instance.store(true, Ordering::SeqCst);
+    dispatch.set_open_instance("ORB-90002");
     let t0 = at(2026, 1, 1, 0, 0);
     upsert_cursor(
         &cursor_state_path(&dispatch.state_dir),
@@ -526,6 +537,10 @@ fn skip_if_open_dry_run_reports_dedupe_without_writing() {
     .expect("dry run");
     assert_eq!(outcome.reports[0].action, "skipped");
     assert_eq!(outcome.reports[0].reason.as_deref(), Some("dedupe_open"));
+    assert_eq!(
+        outcome.reports[0].blocking_task_id.as_deref(),
+        Some("ORB-90002")
+    );
     assert_eq!(
         fs::read_to_string(cursor_state_path(&dispatch.state_dir)).expect("after"),
         before

--- a/crates/orbit-core/assets/activities/run_auto_task_scheduler.yaml
+++ b/crates/orbit-core/assets/activities/run_auto_task_scheduler.yaml
@@ -11,7 +11,8 @@ spec:
     under `.orbit/state/auto-tasks.json`. Catch-up collapses (a downtime gap
     yields one make-up task, never one per missed slot) and `skip_if_open`
     dedupe (never files while a prior instance created by the same definition
-    is still open) are enforced in the scheduler core. Every minted task
+    is still open; a `someday`-parked instance does not count as open) are
+    enforced in the scheduler core. Every minted task
     carries an `auto-task:<name>` provenance tag. Provider-neutral -
     definitions carry no turn-based knobs. An empty or all-skipped
     pass is a clean no-op. `dry_run` reports what would fire without recording
@@ -54,6 +55,10 @@ spec:
                 - type: string
                 - type: "null"
             task_id:
+              oneOf:
+                - type: string
+                - type: "null"
+            blocking_task_id:
               oneOf:
                 - type: string
                 - type: "null"

--- a/crates/orbit-core/src/application/auto_tasks/scheduler.rs
+++ b/crates/orbit-core/src/application/auto_tasks/scheduler.rs
@@ -31,14 +31,25 @@ impl AutoTaskDispatch for OrbitRuntime {
         self.paths().state_dir.clone()
     }
 
-    fn has_open_instance(&self, definition: &AutoTaskDefinition) -> Result<bool, OrbitError> {
+    fn has_open_instance(
+        &self,
+        definition: &AutoTaskDefinition,
+    ) -> Result<Option<String>, OrbitError> {
         let tasks = self.list_tasks_by_tags(&[auto_task_tag(&definition.name)])?;
-        Ok(tasks.iter().any(|task| {
-            !matches!(
-                task.status,
-                TaskStatus::Done | TaskStatus::Archived | TaskStatus::Rejected
-            )
-        }))
+        // `someday` is an explicit "not now" park, not an active instance
+        // [ORB-12148]: it must not block every later mint of this auto-task.
+        Ok(tasks
+            .into_iter()
+            .find(|task| {
+                !matches!(
+                    task.status,
+                    TaskStatus::Done
+                        | TaskStatus::Archived
+                        | TaskStatus::Rejected
+                        | TaskStatus::Someday
+                )
+            })
+            .map(|task| task.id))
     }
 
     fn mint_task(&self, definition: &AutoTaskDefinition) -> Result<String, OrbitError> {
@@ -117,6 +128,7 @@ pub fn run_scheduler_action_json(
                 "reason": report.reason,
                 "slot": report.slot,
                 "task_id": report.task_id,
+                "blocking_task_id": report.blocking_task_id,
                 "automation": report.automation,
             })
         })

--- a/crates/orbit-core/src/application/auto_tasks/tests/scheduler.rs
+++ b/crates/orbit-core/src/application/auto_tasks/tests/scheduler.rs
@@ -173,6 +173,69 @@ fn skip_if_open_never_files_a_second_open_instance() {
     assert_eq!(runtime.list_tasks().expect("tasks").len(), 2);
 }
 
+/// A `someday`-parked instance is an explicit "not now", not an active
+/// instance: it must not block every later mint of the auto-task [ORB-12148].
+#[test]
+fn skip_if_open_ignores_a_someday_instance() {
+    let runtime = runtime();
+    runtime
+        .auto_task_add(interval_params("chore", 60))
+        .expect("add");
+    let t0 = at(2026, 1, 1, 0, 0);
+
+    fire(&runtime, t0); // baseline
+    let first = fire(&runtime, t0 + Duration::minutes(60));
+    assert_eq!(first[0].0, "fired");
+    let task_id = first[0].1.clone().expect("task id");
+
+    runtime
+        .update_task(
+            &task_id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Someday),
+                ..Default::default()
+            },
+        )
+        .expect("park task");
+
+    // The someday-parked instance does not count as open, so the next due
+    // slot fires and mints a second task.
+    let second = fire(&runtime, t0 + Duration::minutes(180));
+    assert_eq!(second[0].0, "fired");
+    assert_eq!(runtime.list_tasks().expect("tasks").len(), 2);
+}
+
+#[test]
+fn dedupe_open_report_names_the_blocking_task() {
+    let runtime = runtime();
+    runtime
+        .auto_task_add(interval_params("chore", 60))
+        .expect("add");
+    let t0 = at(2026, 1, 1, 0, 0);
+
+    fire(&runtime, t0); // baseline
+    let first = fire(&runtime, t0 + Duration::minutes(60));
+    let task_id = first[0].1.clone().expect("task id");
+
+    let outcome = run_auto_task_scheduler_at(
+        &runtime,
+        t0 + Duration::minutes(180),
+        SchedulerOptions::default(),
+    )
+    .expect("scheduler pass");
+    assert_eq!(outcome.reports[0].action, "skipped");
+    assert_eq!(
+        outcome.reports[0].reason.as_deref(),
+        Some("dedupe_open"),
+        "{:?}",
+        outcome.reports[0]
+    );
+    assert_eq!(
+        outcome.reports[0].blocking_task_id.as_deref(),
+        Some(task_id.as_str())
+    );
+}
+
 #[test]
 fn weekly_cron_fires_once_and_dedupes_while_audit_is_open() {
     let runtime = runtime();

--- a/crates/orbit-core/src/application/automation/mod.rs
+++ b/crates/orbit-core/src/application/automation/mod.rs
@@ -235,6 +235,7 @@ fn auto_task_admission_deferral(
         && orbit_automation::auto_tasks::scheduler::AutoTaskDispatch::has_open_instance(
             runtime, definition,
         )?
+        .is_some()
     {
         return Ok(Some("open_instance".into()));
     }


### PR DESCRIPTION
## Task

[ORB-12148](https://orbit-cli.com/tasks/ORB-12148) — Auto-task SkipIfOpen dedupe counts a 'someday' instance as open, silently blocking every later mint of that auto-task

### Description

## Observed (2026-09-11 on-call shift)

`friction-curation` was enabled at 06:50 UTC. The 07:32 scheduler run (`jrun-20260911-0732-t1`) reported `friction-curation skipped dedupe_open slot=2026-09-11T07:15`. No friction-curation task was open in the default `orbit task list` view; `orbit task list --all --tag auto-task:friction-curation` revealed ORB-10656 (created 2026-08-09) parked in `someday`, untouched since creation. It had blocked every mint since then — the auto-task was effectively disabled with no visible signal beyond the scheduler's `dedupe_open` line.

`has_open_instance` in `crates/orbit-core/src/application/auto_tasks/scheduler.rs` treats every status except `done | archived | rejected` as open, so `someday` (an explicit "not now" parking status) counts as an active instance.

## Wanted

- `someday` must not count as an open instance for `SkipIfOpen` dedupe. Either exclude it in `has_open_instance`, or (preferred if the semantics team agrees) define "open" as the set of statuses a drain could still deliver (`proposed | backlog | in-progress | review`) and use that predicate.
- When the scheduler skips for `dedupe_open`, the report should name the blocking task id so an operator can see *what* is open without hunting with `--all`.

### Acceptance Criteria

- With an auto-task definition using SkipIfOpen and one existing instance in `someday`, the scheduler fires and mints a new task; a unit test in the scheduler tests covers this.
- With an existing instance in `proposed`, `backlog`, `in-progress`, or `review`, the scheduler still skips with `dedupe_open`.
- The `dedupe_open` AutoTaskFireReport carries the blocking task id (new field or in `reason` detail) and `orbit run show` on a scheduler run displays it.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Fix

`AutoTaskDispatch::has_open_instance` changed from `Result<bool, OrbitError>` to `Result<Option<String>, OrbitError>` — `None` means dedupe should let the fire proceed, `Some(task_id)` names the blocking instance.

- `crates/orbit-core/src/application/auto_tasks/scheduler.rs`: `OrbitRuntime`'s impl now excludes `TaskStatus::Someday` alongside `Done | Archived | Rejected` from "open", and returns the first blocking task's id instead of a bool.
- `crates/orbit-automation/src/auto_tasks/scheduler.rs`: `AutoTaskFireReport` gained a `blocking_task_id: Option<String>` field, populated at both `SkipIfOpen` dedupe sites (`dry_run_definition` and `fire_locked`); `reason` stays the unchanged `"dedupe_open"` string so existing callers keying off it are unaffected.
- `crates/orbit-core/src/application/auto_tasks/scheduler.rs::run_scheduler_action_json` and `crates/orbit-core/assets/activities/run_auto_task_scheduler.yaml` (`output_schema_json`) project/document the new `blocking_task_id` field, so `orbit run show <run> -s <step> --json` on a scheduler run surfaces it in the step output the activity already returns.
- `crates/orbit-core/src/application/automation/mod.rs::auto_task_admission_deferral` (delivery-schedule admission path, out of the original context_files, added via `orbit.task.update` — see comment): updated to `.is_some()` for the new return type; no behavior change beyond now also treating `someday` as non-blocking there, consistent with the shared `has_open_instance` implementation.

## Acceptance criteria

1. **Someday does not block a mint** — new test `application::auto_tasks::tests::scheduler::skip_if_open_ignores_a_someday_instance` (orbit-core): fires once, parks the minted task as `someday`, asserts the next due slot still fires and mints a second task.
2. **proposed/backlog/in-progress/review still dedupe** — covered by the existing `skip_if_open_never_files_a_second_open_instance` test (default mint status is `backlog`) plus the new default-status coverage; `TaskStatus::Someday` is the only status removed from the open set, so proposed/backlog/in-progress/review are unchanged and still block.
3. **Blocking task id surfaces** — new test `application::auto_tasks::tests::scheduler::dedupe_open_report_names_the_blocking_task` asserts `report.blocking_task_id == Some(task_id)` on a `dedupe_open` skip; the field is also threaded into the scheduler action's JSON output (`run_scheduler_action_json`) and its documented output schema, which is what `orbit run show` renders for a scheduler step.

## Validation

- `cargo test -p orbit-automation -p orbit-core --lib auto_tasks` — passed (75 tests, including both new tests).
- `make ci-fast` — passed.
- `make ci-lint` (workspace clippy, warnings denied) — passed after switching the two dedupe `if` checks to let-chains per `clippy::collapsible_if`.
- `git diff --check` — clean. `git status --short` — only the 6 files above modified, nothing untracked.

No deviations or open risks. Left uncommitted per workflow policy.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12148-6aa3b0c4`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus