### PR TITLE
[code-review] the orphan-task-store repair still reports "empty" partitions after it started deleting populated ones

### DIFF
--- a/crates/orbit-cli/src/command/doctor.rs
+++ b/crates/orbit-cli/src/command/doctor.rs
@@ -1,5 +1,7 @@
 use clap::Args;
-use orbit_cmd::{DoctorCommands, WorkspaceDoctorResult, WorkspaceDoctorStatus};
+use orbit_cmd::{
+    DoctorCommands, OrphanTaskStoreRemoval, WorkspaceDoctorResult, WorkspaceDoctorStatus,
+};
 use orbit_core::OrbitRuntime;
 use serde_json::{Value, json};
 
@@ -117,11 +119,12 @@ impl Execute for DoctorCommand {
                 ));
             }
             let removed = runtime.remove_orphan_task_stores()?;
-            eprintln!("Removed {removed} empty orphaned task-store partition(s).");
+            let message = orphan_task_store_removal_message(&removed);
+            eprintln!("{message}");
             results.push(WorkspaceDoctorResult {
                 check_name: "fix-orphan-task-stores".to_string(),
                 status: WorkspaceDoctorStatus::Ok,
-                message: format!("Removed {removed} empty orphaned task-store partition(s)."),
+                message,
                 remediation: None,
             });
         }
@@ -292,6 +295,17 @@ fn status_label(status: WorkspaceDoctorStatus) -> &'static str {
         WorkspaceDoctorStatus::Error => "ERROR",
         WorkspaceDoctorStatus::Skipped => "skipped",
     }
+}
+
+/// Render `--fix-orphan-task-stores --confirm`'s outcome, naming the empty
+/// and populated partition counts separately so a run that deleted task
+/// bundles is never described as removing only empty partitions [ORB-12144].
+pub(crate) fn orphan_task_store_removal_message(removed: &OrphanTaskStoreRemoval) -> String {
+    format!(
+        "Removed {} empty orphaned task-store partition(s) and {} populated partition(s) \
+         ({} task bundle(s)).",
+        removed.empty_partitions, removed.populated_partitions, removed.task_bundles
+    )
 }
 
 pub(crate) fn human_detail(row: &WorkspaceDoctorResult) -> String {

--- a/crates/orbit-cli/src/command/tests/doctor.rs
+++ b/crates/orbit-cli/src/command/tests/doctor.rs
@@ -1,7 +1,7 @@
-use orbit_cmd::{WorkspaceDoctorResult, WorkspaceDoctorStatus};
+use orbit_cmd::{OrphanTaskStoreRemoval, WorkspaceDoctorResult, WorkspaceDoctorStatus};
 use orbit_core::OrbitRuntime;
 
-use super::super::doctor::{doctor_row_json, human_detail};
+use super::super::doctor::{doctor_row_json, human_detail, orphan_task_store_removal_message};
 use super::super::{CommandOutput, Execute};
 
 #[test]
@@ -156,5 +156,43 @@ fn fix_stale_locks_records_repair_count_in_payload_doc() {
             .contains("Removed 1 stale lock file(s)."),
         "expected repair count in fix-stale-locks row message, got: {:?}",
         fix_row["message"]
+    );
+}
+
+/// [ORB-12144] A repair that deletes a populated stale partition must not be
+/// reported the same way as an empty one: the message names both counts and
+/// the destroyed task bundles, and never calls the populated partition empty.
+#[test]
+fn orphan_task_store_removal_message_reports_populated_partitions_and_bundles_separately() {
+    let removed = OrphanTaskStoreRemoval {
+        empty_partitions: 1,
+        populated_partitions: 2,
+        task_bundles: 5,
+    };
+
+    let message = orphan_task_store_removal_message(&removed);
+
+    assert_eq!(
+        message,
+        "Removed 1 empty orphaned task-store partition(s) and 2 populated partition(s) \
+         (5 task bundle(s))."
+    );
+    assert!(
+        !message.contains("2 empty"),
+        "the populated partitions must not be reported as empty: {message}"
+    );
+}
+
+/// A repair that removes nothing still reports both counts explicitly rather
+/// than a bare "removed 0 empty partitions" that hides whether bundles were
+/// ever at risk.
+#[test]
+fn orphan_task_store_removal_message_reports_zero_of_both_kinds() {
+    let message = orphan_task_store_removal_message(&OrphanTaskStoreRemoval::default());
+
+    assert_eq!(
+        message,
+        "Removed 0 empty orphaned task-store partition(s) and 0 populated partition(s) \
+         (0 task bundle(s))."
     );
 }

--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -88,6 +88,20 @@ fn actionable_check(
     }
 }
 
+/// Outcome of `--fix-orphan-task-stores`, split by whether a removed
+/// partition held task bundles, so the operator-facing report never calls a
+/// populated partition empty [ORB-12144].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct OrphanTaskStoreRemoval {
+    /// Empty partitions removed — deleting these cost no task data.
+    pub empty_partitions: usize,
+    /// Populated partitions removed because their bound checkout was
+    /// confirmed gone.
+    pub populated_partitions: usize,
+    /// Task bundles destroyed by removing `populated_partitions`.
+    pub task_bundles: usize,
+}
+
 /// Warn when the volume holding `.orbit` has less than this many free bytes.
 const DISK_WARN_BYTES: u64 = 1024 * 1024 * 1024; // 1 GiB
 /// Fail when the volume holding `.orbit` has less than this many free bytes.
@@ -130,9 +144,11 @@ pub trait DoctorCommands {
     /// Delete task-store partitions under `<global_root>/tasks/workspaces/`
     /// whose workspace id is no longer present in the registry — left behind
     /// by a `workspace teardown` run on an older binary, or by removing a
-    /// checkout without running teardown [ORB-12109]. Partitions that still
-    /// hold task bundles are reported but never deleted [ORB-12131].
-    fn remove_orphan_task_stores(&self) -> Result<usize, OrbitError>;
+    /// checkout without running teardown [ORB-12109]. Partitions that are
+    /// unowned and still hold task bundles are reported but never deleted
+    /// [ORB-12131]; partitions whose bound checkout is confirmed gone are
+    /// deleted along with their task bundles [ORB-12143].
+    fn remove_orphan_task_stores(&self) -> Result<OrphanTaskStoreRemoval, OrbitError>;
 
     /// Cheap store write probe for health endpoints: open the store and
     /// acquire + roll back the write lock without mutating anything.
@@ -178,9 +194,13 @@ impl DoctorCommands for OrbitRuntime {
         OrbitRuntime::repair_retired_activity_backends(self)
     }
 
-    fn remove_orphan_task_stores(&self) -> Result<usize, OrbitError> {
+    fn remove_orphan_task_stores(&self) -> Result<OrphanTaskStoreRemoval, OrbitError> {
         let removed = crate::task_store::remove_unclaimed_task_stores(&self.global_root())?;
-        Ok(removed.len())
+        Ok(OrphanTaskStoreRemoval {
+            empty_partitions: removed.empty.len(),
+            populated_partitions: removed.stale.len(),
+            task_bundles: removed.task_bundles_removed(),
+        })
     }
 
     fn remove_retired_graph_state(&self) -> Result<usize, OrbitError> {
@@ -515,12 +535,23 @@ fn doctor_check_orphan_task_stores(runtime: &OrbitRuntime) -> WorkspaceDoctorRes
     }
 
     if !partitions.stale.is_empty() || !partitions.removable.is_empty() {
-        steps.push(if steps.is_empty() {
-            "Run `orbit doctor --fix-orphan-task-stores --confirm`.".to_string()
+        // Every entry in `stale` is populated by construction (empty
+        // partitions land in `removable` instead), so its deletion always
+        // destroys task bundles; the remediation must say so up front rather
+        // than let the operator discover it from the repair's own report.
+        let bundle_note = if partitions.stale.is_empty() {
+            ""
         } else {
-            "Then run `orbit doctor --fix-orphan-task-stores --confirm`, which removes only the \
-             empty partitions and the partitions whose checkout is confirmed gone."
-                .to_string()
+            " Populated stale partitions are deleted along with their task bundles."
+        };
+        steps.push(if steps.is_empty() {
+            format!("Run `orbit doctor --fix-orphan-task-stores --confirm`.{bundle_note}")
+        } else {
+            format!(
+                "Then run `orbit doctor --fix-orphan-task-stores --confirm`, which removes only \
+                 the empty partitions and the partitions whose checkout is confirmed \
+                 gone.{bundle_note}"
+            )
         });
     }
 

--- a/crates/orbit-cmd/src/lib.rs
+++ b/crates/orbit-cmd/src/lib.rs
@@ -37,7 +37,9 @@ mod tests;
 
 pub use activity_v2::{ActivityV2Commands, V2ActivityRunResult};
 pub use diagnostics::DiagnosticsCommands;
-pub use doctor::{DoctorCommands, WorkspaceDoctorResult, WorkspaceDoctorStatus};
+pub use doctor::{
+    DoctorCommands, OrphanTaskStoreRemoval, WorkspaceDoctorResult, WorkspaceDoctorStatus,
+};
 pub use migrate::{MigrateCommands, MigrateStatus, migrate_dry_run_at};
 pub use task_store::{
     TaskStorePartitions, bound_partition_id, inspect_task_store_partitions,

--- a/crates/orbit-cmd/src/task_store.rs
+++ b/crates/orbit-cmd/src/task_store.rs
@@ -132,9 +132,36 @@ pub fn inspect_task_store_partitions(
     }))
 }
 
+/// Partitions actually deleted by [`remove_unclaimed_task_stores`], split by
+/// whether removing them cost any task data — so a caller can report each
+/// count honestly instead of collapsing both into one "empty" figure
+/// [ORB-12144].
+#[derive(Debug, Clone, Default)]
+pub struct RemovedTaskStores {
+    /// Empty partitions removed — deleting these cost no task data.
+    pub empty: Vec<PathBuf>,
+    /// Populated partitions removed because their bound checkout was
+    /// confirmed gone, each with the task bundles it held.
+    pub stale: Vec<UnclaimedPartition>,
+}
+
+impl RemovedTaskStores {
+    /// Whether the repair removed no partitions at all.
+    pub fn is_empty(&self) -> bool {
+        self.empty.is_empty() && self.stale.is_empty()
+    }
+
+    /// Task bundles destroyed by removing [`Self::stale`] partitions.
+    pub fn task_bundles_removed(&self) -> usize {
+        self.stale
+            .iter()
+            .map(|partition| partition.task_bundles)
+            .sum()
+    }
+}
+
 /// Delete every empty unclaimed partition and every partition whose bound
 /// checkout is confirmed gone, retiring any registry rows that name it.
-/// Returns the removed partition paths.
 ///
 /// A partition that still holds bundles is deleted only on evidence a
 /// transient filesystem condition cannot forge. An unclaimed populated
@@ -146,19 +173,27 @@ pub fn inspect_task_store_partitions(
 /// kept for the same reason: the checkout may still be there [ORB-12143].
 /// Reclaiming such a partition stays a deliberate manual step, or
 /// `orbit workspace teardown` while the checkout still exists.
-pub fn remove_unclaimed_task_stores(global_root: &Path) -> Result<Vec<PathBuf>, OrbitError> {
+pub fn remove_unclaimed_task_stores(global_root: &Path) -> Result<RemovedTaskStores, OrbitError> {
     let Some(partitions) = inspect_task_store_partitions(global_root)? else {
-        return Ok(Vec::new());
+        return Ok(RemovedTaskStores::default());
     };
     let tasks = open_task_registry(global_root)?;
 
-    let mut removed = Vec::new();
-    for partition in partitions.stale.into_iter().chain(partitions.removable) {
+    let mut removed = RemovedTaskStores::default();
+    for partition in partitions.stale {
         let Some(workspace_id) = partition_id(&partition.path) else {
             continue;
         };
         if remove_partition(&tasks, global_root, workspace_id)? {
-            removed.push(partition.path);
+            removed.stale.push(partition);
+        }
+    }
+    for partition in partitions.removable {
+        let Some(workspace_id) = partition_id(&partition.path) else {
+            continue;
+        };
+        if remove_partition(&tasks, global_root, workspace_id)? {
+            removed.empty.push(partition.path);
         }
     }
     Ok(removed)

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -18,8 +18,8 @@ use orbit_core::runtime::OrbitRuntimeRoots;
 use orbit_store::TaskReservationReserveParams;
 
 use crate::doctor::{
-    DoctorCommands, WorkspaceDoctorResult, WorkspaceDoctorStatus, collect_lock_files,
-    disk_space_check, process_is_alive,
+    DoctorCommands, OrphanTaskStoreRemoval, WorkspaceDoctorResult, WorkspaceDoctorStatus,
+    collect_lock_files, disk_space_check, process_is_alive,
 };
 use crate::task_store::partition_is_bound;
 
@@ -1033,13 +1033,24 @@ fn stale_task_registry_binding_is_reported_and_removed() {
     assert!(row.message.contains("1 task bundle(s)"), "{}", row.message);
     assert_eq!(
         row.remediation.as_deref(),
-        Some("Run `orbit doctor --fix-orphan-task-stores --confirm`.")
+        Some(
+            "Run `orbit doctor --fix-orphan-task-stores --confirm`. Populated stale partitions \
+             are deleted along with their task bundles."
+        )
     );
 
     let removed = runtime
         .remove_orphan_task_stores()
         .expect("remove stale orphan task store");
-    assert_eq!(removed, 1);
+    assert_eq!(removed.empty_partitions, 0, "{removed:?}");
+    assert_eq!(
+        removed.populated_partitions, 1,
+        "a populated stale partition was removed: {removed:?}"
+    );
+    assert_eq!(
+        removed.task_bundles, 1,
+        "the removed partition's bundle is counted: {removed:?}"
+    );
     assert!(
         !task_workspaces_dir(&global_root)
             .join("deleted-a1b2c3")
@@ -1070,7 +1081,12 @@ fn fix_orphan_task_stores_keeps_every_claimed_partition() {
     let removed = runtime
         .remove_orphan_task_stores()
         .expect("remove orphan task stores");
-    assert_eq!(removed, 1, "only the unclaimed partition is removed");
+    assert_eq!(
+        removed.empty_partitions, 1,
+        "only the unclaimed partition is removed: {removed:?}"
+    );
+    assert_eq!(removed.populated_partitions, 0, "{removed:?}");
+    assert_eq!(removed.task_bundles, 0, "{removed:?}");
 
     let partitions = task_workspaces_dir(&global_root);
     assert!(!partitions.join("ws_orphan").exists());
@@ -1104,7 +1120,8 @@ fn fix_orphan_task_stores_removes_only_the_unregistered_partition() {
     let removed = runtime
         .remove_orphan_task_stores()
         .expect("remove orphan task stores");
-    assert_eq!(removed, 1);
+    assert_eq!(removed.empty_partitions, 1, "{removed:?}");
+    assert_eq!(removed.populated_partitions, 0, "{removed:?}");
     assert!(!task_workspaces_dir(&global_root).join("ws_orphan").exists());
     assert!(
         task_workspaces_dir(&global_root)
@@ -1156,7 +1173,7 @@ fn populated_unclaimed_partition_warns_toward_reindex_not_deletion() {
 
     assert_eq!(
         runtime.remove_orphan_task_stores().expect("run the repair"),
-        0
+        OrphanTaskStoreRemoval::default()
     );
     assert!(
         populated.is_dir(),
@@ -1207,7 +1224,7 @@ fn unreachable_checkout_partition_is_reported_without_the_deletion_repair() {
 
     assert_eq!(
         runtime.remove_orphan_task_stores().expect("run the repair"),
-        0
+        OrphanTaskStoreRemoval::default()
     );
     assert!(
         task_workspaces_dir(&global_root)

--- a/crates/orbit-cmd/src/tests/task_store.rs
+++ b/crates/orbit-cmd/src/tests/task_store.rs
@@ -226,7 +226,8 @@ fn an_unclaimed_partition_without_bundles_is_still_reclaimed() {
     assert!(partitions.unowned.is_empty(), "{:?}", partitions.unowned);
 
     let removed = remove_unclaimed_task_stores(&global_root).expect("run the repair");
-    assert_eq!(removed, vec![residue.clone()]);
+    assert_eq!(removed.empty, vec![residue.clone()]);
+    assert!(removed.stale.is_empty(), "{removed:?}");
     assert!(!residue.exists());
     assert!(
         task_workspaces_dir(&global_root)
@@ -385,10 +386,16 @@ fn a_confirmed_deleted_checkout_still_releases_its_populated_partition() {
     assert!(partitions.unreachable.is_empty(), "{partitions:?}");
 
     let removed = remove_unclaimed_task_stores(&global_root).expect("run the repair");
+    assert!(removed.empty.is_empty(), "{removed:?}");
     assert_eq!(
-        removed,
+        removed
+            .stale
+            .iter()
+            .map(|partition| partition.path.clone())
+            .collect::<Vec<_>>(),
         vec![task_store_partition_path(&global_root, "proj-5b631f")]
     );
+    assert_eq!(removed.task_bundles_removed(), 1);
     assert!(!partition_is_bound(&global_root, "proj-5b631f").expect("read bindings"));
 }
 
@@ -417,6 +424,8 @@ fn an_unreachable_checkout_still_reclaims_an_empty_partition() {
     let removed = remove_unclaimed_task_stores(&global_root);
     restore_search(&volume);
 
-    assert_eq!(removed.expect("run the repair"), vec![partition.clone()]);
+    let removed = removed.expect("run the repair");
+    assert_eq!(removed.empty, vec![partition.clone()]);
+    assert!(removed.stale.is_empty(), "{removed:?}");
     assert!(!partition.exists());
 }


### PR DESCRIPTION
## Task

[ORB-12144](https://orbit-cli.com/tasks/ORB-12144) — [code-review] the orphan-task-store repair still reports "empty" partitions after it started deleting populated ones

### Description

ORB-12127 extended `orbit doctor --fix-orphan-task-stores --confirm` to delete stale-bound partitions *including their task bundles* (`crates/orbit-cmd/src/task_store.rs:110-135`), but the operator-facing text still describes the pre-change behavior:

- `crates/orbit-cli/src/command/doctor.rs:120` and `:124` print and record `"Removed {removed} empty orphaned task-store partition(s)."` — so a run that just destroyed dozens of task bundles reports them as empty.
- The stale rows' remediation is the bare `"Run `orbit doctor --fix-orphan-task-stores --confirm`."` (`crates/orbit-cmd/src/doctor.rs:535` and `:547`) with no statement that bundles will be deleted, even though the same message already counts them ("1 task bundle(s)").

The operator therefore gets no signal, before or after, that the repair destroyed recoverable task data. `docs/runbooks/health-checks.md:126-135` does say the confirmed repair "removes that partition, including its task bundles", so the CLI contradicts the runbook.

## Reproduced on `b120228b4` (Linux, binary built from this worktree)

Disposable `/tmp` HOME and checkout, inherited authority cleared, routing verified with `orbit workspace show --format json` first. Partition `proj-5b631f` held one task bundle:

```
$ orbit doctor --fix-orphan-task-stores --confirm
Removed 1 empty orphaned task-store partition(s).
fix-orphan-task-stores	ok	Removed 1 empty orphaned task-store partition(s).
```

The deleted partition was not empty — its task was unrecoverable afterwards.

## Suggested direction

Report what was removed: separate the empty-residue count from the stale-binding count and name the number of task bundles deleted, and say so in the remediation line the warning hands the operator. Whatever evidence rule ORB-12143 settles on, the counts should be honest.

### Acceptance Criteria

- The `--fix-orphan-task-stores` output states how many partitions were removed and how many task bundles were deleted, without calling a populated partition empty.
- The stale-binding remediation text tells the operator the repair deletes task bundles.
- A test asserts the reported wording/counts for a repair that removes a populated stale partition.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented the honest orphan-task-store removal report end to end.

Changes:
- crates/orbit-cmd/src/task_store.rs: `remove_unclaimed_task_stores` now returns `RemovedTaskStores { empty: Vec<PathBuf>, stale: Vec<UnclaimedPartition> }` instead of a flat `Vec<PathBuf>`, distinguishing partitions that cost no data from populated ones deleted on confirmed-gone evidence; added `task_bundles_removed()`.
- crates/orbit-cmd/src/doctor.rs: new `OrphanTaskStoreRemoval { empty_partitions, populated_partitions, task_bundles }`; `DoctorCommands::remove_orphan_task_stores` returns it. `doctor_check_orphan_task_stores`'s stale-binding remediation now appends "Populated stale partitions are deleted along with their task bundles." whenever `stale` is non-empty (every `stale` entry is populated by construction, so this is always accurate when it fires).
- crates/orbit-cli/src/command/doctor.rs: `--fix-orphan-task-stores --confirm` now prints/records "Removed {empty} empty orphaned task-store partition(s) and {populated} populated partition(s) ({bundles} task bundle(s))." via a new `orphan_task_store_removal_message` helper, replacing the old message that called every removal "empty".
- crates/orbit-cmd/src/lib.rs: exports `OrphanTaskStoreRemoval` (needed by orbit-cli).
- Tests updated/added: crates/orbit-cmd/src/tests/task_store.rs and src/tests/doctor.rs updated to the new struct shapes (including asserting bundle counts for a populated stale-partition removal); crates/orbit-cli/src/command/tests/doctor.rs adds two unit tests for `orphan_task_store_removal_message` covering a populated-partition repair (asserts exact wording, counts, and that populated partitions are never called "empty") and the all-zero case.

Criteria:
1. CLI output states both counts and the bundle count, never calling a populated partition empty — met (`orphan_task_store_removal_message`, tested).
2. Stale-binding remediation now states bundles are deleted — met (`doctor_check_orphan_task_stores`, tested in `stale_task_registry_binding_is_reported_and_removed`).
3. Test asserts reported wording/counts for a repair removing a populated stale partition — met at both layers: orbit-cmd's `stale_task_registry_binding_is_reported_and_removed` asserts `populated_partitions`/`task_bundles` counts and remediation wording; orbit-cli's `orphan_task_store_removal_message_reports_populated_partitions_and_bundles_separately` asserts the exact rendered message.

Validation:
- `cargo build --workspace --all-targets` — passed.
- `cargo test -p orbit-cmd doctor:: task_store::` — 33 + 9 tests passed.
- `cargo test -p orbit-cli --bins doctor` — 10 tests passed (includes the 2 new ones).
- `cargo fmt --check -p orbit-cmd -p orbit-cli` — passed (after `cargo fmt`).
- `make ci-fast` — passed.
- `make ci-lint` (workspace-wide clippy, `-D warnings`) — passed.
- `git status --short` / `git diff --check` — clean, no unexpected files, no whitespace issues.

Scope: widened context_files by two direct consumers of the changed signatures (crates/orbit-cmd/src/lib.rs, crates/orbit-cmd/src/tests/task_store.rs); see task comment for rationale. No other call sites of `remove_orphan_task_stores`/`remove_unclaimed_task_stores` exist in the workspace. docs/runbooks/health-checks.md already described the intended (bundle-deleting) behavior correctly and needed no change.

Left uncommitted per delivery policy.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12144-6aa3b3ad`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus