### PR TITLE
[code-review] dashboard still counts a `someday` auto-task instance as an open duplicate, contradicting the scheduler's skip_if_open rule

### DIFF
--- a/crates/orbit-core/src/application/auto_tasks/mod.rs
+++ b/crates/orbit-core/src/application/auto_tasks/mod.rs
@@ -31,8 +31,8 @@ pub use loader::{
 };
 pub use schedule::{AutoTaskDueDecision, decide_due, validate_schedule};
 pub use scheduler::{
-    AutoTaskFireReport, AutoTaskSchedulerOutcome, SchedulerOptions, run_auto_task_scheduler_at,
-    run_scheduler_action_json,
+    AutoTaskFireReport, AutoTaskSchedulerOutcome, SchedulerOptions, open_auto_task_instance,
+    run_auto_task_scheduler_at, run_scheduler_action_json,
 };
 pub use state::{AutoTaskCursor, AutoTaskCursorState, cursor_state_path, load_cursor_state};
 

--- a/crates/orbit-core/src/application/auto_tasks/scheduler.rs
+++ b/crates/orbit-core/src/application/auto_tasks/scheduler.rs
@@ -35,26 +35,50 @@ impl AutoTaskDispatch for OrbitRuntime {
         &self,
         definition: &AutoTaskDefinition,
     ) -> Result<Option<String>, OrbitError> {
-        let tasks = self.list_tasks_by_tags(&[auto_task_tag(&definition.name)])?;
-        // `someday` is an explicit "not now" park, not an active instance
-        // [ORB-12148]: it must not block every later mint of this auto-task.
-        Ok(tasks
-            .into_iter()
-            .find(|task| {
-                !matches!(
-                    task.status,
-                    TaskStatus::Done
-                        | TaskStatus::Archived
-                        | TaskStatus::Rejected
-                        | TaskStatus::Someday
-                )
-            })
-            .map(|task| task.id))
+        open_auto_task_instance(self, definition)
     }
 
     fn mint_task(&self, definition: &AutoTaskDefinition) -> Result<String, OrbitError> {
         mint_task(self, definition).map(|task| task.id)
     }
+}
+
+impl OrbitRuntime {
+    /// The id of a still-open instance of `definition`'s prior mints, if any.
+    /// Returns `None` if no prior mint is open, meaning `skip_if_open` dedupe
+    /// will permit minting and the dashboard reports no open duplicate [ORB-12158].
+    pub fn open_auto_task_instance(
+        &self,
+        definition: &AutoTaskDefinition,
+    ) -> Result<Option<String>, OrbitError> {
+        open_auto_task_instance(self, definition)
+    }
+}
+
+/// The id of a still-open instance of `definition`'s prior mints, if any.
+///
+/// Exactly one definition of "still-open auto-task instance" exists in the
+/// system [ORB-12158]. Both scheduler dedupe (`skip_if_open`) and the dashboard
+/// (`open_duplicate`, `may_create_open_duplicate`) consume this query.
+pub fn open_auto_task_instance(
+    runtime: &OrbitRuntime,
+    definition: &AutoTaskDefinition,
+) -> Result<Option<String>, OrbitError> {
+    let tasks = runtime.list_tasks_by_tags(&[auto_task_tag(&definition.name)])?;
+    // `someday` is an explicit "not now" park, not an active instance
+    // [ORB-12148]: it must not block every later mint of this auto-task.
+    Ok(tasks
+        .into_iter()
+        .find(|task| {
+            !matches!(
+                task.status,
+                TaskStatus::Done
+                    | TaskStatus::Archived
+                    | TaskStatus::Rejected
+                    | TaskStatus::Someday
+            )
+        })
+        .map(|task| task.id))
 }
 
 pub fn run_auto_task_scheduler_at(

--- a/crates/orbit-core/src/application/auto_tasks/tests/scheduler.rs
+++ b/crates/orbit-core/src/application/auto_tasks/tests/scheduler.rs
@@ -188,6 +188,17 @@ fn skip_if_open_ignores_a_someday_instance() {
     assert_eq!(first[0].0, "fired");
     let task_id = first[0].1.clone().expect("task id");
 
+    let definition = runtime
+        .auto_task_show("chore")
+        .expect("show")
+        .expect("chore");
+    assert_eq!(
+        runtime
+            .open_auto_task_instance(&definition)
+            .expect("open check"),
+        Some(task_id.clone())
+    );
+
     runtime
         .update_task(
             &task_id,
@@ -198,8 +209,14 @@ fn skip_if_open_ignores_a_someday_instance() {
         )
         .expect("park task");
 
-    // The someday-parked instance does not count as open, so the next due
-    // slot fires and mints a second task.
+    // The someday-parked instance does not count as open, so open_auto_task_instance
+    // returns None and the next due slot fires and mints a second task.
+    assert_eq!(
+        runtime
+            .open_auto_task_instance(&definition)
+            .expect("open check"),
+        None
+    );
     let second = fire(&runtime, t0 + Duration::minutes(180));
     assert_eq!(second[0].0, "fired");
     assert_eq!(runtime.list_tasks().expect("tasks").len(), 2);

--- a/crates/orbit-core/src/application/automation/mod.rs
+++ b/crates/orbit-core/src/application/automation/mod.rs
@@ -232,10 +232,7 @@ fn auto_task_admission_deferral(
     definition: &AutoTaskDefinition,
 ) -> Result<Option<String>, OrbitError> {
     if definition.dedupe == orbit_types::workflow::DedupePolicy::SkipIfOpen
-        && orbit_automation::auto_tasks::scheduler::AutoTaskDispatch::has_open_instance(
-            runtime, definition,
-        )?
-        .is_some()
+        && runtime.open_auto_task_instance(definition)?.is_some()
     {
         return Ok(Some("open_instance".into()));
     }

--- a/crates/orbit-web/src/api/auto_tasks.rs
+++ b/crates/orbit-web/src/api/auto_tasks.rs
@@ -16,7 +16,6 @@ use orbit_core::application::auto_tasks::{
     AutoTaskCursor, collect_auto_tasks, cursor_state_path, load_cursor_state,
 };
 use orbit_core::application::routines::ScheduleDisplayState;
-use orbit_types::task::TaskStatus;
 use orbit_types::workflow::{
     AutoTaskDefinition, AutoTaskSchedule, AutoTaskTemplate, DedupePolicy, auto_task_tag,
 };
@@ -398,9 +397,9 @@ fn definition_json(
         _ => None,
     };
     let minted = tagged_instances(runtime, &definition.name);
-    let open_duplicate = minted
-        .as_ref()
-        .is_ok_and(|tasks| tasks.iter().any(|task| is_open_status(task.status)));
+    let open_duplicate = runtime
+        .open_auto_task_instance(definition)
+        .is_ok_and(|id| id.is_some());
     let last_minted = minted.as_ref().ok().and_then(|tasks| tasks.first());
     let last_minted_task_id = last_minted
         .map(|task| task.id.to_string())
@@ -457,13 +456,6 @@ fn tagged_instances(
 ) -> Result<Vec<orbit_core::Task>, orbit_core::OrbitError> {
     let tag = auto_task_tag(name);
     runtime.list_tasks_by_tags(std::slice::from_ref(&tag))
-}
-
-fn is_open_status(status: TaskStatus) -> bool {
-    !matches!(
-        status,
-        TaskStatus::Done | TaskStatus::Archived | TaskStatus::Rejected
-    )
 }
 
 fn schedule_summary(schedule: &AutoTaskSchedule) -> String {

--- a/crates/orbit-web/src/api/tests/auto_tasks.rs
+++ b/crates/orbit-web/src/api/tests/auto_tasks.rs
@@ -6,6 +6,7 @@ use axum::body::Body;
 use axum::http::{Method, Request, StatusCode};
 use orbit_common::governance::authorization::OPERATOR_OVERRIDE_ENV;
 use orbit_core::application::auto_tasks::cursor_state_path;
+use orbit_core::application::task::TaskUpdateParams;
 use orbit_core::{AutoTaskAddParams, OrbitRuntime};
 use orbit_types::task::{TaskPriority, TaskStatus, TaskType};
 use orbit_types::workflow::automation::{CoverageClass, DeliveryTrigger};
@@ -845,4 +846,76 @@ async fn toggle_both_directions_reads_back_persisted_state() {
         .await;
         assert_eq!(listed["definitions"][0]["enabled"], enabled);
     }
+}
+
+#[tokio::test]
+async fn list_reports_no_open_duplicate_when_only_instance_is_someday() {
+    let runtime = runtime();
+    runtime
+        .auto_task_add(chore_params("parked-chore"))
+        .expect("add");
+
+    // Mint an instance and park it in Someday.
+    let task = runtime.auto_task_mint("parked-chore").expect("mint");
+    runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Someday),
+                ..Default::default()
+            },
+        )
+        .expect("park task");
+
+    let (app_state, runtime) = state(runtime);
+    let response = send(
+        app_state.clone(),
+        Method::GET,
+        "/auto-tasks?workspace=default",
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let item = json["definitions"]
+        .as_array()
+        .expect("definitions")
+        .iter()
+        .find(|item| item["name"] == "parked-chore")
+        .expect("parked-chore");
+
+    assert_eq!(item["open_duplicate"], false);
+    assert_eq!(item["may_create_open_duplicate"], false);
+    assert_eq!(item["last_minted_task_status"], "someday");
+
+    // Once an active instance exists, the same query marks open_duplicate as true.
+    runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Backlog),
+                ..Default::default()
+            },
+        )
+        .expect("activate task");
+
+    let response = send(
+        app_state,
+        Method::GET,
+        "/auto-tasks?workspace=default",
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let item = json["definitions"]
+        .as_array()
+        .expect("definitions")
+        .iter()
+        .find(|item| item["name"] == "parked-chore")
+        .expect("parked-chore");
+
+    assert_eq!(item["open_duplicate"], true);
+    assert_eq!(item["may_create_open_duplicate"], true);
+    assert_eq!(item["last_minted_task_status"], "backlog");
 }

--- a/crates/orbit-web/src/tests/dashboard_operations.mjs
+++ b/crates/orbit-web/src/tests/dashboard_operations.mjs
@@ -36,7 +36,7 @@ globalThis.fetch = async (path, options = {}) => {
   }
   if (url.pathname === '/api/auto-tasks') {
     if (readbackError) throw new Error('Fixture readback unavailable');
-    const payload = { workspace, controls_authorized: capabilities.auto_task_toggle.authorized && capabilities.auto_task_mint.authorized, capabilities: { ...capabilities }, unconditional_mint_warning: "Manual mint ignores this definition's schedule, enabled flag, and scheduler dedupe policy.", definitions: [{ name: `Chore ${workspace}`, enabled: enabled[workspace], template: { title: 'Fixture chore' }, template_summary: 'Fixture chore', schedule_summary: 'every 15 minutes', description: 'Remediate CI failures for the selected workspace.', may_create_open_duplicate: true, open_duplicate: true, last_minted_task_id: 'ORB-00099', last_minted_task_status: 'backlog', last_evaluation: { kind: 'fired', last_task_id: 'ORB-00001', last_fired_at: '2026-09-07T20:00:00Z' }, next_evaluation: { state: 'scheduled', at: '2026-09-07T22:00:00Z' }, automation: { reason: 'covered', state: { consumer: `auto-task/${workspace}`, baseline: { commit: 'abc1234', tree: 'def5678' }, observed: { commit: 'abc1234', tree: 'def5678' }, covered: { commit: 'abc1234', tree: 'def5678' }, pending: [], pending_commits: [], waived: [], excluded: [], unresolved: {} } } }] };
+    const payload = { workspace, controls_authorized: capabilities.auto_task_toggle.authorized && capabilities.auto_task_mint.authorized, capabilities: { ...capabilities }, unconditional_mint_warning: "Manual mint ignores this definition's schedule, enabled flag, and scheduler dedupe policy.", definitions: [{ name: `Chore ${workspace}`, enabled: enabled[workspace], template: { title: 'Fixture chore' }, template_summary: 'Fixture chore', schedule_summary: 'every 15 minutes', description: 'Remediate CI failures for the selected workspace.', may_create_open_duplicate: true, open_duplicate: true, last_minted_task_id: 'ORB-00099', last_minted_task_status: 'backlog', last_evaluation: { kind: 'fired', last_task_id: 'ORB-00001', last_fired_at: '2026-09-07T20:00:00Z' }, next_evaluation: { state: 'scheduled', at: '2026-09-07T22:00:00Z' }, automation: { reason: 'covered', state: { consumer: `auto-task/${workspace}`, baseline: { commit: 'abc1234', tree: 'def5678' }, observed: { commit: 'abc1234', tree: 'def5678' }, covered: { commit: 'abc1234', tree: 'def5678' }, pending: [], pending_commits: [], waived: [], excluded: [], unresolved: {} } } }, { name: `Someday ${workspace}`, enabled: true, template: { title: 'Parked chore' }, template_summary: 'Parked chore', schedule_summary: 'every 60 minutes', description: 'Auto-task whose only instance is parked in someday.', dedupe: 'skip_if_open', may_create_open_duplicate: false, open_duplicate: false, last_minted_task_id: 'ORB-00100', last_minted_task_status: 'someday', last_evaluation: { kind: 'fired', last_task_id: 'ORB-00100', last_fired_at: '2026-09-07T20:00:00Z' }, next_evaluation: { state: 'scheduled', at: '2026-09-07T22:00:00Z' } }] };
     if (delayGet) await new Promise(resolve => { releaseGet = resolve; });
     return response(payload);
   }
@@ -200,4 +200,17 @@ else autoDetails.listeners?.toggle?.();
 await fetchAndRenderOperations();
 const restored = descendants(get('auto-tasks-body')).find(node => node.className === 'operation-details');
 assert(restored?.open, 'details stay open across rerender');
+
+// A skip_if_open auto-task whose only instance is parked in someday reports no open duplicate and mint confirmation does not claim an open instance exists [ORB-12158].
+const autoCards = descendants(get('auto-tasks-body')).filter(node => String(node.className || '').includes('auto-task-card'));
+const somedayCard = autoCards.find(node => node.textContent?.includes('Someday one'));
+assert(somedayCard, 'someday auto-task card is present');
+assert(somedayCard.textContent.includes('Open duplicate No'), 'someday auto-task card reports no open duplicate');
+assert(!somedayCard.textContent.includes('Yes — mint will create another'), 'someday card does not report duplicate warning');
+const somedayMint = descendants(somedayCard).find(node => node.textContent === 'Mint now' && node.type === 'button');
+somedayMint.click(); await tick(); await tick();
+const somedayConfirm = confirmations.at(-1);
+assert(somedayConfirm.includes('No open instance is currently tagged for this definition.'), 'someday mint confirmation reports no open instance');
+assert(!somedayConfirm.includes('An open instance already exists'), 'someday mint confirmation does not claim open instance exists');
+
 globalThis.operationsTestsPassed = true;


### PR DESCRIPTION
## Task

[ORB-12158](https://orbit-cli.com/tasks/ORB-12158) — [code-review] dashboard still counts a `someday` auto-task instance as an open duplicate, contradicting the scheduler's skip_if_open rule

### Description

ORB-12148 (`7993e82cb`) redefined "open instance" for `skip_if_open` dedupe so a `someday`-parked instance no longer blocks a mint (`crates/orbit-core/src/application/auto_tasks/scheduler.rs:34-55`). The dashboard keeps its own copy of that predicate and was not updated, so the operations panel now reports the opposite of what the scheduler will do.

## Evidence

- Scheduler (authoritative): `crates/orbit-core/src/application/auto_tasks/scheduler.rs:44-54` excludes `TaskStatus::Done | Archived | Rejected | Someday`.
- Dashboard API: `crates/orbit-web/src/api/auto_tasks.rs:462-467` — `is_open_status` excludes only `Done | Archived | Rejected`, so `Someday` is still "open". It feeds `open_duplicate` / `may_create_open_duplicate` at `crates/orbit-web/src/api/auto_tasks.rs:401-403` and `:449-450`.
- Rendering: `crates/orbit-web/assets/dashboard/operations.js:540` renders `Open duplicate: "Yes — mint will create another"` directly beside `Dedupe: "skip if open"` (`operations.js:556,560`), and `operations.js:488-490` puts "An open instance already exists; this will create another open task." into the manual-mint confirmation.

## Failure scenario

An auto-task with `dedupe: skip_if_open` has exactly one tagged instance, parked at `someday`. The scheduler treats it as not open and mints on the next due slot. The dashboard shows `Dedupe: skip if open` next to `Open duplicate: Yes — mint will create another`, which an operator reads as "the scheduler is currently blocked" — the exact misreading ORB-12148 was filed to remove. The mint-now confirmation carries the same wrong sentence.

## Suggested direction

Remove the duplicate predicate: have the dashboard reuse the single scheduler rule (for example by exposing the scheduler's open-instance query, which already returns the blocking task id as `blocking_task_id`) instead of re-deriving "open" from a status list that can drift again.

### Acceptance Criteria

- With a `skip_if_open` auto-task whose only tagged instance is `someday`, the dashboard auto-task card reports no open duplicate and the mint confirmation does not claim an open instance exists.
- Exactly one definition of "still-open auto-task instance" remains in the codebase; the dashboard consumes it rather than re-deriving a status list.
- A test covers the `someday` case at the surface that produces `open_duplicate`, failing against the current predicate.

## Execution Summary

<details>
<summary>Click to expand</summary>

### Acceptance Criteria Results
- **Criterion 1 (Dashboard card reports no open duplicate & mint confirmation excludes open duplicate claim for someday instance)**: Passed. In `crates/orbit-web/src/tests/dashboard_operations.mjs`, asserted that a someday-parked auto-task card renders `Open duplicate No` without warning, and clicking `Mint now` prompts with confirmation containing `No open instance is currently tagged for this definition.` and excluding duplicate warning claims.
- **Criterion 2 (Exactly one definition of still-open auto-task instance remains and dashboard consumes it)**: Passed. Reused `open_auto_task_instance` from `crates/orbit-core/src/application/auto_tasks/scheduler.rs` as the authoritative single definition; exposed it on `OrbitRuntime` and re-exported it from `orbit_core::application::auto_tasks`. Removed `is_open_status` and the unused `TaskStatus` import from `crates/orbit-web/src/api/auto_tasks.rs`, having `definition_json` derive `open_duplicate` and `may_create_open_duplicate` directly via `runtime.open_auto_task_instance(definition)`.
- **Criterion 3 (Test covers someday case at the surface producing open_duplicate and failed against previous predicate)**: Passed. Added `list_reports_no_open_duplicate_when_only_instance_is_someday` in `crates/orbit-web/src/api/tests/auto_tasks.rs`. When run against the previous predicate, it reproduced the failure (`assert_eq!(item["open_duplicate"], false)` failed with `left: Bool(true), right: false`). After unifying with the core seam, the test passes for both Someday (no duplicate) and active Backlog (open duplicate). In addition, direct assertions were added to `crates/orbit-core/src/application/auto_tasks/tests/scheduler.rs`.

### Validation Commands
- `cargo test -p orbit-web list_reports_no_open_duplicate_when_only_instance_is_someday`: passed (confirmed prior failure against buggy predicate, now passing)
- `cargo test -p orbit-core skip_if_open_ignores_a_someday_instance`: passed
- `cargo test -p orbit-core auto_tasks`: passed (40 tests passed)
- `cargo test -p orbit-web api::tests::auto_tasks`: passed (23 tests passed)
- `cargo test -p orbit-web dashboard_operations`: passed (4 tests passed)
- `make ci-fast`: passed
- `make ci-lint`: passed
- `git diff --check`: passed (no whitespace or formatting errors)
- `git status --short`: passed (only tracked modifications within declared context files)

### Scope and File Updates
- Appended `file:crates/orbit-core/src/application/auto_tasks/mod.rs`, `file:crates/orbit-core/src/application/auto_tasks/tests/scheduler.rs`, and `file:crates/orbit-core/src/application/automation/mod.rs` to task `context_files` to reflect the shared seam export, core regression coverage, and internal caller consistency.

### Remaining Risks or Deviations
None.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12158-6aa3c1ec`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus