### PR TITLE
[code-review] epic_pipeline worktrees are never reclaimed: delivery cleanup and the (now 1 h) GC backstop cannot derive an epic worktree's path

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/mod.rs
@@ -79,7 +79,13 @@ impl WorktreeIdentity {
         engine_run_id: Option<&str>,
     ) -> Result<Self, OrbitError> {
         let task_ids = task_ids_from_input(input)?;
+        // The stored epic_pipeline input is the one worktree-owning shape
+        // whose task and naming fields are supplied to the nested worktree
+        // step rather than persisted on the run itself.
+        let epic_run_id =
+            input_string_field(input, "epic_task_id").map(|task_id| format!("epic-{task_id}"));
         let run_id = input_string_field(input, "run_id")
+            .or(epic_run_id)
             .or_else(|| {
                 engine_run_id
                     .map(str::trim)
@@ -88,6 +94,7 @@ impl WorktreeIdentity {
             })
             .unwrap_or_else(|| fallback_run_id_for_tasks(&task_ids));
         let branch_prefix = input_string_field(input, "branch_prefix")
+            .or_else(|| input_string_field(input, "epic_task_id").map(|_| "epic".to_string()))
             .unwrap_or_else(|| DEFAULT_BRANCH_PREFIX.to_string());
         Ok(Self {
             task_ids,
@@ -143,6 +150,10 @@ fn task_ids_from_input(input: &Value) -> Result<Vec<String>, OrbitError> {
         if !task_ids.is_empty() {
             return Ok(task_ids);
         }
+    }
+
+    if let Some(epic_task_id) = input_string_field(input, "epic_task_id") {
+        return Ok(vec![epic_task_id]);
     }
 
     Ok(vec![required_input_string(input, "task_id")?.to_string()])

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/gc.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/gc.rs
@@ -456,6 +456,64 @@ fn setup_and_gc_derive_the_same_worktree_path() {
     );
 }
 
+#[test]
+fn stored_epic_pipeline_input_matches_worktree_setup_path() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    let run = epic_pipeline_run("jrun-epic-derivation", JobRunState::Success, "ORB-EPIC");
+    let stored_input = run.input.clone().unwrap();
+
+    let gc_identity = WorktreeIdentity::from_input(&stored_input, Some(&run.run_id)).unwrap();
+    let setup_input = json!({
+        "task_ids": ["ORB-EPIC"],
+        "run_id": "epic-ORB-EPIC",
+        "branch_prefix": "epic",
+    });
+    let setup_identity = WorktreeIdentity::from_input(&setup_input, None).unwrap();
+
+    assert_eq!(gc_identity.task_ids, vec!["ORB-EPIC".to_string()]);
+    assert_eq!(gc_identity.branch_prefix, "epic");
+    assert_eq!(gc_identity.run_id, "epic-ORB-EPIC");
+    assert_eq!(
+        gc_identity.path(&repo).unwrap(),
+        setup_identity.path(&repo).unwrap()
+    );
+}
+
+#[test]
+fn epic_pipeline_worktree_is_collected_from_stored_run_input() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo);
+    let run = epic_pipeline_run("jrun-epic-gc", JobRunState::Success, "ORB-EPIC-GC");
+    let worktree = resolve_worktree_path_from_prefix(&repo, "epic", "epic-ORB-EPIC-GC").unwrap();
+    add_worktree(&repo, &worktree, "epic/ORB-EPIC-GC");
+    let host = FakeTaskHost::new(vec![task_fixture("ORB-EPIC-GC", TaskStatus::Done)]);
+
+    let result = collect_worktrees(
+        &repo,
+        std::slice::from_ref(&run),
+        &host,
+        &WorktreeGcOptions {
+            delete: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let report = result
+        .reports
+        .iter()
+        .find(|report| report.path == worktree)
+        .expect("the epic worktree must be classified from the stored run input");
+    assert_eq!(report.action, "removed");
+    assert_eq!(report.run_id.as_deref(), Some("jrun-epic-gc"));
+    assert_eq!(report.task_id.as_deref(), Some("ORB-EPIC-GC"));
+    assert_eq!(report.task_status, Some(TaskStatus::Done));
+    assert!(report.bytes_reclaimed > 0);
+    assert!(!worktree.exists());
+}
+
 /// Stored runs from before `task_ids` existed still carry the singular key.
 #[test]
 fn legacy_singular_task_id_run_is_still_recognized() {
@@ -803,6 +861,12 @@ fn pipeline_run(id: &str, state: JobRunState, task_ids: &[&str]) -> JobRun {
 /// the singular key, and gc must keep recognizing them.
 fn legacy_task_id_run(id: &str, state: JobRunState, task_id: &str) -> JobRun {
     job_run(id, state, json!({ "task_id": task_id }))
+}
+
+fn epic_pipeline_run(id: &str, state: JobRunState, epic_task_id: &str) -> JobRun {
+    let mut run = job_run(id, state, json!({ "epic_task_id": epic_task_id }));
+    run.job_id = "epic_pipeline".to_string();
+    run
 }
 
 /// A run that names no task at all — it never went through `setup_worktree`.

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -212,7 +212,10 @@ covers the child rather than only submission ([Delegate workspace ship routines 
 Successful delivery runs remove their own task worktree after the run has been
 durably terminalized. `task_pr_pipeline` does this only after `pr_complete` has
 verified the PR's merged state and completed the task; `task_local_pipeline` and
-`epic_pipeline` use the same boundary after local delivery. The
+`epic_pipeline` use the same boundary after local delivery. For an epic, the
+stored run input carries `epic_task_id`; the shared identity derivation maps it
+to the `epic-epic-<epic_task_id>` worktree created by the epic's `worktree`
+step. The
 `workspace_auto_pipeline` and `task_gate_pipeline` jobs are coordinators: their
 child delivery run owns the worktree and performs the removal, so a drain does
 not need to wait for a separate GC fire.


### PR DESCRIPTION
## Task

[ORB-12157](https://orbit-cli.com/tasks/ORB-12157) — [code-review] epic_pipeline worktrees are never reclaimed: delivery cleanup and the (now 1 h) GC backstop cannot derive an epic worktree's path

### Description

ORB-12140 (`867a23126`) added delivery-time worktree reclamation and lowered the scheduled backstop from 24 h to 1 h on the premise that delivery now reaps worktrees. For `epic_pipeline` that premise does not hold: neither the new delivery hook nor the scheduled GC can identify an epic worktree, so an epic's checkout (the largest and longest-lived kind, ~13 GB with `target/`) is never reclaimed by either path.

## Why the derivation fails

- `delivery_job_owns_worktree` lists `epic_pipeline` as a worktree owner (`crates/orbit-core/src/application/gc.rs:68-73`), and `cleanup_delivered_worktree` hands the run to `collect_worktrees` (`crates/orbit-core/src/application/gc.rs:11-30`).
- `collect_worktrees` derives the candidate directories from the *job run input* via `expected_paths` -> `WorktreeIdentity::from_input` (`crates/orbit-engine/src/executor/automation/vcs/worktree/gc.rs:278-286`).
- `WorktreeIdentity::from_input` requires `task_ids` (array) or `task_id` (`crates/orbit-engine/src/executor/automation/vcs/worktree/mod.rs:126-149`); `required_input_string` errors when the key is absent (`crates/orbit-engine/src/executor/automation/input.rs:6-16`).
- An `epic_pipeline` run's input carries `epic_task_id`, not `task_ids`/`task_id` — see the job's `default_input` (`crates/orbit-core/assets/jobs/epic_pipeline.yaml:20-29`) and the dispatch site (`crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs:246`). `from_input` therefore returns `Err`, `expected_paths` falls back to the shared batch path `parallel-batch-<run_id>` (`gc.rs:278-283`), and `attributed_task_ids` returns empty (`gc.rs:289-297`).
- The real directory is `epic-epic-<ORB-id>`: the worktree step passes `run_id: "epic-{{ input.epic_task_id }}"` and `branch_prefix: epic` (`crates/orbit-core/assets/jobs/epic_pipeline.yaml:44-51`), which `resolve_worktree_path_from_prefix` renders as `<prefix>-<run_id>` (`crates/orbit-engine/src/executor/automation/vcs/worktree/mod.rs:199-214`).

## Consequences

1. Delivery cleanup: `known_paths` holds only the non-existent `parallel-batch-<run_id>` path, `path.exists()` is false, `reports` is empty, and `worktree_cleanup` is persisted as a 0-byte no-op. Listing `epic_pipeline` in `delivery_job_owns_worktree` is currently dead code.
2. Scheduled GC: the same derivation runs for the full sweep, so the on-disk `epic-epic-<id>` directory is not in `known_paths` and is reported `skipped:unrecognized` (`gc.rs:113-122`) — it is never removed regardless of age. This is the same class of drift ORB-10427 fixed for `task_pr_pipeline`.
3. `worktree_gc_pipeline` now defaults to `older_than_hours: 1` (`crates/orbit-core/assets/jobs/worktree_gc_pipeline.yaml:11-14`), justified as a backstop for the delivery reap. Epic worktrees have neither reaper.

## Documentation is also wrong

`docs/design/routines/2_design.md:212-216` states that `task_local_pipeline` and `epic_pipeline` "use the same boundary after local delivery". For `epic_pipeline` the boundary is reached but can never match a directory.

## Suggested direction

Make the identity derivation cover the epic shape at the single owning site (`WorktreeIdentity::from_input`) rather than at the call sites — e.g. accept `epic_task_id` together with the `epic` branch prefix and `epic-<id>` token that `epic_pipeline.yaml` already spells — so delivery cleanup and the scheduled sweep recognise the same directory. Update `docs/design/routines/2_design.md` in the same change.

### Acceptance Criteria

- A terminal, successful `epic_pipeline` run whose epic root task is settled has its `epic-epic-<id>` worktree removed by the delivery cleanup boundary, with a non-empty `worktree_cleanup` report naming the removed path and reclaimed bytes.
- The scheduled `worktree_gc_pipeline` sweep classifies an existing `epic-epic-<id>` worktree by its run and task gates rather than reporting `skipped:unrecognized`.
- A regression test derives the worktree identity from a stored `epic_pipeline` run input (`epic_task_id`, no `task_ids`) and asserts the resolved path equals the directory `worktree_setup` creates for that job spec.
- `docs/design/routines/2_design.md` describes the actual epic behavior.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Extended `WorktreeIdentity::from_input` to recognize stored `epic_pipeline` inputs containing `epic_task_id`, derive the epic task attribution, and reproduce the `epic-epic-<id>` path used by `worktree_setup`.
- Added regressions proving stored epic input matches the nested worktree-step identity and that a terminal successful epic run with a settled root is classified and removed with a non-zero reclaimed-byte report.
- Updated `docs/design/routines/2_design.md` with the actual epic worktree derivation and cleanup behavior.

Acceptance criteria:
- Delivery/collector cleanup: satisfied by the epic deletion regression; it reports `removed`, names the run/task, reclaims bytes, and removes the worktree. The existing delivery hook persists this collector result as `worktree_cleanup`.
- Scheduled GC classification: satisfied by the same shared collector path; the epic worktree is recognized from stored run/task gates and is not `skipped:unrecognized`.
- Stored-input identity regression: satisfied by `stored_epic_pipeline_input_matches_worktree_setup_path`, covering `epic_task_id` with no `task_ids` and asserting path equality with the worktree-step shape.
- Documentation: satisfied in `docs/design/routines/2_design.md`.

Assessment: The fix is centralized at the shared identity boundary, preserves existing task and bundle shapes, and keeps delivery and scheduled GC on one derivation path.

Validation:
- PASSED: `cargo fmt --all`
- PASSED: `cargo test -p orbit-engine worktree::tests::gc --lib` (25 passed)
- PASSED: `make ci-fast`; guardrails passed. The compiler-cache mount-namespace probe reported its documented environment capability skip.
- PASSED: `make ci-lint` (workspace clippy with warnings denied)
- PASSED: `git diff --check`
- PASSED: `GIT_OPTIONAL_LOCKS=0 git status --short`; only the three intended tracked files are modified and no untracked artifacts remain.

Remaining risks: The checks ran on Linux; platform-specific Git worktree behavior outside this environment remains covered only by the existing cross-platform code paths and tests.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12157-6aa3c1ec`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus