### PR TITLE
[qa-sweep] after task-index loss in the external-root layout, the checkout's own tasks vanish silently and `orbit task reindex` refuses to rebuild them

### DIFF
--- a/crates/orbit-cli/src/command/task/list.rs
+++ b/crates/orbit-cli/src/command/task/list.rs
@@ -116,6 +116,15 @@ impl Execute for TaskListArgs {
         let status_by_id = page.status_by_id;
         let tasks: Vec<_> = page.items.into_iter().map(|row| row.task).collect();
 
+        if tasks.is_empty() {
+            let count = runtime.unindexed_task_bundle_count()?;
+            if count > 0 {
+                return Err(OrbitError::InvalidInput(format!(
+                    "task index is missing {count} on-disk bundle(s); run `orbit task reindex` to recover them"
+                )));
+            }
+        }
+
         // `--ops` selects a narrower record shape, not a different output
         // channel: the table is the same either way, and the renderer decides
         // whether the caller sees records or rows.

--- a/crates/orbit-cli/tests/mcp_setup_root.rs
+++ b/crates/orbit-cli/tests/mcp_setup_root.rs
@@ -190,6 +190,53 @@ fn mcp_init_binds_an_external_root_checkout_and_remove_reverses_it() {
 }
 
 #[test]
+fn external_root_task_index_loss_is_reported_and_reindexed() {
+    let fixture = ExternalRootFixture::init();
+    let added = fixture
+        .orbit(
+            &fixture.checkout,
+            &fixture.rooted(&[
+                "task",
+                "add",
+                "--title",
+                "External task",
+                "--complexity",
+                "low",
+                "--json",
+            ]),
+        )
+        .success();
+    let task: Value = serde_json::from_slice(&added.get_output().stdout).expect("task json");
+    let task_id = task["id"].as_str().expect("task id").to_string();
+    let index = fixture.orbit_root.join("tasks/index.sqlite");
+    for suffix in ["", "-wal", "-shm"] {
+        let path = PathBuf::from(format!("{}{}", index.display(), suffix));
+        if path.exists() {
+            fs::remove_file(path).expect("remove task index");
+        }
+    }
+
+    let listed = fixture
+        .orbit(&fixture.checkout, &fixture.rooted(&["task", "list"]))
+        .failure();
+    let stderr = String::from_utf8_lossy(&listed.get_output().stderr);
+    assert!(stderr.contains("on-disk bundle"), "stderr: {stderr}");
+    assert!(stderr.contains("task reindex"), "stderr: {stderr}");
+
+    fixture
+        .orbit(&fixture.checkout, &fixture.rooted(&["task", "reindex"]))
+        .success();
+    let listed = fixture
+        .orbit(
+            &fixture.checkout,
+            &fixture.rooted(&["task", "list", "--json"]),
+        )
+        .success();
+    let tasks: Value = serde_json::from_slice(&listed.get_output().stdout).expect("task list json");
+    assert_eq!(tasks[0]["id"], task_id);
+}
+
+#[test]
 fn mcp_init_resolves_the_registered_checkout_from_an_unrelated_directory() {
     let fixture = ExternalRootFixture::init();
 

--- a/crates/orbit-core/src/bootstrap/task_migration.rs
+++ b/crates/orbit-core/src/bootstrap/task_migration.rs
@@ -6,14 +6,18 @@
 //! [`orbit_store::workflow::task`]; this layer only resolves the registry path,
 //! the target workspace id, and the clock.
 
+use std::collections::BTreeSet;
+use std::fs;
 use std::path::Path;
 
 use chrono::Utc;
 use orbit_common::OrbitError;
 use orbit_store::maintenance::task_registry::{
-    AllocatorSeedOutcome, TaskRegistryStore, task_registry_path,
+    AllocatorSeedOutcome, BindWorkspaceParams, TaskRegistryStore, task_registry_path,
+    task_workspaces_dir,
 };
 use orbit_store::workflow::task::{export_tasks, import_tasks, reindex_workspace};
+use orbit_types::task::is_valid_orb_task_id;
 
 use crate::OrbitRuntime;
 
@@ -40,8 +44,49 @@ impl OrbitRuntime {
     ) -> Result<String, OrbitError> {
         match workspace_id {
             Some(id) => Ok(id.to_string()),
+            None if self.global_root() == self.paths().orbit_dir => {
+                match self.workspace_runtime_binding() {
+                    Some(binding) => Ok(binding.logical_workspace_id.clone()),
+                    None => self.workspace_id(),
+                }
+            }
             None => self.workspace_id(),
         }
+    }
+
+    /// Rebuild the selected checkout's task-registry binding when an explicit
+    /// root recreated `tasks/index.sqlite` without restoring its rows.
+    fn ensure_migration_workspace_binding(
+        &self,
+        registry: &TaskRegistryStore,
+        workspace_id: &str,
+    ) -> Result<(), OrbitError> {
+        if registry.find_workspace_binding(workspace_id)?.is_some() {
+            return Ok(());
+        }
+        let Some(binding) = self.workspace_runtime_binding() else {
+            return Ok(());
+        };
+        if binding.logical_workspace_id != workspace_id {
+            return Ok(());
+        }
+
+        let slug = binding
+            .repo_root
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.trim().is_empty())
+            .unwrap_or("workspace")
+            .to_string();
+        registry.bind_workspace(BindWorkspaceParams {
+            workspace_id: Some(workspace_id.to_string()),
+            slug,
+            repo_root: binding.repo_root.clone(),
+            workspace_path: binding.repo_root.clone(),
+            orbit_dir: self.paths().orbit_dir.clone(),
+            repo_fingerprint: None,
+        })?;
+        Ok(())
     }
 
     /// Export the selected tasks of a workspace to a tar.zst archive.
@@ -71,7 +116,43 @@ impl OrbitRuntime {
     pub fn reindex_tasks(&self, workspace_id: Option<&str>) -> Result<ReindexOutcome, OrbitError> {
         let registry = self.open_task_registry()?;
         let workspace_id = self.resolve_migration_workspace(workspace_id)?;
+        self.ensure_migration_workspace_binding(&registry, &workspace_id)?;
         reindex_workspace(&registry, &workspace_id)
+    }
+
+    /// Return the number of canonical task bundles that are present on disk
+    /// but absent from the generated registry index.
+    pub fn unindexed_task_bundle_count(&self) -> Result<usize, OrbitError> {
+        let workspace_id = self.resolve_migration_workspace(None)?;
+        let registry = self.open_task_registry()?;
+        let indexed = registry
+            .tasks_for_workspace(&workspace_id)?
+            .into_iter()
+            .map(|binding| binding.task_id)
+            .collect::<BTreeSet<_>>();
+        let partition = task_workspaces_dir(&self.global_root()).join(workspace_id);
+        let entries = match fs::read_dir(partition) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+            Err(error) => return Err(OrbitError::Io(error.to_string())),
+        };
+        let mut unindexed = 0;
+        for entry in entries {
+            let entry = entry.map_err(|error| OrbitError::Io(error.to_string()))?;
+            let is_bundle = entry
+                .file_type()
+                .map_err(|error| OrbitError::Io(error.to_string()))?
+                .is_dir();
+            if is_bundle
+                && entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|id| is_valid_orb_task_id(id) && !indexed.contains(id))
+            {
+                unindexed += 1;
+            }
+        }
+        Ok(unindexed)
     }
 
     /// Audit task relation/dependency targets that no longer resolve to a

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -246,6 +246,7 @@ fn build_v2_task_backends(
     if is_explicit_data_dir(global_root, &paths.orbit_dir)
         && let Some(binding) = runtime_binding
     {
+        ensure_explicit_root_task_binding(&registry, paths, binding)?;
         return Ok(coordination_task_backends(
             registry,
             binding.logical_workspace_id.clone(),
@@ -328,6 +329,33 @@ fn build_v2_task_backends(
     }
 
     Ok(workspace_task_backends(registry, binding.workspace_id))
+}
+
+/// Recreate the selected checkout's task-registry binding after its index was
+/// lost. An explicit root has no checkout-local bootstrap path, so the
+/// registry binding supplied by the workspace catalog is the authoritative
+/// identity to restore.
+fn ensure_explicit_root_task_binding(
+    registry: &TaskRegistryStore,
+    paths: &WorkspacePaths,
+    binding: &WorkspaceRuntimeBinding,
+) -> Result<(), OrbitError> {
+    if registry
+        .find_workspace_binding(&binding.logical_workspace_id)?
+        .is_some()
+    {
+        return Ok(());
+    }
+
+    registry.bind_workspace(BindWorkspaceParams {
+        workspace_id: Some(binding.logical_workspace_id.clone()),
+        slug: workspace_slug(&binding.repo_root),
+        repo_root: binding.repo_root.clone(),
+        workspace_path: binding.repo_root.clone(),
+        orbit_dir: paths.orbit_dir.clone(),
+        repo_fingerprint: None,
+    })?;
+    Ok(())
 }
 
 fn rebind_candidate_workspace_id(

--- a/docs/design/task-migration/1_overview.md
+++ b/docs/design/task-migration/1_overview.md
@@ -155,6 +155,29 @@ preserved. Unreadable or partial bundles retain their bytes and any registered
 binding/index; healthy neighbors are indexed, and reindex returns an error listing
 the unresolved task IDs rather than reporting full success.
 
+The command works from either supported layout. With a repo-local root, run it
+from the checkout whose `.orbit` directory identifies the workspace. The task
+index and bundles remain under the home Orbit root:
+
+```sh
+rm -f ~/.orbit/tasks/index.sqlite ~/.orbit/tasks/index.sqlite-wal ~/.orbit/tasks/index.sqlite-shm
+orbit task reindex
+```
+
+With an external root, keep the checkout as the current directory and pass the
+same root that was used for workspace initialization. The runtime restores the
+checkout's task-registry binding before reindexing, so `workspace init --force`
+is not required:
+
+```sh
+rm -f /path/to/orbit-root/tasks/index.sqlite /path/to/orbit-root/tasks/index.sqlite-wal /path/to/orbit-root/tasks/index.sqlite-shm
+orbit --root /path/to/orbit-root task reindex
+```
+
+If `orbit task list` reports that on-disk bundles are missing from the task
+index, run the matching reindex command before treating an empty list as task
+loss. The bundle partitions remain the recovery source until reindex completes.
+
 Full-bundle readers, writers, creation, deletion, and reindex coordinate through
 persistent `.<task-id>.bundle.lock` files beside the canonical bundles.
 These lock files must not be removed while Orbit processes run. Writers recheck


### PR DESCRIPTION
## Task

[ORB-12151](https://orbit-cli.com/tasks/ORB-12151) — [qa-sweep] after task-index loss in the external-root layout, the checkout's own tasks vanish silently and `orbit task reindex` refuses to rebuild them

### Description

## Summary

`orbit task reindex` is the documented recovery for a lost or drifted
`<root>/tasks/index.sqlite` (`crates/orbit-store/src/workflow/task/mod.rs`
module docs; `docs/design/task-migration/1_overview.md` §"Recovering a drifted
index"). In the external-root layout — `orbit --root <dir> workspace init`, where
the checkout has no repo-local `.orbit` — that recovery does not work:

- `orbit task list` reports `no tasks matching the given filters` (exit 0) while
  every bundle is still on disk under `<root>/tasks/workspaces/<ws_id>/`.
- `orbit task reindex` and `orbit task reindex --task-workspace <ws_id>` both fail
  with `invalid input: workspace '<ws_id>' is not registered in the coordination
  registry`.
- `orbit doctor` says nothing: the partition id equals the workspace-catalog id,
  and `partition_claims` (`crates/orbit-cmd/src/task_store.rs:196-226`) treats
  every catalog id as a claim, so the unreachable partition is reported as
  claimed (same masking as ORB-12150).
- `orbit workspace init` refuses with "workspace registration already exists …
  rerun with --force to reconcile it".

The only way back is the undocumented pair `orbit workspace init --force` followed
by `orbit task reindex`. In the home-root layout (repo-local `.orbit`) the runtime
re-registers the current checkout on startup, so plain `orbit task reindex`
recovers it — the defect is specific to the checkout whose Orbit root is external.

## Reproduction (orbit 0.21.0 built from `1fda27b49`, Linux)

Disposable `HOME` under `/tmp`, every `orbit_common::test_env::INHERITED_AUTHORITY_ENV`
variable cleared, routing verified before any mutation.

```sh
orbit --root /tmp/qa/hostB init --non-interactive --host-name hostb --task-prefix BBB
cd /tmp/qa/repoB && orbit --root /tmp/qa/hostB workspace init
cd /tmp/qa/repoB && orbit --root /tmp/qa/hostB workspace show --format json
#   checkout: repo_root=/tmp/qa/repoB  orbit_dir=/tmp/qa/hostB   (ws_repob)
cd /tmp/qa/repoB && orbit --root /tmp/qa/hostB task add --title "local owned" --description v1 --complexity low
#   BBB-00000
orbit --root /tmp/qa/hostB task list          # ['BBB-00000']

rm -f /tmp/qa/hostB/tasks/index.sqlite*       # index lost (corruption, partial restore, manual rebuild)

orbit --root /tmp/qa/hostB task list
#   no tasks matching the given filters                      <- exit 0, no warning
orbit --root /tmp/qa/hostB task reindex
#   error: invalid input: workspace 'ws_repob' is not registered in the coordination registry
orbit --root /tmp/qa/hostB task reindex --task-workspace ws_repob
#   error: (same)
orbit --root /tmp/qa/hostB doctor | grep orphan-task
#   orphan-task-stores  warning  1 task-store partition(s) hold task bundles that no workspace
#   binding claims: ws_repoa …                               <- ws_repob is not mentioned
ls /tmp/qa/hostB/tasks/workspaces/ws_repob    # BBB-00000    <- the bundle is intact

orbit --root /tmp/qa/hostB workspace init
#   error: workspace error: workspace registration already exists for 'ws_repob' or
#          '/tmp/qa/repoB'; rerun with --force to reconcile it
orbit --root /tmp/qa/hostB workspace init --force && orbit --root /tmp/qa/hostB task reindex
#   reindexed workspace 'ws_repob': 1 bundle(s), 0 stale binding(s) dropped
orbit --root /tmp/qa/hostB task list          # ['BBB-00000']   <- recovered
```

Contrast (home-root layout, same binary): after `rm -f ~/.orbit/tasks/index.sqlite*`,
`orbit task reindex` in the checkout succeeds immediately —
`reindexed workspace 'ws_repod': 1 bundle(s), 0 stale binding(s) dropped` — because
the runtime re-created the checkout binding on startup.

## Why it matters

An operator whose index is lost sees an empty task list with no error and a
documented recovery command that refuses. The data is intact on disk, so this is
recoverable, but the failure presents as total task loss and the working
sequence is not documented anywhere.

The window under QA renamed this command's selector (`92d2f53f4`, ORB-12134) and
its module/design docs, so the recovery path is in scope even though the
underlying registration gap predates it.

## Suggested direction

Re-register the current checkout's task-registry binding during runtime startup
in the external-root layout the same way the repo-local layout does (or let
`task reindex` register the binding it is about to rebuild, since it already has
the checkout identity from `config.yaml`). Failing that, make `orbit task list`
say that the checkout has no registered task partition while bundles exist, and
document `workspace init --force` + `task reindex` as the recovery.

Validation impact: none — no test or prescribed validation command is blocked.
Production impact: yes — the documented index-recovery path fails for
external-root checkouts and the interim symptom is indistinguishable from
losing every task.

### Acceptance Criteria

- After `<root>/tasks/index.sqlite` is deleted, `orbit task reindex` inside an external-root checkout rebuilds that checkout's task rows without requiring `orbit workspace init --force` first.
- While the checkout's task partition holds bundles that the index does not know, a user-facing surface says so rather than reporting an empty task list with exit 0.
- The recovery sequence for a lost task index is documented for both the repo-local and external-root layouts.
- Regression coverage exercises index loss in the external-root layout, not only the repo-local one.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Restored the selected external-root checkout's task-registry binding during explicit-root runtime bootstrap and before reindex when the rebuilt index lacks the binding.
- Made `orbit task list` fail with a recovery message when valid task bundles exist on disk but are absent from the generated index.
- Documented recovery for repo-local (`~/.orbit` task root with checkout-local `.orbit/config.yaml`) and external-root layouts.
- Added an end-to-end external-root regression covering task creation, deletion of index/WAL/SHM files, list-time reporting, plain reindex, and post-recovery listing.

Acceptance criteria:
1. Passed — external-root `task reindex` now restores the current checkout binding and indexes the surviving bundle without `workspace init --force`.
2. Passed — `task list` reports missing on-disk bundles and points to `orbit task reindex`, with a non-zero failure instead of an empty successful result.
3. Passed — design documentation now gives explicit repo-local and external-root recovery commands and explains the external binding restoration.
4. Passed — `external_root_task_index_loss_is_reported_and_reindexed` exercises index loss in the external-root fixture.

Validation:
- Passed: `cargo fmt --all`.
- Passed: `cargo test -p orbit-cli --test mcp_setup_root` (8 tests).
- Passed: `cargo test -p orbit-cli --test shared_root_task_isolation`.
- Passed: `cargo test -p orbit-cli --test table_rendering` (6 tests).
- Passed: `make ci-fast`; its compiler-cache namespace probe was explicitly skipped because bubblewrap user namespaces are unavailable in this environment.
- Passed: `make ci-lint` (`cargo clippy --workspace --all-targets -- -D warnings`).
- Passed: `git diff --check`.
- Final worktree contains only the five task-scoped modified files; changes remain uncommitted for pipeline delivery.

Assessment: The fix is scoped to explicit-root task registration and task migration/listing recovery, preserves shared-root task isolation under regression coverage, and leaves no known task-scoped validation failures.
Risks: The namespace probe in `ci-fast` could not run due to the host sandbox restriction; all other required guardrails and lint checks passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12151-6aa3b856`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus