### PR TITLE
ci-failure-sweep files duplicate repairs: it ignores an existing repair task for the same failing runs unless it filed it, and files one task per failing job for a single failing test

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -256,6 +256,8 @@ where
         ));
     }
     let (complete, mut deferred) = split_deferred_failures(&failures, &run_errors, schema_version);
+    let (complete, already_repaired) = exclude_already_repaired(complete, evidence);
+    let audit = repaired_audit(audit, &already_repaired);
     // A run-scoped retryable error whose run never made it into
     // `current_failures` at all — an in-flight run with an observed failed
     // job but logs collection could not read yet — has no failure row for
@@ -331,6 +333,7 @@ where
             "skipped_over_cap": [],
             "deferred": [],
             "inconclusive": inconclusive,
+            "already_repaired": already_repaired,
             "audit": audit,
             "detail": if inconclusive.is_empty() {
                 "the queries ran and found no current, non-superseded failure"
@@ -538,6 +541,7 @@ where
         "skipped_over_cap": skipped_over_cap,
         "deferred": deferred,
         "inconclusive": inconclusive,
+        "already_repaired": already_repaired,
         "max_tasks": max_tasks,
         "audit": final_audit,
     }))
@@ -754,6 +758,113 @@ fn split_deferred_failures(
     (complete, deferred)
 }
 
+/// A newer green push on the same branch is stronger evidence than an older
+/// red finding. The collector normally moves that red run to
+/// `stale_or_superseded`; retaining this check at filing keeps a replayed or
+/// hand-constructed snapshot from filing a repair after the branch is already
+/// green.
+fn exclude_already_repaired(failures: Vec<Value>, evidence: &Value) -> (Vec<Value>, Vec<Value>) {
+    let mut remaining = Vec::new();
+    let mut repaired = Vec::new();
+    for failure in failures {
+        let Some(green) = newer_green_push_run(&failure, evidence) else {
+            remaining.push(failure);
+            continue;
+        };
+        repaired.push(json!({
+            "run_id": failure.get("run_id"),
+            "workflow": failure.get("workflow"),
+            "head_branch": failure.get("head_branch"),
+            "reason": "newer_push_run_green",
+            "superseded_by": green,
+        }));
+    }
+    let mut repaired_ids = repaired
+        .iter()
+        .filter_map(run_id_key)
+        .collect::<BTreeSet<_>>();
+    for stale in evidence
+        .get("stale_or_superseded")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        if repaired_ids.contains(&run_id_key(stale).unwrap_or_default()) {
+            continue;
+        }
+        let Some(green) = newer_green_push_run(stale, evidence) else {
+            continue;
+        };
+        repaired.push(json!({
+            "run_id": stale.get("run_id"),
+            "workflow": stale.get("workflow"),
+            "head_branch": stale.get("head_branch"),
+            "reason": "newer_push_run_green",
+            "superseded_by": green,
+        }));
+        if let Some(run_id) = run_id_key(stale) {
+            repaired_ids.insert(run_id);
+        }
+    }
+    (remaining, repaired)
+}
+
+fn newer_green_push_run<'a>(failure: &Value, evidence: &'a Value) -> Option<&'a Value> {
+    let workflow = value_string(failure, "workflow");
+    let branch = value_string(failure, "head_branch");
+    let failure_order = run_order(failure);
+    let runs = evidence
+        .get("latest_runs")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten();
+    runs.filter(|run| {
+        value_string(run, "workflow") == workflow
+            && value_string(run, "head_branch") == branch
+            && value_string(run, "event") == "push"
+            && run_order(run) > failure_order
+            && run_is_completed_success(run)
+    })
+    .max_by_key(|run| run_order(run))
+    .or_else(|| superseding_green_run(failure, evidence))
+}
+
+fn superseding_green_run<'a>(failure: &Value, evidence: &'a Value) -> Option<&'a Value> {
+    let stale = evidence
+        .get("stale_or_superseded")
+        .and_then(Value::as_array)?;
+    stale.iter().find_map(|entry| {
+        if run_id_key(entry) != run_id_key(failure)
+            || value_string(entry, "workflow") != value_string(failure, "workflow")
+            || value_string(entry, "head_branch") != value_string(failure, "head_branch")
+        {
+            return None;
+        }
+        let superseded_by = entry.get("superseded_by")?;
+        (value_string(superseded_by, "event") == "push" && run_is_completed_success(superseded_by))
+            .then_some(superseded_by)
+    })
+}
+
+fn run_is_completed_success(run: &Value) -> bool {
+    run.get("status").and_then(Value::as_str) == Some("completed")
+        && matches!(
+            run.get("conclusion").and_then(Value::as_str),
+            Some("success" | "neutral" | "skipped")
+        )
+}
+
+fn repaired_audit(mut audit: Value, already_repaired: &[Value]) -> Value {
+    audit["already_repaired_count"] = json!(already_repaired.len());
+    audit["already_repaired_run_ids"] = json!(
+        already_repaired
+            .iter()
+            .filter_map(|entry| entry.get("run_id").cloned())
+            .collect::<Vec<_>>()
+    );
+    audit
+}
+
 /// Old snapshots did not bind the run log or its checkout scan to the named
 /// job. They remain readable audit evidence, but must be recollected before
 /// filing; inferring attribution from job order would repeat the original bug.
@@ -933,6 +1044,8 @@ fn audit_summary(evidence: &Value, failures: &[Value]) -> Value {
         "deferred_failures": 0,
         "deferred_failure_run_ids": [],
         "retryable_errors": 0,
+        "already_repaired_count": 0,
+        "already_repaired_run_ids": [],
     })
 }
 
@@ -1001,6 +1114,7 @@ struct FailureCluster {
     cluster_key: String,
     workflow: String,
     job: String,
+    jobs: BTreeSet<String>,
     step: String,
     tested_commit: String,
     signature: String,
@@ -1076,16 +1190,16 @@ impl FailureCluster {
     fn duplicate_candidate(&self) -> DuplicateCandidate {
         let exact_tag = format!("{CI_FAILURE_KEY_TAG_PREFIX}{}", self.failure_key);
         if let Some(cause) = &self.compiler_cause {
-            return DuplicateCandidate::new(
-                exact_tag,
-                vec![CoverageFingerprint::new(
-                    "ci_compiler_cause",
-                    vec![
-                        CoverageAnchor::new("compiler_cause", digest(&[cause])),
-                        CoverageAnchor::new("tested_commit", &self.tested_commit),
-                    ],
-                )],
-            );
+            let mut fingerprints = vec![CoverageFingerprint::new(
+                "ci_compiler_cause",
+                vec![
+                    CoverageAnchor::new("compiler_cause", digest(&[cause])),
+                    CoverageAnchor::new("tested_commit", &self.tested_commit),
+                ],
+            )];
+            fingerprints.extend(self.provenance_fingerprints());
+            return DuplicateCandidate::new(exact_tag, fingerprints)
+                .with_completed_fingerprints(self.provenance_fingerprints());
         }
         let mut fingerprints = if self.signature_is_step_fallback {
             // A step-name fallback contains no diagnostic. It is sufficient
@@ -1126,7 +1240,44 @@ impl FailureCluster {
                 fingerprints.push(fingerprint);
             }
         }
+        fingerprints.extend(self.provenance_fingerprints());
         DuplicateCandidate::new(exact_tag, fingerprints)
+            .with_completed_fingerprints(self.provenance_fingerprints())
+    }
+
+    fn provenance_fingerprints(&self) -> Vec<CoverageFingerprint> {
+        let mut fingerprints = Vec::new();
+        let mut seen = BTreeSet::new();
+        for run in &self.runs {
+            let run_id = value_string(run, "run_id");
+            if !run_id.is_empty() && seen.insert(("run_id", run_id.clone())) {
+                fingerprints.push(CoverageFingerprint::new(
+                    "ci_failure_run_id",
+                    vec![CoverageAnchor::new("run_id", run_id)],
+                ));
+            }
+            for sha in [
+                value_string(run, "event_reported_head_sha"),
+                value_string(run, "current_ref_head_sha"),
+                tested_commit(run),
+            ] {
+                if !sha.is_empty() && seen.insert(("head_sha", sha.clone())) {
+                    fingerprints.push(CoverageFingerprint::new(
+                        "ci_failure_head_sha",
+                        vec![CoverageAnchor::new("head_sha", sha)],
+                    ));
+                }
+            }
+            for name in failure_test_names(run) {
+                if seen.insert(("test_name", name.clone())) {
+                    fingerprints.push(CoverageFingerprint::new(
+                        "ci_failure_test_name",
+                        vec![CoverageAnchor::new("test_name", name)],
+                    ));
+                }
+            }
+        }
+        fingerprints
     }
 
     fn run_urls(&self) -> Vec<String> {
@@ -1152,6 +1303,7 @@ impl FailureCluster {
             "workflow": self.workflow,
             "job": self.job,
             "step": self.step,
+            "jobs": self.jobs,
             "tested_commit": self.tested_commit,
             "sources": self.runs.iter().map(|run| json!({
                 "run_id": run["run_id"], "job_id": run["job_id"],
@@ -1227,6 +1379,18 @@ impl FailureCluster {
         out.push_str("## Failure\n\n");
         out.push_str(&format!("- Workflow: `{}`\n", display(&self.workflow)));
         out.push_str(&format!("- Failing job: `{}`\n", display(&self.job)));
+        if self.jobs.len() > 1 {
+            let additional = self
+                .jobs
+                .iter()
+                .filter(|job| *job != &self.job)
+                .map(|job| format!("`{}`", display(job)))
+                .collect::<Vec<_>>()
+                .join(", ");
+            out.push_str(&format!(
+                "- Other failing jobs in this test cluster: {additional}\n"
+            ));
+        }
         out.push_str(&format!("- Failing step: `{}`\n", display(&self.step)));
         out.push_str(&format!(
             "- Commit the runner actually checked out: `{}`\n",
@@ -1531,6 +1695,13 @@ fn cluster_failures(failures: &[Value]) -> Vec<FailureCluster> {
             .map(ToOwned::to_owned)
             .unwrap_or_else(|| value_string(failure, "log_excerpt"));
         let signature = error_signature(&log_excerpt, &step);
+        let test_names = failure_test_names(failure);
+        let test_identity = test_names.join("\u{1f}");
+        let grouping_identity = if test_identity.is_empty() {
+            format!("signature:{}", signature.text)
+        } else {
+            format!("test:{test_identity}")
+        };
         let tested_commit = tested_commit(failure);
 
         let regions = valid_failure_regions(&failure["diagnostic_unit"]);
@@ -1551,7 +1722,7 @@ fn cluster_failures(failures: &[Value]) -> Vec<FailureCluster> {
         let cluster_key = if compiler_cause.is_some() {
             digest(&[&failure_key, &tested_commit])
         } else {
-            digest(&[&workflow, &job, &step, &signature.text, &tested_commit])
+            digest(&[&workflow, &step, &grouping_identity, &tested_commit])
         };
 
         let cluster = grouped.entry(cluster_key.clone()).or_insert_with(|| {
@@ -1560,7 +1731,8 @@ fn cluster_failures(failures: &[Value]) -> Vec<FailureCluster> {
                 failure_key,
                 cluster_key: cluster_key.clone(),
                 workflow,
-                job,
+                job: job.clone(),
+                jobs: BTreeSet::new(),
                 step,
                 tested_commit,
                 signature: signature.text,
@@ -1584,6 +1756,9 @@ fn cluster_failures(failures: &[Value]) -> Vec<FailureCluster> {
                 runs: Vec::new(),
             }
         });
+        if !job.is_empty() {
+            cluster.jobs.insert(job);
+        }
         if let Some(key) = legacy_key {
             cluster.legacy_keys.insert(key);
         }
@@ -1624,6 +1799,92 @@ fn tested_commit(failure: &Value) -> String {
         .and_then(Value::as_str)
         .map(ToOwned::to_owned)
         .unwrap_or_default()
+}
+
+/// Extract stable test identities from the diagnostic or an explicit
+/// collector field. These are intentionally separate from the normalized
+/// error signature: a manual task may name the test without copying the CI
+/// wrapper labels or the exact diagnostic wording.
+fn failure_test_names(failure: &Value) -> Vec<String> {
+    let mut names = BTreeSet::new();
+    for key in ["test_name", "failing_test", "failed_test"] {
+        if let Some(name) = failure.get(key).and_then(Value::as_str)
+            && !name.trim().is_empty()
+        {
+            names.insert(name.trim().to_string());
+        }
+    }
+    for key in ["test_names", "failing_tests", "failed_tests"] {
+        if let Some(values) = failure.get(key).and_then(Value::as_array) {
+            names.extend(
+                values
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::trim)
+                    .filter(|name| !name.is_empty())
+                    .map(ToOwned::to_owned),
+            );
+        }
+    }
+
+    let log = {
+        let excerpt = value_string(failure, "log_excerpt");
+        if excerpt.is_empty() {
+            value_string(&failure["diagnostic_unit"], "text")
+        } else {
+            excerpt
+        }
+    };
+    let mut after_failures_header = false;
+    for line in log.lines() {
+        let payload = signature_payload(line);
+        let line = payload.trim().to_string();
+        if line == "failures:" || line == "errors:" {
+            after_failures_header = true;
+            continue;
+        }
+        if is_libtest_stdout_header(&line) || line.starts_with("test result:") {
+            after_failures_header = false;
+        }
+        if let Some(rest) = line.strip_prefix("test ")
+            && let Some((name, suffix)) = rest.split_once(" ... ")
+            && matches!(suffix.split_whitespace().next(), Some("failed"))
+            && !name.trim().is_empty()
+        {
+            names.insert(name.trim().to_string());
+        }
+        if let Some(rest) = line.strip_prefix("thread '")
+            && let Some((name, suffix)) = rest.split_once("' panicked")
+            && !name.trim().is_empty()
+            && !suffix.trim().is_empty()
+        {
+            names.insert(name.trim().to_string());
+        }
+        if let Some(rest) = line.strip_prefix("thread \"")
+            && let Some((name, suffix)) = rest.split_once("\" panicked")
+            && !name.trim().is_empty()
+            && !suffix.trim().is_empty()
+        {
+            names.insert(name.trim().to_string());
+        }
+        if let Some(rest) = line.strip_prefix("fail [")
+            && let Some((_, name)) = rest.split_once(']')
+            && !name.trim().is_empty()
+        {
+            names.insert(name.trim().to_string());
+        }
+        if after_failures_header
+            && (payload.starts_with(' ') || payload.starts_with('\t'))
+            && !line.contains(' ')
+            && !line.starts_with("----")
+            && !line.starts_with("thread")
+            && !line.starts_with("error")
+            && !line.starts_with("assertion")
+        {
+            names.insert(line.trim().to_string());
+        }
+    }
+    names.into_iter().collect()
 }
 
 /// Generated descriptions shipped these exact provenance labels. This is a
@@ -2517,6 +2778,13 @@ fn value_string(value: &Value, key: &str) -> String {
         Some(Value::Number(number)) => number.to_string(),
         _ => String::new(),
     }
+}
+
+fn run_order(run: &Value) -> (String, u64) {
+    (
+        value_string(run, "created_at"),
+        run.get("run_id").and_then(Value::as_u64).unwrap_or(0),
+    )
 }
 
 fn display(value: &str) -> &str {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/duplicate_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/duplicate_tasks.rs
@@ -56,6 +56,7 @@ impl DuplicateTaskLookup for crate::OrbitRuntime {
 pub(in crate::adapter::engine_host::v2_host) struct DuplicateCandidate {
     exact_tag: String,
     fingerprints: Vec<CoverageFingerprint>,
+    completed_fingerprints: Vec<CoverageFingerprint>,
 }
 
 impl DuplicateCandidate {
@@ -66,7 +67,16 @@ impl DuplicateCandidate {
         Self {
             exact_tag,
             fingerprints,
+            completed_fingerprints: Vec::new(),
         }
+    }
+
+    pub(in crate::adapter::engine_host::v2_host) fn with_completed_fingerprints(
+        mut self,
+        fingerprints: Vec<CoverageFingerprint>,
+    ) -> Self {
+        self.completed_fingerprints = fingerprints;
+        self
     }
 }
 
@@ -144,14 +154,19 @@ where
     let mut open_tasks = lookup
         .list_tasks()?
         .into_iter()
-        .filter(|task| is_open_status(task.status))
+        .filter(|task| is_open_status(task.status) || recently_completed(task))
         .collect::<Vec<_>>();
     open_tasks.sort_by(|left, right| left.id.cmp(&right.id));
 
     for task in open_tasks {
-        let searchable = searchable_task_text(&task);
-        if let Some(fingerprint) = candidate
-            .fingerprints
+        let comments = lookup.get_task_comments(&task.id)?;
+        let searchable = searchable_task_text(&task, &comments);
+        let fingerprints = if is_open_status(task.status) {
+            &candidate.fingerprints
+        } else {
+            &candidate.completed_fingerprints
+        };
+        if let Some(fingerprint) = fingerprints
             .iter()
             .find(|fingerprint| fingerprint_matches(&searchable, fingerprint))
         {
@@ -295,7 +310,7 @@ fn fingerprint_matches(searchable: &str, fingerprint: &CoverageFingerprint) -> b
     })
 }
 
-fn searchable_task_text(task: &Task) -> String {
+fn searchable_task_text(task: &Task, comments: &[TaskComment]) -> String {
     let mut text = String::new();
     for value in std::iter::once(task.title.as_str())
         .chain(std::iter::once(task.description.as_str()))
@@ -303,6 +318,14 @@ fn searchable_task_text(task: &Task) -> String {
         .chain(std::iter::once(task.plan.as_str()))
         .chain(task.tags.iter().map(String::as_str))
         .chain(task.context_files.iter().map(String::as_str))
+        .chain(task.external_refs.iter().flat_map(|reference| {
+            [
+                reference.system.as_str(),
+                reference.id.as_str(),
+                reference.url.as_deref().unwrap_or(""),
+            ]
+        }))
+        .chain(comments.iter().map(|comment| comment.message.as_str()))
     {
         text.push(' ');
         text.push_str(value);
@@ -359,6 +382,11 @@ pub(in crate::adapter::engine_host::v2_host) fn is_open_status(status: TaskStatu
         status,
         TaskStatus::Done | TaskStatus::Archived | TaskStatus::Rejected
     )
+}
+
+fn recently_completed(task: &Task) -> bool {
+    task.status == TaskStatus::Done
+        && task.updated_at >= chrono::Utc::now() - chrono::Duration::days(30)
 }
 
 #[cfg(test)]

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_admission.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_admission.rs
@@ -323,17 +323,17 @@ fn already_landed_release_stays_proposed_but_distinct_current_regression_advance
         old_filing["task_id"]
     );
 
-    let current = file(
-        &runtime,
-        vec![failure(
-            11,
-            "ci",
-            "build",
-            "cargo build",
-            "ci\tbuild\terror: distinct current type failure\n",
-            NEXT_HEAD,
-        )],
+    let mut current_failure = failure(
+        11,
+        "ci",
+        "build",
+        "cargo build",
+        "ci\tbuild\terror: distinct current type failure\n",
+        NEXT_HEAD,
     );
+    current_failure["event_reported_head_sha"] = json!(NEXT_HEAD);
+    current_failure["current_ref_head_sha"] = json!(NEXT_HEAD);
+    let current = file(&runtime, vec![current_failure]);
     let current_filing = &current["filed"][0];
     apply_pilot(
         &runtime,
@@ -448,17 +448,17 @@ fn pending_release_publication_withholds_promotion_and_names_the_operator_action
 
     // No filename denylist: a repository-owned dependency contract defect in
     // the same kind of manifest stays eligible once a pilot establishes it.
-    let owned = file(
-        &runtime,
-        vec![failure(
-            22,
-            "ci",
-            "build",
-            "cargo build",
-            "ci\tbuild\terror: failed to select a version for the requirement\n",
-            CHECKOUT,
-        )],
+    let mut owned_failure = failure(
+        22,
+        "ci",
+        "build",
+        "cargo build",
+        "ci\tbuild\terror: failed to select a version for the requirement\n",
+        NEXT_HEAD,
     );
+    owned_failure["event_reported_head_sha"] = json!(NEXT_HEAD);
+    owned_failure["current_ref_head_sha"] = json!(NEXT_HEAD);
+    let owned = file(&runtime, vec![owned_failure]);
     let owned_filing = &owned["filed"][0];
     let admitted = apply_pilot(
         &runtime,

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -700,7 +700,13 @@ fn a_closed_task_does_not_suppress_a_recurrence() {
         )
         .expect("close the first task");
 
-    let second = file(&runtime, json!({"ci_evidence": evidence}));
+    let mut second_failure = failure(11, "ci", "build", "cargo build", log, NEXT_HEAD);
+    second_failure["event_reported_head_sha"] = json!(NEXT_HEAD);
+    second_failure["current_ref_head_sha"] = json!(NEXT_HEAD);
+    let second = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![second_failure])}),
+    );
 
     assert_eq!(second["filed_count"], json!(1));
     assert_ne!(filed_task_ids(&second).first(), Some(&task_id));
@@ -1736,18 +1742,19 @@ fn wrangler_error_outranks_generic_npx_process_failed() {
         "generic process/action trailers must not be the signature: {signature}"
     );
 
+    let mut second_failure = failure(
+        11,
+        "Website",
+        "Publish to Cloudflare Pages",
+        "Deploy static site",
+        &missing_pages,
+        NEXT_HEAD,
+    );
+    second_failure["event_reported_head_sha"] = json!(NEXT_HEAD);
+    second_failure["current_ref_head_sha"] = json!(NEXT_HEAD);
     let second = file(
         &runtime,
-        json!({"ci_evidence": snapshot(vec![
-            failure(
-                11,
-                "Website",
-                "Publish to Cloudflare Pages",
-                "Deploy static site",
-                &missing_pages,
-                CHECKOUT,
-            ),
-        ])}),
+        json!({"ci_evidence": snapshot(vec![second_failure])}),
     );
     assert_eq!(second["filed_count"], json!(1));
     assert_ne!(

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sweep_duplicate_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sweep_duplicate_tasks.rs
@@ -197,6 +197,115 @@ fn ci_reports_an_untagged_manual_task_with_bounded_match_evidence() {
 }
 
 #[test]
+fn ci_run_reference_dedupes_open_and_recently_completed_manual_tasks() {
+    for status in [TaskStatus::InProgress, TaskStatus::Done] {
+        let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+        let task_id = seed_manual_task(
+            &runtime,
+            "Investigate the failing CI test",
+            "The incident is tracked by GitHub Actions run 10; preserve its evidence.",
+            status,
+        );
+
+        let output = file_ci(&runtime, ci_evidence());
+
+        assert_eq!(output["filed_count"], json!(0), "{output}");
+        assert_eq!(output["skipped_existing"][0]["task_id"], json!(task_id));
+        assert_eq!(
+            output["skipped_existing"][0]["match_evidence"]["fingerprint"],
+            json!("ci_failure_run_id")
+        );
+    }
+}
+
+#[test]
+fn ci_run_reference_in_a_manual_comment_dedupes_without_sweep_metadata() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let task_id = seed_manual_task(
+        &runtime,
+        "Investigate the CI regression",
+        "Follow up on the reported failure after the incident review.",
+        TaskStatus::InProgress,
+    );
+    runtime
+        .update_task(
+            &task_id,
+            TaskUpdateParams {
+                comment: Some("The owner is tracking Actions run 10.".to_string()),
+                ..TaskUpdateParams::default()
+            },
+        )
+        .expect("add manual ownership comment");
+
+    let output = file_ci(&runtime, ci_evidence());
+
+    assert_eq!(output["filed_count"], json!(0), "{output}");
+    assert_eq!(output["skipped_existing"][0]["task_id"], json!(task_id));
+}
+
+#[test]
+fn failures_from_two_jobs_for_one_test_form_one_repair_task() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let log = "ci\tjob\t2026-08-30T01:00:00Z test init_report::requested_mcp_records_none_detected_when_no_providers_exist ... FAILED\n";
+    let first = failure(10, "CI", "Linux", "Run tests", log, CHECKOUT);
+    let mut second = failure(
+        10,
+        "CI",
+        "macOS",
+        "Run tests",
+        &format!("{log}assertion failed: platform-specific output\n"),
+        CHECKOUT,
+    );
+    second["job_id"] = json!(9910);
+    second["log_job_id"] = json!(9910);
+    second["checkout_identity"]["provenance"]["job_id"] = json!(9910);
+    second["failed_jobs"][0]["job_id"] = json!(9910);
+    second["failed_jobs"][0]["url"] =
+        json!("https://github.com/acme/orbit/actions/runs/10/job/9910");
+
+    let output = file_ci(&runtime, ci_snapshot(vec![first, second]));
+
+    assert_eq!(output["filed_count"], json!(1), "{output}");
+    let task = runtime
+        .get_task(output["filed"][0]["task_id"].as_str().expect("task id"))
+        .expect("filed task");
+    assert!(task.description.contains("Linux"), "{}", task.description);
+    assert!(task.description.contains("macOS"), "{}", task.description);
+    assert_eq!(output["filed"][0]["jobs"], json!(["Linux", "macOS"]));
+}
+
+#[test]
+fn newer_green_push_run_marks_an_older_red_run_already_repaired() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let old = failure(10, "CI", "Linux", "Run tests", CI_LOG, CHECKOUT);
+    let mut green = failure(11, "CI", "Linux", "Run tests", "", CHECKOUT);
+    green["created_at"] = json!("2026-08-30T02:00:00Z");
+    green["conclusion"] = json!("success");
+    green["failed_jobs"] = json!([]);
+
+    let mut evidence = ci_snapshot(vec![old.clone()]);
+    evidence["latest_runs"] = json!([green]);
+
+    let output = file_ci(&runtime, evidence.clone());
+
+    assert_eq!(output["filed_count"], json!(0), "{output}");
+    assert_eq!(output["already_repaired"].as_array().map(Vec::len), Some(1));
+    assert_eq!(output["already_repaired"][0]["run_id"], json!(10));
+    assert_eq!(output["audit"]["already_repaired_run_ids"], json!([10]));
+    assert!(runtime.list_tasks().expect("list tasks").is_empty());
+
+    let mut stale_evidence = ci_snapshot(Vec::new());
+    stale_evidence["latest_runs"] = json!([evidence["latest_runs"][0].clone()]);
+    stale_evidence["stale_or_superseded"] = json!([old]);
+    let stale_output = file_ci(&runtime, stale_evidence);
+    assert_eq!(stale_output["filed_count"], json!(0), "{stale_output}");
+    assert_eq!(
+        stale_output["audit"]["already_repaired_run_ids"],
+        json!([10])
+    );
+}
+
+#[test]
 fn ci_does_not_suppress_a_distinct_error_signature() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
     seed_manual_ci_task(&runtime, "error: cannot find type Widget in this scope");
@@ -600,10 +709,14 @@ fn shared_workflow_generic_npx_or_same_file_do_not_suppress_unrelated_failures()
 #[test]
 fn a_done_manual_repair_does_not_hide_a_later_recurrence() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let prior_incident = orb_11511_manual_brief().replace(
+        "a93caa13890764380e184d996fa709b1bcbe278c",
+        "4444444444444444444444444444444444444444",
+    );
     seed_manual_task(
         &runtime,
         "Fix website Pages deployment failing on missing Wrangler project name",
-        orb_11511_manual_brief(),
+        &prior_incident,
         TaskStatus::Done,
     );
 


### PR DESCRIPTION
## Task

[ORB-12167](https://orbit-cli.com/tasks/ORB-12167) — ci-failure-sweep files duplicate repairs: it ignores an existing repair task for the same failing runs unless it filed it, and files one task per failing job for a single failing test

### Description

## Observed (2026-09-11 on-call shift)

agent-main went red at 5d821d03 on one unit test (`init_report::requested_mcp_records_none_detected_when_no_providers_exist`), failing in both the `Check / Clippy / Test` and `Coverage (informational)` jobs. The orchestrator filed ORB-12159 at 08:54 (title names the test, description lists the failing run ids and the commits), and it merged as PR #1956 at ~09:05.

The 09:00 `ci-failure-sweep-orbit` run then filed **two** more tasks for the same failure:
- ORB-12162 `[ci-failure-sweep] Fix red CI: CI / Coverage (informational) / Collect workspace coverage`
- ORB-12163 `[ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails`

Both cite the same failing run ids (34577504057, 34578421294, 34578583836, 34578995874). ORB-12163 was admitted and a `system`-crew worker started on it (jrun-20260911-0912-c1) against a base that already contained the fix; the orchestrator had to cancel the run and reject both tasks by hand. The audit of the sweep run reported `existing_task_owners: []`, so its dedupe recognised nothing.

The same shape happened earlier in the night: ORB-12155 (orchestrator-authored, merged as PR #1947) fixed the `worktree_gc_routing` red; the sweep was only saved from duplicating it by GitHub API TLS timeouts (jrun-20260911-0803-t2).

## Wanted

1. Dedupe against **any** open or recently-completed task that references the same failing run ids, the same failing test name, or the same head SHAs — not only tasks the sweep itself created. A task comment/`external_refs` entry with the run id, or the run id/test name in the description, must count as an owner.
2. Group by failing test/step, not by job: when N jobs fail on the same test, file one repair task listing all N jobs, not N tasks.
3. Before filing, re-check the branch tip: if a newer push run on the same branch is green (or in progress with the failing test already fixed), record `already_repaired` in the audit and file nothing.

### Acceptance Criteria

- With an open task whose description contains a failing run id (created by any actor, not tagged ci-failure-sweep), the sweep reports it under existing_task_owners and files nothing; a unit test covers it.
- When two jobs in one run fail on the same test, the sweep files exactly one task whose description lists both jobs; a unit test covers it.
- When the newest push run on the branch is green, the sweep records already_repaired for the older red runs and files nothing.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented and validated ORB-12167.

Criteria:
- Existing-task ownership: the CI sweep now searches all open tasks and recent Done tasks, includes task comments and external references, and matches failing run IDs, test names, and head SHAs. Manual ownership is reported in skipped_existing/existing_task_owners without filing a duplicate. Covered by ci_run_reference_dedupes_open_and_recently_completed_manual_tasks and ci_run_reference_in_a_manual_comment_dedupes_without_sweep_metadata.
- Same-test grouping: failures are clustered by extracted failing test identity across jobs and the filed description and filing entry list every contributing job. Covered by failures_from_two_jobs_for_one_test_form_one_repair_task.
- Green branch repair: newer successful push runs on the same workflow/branch suppress older failures and are recorded in already_repaired and the audit, including stale/superseded evidence. Covered by newer_green_push_run_marks_an_older_red_run_already_repaired.

Validation:
- cargo test -p orbit-core --lib — passed: 1409 passed, 0 failed, 2 ignored.
- Focused sweep_duplicate_tasks tests — passed: 22 passed, 0 failed.
- Focused ci_failure_tasks tests — passed: 50 passed, 0 failed, 1 ignored.
- Focused ci_failure_admission tests — passed: 5 passed, 0 failed.
- cargo fmt --all -- --check — passed.
- make ci-fast — passed; its compiler-cache namespace subcheck reported an environment-limited skip because unprivileged bubblewrap namespaces are unavailable.
- make ci-lint — passed.
- git diff --check — passed.
- GIT_OPTIONAL_LOCKS=0 git status --short — passed; only the five task-scoped source/test files remain intentionally uncommitted for pipeline delivery.

Remaining risk: GitHub API behavior was not exercised live; collector-shaped unit fixtures cover the new filing boundary.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12167-6aa3c72b`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus