### PR TITLE
[qa-sweep] a checkout deleted without teardown is undiagnosable and unreclaimable: doctor calls its task partition claimed and workspace remove refuses every selector

### DIFF
--- a/crates/orbit-cli/src/command/workspace/remove.rs
+++ b/crates/orbit-cli/src/command/workspace/remove.rs
@@ -1,12 +1,15 @@
+use std::path::Path;
+
 use clap::Args;
 use orbit_core::OrbitRuntime;
 use orbit_registry::workspace_registry;
+use orbit_types::workspace::WorkspaceRegistry;
 
 use crate::command::{CommandOut, CommandOutput, Execute};
 
 #[derive(Args)]
 pub struct WorkspaceRemoveArgs {
-    /// Workspace name or id
+    /// Workspace name, id, or absolute checkout path
     pub workspace: String,
 }
 
@@ -15,9 +18,33 @@ impl Execute for WorkspaceRemoveArgs {
         let global_root = runtime.global_root();
         let registry_path = workspace_registry::registry_path_for(&global_root);
         let mut registry = workspace_registry::load_registry_from(&registry_path)?;
-        let removed = workspace_registry::remove_workspace(&mut registry, &self.workspace)?;
+        let workspace_id = workspace_id_for_selector(&registry, &self.workspace)?;
+        let removed = match workspace_id {
+            Some(workspace_id) => {
+                workspace_registry::remove_workspace(&mut registry, &workspace_id)?
+            }
+            None => workspace_registry::remove_workspace(&mut registry, &self.workspace)?,
+        };
         workspace_registry::save_registry_to(&registry, &registry_path)?;
         println!("workspace '{}' removed from registry", removed.name);
         Ok(CommandOutput::Silent)
     }
+}
+
+fn workspace_id_for_selector(
+    registry: &WorkspaceRegistry,
+    selector: &str,
+) -> Result<Option<String>, orbit_core::OrbitError> {
+    if let Some(workspace) = workspace_registry::find_workspace(registry, selector)? {
+        return Ok(Some(workspace.id.clone()));
+    }
+
+    if Path::new(selector).is_absolute() {
+        return Ok(
+            workspace_registry::find_checkout_by_path(registry, Path::new(selector))
+                .map(|checkout| checkout.workspace_id.clone()),
+        );
+    }
+
+    Ok(None)
 }

--- a/crates/orbit-cli/src/command/workspace/tests/mod.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/mod.rs
@@ -1,6 +1,7 @@
 mod init;
 mod init_report;
 mod publication;
+mod remove;
 mod shared_root;
 mod source_remote;
 mod teardown;

--- a/crates/orbit-cli/src/command/workspace/tests/remove.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/remove.rs
@@ -1,0 +1,67 @@
+use chrono::Utc;
+use orbit_core::OrbitRuntime;
+use orbit_registry::workspace_registry;
+use orbit_types::workspace::{Workspace, WorkspaceCheckout, WorkspaceStatus};
+use tempfile::tempdir;
+
+use crate::command::Execute;
+
+use super::super::remove::WorkspaceRemoveArgs;
+
+#[test]
+fn remove_accepts_the_recorded_path_of_a_deleted_checkout() {
+    let temp = tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let survivor_orbit = temp.path().join("survivor").join(".orbit");
+    let deleted_repo = temp.path().join("deleted");
+    let deleted_orbit = deleted_repo.join(".orbit");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::create_dir_all(&survivor_orbit).expect("create survivor runtime");
+
+    let registry_path = workspace_registry::registry_path_for(&global_root);
+    let mut registry =
+        workspace_registry::load_registry_from(&registry_path).expect("load registry");
+    let now = Utc::now();
+    workspace_registry::register_workspace(
+        &mut registry,
+        Workspace {
+            id: "ws_deleted".to_string(),
+            name: "deleted".to_string(),
+            owner_machine_id: None,
+            git_remote: None,
+            ship_mode: None,
+            base_branch: "main".to_string(),
+            status: WorkspaceStatus::Invalid,
+            created_at: now,
+            updated_at: now,
+        },
+    )
+    .expect("register deleted workspace");
+    workspace_registry::register_checkout(
+        &mut registry,
+        WorkspaceCheckout::owner("ws_deleted".to_string(), deleted_repo, deleted_orbit),
+    )
+    .expect("register deleted checkout");
+    workspace_registry::save_registry_to(&registry, &registry_path).expect("save registry");
+
+    let runtime = OrbitRuntime::from_roots(&global_root, &survivor_orbit).expect("runtime");
+    WorkspaceRemoveArgs {
+        workspace: temp.path().join("deleted").to_string_lossy().into_owned(),
+    }
+    .execute(&runtime)
+    .expect("remove deleted checkout");
+
+    let registry =
+        workspace_registry::load_registry_from(&registry_path).expect("load updated registry");
+    assert!(
+        workspace_registry::find_workspace_by_id(&registry, "ws_deleted").is_none(),
+        "path removal must deregister the missing workspace"
+    );
+    assert!(
+        registry
+            .checkouts
+            .iter()
+            .all(|checkout| checkout.workspace_id != "ws_deleted"),
+        "path removal must remove the checkout binding too"
+    );
+}

--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -445,12 +445,13 @@ fn doctor_check_task_reservations(runtime: &OrbitRuntime) -> WorkspaceDoctorResu
 /// [ORB-12109]. Scoped to the whole host, not just this workspace, because the
 /// partition directory is itself host-global.
 ///
-/// A partition is named for its *task-registry* workspace id, so the task
-/// registry is what claims it while the bound checkout's `orbit_dir` exists.
-/// The workspace catalog and the synthetic `--root` partition are the other
-/// claimants. Comparing the directory name against catalog `ws_*` ids alone
-/// reported every `<slug>-<hash>` partition — including live ones — as
-/// orphaned [ORB-12119].
+/// A partition is normally named for its *task-registry* workspace id, so the
+/// task registry claims it while the bound checkout's `orbit_dir` exists.
+/// `orbit workspace init` may use the catalog's `ws_*` id directly; that
+/// catalog claim is live only while its recorded checkout is present. The
+/// synthetic `--root` partition is the other permanent claimant. Comparing
+/// the directory name against catalog `ws_*` ids alone reported every
+/// `<slug>-<hash>` partition — including live ones — as orphaned [ORB-12119].
 ///
 /// Partitions that still hold task bundles are reported without inviting a
 /// deletion unless their checkout is confirmed gone. A lost or rebuilt

--- a/crates/orbit-cmd/src/task_store.rs
+++ b/crates/orbit-cmd/src/task_store.rs
@@ -10,9 +10,10 @@
 //! The partition directory name is a *task-registry* workspace id
 //! (`workspace_bindings.workspace_id` in `<global_root>/tasks/index.sqlite`),
 //! which is minted as `<slug>-<hash>` whenever a checkout binds without an
-//! explicit id. It is not the workspace catalog's `ws_*` id space, so the
-//! task registry — not `workspaces.json` — decides which partition a checkout's
-//! task state lives in and which partitions are still claimed [ORB-12119].
+//! explicit id. `orbit workspace init` may instead bind the catalog's `ws_*`
+//! id directly. The task registry and the workspace catalog therefore both
+//! contribute claims, using checkout evidence to distinguish live, stale, and
+//! unreachable state [ORB-12119].
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -23,6 +24,7 @@ use orbit_registry::workspace_registry;
 pub use orbit_store::maintenance::task_registry::task_workspaces_dir;
 use orbit_store::maintenance::task_registry::{TaskRegistryStore, task_registry_path};
 use orbit_types::task::is_valid_orb_task_id;
+use orbit_types::workspace::WorkspaceCheckout;
 
 /// Path to one workspace's task-store partition under
 /// `<global_root>/tasks/workspaces/<workspace_id>/`.
@@ -256,14 +258,13 @@ pub fn partition_is_bound(global_root: &Path, workspace_id: &str) -> Result<bool
 
 /// Who claims each partition on this host, and why the rest do not.
 struct PartitionClaims {
-    /// Registered task workspaces, live checkout bindings, workspace catalog
-    /// ids, and the synthetic partition every `--root <data-dir>` write lands
-    /// in.
+    /// Registered task workspaces, live workspace catalog ids, and the
+    /// synthetic partition every `--root <data-dir>` write lands in.
     claimed: BTreeSet<String>,
-    /// Bindings whose checkout is confirmed absent.
+    /// Bindings or catalog checkouts that are confirmed absent.
     gone: BTreeSet<String>,
-    /// Bindings whose checkout the filesystem could not answer for, mapped to
-    /// the failure that stopped the answer.
+    /// Bindings or catalog checkouts whose filesystem state could not be
+    /// answered, mapped to the failure that stopped the answer.
     unreachable: BTreeMap<String, String>,
 }
 
@@ -303,14 +304,52 @@ fn partition_claims(global_root: &Path) -> Result<PartitionClaims, OrbitError> {
     let registry_path = workspace_registry::registry_path_for(global_root);
     if registry_path.exists() {
         let registry = workspace_registry::load_registry_from(&registry_path)?;
-        claims.claimed.extend(
-            registry
-                .workspaces
-                .into_iter()
-                .map(|workspace| workspace.id),
-        );
+        for workspace in registry.workspaces {
+            let Some(checkout) = registry
+                .checkouts
+                .iter()
+                .find(|checkout| checkout.workspace_id == workspace.id)
+            else {
+                // A checkoutless catalog entry is an imported logical
+                // workspace. Its partition remains recoverable task state.
+                claims.claimed.insert(workspace.id);
+                continue;
+            };
+
+            // `workspace init` uses the catalog id as its task partition id.
+            // Do not let that catalog claim mask stale or unreachable checkout
+            // evidence when both id spaces name the same partition.
+            record_catalog_checkout_evidence(&mut claims, &workspace.id, checkout);
+        }
     }
     Ok(claims)
+}
+
+/// Add a catalog checkout's claim without overriding stronger evidence from a
+/// task-registry binding that uses the same partition id.
+fn record_catalog_checkout_evidence(
+    claims: &mut PartitionClaims,
+    workspace_id: &str,
+    checkout: &WorkspaceCheckout,
+) {
+    match checkout_evidence(&checkout.orbit_dir) {
+        CheckoutEvidence::Present => {
+            claims.claimed.insert(workspace_id.to_string());
+            claims.gone.remove(workspace_id);
+            claims.unreachable.remove(workspace_id);
+        }
+        CheckoutEvidence::Gone => {
+            if !claims.claimed.contains(workspace_id) {
+                claims.gone.insert(workspace_id.to_string());
+                claims.unreachable.remove(workspace_id);
+            }
+        }
+        CheckoutEvidence::Unreachable(reason) => {
+            if !claims.claimed.contains(workspace_id) && !claims.gone.contains(workspace_id) {
+                claims.unreachable.insert(workspace_id.to_string(), reason);
+            }
+        }
+    }
 }
 
 /// What the filesystem can testify about a bound checkout directory.

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -10,7 +10,7 @@ use orbit_store::maintenance::task_registry::{
     BindWorkspaceParams, TaskRegistryStore, task_registry_path, task_workspaces_dir,
 };
 use orbit_types::workflow::{JobRun, JobRunState};
-use orbit_types::workspace::{Workspace, WorkspaceStatus};
+use orbit_types::workspace::{Workspace, WorkspaceCheckout, WorkspaceStatus};
 use sha2::{Digest, Sha256};
 
 use orbit_core::OrbitRuntime;
@@ -79,6 +79,22 @@ fn write_registered_workspace(global_root: &Path, workspace_id: &str, name: &str
         },
     )
     .expect("register workspace");
+    workspace_registry::save_registry_to(&registry, &registry_path).expect("save registry");
+}
+
+fn write_registered_checkout(global_root: &Path, workspace_id: &str, repo_root: &Path) {
+    let registry_path = workspace_registry::registry_path_for(global_root);
+    let mut registry =
+        workspace_registry::load_registry_from(&registry_path).expect("load registry");
+    workspace_registry::register_checkout(
+        &mut registry,
+        WorkspaceCheckout::owner(
+            workspace_id.to_string(),
+            repo_root.to_path_buf(),
+            repo_root.join(".orbit"),
+        ),
+    )
+    .expect("register checkout");
     workspace_registry::save_registry_to(&registry, &registry_path).expect("save registry");
 }
 
@@ -1057,6 +1073,93 @@ fn stale_task_registry_binding_is_reported_and_removed() {
             .exists()
     );
     assert!(!partition_is_bound(&global_root, "deleted-a1b2c3").expect("read binding"));
+}
+
+/// `orbit workspace init` uses the catalog `ws_*` id as the task partition in
+/// this layout. A deleted checkout must therefore be stale even while the
+/// catalog entry remains present.
+#[test]
+fn deleted_catalog_checkout_partition_is_reported_and_removed() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let global_root = temp.path().join("global");
+    let deleted_root = temp.path().join("deleted");
+    fs::create_dir_all(deleted_root.join(".orbit")).expect("create deleted checkout");
+
+    write_registered_workspace(&global_root, "ws_deleted", "deleted");
+    write_registered_checkout(&global_root, "ws_deleted", &deleted_root);
+    bind_task_partition(&global_root, "ws_deleted", "deleted", &deleted_root);
+    write_task_bundle(&global_root, "ws_deleted", "ORB-3");
+    fs::remove_dir_all(&deleted_root).expect("delete checkout");
+
+    let results = runtime.doctor_workspace().expect("doctor");
+    let row = status_of(&results, "orphan-task-stores");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Warning, "{row:?}");
+    assert!(row.message.contains("ws_deleted"), "{}", row.message);
+    assert!(row.message.contains("1 task bundle(s)"), "{}", row.message);
+    assert!(
+        row.message.contains("missing checkout directories"),
+        "{}",
+        row.message
+    );
+
+    let removed = runtime
+        .remove_orphan_task_stores()
+        .expect("remove stale catalog partition");
+    assert_eq!(removed.populated_partitions, 1, "{removed:?}");
+    assert_eq!(removed.task_bundles, 1, "{removed:?}");
+    assert!(
+        !task_workspaces_dir(&global_root)
+            .join("ws_deleted")
+            .exists()
+    );
+    assert!(!partition_is_bound(&global_root, "ws_deleted").expect("read binding"));
+}
+
+/// A catalog checkout that cannot be stat-ed is not evidence of deletion. Its
+/// populated task partition remains recoverable until the path is resolved.
+#[test]
+fn unreachable_catalog_checkout_partition_is_not_deleted() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let global_root = temp.path().join("global");
+    let unreachable_root = temp.path().join("unreachable");
+    fs::create_dir_all(unreachable_root.join(".orbit")).expect("create checkout");
+
+    write_registered_workspace(&global_root, "ws_unreachable", "unreachable");
+    write_registered_checkout(&global_root, "ws_unreachable", &unreachable_root);
+    bind_task_partition(
+        &global_root,
+        "ws_unreachable",
+        "unreachable",
+        &unreachable_root,
+    );
+    write_task_bundle(&global_root, "ws_unreachable", "ORB-4");
+    fs::remove_dir_all(&unreachable_root).expect("remove checkout directory");
+    fs::write(&unreachable_root, b"not a directory").expect("write path obstruction");
+
+    let results = runtime.doctor_workspace().expect("doctor");
+    let row = status_of(&results, "orphan-task-stores");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Warning, "{row:?}");
+    assert!(
+        row.message.contains("could not be reached"),
+        "{}",
+        row.message
+    );
+    assert!(row.message.contains("ws_unreachable"), "{}", row.message);
+    assert!(row.message.contains("1 task bundle(s)"), "{}", row.message);
+
+    assert_eq!(
+        runtime.remove_orphan_task_stores().expect("run repair"),
+        OrphanTaskStoreRemoval::default()
+    );
+    assert!(
+        task_workspaces_dir(&global_root)
+            .join("ws_unreachable")
+            .join("ORB-4")
+            .is_dir(),
+        "the repair must not delete a catalog partition without absence evidence"
+    );
 }
 
 /// [ORB-12119] The fix deletes only partitions no registry claims: a

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -101,14 +101,14 @@ individual flag; neither command upgrades the binary or pulls a remote repositor
 `.orbit/` and the global task-store partition its task state is bound to, retiring that
 partition's rows in `~/.orbit/tasks/index.sqlite` in the same step.
 
-A partition directory is named for a **task-registry** workspace id
+A partition directory is normally named for a **task-registry** workspace id
 (`workspace_bindings.workspace_id` in `~/.orbit/tasks/index.sqlite`), minted as `<slug>-<hash>`
-for a checkout that binds without an explicit id. That is a different id space from the workspace
-catalog's `ws_*` ids in `~/.orbit/workspaces.json`. A task-registry binding claims its partition
-while the binding's recorded `orbit_dir` is present on disk. Catalog `ws_*` ids and the synthetic
-`ws_unbound-data-dir` partition every `--root <data-dir>` write lands in remain claims, so they are
-never reported. `orphan-task-stores` names each reported workspace id, its partition path, and its
-task-bundle count.
+for a checkout that binds without an explicit id. `orbit workspace init` may instead use its
+catalog `ws_*` id directly. A task-registry or catalog checkout claim is live while its recorded
+`orbit_dir` is present on disk; a missing checkout is reported as stale, and an unreadable path is
+reported as unreachable. Checkoutless catalog entries and the synthetic `ws_unbound-data-dir`
+partition every `--root <data-dir>` write lands in remain claims. `orphan-task-stores` names each
+reported workspace id, its partition path, and its task-bundle count.
 
 **Evidence rule for deleting task bundles.** A partition that holds task bundles is deleted by the
 repair only when its bound checkout is *confirmed gone*: `orbit_dir` stats as absent, and the
@@ -142,7 +142,16 @@ readable becomes a confirmed-stale binding, which the repair can then remove.
 
 For a partition whose binding is confirmed stale, the missing `orbit_dir` is the evidence that the
 checkout is gone. The confirmed repair removes that partition, including its task bundles, and
-retires the stale registry rows — as it does for every empty unclaimed partition:
+retires the stale registry rows — as it does for every empty unclaimed partition. If the deleted
+checkout is still listed in the workspace catalog, first deregister it with its name, `ws_*` id, or
+recorded absolute checkout path:
+
+```sh
+ORBIT_OPERATOR=1 orbit workspace remove <workspace-name-or-id-or-absolute-checkout-path>
+```
+
+That command changes only the catalog; it does not delete `.orbit` or task bundles. The subsequent
+doctor repair removes the now-confirmed stale task-store partition:
 
 ```sh
 orbit doctor --fix-orphan-task-stores --confirm


### PR DESCRIPTION
## Task

[ORB-12150](https://orbit-cli.com/tasks/ORB-12150) — [qa-sweep] a checkout deleted without teardown is undiagnosable and unreclaimable: doctor calls its task partition claimed and workspace remove refuses every selector

### Description

## Summary

ORB-12109 added the `orphan-task-stores` doctor check for two states, one of
them "removing a checkout without running teardown". ORB-12127 (`67dc5ce2f`)
then added stale-binding detection so a task-registry binding whose
`orbit_dir` is gone stops counting as a claim. That detection cannot fire for
the partition layout `orbit workspace init` produces today, and the workspace
itself cannot be deregistered, so the state remains invisible with no
reclamation path.

Two independent gates keep the claim alive in `partition_claims`
(`crates/orbit-cmd/src/task_store.rs:196-226`): the stale check only applies to
ids reached through `workspace_checkout_bindings`, but
`claimed.extend(registry.workspaces.…id)` unconditionally adds every workspace
*catalog* id regardless of whether its checkout still exists. A checkout
registered by `orbit workspace init` binds its partition under the catalog id
(`ws_<name>`), so the catalog claim always wins and the partition is skipped
before the stale branch is reached. `partitions.stale` is therefore only
reachable for a partition whose id is *not* in the catalog — the legacy
`<slug>-<hash>` shape, which is exactly what the new regression test uses
(`crates/orbit-cmd/src/tests/doctor.rs`, `stale_task_registry_binding_is_reported_and_removed`,
partition `deleted-a1b2c3`). The test passes while the shipped layout is unaffected.

Recovery is also unavailable: `orbit workspace remove` refuses the workspace in
every selector form once its checkout directory is gone, and `orbit workspace
teardown` has no target argument — it acts on the current directory, which no
longer exists.

## Reproduction (orbit 0.21.0 built from `1fda27b49`, Linux)

Disposable `HOME` under `/tmp`, every `orbit_common::test_env::INHERITED_AUTHORITY_ENV`
variable cleared, routing verified with `orbit workspace show --format json`
before any mutation.

```sh
cd /tmp/qa/repoH && orbit workspace init --name repoH
#   id: ws_repoh   orbit_dir: /tmp/qa/repoH/.orbit
cd /tmp/qa/repoH && orbit task add --title "H task" --description h --complexity low
#   CCC-00007

rm -rf /tmp/qa/repoH                       # checkout deleted, no teardown

cd /tmp/qa/repoD && orbit workspace list
#   repoH  ws_repoh  invalid  pr  hm_…  owner  /tmp/qa/repoH

cd /tmp/qa/repoD && orbit doctor | grep orphan-task
#   orphan-task-stores  ok  4 task-store partition(s) scanned, all claimed by a workspace binding

ls ~/.orbit/tasks/workspaces/ws_repoh/     # CCC-00007  (bundle still there, unclaimable)

cd /tmp/qa/repoD && ORBIT_OPERATOR=1 orbit workspace remove repoH
#   error: invalid input: unknown workspace selector 'repoH'; pass a registered workspace name,
#          a logical workspace ID, or an absolute local checkout path
cd /tmp/qa/repoD && ORBIT_OPERATOR=1 orbit workspace remove ws_repoh              # same error
cd /tmp/qa/repoD && ORBIT_OPERATOR=1 orbit workspace remove /tmp/qa/repoH         # same error
```

`orbit workspace list` knows the workspace is `invalid`, so the information
needed for the diagnosis is already on hand; the `orphan-task-stores` row just
does not use it, and no other doctor row covers a registered workspace whose
checkout has vanished.

The stale branch *is* reachable when the catalog entry is removed first, which
confirms the masking is the catalog claim and nothing else:

```sh
cd /tmp/qa/repoD && ORBIT_OPERATOR=1 orbit workspace remove repoG   # while repoG still exists
rm -rf /tmp/qa/repoG
cd /tmp/qa/repoD && orbit doctor | grep orphan-task
#   orphan-task-stores  warning  1 stale task-store partition(s) point at missing checkout
#   directories: ws_repog (…/workspaces/ws_repog, 2 task bundle(s)) | Action: Run
#   `orbit doctor --fix-orphan-task-stores --confirm`.
```

## Suggested direction

Treat a workspace-catalog id as a claim only while its checkout is resolvable
(the same evidence `orbit workspace list` uses to print `invalid`), and let the
existing stale classification cover the rest — subject to whatever evidence rule
ORB-12143 settles on for populated partitions, since a catalog-claimed
partition can hold task data. Separately, give the operator a way out: allow
`orbit workspace remove` to deregister an `invalid` workspace (its own help says
it "does not delete .orbit", so a missing checkout should not block it), or give
`workspace teardown` an explicit target.

Validation impact: none — no test or prescribed validation command is blocked.
Production impact: no data loss, but a deleted checkout leaves a registry entry
and a populated task-store partition that no command reports and no command can
reclaim, which is the state the `orphan-task-stores` check was added for.

### Acceptance Criteria

- After a checkout registered by `orbit workspace init` is deleted without teardown, `orbit doctor` reports its task-store partition (naming the partition and its task-bundle count) instead of `all claimed by a workspace binding`.
- A deleted checkout's workspace can be deregistered through a supported command, and doing so leaves no unreachable task-store partition behind.
- Regression coverage uses a partition id of the shape `orbit workspace init` actually mints (catalog `ws_*`), not only a legacy `<slug>-<hash>` id.
- A partition whose catalog-claimed checkout is merely unreachable is not deleted on that evidence alone.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated task-store partition claims so catalog `ws_*` IDs are classified using their recorded checkout evidence: present remains claimed, confirmed absence becomes stale, and unreadable paths remain unreachable and protected from deletion.
- Added doctor regressions for deleted and unreachable catalog checkouts using `ws_*` partition IDs, including task-bundle counts and repair behavior.
- Extended `orbit workspace remove` to accept a recorded absolute checkout path, allowing deregistration after the checkout directory is gone without deleting `.orbit` or task bundles.
- Added CLI regression coverage for removing an invalid workspace by its recorded missing path.
- Updated `docs/runbooks/health-checks.md` to document catalog-ID partitions, evidence classification, and the deregistration-plus-doctor-repair recovery path.

Acceptance criteria:
- Deleted `orbit workspace init` checkout: passed. `deleted_catalog_checkout_partition_is_reported_and_removed` reports `ws_deleted` and its one task bundle instead of the all-claimed message, then removes the confirmed-stale partition.
- Deregistration/recovery: passed. `remove_accepts_the_recorded_path_of_a_deleted_checkout` removes the invalid catalog record and checkout binding; the documented follow-up doctor repair removes the stale task partition.
- Minted ID shape: passed. Regression fixtures use `ws_deleted` and `ws_unreachable`, the catalog `ws_*` namespace used by `orbit workspace init`.
- Unreachable evidence: passed. `unreachable_catalog_checkout_partition_is_not_deleted` retains the populated partition and reports it as unreachable.

Validation:
- `cargo test -p orbit-cmd --lib tests::doctor`: passed, 35 tests.
- `cargo test -p orbit-cli --bin orbit command::workspace::tests`: passed, 50 tests.
- `cargo test -p orbit-cli remove_accepts_the_recorded_path_of_a_deleted_checkout`: passed, 1 test.
- `cargo fmt --all -- --check`: passed.
- `make ci-fast`: passed; its compiler-cache mount-namespace probe was skipped because the host denied unprivileged bubblewrap namespaces.
- `make ci-lint`: passed.
- `git diff --check`: passed.
- `git status --short`: passed; only task-scoped source, test, and runbook changes remain uncommitted as required.

Assessment: The fix keeps catalog and task-registry evidence consistent, preserves the no-delete-on-unreachable safety rule, and provides a recoverable operator path for deleted checkouts.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12150-6aa3b92d`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus