### PR TITLE
Fix red CI on agent-main: worktree_gc_routing test still expects the pre-ORB-12140 'older_than_hours: 24' seeded default

### DIFF
--- a/crates/orbit-cli/tests/worktree_gc_routing.rs
+++ b/crates/orbit-cli/tests/worktree_gc_routing.rs
@@ -346,14 +346,45 @@ fn zero_worktree_gc_age_floor(home: &Path) {
     let path = home.join(".orbit/resources/jobs/worktree_gc_pipeline.yaml");
     let content = fs::read_to_string(&path)
         .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
-    let updated = content.replace("older_than_hours: 24", "older_than_hours: 0");
-    assert_ne!(
-        content,
-        updated,
-        "expected an `older_than_hours: 24` default in {}",
+    let updated = replace_seeded_older_than_hours_default(&content);
+    assert!(
+        updated.contains("older_than_hours: 0"),
+        "expected an `older_than_hours: 0` default after rewriting the seeded job in {}",
         path.display()
     );
     fs::write(&path, updated).unwrap_or_else(|error| panic!("write {}: {error}", path.display()));
+}
+
+/// Rewrites the seeded pipeline's own `older_than_hours: <integer>` default to
+/// `0`, whatever integer it currently holds — independent of the exact seeded
+/// value so a future default change doesn't desync this fixture. Leaves the
+/// step config's templated passthrough (`older_than_hours: "{{ input.older_than_hours }}"`)
+/// untouched: its value isn't a bare integer, so it never matches.
+fn replace_seeded_older_than_hours_default(content: &str) -> String {
+    let mut replaced_any = false;
+    let mut updated: String = content
+        .lines()
+        .map(|line| {
+            let Some(key_start) = line.find("older_than_hours:") else {
+                return line.to_string();
+            };
+            let value = line[key_start + "older_than_hours:".len()..].trim();
+            if value.parse::<u64>().is_err() {
+                return line.to_string();
+            }
+            replaced_any = true;
+            format!("{}older_than_hours: 0", &line[..key_start])
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        replaced_any,
+        "found no numeric `older_than_hours:` default to rewrite in seeded job"
+    );
+    if content.ends_with('\n') {
+        updated.push('\n');
+    }
+    updated
 }
 
 fn configure_fixture_crew(root: &Path) {


### PR DESCRIPTION
## Task

[ORB-12155](https://orbit-cli.com/tasks/ORB-12155) — Fix red CI on agent-main: worktree_gc_routing test still expects the pre-ORB-12140 'older_than_hours: 24' seeded default

### Description

## Red CI

`agent-main` CI is red from 867a2312 (ORB-12140, PR #1941) onward — run 34575339983 and every later run (e.g. 34576207233 on 6e7475cc). Failing jobs: `Check / Clippy / Test :: Run CI guardrails` and `Coverage (informational) :: Collect workspace coverage`. Single failing test:

```
routine_dispatch_ignores_ambient_orbit_root_and_reaps_only_the_owning_workspaces_worktree
  panicked at crates/orbit-cli/tests/worktree_gc_routing.rs:350:5:
  assertion `left != right` failed: expected an `older_than_hours: 24` default in <home>/.orbit/resources/jobs/worktree_gc_pipeline.yaml
```

## Cause

ORB-12140 changed the embedded `crates/orbit-core/assets/jobs/worktree_gc_pipeline.yaml` default from `older_than_hours: 24` to `older_than_hours: 1` (delivery now reaps worktrees itself; the routine is a 1 h backstop). The test helper `zero_worktree_gc_age_floor` in `crates/orbit-cli/tests/worktree_gc_routing.rs` does `content.replace("older_than_hours: 24", "older_than_hours: 0")` and asserts the text changed, so it now panics before the routine dispatch it is meant to exercise.

## Fix

Make the helper independent of the exact seeded default: replace whatever integer follows `older_than_hours:` in the seeded job (a small regex or line scan), and assert that the resulting file contains `older_than_hours: 0`. Do not change the seeded default back, and do not weaken the test's actual assertion (the routine reaps only the owning workspace's worktree).

### Acceptance Criteria

- `cargo test -p orbit-cli --test worktree_gc_routing` passes against the current seeded default (`older_than_hours: 1`) and would still pass if the default were changed again to any integer.
- The seeded `worktree_gc_pipeline.yaml` default introduced by ORB-12140 is unchanged.
- CI on agent-main is green on the merge commit (Check / Clippy / Test and Coverage jobs).

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed the seeded-default-coupled regression test in crates/orbit-cli/tests/worktree_gc_routing.rs.

Root cause: `zero_worktree_gc_age_floor` did `content.replace("older_than_hours: 24", "older_than_hours: 0")` and asserted the text changed via `assert_ne!`. ORB-12140 changed the seeded `crates/orbit-core/assets/jobs/worktree_gc_pipeline.yaml` default from 24 to 1, so the literal "24" string no longer matched and the helper panicked before the routine-dispatch behavior under test ever ran.

Fix: replaced the hardcoded literal replace with `replace_seeded_older_than_hours_default`, a line-scan that finds the `older_than_hours:` key, parses its value as a bare `u64` (skipping the templated step-config passthrough `older_than_hours: "{{ input.older_than_hours }}"`, which fails the u64 parse and is left untouched), and rewrites only that numeric default to 0. The helper now asserts the result contains `older_than_hours: 0` and that at least one numeric default was found, instead of asserting the old literal text changed. This makes the fixture independent of the exact seeded integer while still failing loudly if the key disappears entirely.

Did not touch the seeded `crates/orbit-core/assets/jobs/worktree_gc_pipeline.yaml` (still `older_than_hours: 1`, confirmed via grep) — only the test fixture changed.

Criteria:
1. `cargo test -p orbit-cli --test worktree_gc_routing` passes against the current seeded default (1) and is no longer coupled to any specific integer (verified by code: it parses/replaces whatever integer is present, not a fixed literal) — evidenced by the passing run below.
2. Seeded `worktree_gc_pipeline.yaml` default unchanged — confirmed via `grep -n older_than_hours crates/orbit-core/assets/jobs/worktree_gc_pipeline.yaml` (still `older_than_hours: 1`); `git status --short` shows only the test file modified.
3. CI on agent-main green on the merge commit — not verifiable from this worktree; deferred to the pipeline's merge/CI step (outside this task's execution boundary).

Validation:
- `cargo fmt -p orbit-cli -- --check` — passed, no output.
- `make ci-fast` — passed (guardrails, fmt-check, installer/security/import/terminal-state/error-translation/orphan-module guards, plugin/skill sync checks all green).
- `cargo test -p orbit-cli --test worktree_gc_routing -- --nocapture` — passed: `test routine_dispatch_ignores_ambient_orbit_root_and_reaps_only_the_owning_workspaces_worktree ... ok`, `test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 21.29s`.
- `git diff --check` — clean (no whitespace errors).
- `git status --short` — only `crates/orbit-cli/tests/worktree_gc_routing.rs` modified; no untracked files.

Not run: full `make ci` / `make ci-lint` (workspace-wide clippy) — per workspace instructions the full `make ci` is the canonical merge gate run by CI itself, not expected per-task; `ci-fast` was run instead as required before moving to review.

Scope: single-file change, matches the task's sole `context_files` entry (`file:crates/orbit-cli/tests/worktree_gc_routing.rs`). No scope expansion needed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12155-6aa3b837`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus