### PR TITLE
[qa-sweep] owner-wins import fails with a raw "task bundle already exists" error when the task index is lost, and the failed run still leaves the source workspace registered

### DIFF
--- a/crates/orbit-store/src/workflow/task/mod.rs
+++ b/crates/orbit-store/src/workflow/task/mod.rs
@@ -17,7 +17,9 @@
 //! - Import validates everything *before* mutating state, then keeps free ids,
 //!   renumbers collisions (rewriting relation targets within the imported set),
 //!   rebuilds index rows from bundle YAML, bumps the allocator past the max
-//!   landed id.
+//!   landed id. Fresh bundles and a workspace registration created by a failed
+//!   run are rolled back; owner-wins replacements remain because the incoming
+//!   owner's copy is authoritative.
 //! - Idempotency is scoped to *kept* ids: re-importing an archive whose ids are
 //!   free (or already landed unchanged) is a no-op. A `--on-conflict=renumber`
 //!   run is **not** idempotent — a collision means "these are new local tasks,"
@@ -31,9 +33,11 @@
 //! repeatable sync of those mirrors — a colliding foreign-prefix id is replaced
 //! by the owner's bundle ([`ImportAction::Updated`]), a colliding local-prefix
 //! id is left alone ([`ImportAction::SkippedLocalOwned`]), and nothing is ever
-//! renumbered. Foreign relation targets therefore survive verbatim, no
-//! `.idmap.json` is written, and a second run of the same archive reports every
-//! task as already-present.
+//! renumbered. An owner-wins import also repairs an orphaned canonical bundle
+//! whose registry binding is missing by replacing it and restoring the binding.
+//! Foreign relation targets therefore survive verbatim, no `.idmap.json` is
+//! written, and a second run of the same archive reports every task as
+//! already-present.
 //!
 //! # Artifact blobs
 //! Bundles carry a `artifacts/manifest.yaml` sidecar and the referenced blobs
@@ -320,6 +324,9 @@ struct StagedBundle {
 struct MirrorReplacement {
     staged: StagedBundle,
     bundle_dir: PathBuf,
+    /// The canonical directory existed without its registry binding, so the
+    /// successful refresh must restore that binding.
+    register_binding: bool,
 }
 
 /// Resolved import target after workspace resolution.
@@ -369,7 +376,23 @@ pub fn import_tasks(
     let mut records: Vec<ImportedTask> = Vec::new();
     for staged in staged {
         match registry.find_task_binding(&staged.source_id)? {
-            None => kept.push(staged),
+            None => {
+                if policy == ImportConflictPolicy::OwnerWins {
+                    let bundle_dir = registry
+                        .canonical_task_bundle_path(&target.workspace_id, &staged.source_id)?;
+                    if bundle_dir.is_dir() {
+                        to_overwrite.push(MirrorReplacement {
+                            staged,
+                            bundle_dir,
+                            register_binding: true,
+                        });
+                    } else {
+                        kept.push(staged);
+                    }
+                } else {
+                    kept.push(staged);
+                }
+            }
             Some(existing) => {
                 let identical = existing.workspace_id == target.workspace_id
                     && read_bundle_at(&existing.canonical_path)
@@ -411,7 +434,11 @@ pub fn import_tasks(
                                     action: ImportAction::SkippedLocalOwned,
                                 }),
                                 MirrorVerdict::Replace(bundle_dir) => {
-                                    to_overwrite.push(MirrorReplacement { staged, bundle_dir })
+                                    to_overwrite.push(MirrorReplacement {
+                                        staged,
+                                        bundle_dir,
+                                        register_binding: false,
+                                    })
                                 }
                             }
                         }
@@ -435,13 +462,13 @@ pub fn import_tasks(
     // ---- Phase 2: mutate. Track writes for best-effort rollback. ----
     // Note: the monotonic allocator bumps below are intentionally never rolled
     // back — the counter only moves forward and holes are expected. A newly
-    // created workspace *binding* is likewise left in place on rollback (an
-    // empty binding is benign and idempotent to re-create); only the synthetic
-    // directory we created for it is cleaned up.
+    // created workspace binding is tracked and retired on rollback, while
+    // pre-existing workspace bindings are never touched.
     let mut guard = WriteGuard::new(registry);
 
     let registered_workspace = if let Some(params) = &target.register {
         registry.register_workspace(params.clone())?;
+        guard.registered_workspace = Some(target.workspace_id.clone());
         true
     } else {
         false
@@ -521,6 +548,14 @@ pub fn import_tasks(
                 "task migration import",
                 || replace_bundle_at(&replacement.bundle_dir, &staged.bundle, &staged.staging_dir),
             )?;
+            if replacement.register_binding {
+                registry.register_task_bundle(
+                    &staged.source_id,
+                    &target.workspace_id,
+                    &replacement.bundle_dir,
+                )?;
+                guard.registered_ids.push(staged.source_id.clone());
+            }
             records.push(ImportedTask {
                 source_id: staged.source_id.clone(),
                 final_id: staged.source_id.clone(),
@@ -764,6 +799,7 @@ struct WriteGuard<'a> {
     registry: &'a TaskRegistryStore,
     written_dirs: Vec<PathBuf>,
     registered_ids: Vec<String>,
+    registered_workspace: Option<String>,
     armed: bool,
 }
 
@@ -773,6 +809,7 @@ impl<'a> WriteGuard<'a> {
             registry,
             written_dirs: Vec::new(),
             registered_ids: Vec::new(),
+            registered_workspace: None,
             armed: true,
         }
     }
@@ -792,6 +829,9 @@ impl<'a> WriteGuard<'a> {
     /// rows can be left behind the bundle until the next successful sync (or
     /// `orbit task reindex`) rebuilds them.
     fn rollback(&mut self) {
+        if let Some(workspace_id) = self.registered_workspace.take() {
+            let _ = self.registry.unbind_workspace(&workspace_id);
+        }
         for id in self.registered_ids.drain(..) {
             // workspace_id is not needed to look up the (global) binding, but the
             // API takes it; recover it from the binding.

--- a/crates/orbit-store/src/workflow/task/tests/mod.rs
+++ b/crates/orbit-store/src/workflow/task/tests/mod.rs
@@ -470,6 +470,44 @@ fn import_into_unregistered_workspace_registers_it() {
 }
 
 #[test]
+fn failed_import_removes_workspace_registered_by_that_run() {
+    let src = TempDir::new().unwrap();
+    let dst = TempDir::new().unwrap();
+    let archive = src.path().join("tasks.tar.zst");
+    let ws = "orbit-src-bbbbbb";
+    build_source_archive(src.path(), ws, &archive);
+
+    let registry = open_registry(dst.path());
+    let binding = bind(&registry, dst.path(), ws);
+    let store = bundle_store(&registry, &binding);
+    seed(
+        &store,
+        &registry,
+        ws,
+        &make_bundle("ORB-00000", "orphaned bundle", Vec::new()),
+    );
+    registry
+        .unbind_workspace(ws)
+        .expect("remove the index while retaining the canonical bundle");
+    assert!(registry.find_workspace_binding(ws).unwrap().is_none());
+
+    let error = import_tasks(&registry, &archive, None, ImportConflictPolicy::Fail)
+        .expect_err("creation-only import must reject the orphaned directory");
+    assert!(error.to_string().contains("task bundle already exists"));
+    assert!(
+        registry.find_workspace_binding(ws).unwrap().is_none(),
+        "a failed import must not leave its newly registered workspace behind"
+    );
+    assert!(
+        registry
+            .canonical_task_bundle_path(ws, "ORB-00000")
+            .unwrap()
+            .is_dir(),
+        "rollback must preserve the pre-existing orphaned bundle"
+    );
+}
+
+#[test]
 fn allocator_bumped_past_max_imported_id() {
     let src = TempDir::new().unwrap();
     let dst = TempDir::new().unwrap();

--- a/crates/orbit-store/src/workflow/task/tests/owner_wins.rs
+++ b/crates/orbit-store/src/workflow/task/tests/owner_wins.rs
@@ -365,6 +365,69 @@ fn owner_wins_recreates_a_missing_bound_mirror_and_is_rerunnable() {
 }
 
 #[test]
+fn owner_wins_repairs_an_unbound_existing_bundle_and_lands_the_rest() {
+    let src = TempDir::new().unwrap();
+    let dst = TempDir::new().unwrap();
+    let ws = "orbit-owner-ababab";
+    let archive = src.path().join("tasks.tar.zst");
+    let incoming = make_bundle("ORB-00000", "owner truth", Vec::new());
+    export_owner_archive(
+        src.path(),
+        ws,
+        &archive,
+        &[
+            incoming.clone(),
+            make_bundle("ORB-00003", "new peer task", Vec::new()),
+        ],
+    );
+
+    let registry = open_mirror_registry(dst.path());
+    let binding = bind(&registry, dst.path(), ws);
+    let store = bundle_store(&registry, &binding);
+    seed(
+        &store,
+        &registry,
+        ws,
+        &make_bundle("ORB-00000", "orphaned mirror", Vec::new()),
+    );
+    registry
+        .unregister_task_bundle("ORB-00000", ws)
+        .expect("remove only the orphan's registry binding");
+    assert!(
+        registry
+            .canonical_task_bundle_path(ws, "ORB-00000")
+            .unwrap()
+            .is_dir()
+    );
+
+    let outcome =
+        import_tasks(&registry, &archive, None, ImportConflictPolicy::OwnerWins).expect("sync");
+
+    assert_eq!(outcome.tasks.len(), 2);
+    assert_eq!(
+        outcome
+            .tasks
+            .iter()
+            .find(|task| task.source_id == "ORB-00000")
+            .unwrap()
+            .action,
+        ImportAction::Updated
+    );
+    assert_eq!(
+        outcome
+            .tasks
+            .iter()
+            .find(|task| task.source_id == "ORB-00003")
+            .unwrap()
+            .action,
+        ImportAction::Kept
+    );
+    assert_eq!(landed_bundle(&registry, ws, "ORB-00000"), incoming);
+    assert!(registry.find_task_binding("ORB-00000").unwrap().is_some());
+    assert_eq!(registry.tasks_for_workspace(ws).unwrap().len(), 2);
+}
+
+#[test]
 fn owner_wins_preserves_foreign_relation_targets() {
     let first_export = TempDir::new().unwrap();
     let second_export = TempDir::new().unwrap();

--- a/docs/design/task-migration/1_overview.md
+++ b/docs/design/task-migration/1_overview.md
@@ -71,7 +71,7 @@ machine a disjoint id range).
 | Concern | File | Task |
 |---------|------|------|
 | Archive pack/unpack (tar.zst) | [crates/orbit-store/src/workflow/task/archive.rs](../../../crates/orbit-store/src/workflow/task/archive.rs) | [ORB-00034] |
-| Export / transactional import + renumber | [crates/orbit-store/src/workflow/task/mod.rs](../../../crates/orbit-store/src/workflow/task/mod.rs) | [ORB-00034] |
+| Export / validated import + renumber | [crates/orbit-store/src/workflow/task/mod.rs](../../../crates/orbit-store/src/workflow/task/mod.rs) | [ORB-00034] |
 | Reindex from disk | [crates/orbit-store/src/workflow/task/reindex.rs](../../../crates/orbit-store/src/workflow/task/reindex.rs) | [ORB-00034] |
 | Allocator seed/bump + prefix primitives | [crates/orbit-store/src/driver/sqlite/task_registry/store.rs](../../../crates/orbit-store/src/driver/sqlite/task_registry/store.rs) | [ORB-00034], [ORB-10721] |
 | Prefix projection into the allocator | [crates/orbit-cmd/src/registry_runtime.rs](../../../crates/orbit-cmd/src/registry_runtime.rs) | [ORB-10721] |
@@ -96,9 +96,12 @@ orbit task import /tmp/tasks.tar.zst \
   --task-workspace <target-task-workspace-id> --on-conflict=renumber
 ```
 
-Import is transactional: it validates the manifest version and every bundle's
-integrity *before* touching state, so a corrupt or version-incompatible archive
-fails with no partial writes. `--task-workspace` selects the task-registry
+Import validates the manifest version and every bundle's integrity *before*
+touching state, so a corrupt or version-incompatible archive fails with no
+partial writes. During the mutation phase, fresh bundles and a source workspace
+registration created by the import are rolled back if a later write fails;
+owner-wins replacements remain because the owner's copy is authoritative.
+`--task-workspace` selects the task-registry
 partition, whose id is the `workspace_id` in B's checkout `.orbit/config.yaml`;
 the checkout must already be registered locally. If omitted, import resolves the
 archive's source workspace if registered locally, otherwise it registers the
@@ -220,18 +223,22 @@ algorithm:
   aborts). `--on-conflict=owner-wins` resolves it from the id alone — a
   colliding foreign-prefix bundle is replaced by the owner's copy (reported
   `updated`), a colliding local-prefix bundle is left untouched (reported
-  `skipped-local-owned`), and nothing is ever renumbered ([ORB-12126]).
-  Because it never mints, foreign relation targets survive verbatim, no
-  `.idmap.json` is written, and re-running the same archive reports every task
-  as `already-present` — so it is safe on a timer:
+  `skipped-local-owned`), and nothing is ever renumbered ([ORB-12126]). If the
+  task id has no registry binding but its canonical bundle directory remains,
+  owner-wins refreshes that orphaned mirror and restores its binding; `reindex`
+  remains the recovery command for other index drift. Because it never mints,
+  foreign relation targets survive verbatim, no `.idmap.json` is written, and
+  re-running the same archive reports every task as `already-present` — so it
+  is safe on a timer:
 
   ```sh
   orbit task import /tmp/peer-tasks.tar.zst --on-conflict=owner-wins
   ```
 
   Pull before push: a cross-host `depends_on` only resolves once its target's
-  mirror has landed. A failed run is re-runnable rather than rolled back —
-  replacements already applied stay, since the owner's copy is the newer one.
+  mirror has landed. A failed run is re-runnable: fresh bundles and any
+  workspace registration created by that run are rolled back, while owner-wins
+  replacements already applied stay because the owner's copy is the newer one.
 
 The reasoning for choosing prefix ownership over a single authoritative host is
 in [4_decisions](./4_decisions.md).


### PR DESCRIPTION
## Task

[ORB-12152](https://orbit-cli.com/tasks/ORB-12152) — [qa-sweep] owner-wins import fails with a raw "task bundle already exists" error when the task index is lost, and the failed run still leaves the source workspace registered

### Description

Two defects in the same failure path, both on the owner-wins import ORB-12126
(`b120228b4`) shipped as a policy that is "safe on a timer"
(`docs/design/task-migration/1_overview.md` §5).

## 1. A lost or rebuilt task index wedges the sync with an unactionable error

`import_tasks` classifies an incoming id by its *registry binding*
(`crates/orbit-store/src/workflow/task/mod.rs:370-372`). When the binding is
absent the bundle is treated as new and goes to `write_bundle_at`, whose new
`refuse_existing_bundle` guard
(`crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs:120-129`, added
by the same commit) rejects the still-present directory:

```
error: store error: task bundle already exists at <root>/tasks/workspaces/ws_peer/AAA-00000
```

Nothing else in the archive lands, the message names an internal path, and it
offers no recovery. The trigger is the exact state the module documents as
ordinary ("bundles were `rsync`'d or moved by hand", a lost/rebuilt
`index.sqlite`) and for which `orbit task reindex` is the documented cure — but a
scheduled `--on-conflict=owner-wins` sync just fails until someone reads the
source. This is a sibling of ORB-12146 (missing bundle directory, binding
present); here the bundle is present and the binding is missing.

## 2. The failed run leaves the archive's source workspace registered

`resolve_target` registers the source workspace before the write phase
(`crates/orbit-store/src/workflow/task/mod.rs:~700`), and the rollback guard only
retracts written bundle dirs and task bindings — not the workspace registration.
So a failed import leaves a `workspace_bindings` row with no checkout, which is
exactly the state ORB-12145 reports as a permanent doctor warning. The module and
design docs advertise the opposite: "Import is transactional: it validates the
manifest version and every bundle's integrity *before* touching state, so a
corrupt or version-incompatible archive fails with no partial writes."

## Reproduction (orbit 0.21.0 built from `1fda27b49`, Linux)

Disposable `HOME` under `/tmp`, every `orbit_common::test_env::INHERITED_AUTHORITY_ENV`
variable cleared, routing verified with `orbit workspace show --format json`
(`repo_root=/tmp/qa/repoJ`, `orbit_dir=/tmp/qa/repoJ/.orbit`) before any mutation.

```sh
cd /tmp/qa/repoJ && orbit task import /tmp/qa/peer.tar.zst --on-conflict=owner-wins --json
#   workspace_id=ws_repoa registered_workspace=true  [(AAA-00000,kept),(AAA-00001,kept)]
sqlite3 ~/.orbit/tasks/index.sqlite 'select workspace_id from workspace_bindings'
#   ws_repoa | ws_repoj

rm -f ~/.orbit/tasks/index.sqlite*            # index lost / rebuilt; bundles untouched

cd /tmp/qa/repoJ && orbit task import /tmp/qa/peer.tar.zst --on-conflict=owner-wins
#   error: store error: task bundle already exists at
#          /tmp/qa/homeE/.orbit/tasks/workspaces/ws_repoa/AAA-00000
sqlite3 ~/.orbit/tasks/index.sqlite 'select workspace_id from workspace_bindings'
#   ws_repoa | ws_repoj          <- ws_repoa re-registered by the *failed* run
sqlite3 ~/.orbit/tasks/index.sqlite 'select task_id from task_bundle_bindings'
#   (empty)                      <- nothing else landed
```

Recovery for (1) is `orbit task reindex --task-workspace ws_repoa` followed by a
re-run, which then reports the tasks `already-present`/`updated` as expected —
the machinery is fine, only the failure handling is not.

## Suggested direction

For (1): when the id is unbound but the canonical directory exists, treat the
bundle as a mirror to refresh (owner's copy is authoritative either way) or fail
the *single* task with a message naming `orbit task reindex --task-workspace <id>`
while the rest of the archive lands — consistent with whatever ORB-12146 settles
on. For (2): register the target workspace inside the rollback scope, or
unregister it when the import aborts and the registration was created by that
run (`ImportOutcome::registered_workspace` already tracks it).

Validation impact: none — no test or prescribed validation command is blocked.
Production impact: a scheduled cross-host sync stops working after any index
rebuild until an operator diagnoses an internal-path error, and each failed
attempt adds a checkout-less workspace row that doctor then warns about forever.

### Acceptance Criteria

- An owner-wins import whose incoming id has no registry binding but whose canonical bundle directory exists either refreshes that bundle or fails only that task with an error naming the `orbit task reindex` recovery, while the rest of the archive lands.
- A failed `orbit task import` leaves no workspace registration that the same run created.
- The transactional-import claim in the task-migration module and design docs matches the implemented failure behavior.
- Regression coverage exercises import with a present bundle directory and an absent task binding.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Owner-wins now refreshes an existing canonical bundle when its task binding is missing, restores the binding, and continues importing other archive tasks.
- Import rollback now removes a workspace registration created by the failed run while preserving pre-existing orphaned bundles and owner-wins replacements.
- Added regressions for unbound-bundle recovery plus sibling landing, and failed-import workspace cleanup.
- Updated task-migration module and design documentation to describe validation-before-mutation, rollback scope, and orphan recovery.

Acceptance criteria:
- 1: Passed. Owner-wins replaces an unbound existing canonical directory, registers its task binding, and the regression proves a second task lands.
- 2: Passed. A failing creation-only import removes the workspace binding created during that run; the regression verifies it.
- 3: Passed. Module docs and design docs now state the actual rollback/replacement behavior and no longer claim unconditional no-partial-write transactionality.
- 4: Passed. Regression coverage exercises a present bundle directory with an absent task binding.

Validation:
- Passed: cargo test -p orbit-store workflow::task (71 passed, 0 failed).
- Passed: cargo fmt --all -- --check.
- Passed: make ci-fast (all guardrails passed; compiler-cache namespace subcheck reported its documented environment skip).
- Passed: make ci-lint (workspace clippy with -D warnings).
- Passed: git diff --check.
- Passed: git status --short; only the four scoped tracked files are modified.

Assessment: The import path now repairs the reported lost-index state and cleans up failed-run workspace registration without changing existing owner-wins replacement semantics. No known remaining risks within the scoped behavior.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12152-6aa3bad7`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus