### PR TITLE
[code-review] a workspace registered without a checkout (every cross-host import mirror) lost its partition claim, so doctor warns about it forever

### DIFF
--- a/crates/orbit-cmd/src/task_store.rs
+++ b/crates/orbit-cmd/src/task_store.rs
@@ -256,8 +256,9 @@ pub fn partition_is_bound(global_root: &Path, workspace_id: &str) -> Result<bool
 
 /// Who claims each partition on this host, and why the rest do not.
 struct PartitionClaims {
-    /// Live checkout bindings, workspace catalog ids, and the synthetic
-    /// partition every `--root <data-dir>` write lands in.
+    /// Registered task workspaces, live checkout bindings, workspace catalog
+    /// ids, and the synthetic partition every `--root <data-dir>` write lands
+    /// in.
     claimed: BTreeSet<String>,
     /// Bindings whose checkout is confirmed absent.
     gone: BTreeSet<String>,
@@ -277,6 +278,10 @@ fn partition_claims(global_root: &Path) -> Result<PartitionClaims, OrbitError> {
     };
     for workspace_id in tasks.workspace_ids()? {
         let Some(checkout) = tasks.find_workspace_checkout(&workspace_id)? else {
+            // Imported task archives register their source workspace without a
+            // machine-local checkout. That logical registration still owns its
+            // partition on this host.
+            claims.claimed.insert(workspace_id);
             continue;
         };
         match checkout_evidence(&checkout.orbit_dir) {

--- a/crates/orbit-cmd/src/tests/task_store.rs
+++ b/crates/orbit-cmd/src/tests/task_store.rs
@@ -5,7 +5,8 @@ use std::fs;
 use std::path::Path;
 
 use orbit_store::maintenance::task_registry::{
-    BindWorkspaceParams, TaskRegistryStore, task_registry_path, task_workspaces_dir,
+    BindWorkspaceParams, RegisterWorkspaceParams, TaskRegistryStore, task_registry_path,
+    task_workspaces_dir,
 };
 
 use crate::task_store::{
@@ -26,6 +27,18 @@ fn bind(global_root: &Path, workspace_id: &str, slug: &str, repo_root: &Path) {
             repo_fingerprint: None,
         })
         .expect("bind task-registry workspace");
+}
+
+fn register_logical_workspace(global_root: &Path, workspace_id: &str, slug: &str) {
+    let tasks =
+        TaskRegistryStore::open(&task_registry_path(global_root)).expect("open task registry");
+    tasks
+        .register_workspace(RegisterWorkspaceParams {
+            workspace_id: workspace_id.to_string(),
+            slug: slug.to_string(),
+            repo_fingerprint: None,
+        })
+        .expect("register logical workspace");
 }
 
 /// Delete the task registry the way a corrupted restore or a manual rebuild
@@ -199,6 +212,42 @@ fn losing_the_task_registry_leaves_populated_partitions_for_reindex() {
             .join("ORB-2")
             .is_dir(),
         "the unclaimed checkout's task bundle must survive the repair"
+    );
+}
+
+/// An imported workspace is registered on the host without a machine-local
+/// checkout. Its partition is still owned task state and must survive the
+/// orphan-store scan and repair.
+#[test]
+fn registered_checkoutless_workspace_claims_its_partition() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    fs::create_dir_all(&global_root).expect("create global root");
+
+    register_logical_workspace(&global_root, "ws_mirror", "mirror");
+    write_task_bundle(&global_root, "ws_mirror", "ORB-1");
+
+    let partitions = inspect_task_store_partitions(&global_root)
+        .expect("inspect partitions")
+        .expect("partitions directory exists");
+    assert_eq!(partitions.scanned, 1);
+    assert!(partitions.removable.is_empty(), "{partitions:?}");
+    assert!(partitions.stale.is_empty(), "{partitions:?}");
+    assert!(partitions.unowned.is_empty(), "{partitions:?}");
+    assert!(partitions.unreachable.is_empty(), "{partitions:?}");
+
+    let removed = remove_unclaimed_task_stores(&global_root).expect("run the repair");
+    assert!(removed.is_empty(), "the repair removed {removed:?}");
+    assert!(
+        task_workspaces_dir(&global_root)
+            .join("ws_mirror")
+            .join("ORB-1")
+            .is_dir(),
+        "a registered checkout-less workspace's task bundle must survive"
+    );
+    assert!(
+        partition_is_bound(&global_root, "ws_mirror").expect("read bindings"),
+        "the logical workspace registration must survive"
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-12145](https://orbit-cli.com/tasks/ORB-12145) — [code-review] a workspace registered without a checkout (every cross-host import mirror) lost its partition claim, so doctor warns about it forever

### Description

`partition_claims` replaced `claimed_partition_ids`'s "every id in `workspace_bindings` claims its partition" with a per-workspace checkout lookup (`crates/orbit-cmd/src/task_store.rs:197-215`). Its `None => {}` arm drops the claim entirely for a logical workspace that has no row in `workspace_checkout_bindings` — a state Orbit creates deliberately: `import_tasks` registers the archive's source workspace with `register_workspace` and "must never fabricate checkout paths" (`crates/orbit-store/src/workflow/task/mod.rs:701-712`, `crates/orbit-store/src/driver/sqlite/task_registry/store.rs:311-345`).

That is exactly the shape ORB-12126's owner-wins sync produces on every mirror host, landed in the same window. The partition is not in the `ws_*` workspace catalog either (import never writes `workspaces.json`), so nothing claims it, and `doctor_check_orphan_task_stores` reports it as an unclaimed populated partition with a remediation that cannot apply: "Run `orbit task reindex` from each checkout that owns these bundles" — there is no such checkout on this host — followed by "remove one by hand only after confirming its checkout is gone", which invites deleting a healthy mirror.

## Reproduced on `b120228b4` (Linux, binary built from this worktree)

Two disposable `/tmp` hosts, inherited authority cleared, routing verified with `orbit workspace show --format json` before any mutation. Host A exports `ws_fxrepo`; host B imports it normally:

```
$ orbit task import /tmp/orbfx1/peer.tar.zst
imported into workspace 'ws_fxrepo'
  registered new workspace binding
  kept  ORB-00000

$ orbit doctor
orphan-task-stores	warning	1 task-store partition(s) hold task bundles that no workspace
  binding claims: ws_fxrepo (.../workspaces/ws_fxrepo, 1 task bundle(s))
  | Action: Run `orbit task reindex` from each checkout that owns these bundles ...

$ orbit task reindex --task-workspace ws_fxrepo
reindexed workspace 'ws_fxrepo': 1 bundle(s), 0 stale binding(s) dropped
$ orbit doctor            # unchanged — the suggested repair cannot clear it
orphan-task-stores	warning	1 task-store partition(s) hold task bundles that no workspace binding claims: ws_fxrepo ...
```

sqlite confirms the cause: `workspace_bindings` holds `ws_fxrepo` and `ws_mirrorhost`, `workspace_checkout_bindings` only `ws_mirrorhost`. Before this change `claimed_partition_ids` returned `tasks.workspace_ids()`, which includes `ws_fxrepo`, so the row was `ok`.

A host that syncs a peer's tasks on a timer therefore can never get a clean `orbit doctor` again. By the same classification (code path, not reproduced), a checkout-less workspace whose partition happens to be *empty* falls into `removable` and the confirmed repair deletes it and calls `unbind_workspace`, dropping the registered mirror workspace so the next `orbit task import --task-workspace <id>` fails with "register it first".

## Suggested direction

Keep a registered logical workspace a claimant whether or not it has a machine-local checkout; reserve the stale classification for a workspace that *has* a checkout binding pointing at a directory that is genuinely gone.

### Acceptance Criteria

- After a normal `orbit task import` of a peer archive, `orbit doctor` reports `orphan-task-stores` as ok on the importing host.
- A partition belonging to a registered checkout-less workspace is neither deleted nor unbound by `orbit doctor --fix-orphan-task-stores --confirm`.
- A regression test covers the checkout-less registered workspace at the `inspect_task_store_partitions` boundary.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated partition_claims so a registered logical workspace with no machine-local checkout still claims its task-store partition; existing stale and unreachable checkout handling is unchanged.
- Added a boundary regression test covering inspect_task_store_partitions and the repair path, proving a populated checkout-less workspace remains registered and its bundle survives.

Acceptance criteria:
1. Passed — a disposable two-root CLI scenario performed normal task export/import and reported orphan-task-stores as ok on the importing host.
2. Passed — the same scenario ran doctor --fix-orphan-task-stores --confirm and verified the imported partition remained; the boundary test also verified the registry binding remained.
3. Passed — registered_checkoutless_workspace_claims_its_partition exercises the inspect_task_store_partitions boundary.

Validation:
- Passed: cargo test -p orbit-cmd --lib task_store (14 passed).
- Passed: cargo test -p orbit-cli --test orbit12145_e2e -- --nocapture (temporary disposable integration harness; 1 passed, then removed).
- Passed: cargo fmt --all -- --check.
- Passed: make ci-fast. Its compiler-cache mount-namespace subcheck was skipped because bubblewrap could not create a non-privileged namespace; the remaining guardrails passed.
- Passed: make ci-lint.
- Passed: git diff --check and git status --short; only the two task-scoped files are modified.

Assessment: The fix is minimal and authoritative at the partition-claim boundary. No permanent files outside the declared context were changed.

Remaining risk / deviation: cargo clean was attempted after validation but failed with Device or resource busy while removing the worktree target directory; it was not retried. The leftover Cargo output is outside the patch and does not affect source validation.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12145-6aa3b681`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus