### PR TITLE
[qa-sweep] orbit mcp init --claude writes config paths Claude Code does not read, so the Orbit MCP server is never registered

### DIFF
--- a/crates/orbit-cli/src/command/mcp/setup/args.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/args.rs
@@ -12,7 +12,7 @@ use crate::command::{CommandOut, CommandOutput};
 pub enum ScopeArg {
     /// Write to user-level config (~/.claude, ~/.codex, ~/.gemini, ~/.grok, Antigravity mcp_config).
     Home,
-    /// Write to repo-local config (.claude.json, .codex/, .gemini/, .grok/). Default.
+    /// Write to repo-local config (.mcp.json, .codex/, .gemini/, .grok/). Default.
     #[default]
     Workspace,
 }

--- a/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
@@ -66,6 +66,7 @@ pub(super) fn run_action(
 /// or in the repo.
 pub(super) struct ConfigTarget {
     pub(super) mcp_path: PathBuf,
+    pub(super) legacy_mcp_path: Option<PathBuf>,
     pub(super) settings_path: Option<PathBuf>,
 }
 
@@ -80,78 +81,92 @@ impl ConfigTarget {
             (ScopeArg::Home, McpProvider::Claude) => {
                 let home = require_home_dir(home_dir)?;
                 Ok(Self {
-                    mcp_path: home.join(".claude").join(".mcp.json"),
+                    mcp_path: home.join(".claude.json"),
+                    legacy_mcp_path: Some(home.join(".claude").join(".mcp.json")),
                     settings_path: Some(home.join(".claude").join("settings.json")),
                 })
             }
             (ScopeArg::Workspace, McpProvider::Claude) => Ok(Self {
-                mcp_path: repo_root.join(".claude.json"),
+                mcp_path: repo_root.join(".mcp.json"),
+                legacy_mcp_path: Some(repo_root.join(".claude.json")),
                 settings_path: Some(repo_root.join(".claude").join("settings.json")),
             }),
             (ScopeArg::Home, McpProvider::Codex) => {
                 let home = require_home_dir(home_dir)?;
                 Ok(Self {
                     mcp_path: home.join(".codex").join("config.toml"),
+                    legacy_mcp_path: None,
                     settings_path: None,
                 })
             }
             (ScopeArg::Workspace, McpProvider::Codex) => Ok(Self {
                 mcp_path: repo_root.join(".codex").join("config.toml"),
+                legacy_mcp_path: None,
                 settings_path: None,
             }),
             (ScopeArg::Home, McpProvider::Gemini) => {
                 let home = require_home_dir(home_dir)?;
                 Ok(Self {
                     mcp_path: home.join(".gemini").join("settings.json"),
+                    legacy_mcp_path: None,
                     settings_path: None,
                 })
             }
             (ScopeArg::Workspace, McpProvider::Gemini) => Ok(Self {
                 mcp_path: repo_root.join(".gemini").join("settings.json"),
+                legacy_mcp_path: None,
                 settings_path: None,
             }),
             (ScopeArg::Home, McpProvider::Antigravity) => {
                 let home = require_home_dir(home_dir)?;
                 Ok(Self {
                     mcp_path: home.join(".gemini").join("config").join("mcp_config.json"),
+                    legacy_mcp_path: None,
                     settings_path: None,
                 })
             }
             (ScopeArg::Workspace, McpProvider::Antigravity) => Ok(Self {
                 mcp_path: repo_root.join(".agents").join("mcp_config.json"),
+                legacy_mcp_path: None,
                 settings_path: None,
             }),
             (ScopeArg::Home, McpProvider::Grok) => {
                 let home = require_home_dir(home_dir)?;
                 Ok(Self {
                     mcp_path: home.join(".grok").join("config.toml"),
+                    legacy_mcp_path: None,
                     settings_path: None,
                 })
             }
             (ScopeArg::Workspace, McpProvider::Grok) => Ok(Self {
                 mcp_path: repo_root.join(".grok").join("config.toml"),
+                legacy_mcp_path: None,
                 settings_path: None,
             }),
             (ScopeArg::Home, McpProvider::Cursor) => {
                 let home = require_home_dir(home_dir)?;
                 Ok(Self {
                     mcp_path: home.join(".cursor").join("mcp.json"),
+                    legacy_mcp_path: None,
                     settings_path: None,
                 })
             }
             (ScopeArg::Workspace, McpProvider::Cursor) => Ok(Self {
                 mcp_path: repo_root.join(".cursor").join("mcp.json"),
+                legacy_mcp_path: None,
                 settings_path: None,
             }),
             (ScopeArg::Home, McpProvider::Vscode) => {
                 let home = require_home_dir(home_dir)?;
                 Ok(Self {
                     mcp_path: vscode_home_user_dir(home).join("mcp.json"),
+                    legacy_mcp_path: None,
                     settings_path: None,
                 })
             }
             (ScopeArg::Workspace, McpProvider::Vscode) => Ok(Self {
                 mcp_path: repo_root.join(".vscode").join("mcp.json"),
+                legacy_mcp_path: None,
                 settings_path: None,
             }),
             (ScopeArg::Home, McpProvider::Windsurf) => {
@@ -161,6 +176,7 @@ impl ConfigTarget {
                         .join(".codeium")
                         .join("windsurf")
                         .join("mcp_config.json"),
+                    legacy_mcp_path: None,
                     settings_path: None,
                 })
             }
@@ -169,6 +185,7 @@ impl ConfigTarget {
                     .join(".codeium")
                     .join("windsurf")
                     .join("mcp_config.json"),
+                legacy_mcp_path: None,
                 settings_path: None,
             }),
         }
@@ -226,7 +243,11 @@ pub(super) fn auto_detected_providers(
     home_dir: Option<&Path>,
 ) -> Vec<McpProvider> {
     let mut providers = Vec::new();
-    if repo_root.join(".claude").is_dir() {
+    let claude_repo = repo_root.join(".claude").is_dir();
+    let claude_home = home_dir
+        .map(|home| home.join(".claude").is_dir())
+        .unwrap_or(false);
+    if claude_repo || claude_home {
         providers.push(McpProvider::Claude);
     }
     if home_dir

--- a/crates/orbit-cli/src/command/mcp/setup/providers/claude.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/claude.rs
@@ -16,6 +16,8 @@ pub(in crate::command::mcp::setup) fn apply_claude_init(
     launch: ServerLaunch<'_>,
 ) -> Result<(), OrbitError> {
     let server_id = server_id(launch);
+    cleanup_legacy_mcp_path(target, server_id)?;
+
     let mut root = load_json_object(&target.mcp_path)?;
     let mcp_servers = ensure_json_object(&mut root, "mcpServers")?;
     mcp_servers.insert(server_id.to_string(), claude_mcp_server_value(launch));
@@ -46,6 +48,7 @@ pub(in crate::command::mcp::setup) fn apply_claude_remove(
         }
     }
     write_or_remove_json_object(&target.mcp_path, &root)?;
+    cleanup_legacy_mcp_path(target, server_id)?;
 
     if let Some(settings_path) = &target.settings_path {
         let mut settings = load_json_object(settings_path)?;
@@ -85,6 +88,24 @@ pub(in crate::command::mcp::setup) fn apply_claude_remove(
         }
     }
     Ok(())
+}
+
+fn cleanup_legacy_mcp_path(target: &ConfigTarget, server_id: &str) -> Result<(), OrbitError> {
+    let Some(legacy_path) = &target.legacy_mcp_path else {
+        return Ok(());
+    };
+
+    let mut root = load_json_object(legacy_path)?;
+    if let Some(mcp_servers) = root
+        .get_mut("mcpServers")
+        .and_then(JsonValue::as_object_mut)
+    {
+        mcp_servers.remove(server_id);
+        if mcp_servers.is_empty() {
+            root.remove("mcpServers");
+        }
+    }
+    write_or_remove_json_object(legacy_path, &root)
 }
 
 /// Remove `dir` if it exists and is now empty.

--- a/crates/orbit-cli/src/command/mcp/setup/providers/tests/claude.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/tests/claude.rs
@@ -12,10 +12,15 @@ fn claude_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     let home = tempdir().expect("home tempdir");
     std::fs::create_dir_all(repo.path().join(".claude")).expect("create .claude");
     std::fs::write(
-        repo.path().join(".claude.json"),
+        repo.path().join(".mcp.json"),
         "{\n  \"mcpServers\": {\n    \"other\": {\"command\": \"demo\"}\n  }\n}\n",
     )
     .expect("write mcp file");
+    std::fs::write(
+        repo.path().join(".claude.json"),
+        "{\n  \"mcpServers\": {\n    \"orbit\": {\"command\": \"orbit\"},\n    \"legacy-other\": {\"command\": \"demo\"}\n  }\n}\n",
+    )
+    .expect("write legacy mcp file");
     std::fs::write(
         repo.path().join(".claude").join("settings.json"),
         "{\n  \"permissions\": {\n    \"allow\": [\"OtherTool\"]\n  },\n  \"theme\": \"light\"\n}\n",
@@ -37,7 +42,7 @@ fn claude_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     assert_eq!(providers, vec![McpProvider::Claude]);
 
     let mcp: serde_json::Value = serde_json::from_str(
-        &std::fs::read_to_string(repo.path().join(".claude.json")).expect("read mcp"),
+        &std::fs::read_to_string(repo.path().join(".mcp.json")).expect("read mcp"),
     )
     .expect("parse mcp");
     assert!(mcp["mcpServers"]["orbit"].is_object());
@@ -48,6 +53,13 @@ fn claude_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     assert_eq!(args.len(), 2);
     assert_eq!(args[0].as_str(), Some("mcp"));
     assert_eq!(args[1].as_str(), Some("serve"));
+
+    let legacy_mcp: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(repo.path().join(".claude.json")).expect("read legacy mcp"),
+    )
+    .expect("parse legacy mcp");
+    assert!(legacy_mcp["mcpServers"]["orbit"].is_null());
+    assert!(legacy_mcp["mcpServers"]["legacy-other"].is_object());
 
     let settings: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(repo.path().join(".claude").join("settings.json"))
@@ -92,11 +104,68 @@ fn claude_workspace_scope_init_and_remove_preserve_unrelated_entries() {
     .expect("remove claude");
 
     let mcp: serde_json::Value = serde_json::from_str(
-        &std::fs::read_to_string(repo.path().join(".claude.json")).expect("read mcp"),
+        &std::fs::read_to_string(repo.path().join(".mcp.json")).expect("read mcp"),
     )
     .expect("parse mcp");
     assert!(mcp["mcpServers"]["orbit"].is_null());
     assert!(mcp["mcpServers"]["other"].is_object());
+}
+
+#[test]
+fn claude_home_scope_uses_documented_user_file_and_cleans_legacy_file() {
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    std::fs::create_dir_all(home.path().join(".claude")).expect("create claude home");
+    std::fs::write(
+        home.path().join(".claude").join(".mcp.json"),
+        "{\n  \"mcpServers\": {\n    \"orbit\": {\"command\": \"orbit\"},\n    \"legacy-other\": {\"command\": \"demo\"}\n  }\n}\n",
+    )
+    .expect("write legacy home mcp file");
+    let orbit_root = repo.path().join(".orbit");
+    std::fs::create_dir_all(&orbit_root).expect("create orbit root");
+
+    run_action(
+        McpAction::Init(ServerLaunch::default()),
+        repo.path(),
+        &orbit_root,
+        ProviderSelectionMode::Explicit(vec![McpProvider::Claude]),
+        Some(home.path().to_path_buf()),
+        ScopeArg::Home,
+    )
+    .expect("init claude home scope");
+
+    let mcp: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(home.path().join(".claude.json")).expect("read user mcp"),
+    )
+    .expect("parse user mcp");
+    assert!(mcp["mcpServers"]["orbit"].is_object());
+
+    let legacy: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(home.path().join(".claude").join(".mcp.json"))
+            .expect("read legacy user mcp"),
+    )
+    .expect("parse legacy user mcp");
+    assert!(legacy["mcpServers"]["orbit"].is_null());
+    assert!(legacy["mcpServers"]["legacy-other"].is_object());
+
+    run_action(
+        McpAction::Remove,
+        repo.path(),
+        &orbit_root,
+        ProviderSelectionMode::Explicit(vec![McpProvider::Claude]),
+        Some(home.path().to_path_buf()),
+        ScopeArg::Home,
+    )
+    .expect("remove claude home scope");
+
+    assert!(!home.path().join(".claude.json").exists());
+    let legacy: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(home.path().join(".claude").join(".mcp.json"))
+            .expect("read legacy user mcp after remove"),
+    )
+    .expect("parse legacy user mcp after remove");
+    assert!(legacy["mcpServers"]["orbit"].is_null());
+    assert!(legacy["mcpServers"]["legacy-other"].is_object());
 }
 
 #[test]
@@ -207,7 +276,7 @@ fn claude_operator_init_writes_single_operator_flag_and_refresh_is_idempotent() 
 
     let assert_single_operator_entry = || {
         let mcp: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(repo.path().join(".claude.json")).expect("read mcp"),
+            &std::fs::read_to_string(repo.path().join(".mcp.json")).expect("read mcp"),
         )
         .expect("parse mcp");
         let args = mcp["mcpServers"]["orbit"]["args"]

--- a/crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs
@@ -59,6 +59,17 @@ fn auto_detects_grok_from_home_when_repo_lacks_dotgrok() {
 }
 
 #[test]
+fn auto_detects_claude_from_home_when_repo_lacks_dotclaude() {
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    std::fs::create_dir_all(home.path().join(".claude")).expect("create claude home dir");
+
+    let providers = auto_detected_providers(repo.path(), Some(home.path()));
+
+    assert_eq!(providers, vec![McpProvider::Claude]);
+}
+
+#[test]
 fn home_scope_writes_to_home_paths_and_skips_repo_files() {
     let repo = tempdir().expect("repo tempdir");
     let home = tempdir().expect("home tempdir");
@@ -81,8 +92,7 @@ fn home_scope_writes_to_home_paths_and_skips_repo_files() {
     .expect("init home scope");
 
     let claude_mcp: serde_json::Value = serde_json::from_str(
-        &std::fs::read_to_string(home.path().join(".claude").join(".mcp.json"))
-            .expect("read claude home mcp"),
+        &std::fs::read_to_string(home.path().join(".claude.json")).expect("read claude home mcp"),
     )
     .expect("parse claude mcp");
     let claude_args = claude_mcp["mcpServers"]["orbit"]["args"]
@@ -152,6 +162,7 @@ fn home_scope_writes_to_home_paths_and_skips_repo_files() {
     assert!(grok_parsed["mcp_servers"]["orbit"].get("cwd").is_none());
 
     // Repo-local files should not have been touched.
+    assert!(!repo.path().join(".mcp.json").exists());
     assert!(!repo.path().join(".claude.json").exists());
     assert!(!repo.path().join(".codex").join("config.toml").exists());
     assert!(!repo.path().join(".gemini").join("settings.json").exists());
@@ -192,8 +203,7 @@ fn federated_home_scope_preserves_v1_entries() {
     .expect("init federated home scope");
 
     let claude: serde_json::Value = serde_json::from_str(
-        &std::fs::read_to_string(home.path().join(".claude").join(".mcp.json"))
-            .expect("read claude mcp"),
+        &std::fs::read_to_string(home.path().join(".claude.json")).expect("read claude mcp"),
     )
     .expect("parse claude mcp");
     assert_eq!(
@@ -267,7 +277,7 @@ fn federated_home_scope_preserves_v1_entries() {
     .expect("remove federated home scope");
 
     let claude: serde_json::Value = serde_json::from_str(
-        &std::fs::read_to_string(home.path().join(".claude").join(".mcp.json"))
+        &std::fs::read_to_string(home.path().join(".claude.json"))
             .expect("read claude after remove"),
     )
     .expect("parse claude after remove");
@@ -473,7 +483,7 @@ fn action_summary_names_the_resolved_home_scope_file_and_workspace_id() {
         summary,
         format!(
             "mcp init: claude -> {} (bound to ws_wshome)",
-            home.path().join(".claude").join(".mcp.json").display()
+            home.path().join(".claude.json").display()
         )
     );
 }
@@ -494,7 +504,7 @@ fn action_summary_omits_workspace_id_for_home_scope_when_unregistered() {
         summary,
         format!(
             "mcp remove: claude -> {}, codex -> {}",
-            home.path().join(".claude").join(".mcp.json").display(),
+            home.path().join(".claude.json").display(),
             home.path().join(".codex").join("config.toml").display()
         )
     );

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -1226,7 +1226,7 @@ fn workspace_init_seeds_auto_detected_mcp_configs() {
     // bootstrap path (ORB-10960): every auto-detected client must launch the
     // Orbit server with `mcp serve --operator`, exactly.
     let claude_mcp: serde_json::Value = serde_json::from_str(
-        &std::fs::read_to_string(workspace.path().join(".claude.json")).expect("read claude mcp"),
+        &std::fs::read_to_string(workspace.path().join(".mcp.json")).expect("read claude mcp"),
     )
     .expect("parse claude mcp");
     let workspace_id = registered_workspace_id(home.path());
@@ -1326,7 +1326,7 @@ fn workspace_reinit_with_force_mcp_refreshes_operator_argv_without_duplicating_i
     };
 
     init(false);
-    let claude_path = workspace.path().join(".claude.json");
+    let claude_path = workspace.path().join(".mcp.json");
     let first: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&claude_path).expect("read claude mcp"))
             .expect("parse claude mcp");

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -2059,7 +2059,7 @@ fn workspace_init_mcp_config_reaches_a_governed_tool_over_the_real_transport() {
 
     let read_generated_args = || -> Vec<String> {
         let claude_mcp: Value = serde_json::from_str(
-            &std::fs::read_to_string(workspace.work.join(".claude.json"))
+            &std::fs::read_to_string(workspace.work.join(".mcp.json"))
                 .expect("read generated claude mcp config"),
         )
         .expect("parse generated claude mcp config");
@@ -3768,7 +3768,7 @@ fn generate_agent_mcp_config(workspace: &McpWorkspace) -> Vec<String> {
 
 fn read_generated_claude_args(workspace: &McpWorkspace) -> Vec<String> {
     let claude_mcp: Value = serde_json::from_str(
-        &std::fs::read_to_string(workspace.work.join(".claude.json"))
+        &std::fs::read_to_string(workspace.work.join(".mcp.json"))
             .expect("read generated claude mcp config"),
     )
     .expect("parse generated claude mcp config");

--- a/crates/orbit-cli/tests/mcp_setup_root.rs
+++ b/crates/orbit-cli/tests/mcp_setup_root.rs
@@ -136,7 +136,7 @@ impl ExternalRootFixture {
     }
 
     fn claude_config(&self) -> PathBuf {
-        self.checkout.join(".claude.json")
+        self.checkout.join(".mcp.json")
     }
 
     fn claude_settings(&self) -> PathBuf {
@@ -147,7 +147,7 @@ impl ExternalRootFixture {
     fn assert_no_client_config_outside_the_checkout(&self) {
         let root_parent = self.orbit_root.parent().expect("orbit root parent");
         for directory in [&self.orbit_root, root_parent, &self.elsewhere, &self.home] {
-            for entry in [".claude.json", ".claude"] {
+            for entry in [".mcp.json", ".claude.json", ".claude"] {
                 let stray = directory.join(entry);
                 assert!(
                     !stray.exists(),
@@ -265,9 +265,9 @@ fn explicit_root_outranks_a_different_registered_cwd_checkout() {
         )
         .success();
 
-    assert!(!fixture.checkout_a.join(".claude.json").exists());
+    assert!(!fixture.checkout_a.join(".mcp.json").exists());
     assert_eq!(
-        generated_server_args(&fixture.checkout_b.join(".claude.json")),
+        generated_server_args(&fixture.checkout_b.join(".mcp.json")),
         vec!["mcp", "serve", "--workspace", "ws_beta"]
     );
 
@@ -280,8 +280,8 @@ fn explicit_root_outranks_a_different_registered_cwd_checkout() {
         )
         .success();
 
-    assert!(!fixture.checkout_a.join(".claude.json").exists());
-    assert!(!fixture.checkout_b.join(".claude.json").exists());
+    assert!(!fixture.checkout_a.join(".mcp.json").exists());
+    assert!(!fixture.checkout_b.join(".mcp.json").exists());
 }
 
 #[test]
@@ -300,8 +300,8 @@ fn shared_root_mcp_setup_uses_cwd_checkout_for_init_and_remove() {
         stderr.contains("does not identify exactly one registered checkout"),
         "unexpected outside-checkout failure: {stderr}"
     );
-    assert!(!fixture.checkout_a.join(".claude.json").exists());
-    assert!(!fixture.checkout_b.join(".claude.json").exists());
+    assert!(!fixture.checkout_a.join(".mcp.json").exists());
+    assert!(!fixture.checkout_b.join(".mcp.json").exists());
 
     fixture
         .orbit(
@@ -310,10 +310,10 @@ fn shared_root_mcp_setup_uses_cwd_checkout_for_init_and_remove() {
         )
         .success();
     assert_eq!(
-        generated_server_args(&fixture.checkout_a.join(".claude.json")),
+        generated_server_args(&fixture.checkout_a.join(".mcp.json")),
         vec!["mcp", "serve", "--workspace", "ws_alpha"]
     );
-    assert!(!fixture.checkout_b.join(".claude.json").exists());
+    assert!(!fixture.checkout_b.join(".mcp.json").exists());
 
     fixture
         .orbit(
@@ -322,7 +322,7 @@ fn shared_root_mcp_setup_uses_cwd_checkout_for_init_and_remove() {
         )
         .success();
     assert_eq!(
-        generated_server_args(&fixture.checkout_b.join(".claude.json")),
+        generated_server_args(&fixture.checkout_b.join(".mcp.json")),
         vec!["mcp", "serve", "--workspace", "ws_beta"]
     );
 
@@ -332,8 +332,8 @@ fn shared_root_mcp_setup_uses_cwd_checkout_for_init_and_remove() {
             &argv(&["--root", root, "mcp", "remove", "--claude"]),
         )
         .success();
-    assert!(!fixture.checkout_a.join(".claude.json").exists());
-    assert!(fixture.checkout_b.join(".claude.json").exists());
+    assert!(!fixture.checkout_a.join(".mcp.json").exists());
+    assert!(fixture.checkout_b.join(".mcp.json").exists());
 
     fixture
         .orbit(
@@ -341,7 +341,7 @@ fn shared_root_mcp_setup_uses_cwd_checkout_for_init_and_remove() {
             &argv(&["--root", root, "mcp", "remove", "--claude"]),
         )
         .success();
-    assert!(!fixture.checkout_b.join(".claude.json").exists());
+    assert!(!fixture.checkout_b.join(".mcp.json").exists());
 }
 
 #[test]
@@ -371,7 +371,7 @@ fn a_root_without_a_registered_checkout_refuses_instead_of_writing() {
         stderr.contains("does not identify exactly one registered checkout"),
         "unexpected failure message: {stderr}"
     );
-    assert!(!unrelated_root.join(".claude.json").exists());
+    assert!(!unrelated_root.join(".mcp.json").exists());
     fixture.assert_no_client_config_outside_the_checkout();
     assert!(!fixture.claude_config().exists());
 }


### PR DESCRIPTION
## Task

[ORB-12149](https://orbit-cli.com/tasks/ORB-12149) — [qa-sweep] orbit mcp init --claude writes config paths Claude Code does not read, so the Orbit MCP server is never registered

### Description

## Summary

`orbit mcp init --claude` (and therefore `orbit workspace init --mcp`, which calls
`init_auto_for_workspace`) reports success and writes a well-formed `mcpServers`
entry — into files Claude Code does not read:

- workspace scope (default): `<repo_root>/.claude.json`
  (`crates/orbit-cli/src/command/mcp/setup/dispatch.rs:87-90`)
- home scope (`--scope home`): `<home>/.claude/.mcp.json`
  (`crates/orbit-cli/src/command/mcp/setup/dispatch.rs:80-86`)

Claude Code reads project-scope MCP servers from `<repo_root>/.mcp.json` and
user-scope servers from `<home>/.claude.json` (top-level `mcpServers`). Orbit
writes the two names crossed over, so neither registration takes effect. The
operator gets `mcp init: claude -> /path/to/repo (ws_x)` and no working server.

Orbit's own documentation already records the correct user-scope location:
`docs/design/policy-sandbox/4_decisions.md:231` — "Claude Code persists its main
settings to `$HOME/.claude.json` — a sibling *file* at the home root".

## Evidence (orbit 0.21.0 built from `1fda27b49`, Claude Code 2.1.268, Linux)

Disposable `HOME` under `/tmp`, every `orbit_common::test_env::INHERITED_AUTHORITY_ENV`
variable cleared, routing verified with `orbit workspace show --format json`
(`repo_root=/tmp/qa/repoD`, `orbit_dir=/tmp/qa/repoD/.orbit`) before any mutation.

```sh
# workspace scope
cd /tmp/qa/repoD && orbit mcp init --claude
#   mcp init: claude -> /tmp/qa/repoD (ws_repod)
cat /tmp/qa/repoD/.claude.json
#   {"mcpServers":{"orbit":{"args":["mcp","serve","--workspace","ws_repod"],"command":"orbit"}}}

cd /tmp/qa/repoD && HOME=/tmp/qa/homeD claude mcp list
#   demo-echo: echo hi - ✘ Failed to connect …          <- only the user-scope control server
#   (no `orbit` entry)

# control: the same JSON at the path Claude Code actually reads
cp /tmp/qa/repoD/.claude.json /tmp/qa/repoD/.mcp.json
cd /tmp/qa/repoD && HOME=/tmp/qa/homeD claude mcp list
#   demo-echo: echo hi - ✘ Failed to connect …
#   orbit: orbit mcp serve --workspace ws_repod - ⏸ Pending approval (run `claude` to approve)
```

```sh
# home scope
cd /tmp/qa/repoD && orbit mcp init --claude --scope home
#   mcp init: claude -> /tmp/qa/homeC/.claude/.mcp.json (bound to ws_repod)
cat /tmp/qa/homeC/.claude/.mcp.json
#   {"mcpServers":{"orbit":{"args":["mcp","serve","--workspace","ws_repod"],"command":"orbit"}}}
HOME=/tmp/qa/homeC claude mcp list
#   No MCP servers configured. Use `claude mcp add` to add a server.

# where Claude Code actually keeps user scope
HOME=/tmp/qa/homeD claude mcp add --scope user demo-echo echo hi
#   Added stdio MCP server demo-echo … to user config
#   File modified: /tmp/qa/homeD/.claude.json          <- home root, not ~/.claude/
```

The live host agrees: `~/.claude.json` holds a top-level `mcpServers`
map, `~/.claude/.mcp.json` does not exist, and this repository carries
a hand-written `.mcp.json` (`git log -- .mcp.json`) alongside the Orbit-generated
`.claude.json` — the `.mcp.json` is what makes the `orbit` server load, while
commit `dcc50a13b` ("Implement .claude.json configuration and update references
from .mcp.json") is where the generated path diverged.

## Why it matters

`orbit mcp init` / `orbit workspace init --mcp` is the documented onboarding step
for the flagship provider, and it is inert. Only the plugin path is unaffected —
`plugin/mcp.json` is loaded by the Claude Code plugin loader, not by this code.
Earlier QA (ORB-12121, ORB-12132) treated `<checkout>/.claude.json` as the
correct destination and only checked that the file was written; this sweep
checked whether Claude Code picks it up.

The recent window did not introduce the path, but it did rework both scopes'
reporting (`df0fa792d`, `55ac8832e`/ORB-12139 now prints the home file as "the
file the run actually touched"), so the claim is newly explicit and newly wrong.

## Suggested direction

Write the destinations Claude Code reads: `<repo_root>/.mcp.json` for workspace
scope and `<home>/.claude.json` (top-level `mcpServers`) for home scope, with a
one-shot migration in `apply_claude_remove`-style cleanup for the legacy
`.claude.json` / `~/.claude/.mcp.json` entries, and keep
`<repo>/.claude/settings.json` (permissions) where it is — that file is correct.
Consider asserting registration end-to-end (`claude mcp list` or a parse of the
documented path) in the mcp-setup integration tests, since a path-only assertion
cannot catch this class of defect.

Validation impact: none — no test or prescribed validation command is blocked.
Production impact: yes — the primary MCP onboarding command for Claude Code
silently does nothing on both scopes.

### Acceptance Criteria

- `orbit mcp init --claude` in a registered checkout produces a registration that `claude mcp list` reports from that checkout, and `orbit mcp remove --claude` removes it.
- `orbit mcp init --claude --scope home` produces a registration that `claude mcp list` reports with no project config present, and remove reverses it.
- Existing legacy entries written to `<repo>/.claude.json` or `~/.claude/.mcp.json` are migrated or cleaned by the init/remove paths rather than left behind.
- Auto provider detection selects Claude from a home-level Claude Code marker as it already does for the other providers, not only from a repo-local `.claude/` directory.
- A test exercises the registration at the documented Claude Code config path instead of asserting only that some file was written.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Corrected Claude Code MCP destinations: workspace scope now writes <repo>/.mcp.json and home scope writes <home>/.claude.json; Claude permissions remain in the existing .claude/settings.json locations.
- Added idempotent cleanup of legacy <repo>/.claude.json and <home>/.claude/.mcp.json Orbit entries during init/remove while preserving unrelated servers.
- Auto detection now recognizes a home-level <home>/.claude marker.
- Updated focused, workspace-init, root-routing, and MCP round-trip tests and CLI scope help. Added boundary coverage that parses the documented Claude paths and checks legacy cleanup.

Acceptance criteria:
1. Passed: registered-checkout integration tests and MCP round-trip tests verify workspace init/remove using .mcp.json; Claude Code 2.1.268 project-scope smoke reported the server from a temp checkout config.
2. Passed: focused provider coverage verifies home init/remove using <home>/.claude.json; Claude Code user-scope smoke reported the server from the temp home config.
3. Passed: workspace and home provider tests seed legacy entries, verify Orbit cleanup preserves unrelated entries, and verify remove reverses canonical registrations.
4. Passed: focused dispatch test detects Claude from a home-level .claude directory without a repo-local marker.
5. Passed: provider boundary tests read and parse the exact documented .mcp.json and .claude.json paths rather than only checking an arbitrary output file.

Validation:
- Passed: cargo fmt --all -- --check
- Passed: cargo test -p orbit-cli mcp::setup (61 tests)
- Passed: cargo test -p orbit-cli --test mcp_setup_root --test mcp_roundtrip (7 + 53 tests)
- Passed: cargo test -p orbit-cli workspace_init (20 unit tests plus matching filtered integration checks)
- Passed: make ci-fast; compiler-cache namespace subcheck was explicitly skipped by the environment because bubblewrap namespaces are unavailable.
- Passed: make ci-lint (workspace clippy with warnings denied)
- Passed: git diff --check
- Passed: Claude Code path smoke with claude 2.1.268 using disposable HOME/project fixtures.

Assessment: The scoped implementation and affected consumers are consistent, tests cover both canonical scopes and legacy cleanup, and the worktree contains only the intended tracked modifications. The direct Claude smoke used disposable configs; registered-checkout behavior is covered by the repository integration tests.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12149-6aa3b701`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus