### PR TITLE
Fix red CI on agent-main: init_report::requested_mcp_records_none_detected_when_no_providers_exist returns 'configured' on every push since 5d821d03

### DIFF
--- a/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
@@ -244,8 +244,16 @@ pub(super) fn auto_detected_providers(
 ) -> Vec<McpProvider> {
     let mut providers = Vec::new();
     let claude_repo = repo_root.join(".claude").is_dir();
+    // A bare `~/.claude` directory is not evidence that Claude Code is
+    // installed: `orbit init` creates `~/.claude/skills/` for its own skill
+    // links (`orbit_core::bootstrap::init`), so a directory test would detect
+    // Claude on every host Orbit has ever touched. Require a config file
+    // Claude Code itself writes, the way every other home probe below does.
     let claude_home = home_dir
-        .map(|home| home.join(".claude").is_dir())
+        .map(|home| {
+            home.join(".claude.json").is_file()
+                || home.join(".claude").join("settings.json").is_file()
+        })
         .unwrap_or(false);
     if claude_repo || claude_home {
         providers.push(McpProvider::Claude);

--- a/crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs
@@ -62,11 +62,43 @@ fn auto_detects_grok_from_home_when_repo_lacks_dotgrok() {
 fn auto_detects_claude_from_home_when_repo_lacks_dotclaude() {
     let repo = tempdir().expect("repo tempdir");
     let home = tempdir().expect("home tempdir");
-    std::fs::create_dir_all(home.path().join(".claude")).expect("create claude home dir");
+    std::fs::write(home.path().join(".claude.json"), "{}\n").expect("write claude home config");
 
     let providers = auto_detected_providers(repo.path(), Some(home.path()));
 
     assert_eq!(providers, vec![McpProvider::Claude]);
+}
+
+#[test]
+fn auto_detects_claude_from_home_settings_when_repo_lacks_dotclaude() {
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    std::fs::create_dir_all(home.path().join(".claude")).expect("create claude home dir");
+    std::fs::write(home.path().join(".claude").join("settings.json"), "{}\n")
+        .expect("write claude home settings");
+
+    let providers = auto_detected_providers(repo.path(), Some(home.path()));
+
+    assert_eq!(providers, vec![McpProvider::Claude]);
+}
+
+#[test]
+fn orbit_own_home_skill_links_do_not_auto_detect_claude() {
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    // Exactly what `orbit init` leaves behind in a home that has never run
+    // Claude Code: skill-link directories and nothing else.
+    for provider_dir in [".claude", ".agents"] {
+        std::fs::create_dir_all(home.path().join(provider_dir).join("skills"))
+            .expect("create orbit skill link dir");
+    }
+
+    let providers = auto_detected_providers(repo.path(), Some(home.path()));
+
+    assert!(
+        !providers.contains(&McpProvider::Claude),
+        "orbit-created ~/.claude/skills must not count as a Claude install: {providers:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-12159](https://orbit-cli.com/tasks/ORB-12159) — Fix red CI on agent-main: init_report::requested_mcp_records_none_detected_when_no_providers_exist returns 'configured' on every push since 5d821d03

### Description

## Red CI

`agent-main` push runs fail on `Check / Clippy / Test` and `Coverage (informational)` for every merge since `5d821d03` (ORB-12145, PR #1948): 5d821d03, 7001a687, 0798675b so far, plus the PR runs for ORB-12149/12151/12152. The preceding push `1dd020d2` (ORB-12155) passed the full suite. One unit test fails, consistently:

```
command::workspace::tests::init_report::requested_mcp_records_none_detected_when_no_providers_exist
  panicked at crates/orbit-cli/src/command/workspace/tests/init_report.rs:312:5
  assertion `left == right` failed
    left: String("configured")
   right: "none_detected"
test result: FAILED. 527 passed; 1 failed
```

## What is known

- `5d821d03` changed only `crates/orbit-cmd/src/tests/task_store.rs` (a fully tempdir-isolated test in a different crate/binary). It cannot be the cause by content; the failure window starting there is either timing (parallel test scheduling) or an interaction with what was merged just before it (`1dd020d2` touched only `crates/orbit-cli/tests/worktree_gc_routing.rs`; `cb9809dd`/ORB-12144, `7993e82c`/ORB-12148, `ef18bb06`/ORB-12143, `67308b0b`/ORB-12146 landed within the previous hour).
- The test uses `IsolatedWorkspace::with_prefix` → `EnvGuard::acquire().home(tmp).cwd(tmp)` (`crates/orbit-cli/src/tests/env_isolation.rs`, global `ENV_LOCK`). Provider detection is `auto_detected_providers(repo_root, home_dir)` in `crates/orbit-cli/src/command/mcp/setup/dispatch.rs:224` — pure filesystem checks (`<repo_root>/.claude` dir, `<home>/.codex/config.toml`, …). `"configured"` therefore means the resolved `repo_root`/`home_dir` was NOT the isolated tempdir at the moment of the call — most plausibly the real checkout (which has a `.claude/` directory) because the process-wide cwd was changed by a sibling test that does not hold `ENV_LOCK`.
- Unguarded `std::env::set_current_dir` calls exist in the same test binary: `crates/orbit-cli/src/command/workspace/tests/init.rs:392` (b340df21, 2026-08-01) and `:1724` (0b9eebcd, 2026-09-05), and `crates/orbit-cli/src/command/workspace/tests/shared_root.rs:46` (bf3daa22, 2026-08-15). Verify whether each holds the guard through some other path; any that does not is a candidate.
- Alternative: `home_dir` is not read from `$HOME` on the path `execute_without_runtime(None)` takes, so `.home(tmp)` is ineffective and the runner's real home (which may now carry provider files from an earlier job step, e.g. a cached `~/.codex/config.toml`) is consulted. Check how `init_auto_for_workspace` obtains `home_dir`.

## Wanted

Find the actual cause with evidence (reproduce locally with `cargo test -p orbit-cli --lib -- command::workspace::tests` under `--test-threads` ≥ 8, and with the isolation hypothesis toggled), fix the isolation so the test is deterministic, and get the agent-main push run green. Do not `#[ignore]` the test and do not weaken its assertion; if a sibling test is the leak, fix the sibling.

### Acceptance Criteria

- The failing test passes 20/20 locally with `cargo test -p orbit-cli --lib -- command::workspace::tests --test-threads 16` and the root cause is stated in the PR description with the evidence that proves it.
- No test is ignored or has its assertion weakened; any sibling test found mutating process-wide cwd/HOME without ENV_LOCK is brought under the guard.
- The agent-main push CI run on the merge commit is green on Check / Clippy / Test and Coverage.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Root cause: not a test-isolation leak — a real product defect from ORB-12149

The failing test reproduces **standalone**, single-threaded, at HEAD `6e4a918bb`:

```
cargo test -p orbit-cli --bin orbit -- \
  command::workspace::tests::init_report::requested_mcp_records_none_detected_when_no_providers_exist --exact
=> FAILED (left: "configured", right: "none_detected")
```

so parallel scheduling and sibling cwd leakage are excluded as causes.

Instrumenting `auto_detected_providers` (temporary `eprintln!`, reverted) showed the
isolation is intact and the input is what produces the wrong answer:

```
DEBUG auto_detect repo_root="/tmp/.tmpJK7GOs" home_dir=Some("/tmp/.tmpCekgmW") HOME=Some("/tmp/.tmpCekgmW")
DEBUG home entry "/tmp/.tmpCekgmW/.claude"     <-- created by the command under test
DEBUG home entry "/tmp/.tmpCekgmW/.agents"
DEBUG home entry "/tmp/.tmpCekgmW/.orbit"
DEBUG repo entry "/tmp/.tmpJK7GOs/.orbit"
```

`EnvGuard` pointed `HOME` and cwd at tempdirs correctly. The `.claude` directory in that
isolated home was created *by `orbit workspace init` itself*: the global branch of
`orbit_core::bootstrap::init` seeds skill symlinks into `~/.agents/skills` and
`~/.claude/skills` (`skill_link_roots`, `ensure_skill_links`), and `collect_init_report`
then runs MCP auto-detection in the same command
(`crates/orbit-cli/src/command/workspace/init.rs:727` → `init_auto_for_workspace`).

`62ded8f28` (ORB-12149, PR #1949) had just widened Claude detection from
`repo_root/.claude` to `repo_root/.claude || home_dir/.claude`:

```
-    if repo_root.join(".claude").is_dir() {
+    let claude_home = home_dir.map(|home| home.join(".claude").is_dir())...
```

so Orbit's own skill-link directory now counts as an installed Claude. The test's premise —
"no providers exist" — became unsatisfiable, and on a real fresh machine
`orbit workspace init --mcp` would always report Claude as auto-detected even where Claude
Code was never installed.

### Why the failure window looked like it started at 5d821d03

It did not. The push run for `5d821d03` (run 34578421294) reports in its own log:

```
event_sha=5d821d0324fa5dce202c9e688b509e0bd70e0f68 pr_head_sha= tested_sha=62ded8f2889f17717108fc9eccedc2e59d3f8241
```

The run was labelled with the pushed SHA but checked out `agent-main`'s head, which was
already `62ded8f28` (merged 2 minutes later). Every red run since is consistent with
`62ded8f28` being the first red commit, including its own PR run for ORB-12149.

## Fix

`crates/orbit-cli/src/command/mcp/setup/dispatch.rs` — home-scope Claude detection now
requires a config file Claude Code actually writes (`~/.claude.json`, the home MCP path
ORB-12149 itself established, or `~/.claude/settings.json`) instead of a bare `~/.claude`
directory. This matches every other home probe in the same function, all of which test for
a specific file, and preserves ORB-12149's intent (detect a home-only Claude install).
The repo-local `repo_root/.claude` signal is unchanged.

`crates/orbit-cli/src/command/mcp/setup/tests/dispatch.rs` —
`auto_detects_claude_from_home_when_repo_lacks_dotclaude` now seeds `~/.claude.json`;
added `auto_detects_claude_from_home_settings_when_repo_lacks_dotclaude` for the
`settings.json` signal; added `orbit_own_home_skill_links_do_not_auto_detect_claude`, which
builds exactly what `orbit init` leaves behind (`~/.claude/skills`, `~/.agents/skills`) and
asserts Claude is not detected.

Regression coverage verified: with the pre-fix predicate restored, both the new
`orbit_own_home_skill_links_do_not_auto_detect_claude` and the original
`requested_mcp_records_none_detected_when_no_providers_exist` fail (2 failed); with the fix
both pass.

No test was ignored, and no assertion was weakened — `init_report.rs:312` is untouched.

## Criteria

1. **Test passes 20/20, root cause stated with evidence** — met. `--lib` does not exist for
   `orbit-cli` (bin-only target), so the equivalent `--bin orbit` form was used:
   `cargo test -q -p orbit-cli --bin orbit -- command::workspace::tests --test-threads 16`,
   20 consecutive runs, `pass=20 fail=0`. Root cause and evidence above.
2. **No ignore/weakened assertion; unguarded sibling cwd/HOME mutations brought under the
   guard** — met, with an audit finding nothing to change. The three direct
   `std::env::set_current_dir` calls in this binary (`workspace/tests/init.rs:392`,
   `init.rs:1724`, `workspace/tests/shared_root.rs:46`) each run inside a test that already
   holds a live `EnvGuard` acquired with `.cwd(...)` before the call, so `ENV_LOCK` is held
   and the original cwd is restored on drop/unwind. A crate-wide grep found no
   `set_var("HOME"/"USERPROFILE")` outside `env_isolation.rs`
   (`audit_middleware.rs:81` sets only `ORBIT_AGENT_MODEL`). The isolation was not the bug.
3. **Green agent-main push CI on the merge commit** — not verifiable from here; the pipeline
   owns commit, merge and push. Local evidence below is the closest available proxy.

## Validation

| command | outcome |
| --- | --- |
| `cargo test -q -p orbit-cli --bin orbit -- command::workspace::tests --test-threads 16` ×20 | passed (20/20) |
| `cargo test -q -p orbit-cli --bin orbit` (full unit binary) | passed (531 passed, 0 failed) |
| `cargo test -q -p orbit-cli --bin orbit -- command::mcp command::workspace --test-threads 16` | passed (129 passed) |
| `cargo test -q -p orbit-cli --test mcp_setup_root` | passed (8 passed) |
| `make ci-fast` | passed (one pre-existing environment skip: `test-compiler-cache-namespaces`, bwrap cannot create a user namespace on this host) |
| `make ci-lint` | passed (clean, warnings denied) |
| `git diff --check` / `git status --short` | clean; only the two intended modified files |
| full `make ci` | not run — workspace policy puts it on the PR gate, not per task |

## Risk

Behavior change beyond the test: a host whose only Claude artifact is a bare `~/.claude`
directory with no `~/.claude.json` and no `~/.claude/settings.json` will no longer
auto-detect Claude. That is the intended correction — such a directory is what Orbit's own
skill linking creates — and an explicit `orbit mcp init --claude` still targets Claude
directly. `crates/orbit-cli/tests/mcp_roundtrip.rs` and `mcp_setup_root.rs` use repo-local
`.claude` markers and are unaffected.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12159-6aa3c1ae`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus