### PR TITLE
[code-review] owner-wins import overwrites a local-prefix task whose registry binding is missing

### DIFF
--- a/crates/orbit-store/src/workflow/task/mod.rs
+++ b/crates/orbit-store/src/workflow/task/mod.rs
@@ -33,8 +33,9 @@
 //! repeatable sync of those mirrors — a colliding foreign-prefix id is replaced
 //! by the owner's bundle ([`ImportAction::Updated`]), a colliding local-prefix
 //! id is left alone ([`ImportAction::SkippedLocalOwned`]), and nothing is ever
-//! renumbered. An owner-wins import also repairs an orphaned canonical bundle
-//! whose registry binding is missing by replacing it and restoring the binding.
+//! renumbered. An owner-wins import also repairs an orphaned *foreign-prefix*
+//! canonical bundle whose registry binding is missing by replacing it and
+//! restoring the binding; an orphaned local-prefix bundle stays local-owned.
 //! Foreign relation targets therefore survive verbatim, no `.idmap.json` is
 //! written, and a second run of the same archive reports every task as
 //! already-present.
@@ -377,20 +378,30 @@ pub fn import_tasks(
     for staged in staged {
         match registry.find_task_binding(&staged.source_id)? {
             None => {
-                if policy == ImportConflictPolicy::OwnerWins {
-                    let bundle_dir = registry
-                        .canonical_task_bundle_path(&target.workspace_id, &staged.source_id)?;
-                    if bundle_dir.is_dir() {
-                        to_overwrite.push(MirrorReplacement {
-                            staged,
-                            bundle_dir,
-                            register_binding: true,
+                // An owner-wins sync repairs a canonical bundle the registry
+                // has lost track of, but authority still follows the prefix:
+                // a local-prefix bundle is ours no matter what the index says.
+                let orphan_dir = (policy == ImportConflictPolicy::OwnerWins)
+                    .then(|| {
+                        registry.canonical_task_bundle_path(&target.workspace_id, &staged.source_id)
+                    })
+                    .transpose()?
+                    .filter(|bundle_dir| bundle_dir.is_dir());
+
+                match orphan_dir {
+                    Some(_) if task_id_prefix(&staged.source_id) == Some(local_prefix.as_str()) => {
+                        records.push(ImportedTask {
+                            source_id: staged.source_id.clone(),
+                            final_id: staged.source_id,
+                            action: ImportAction::SkippedLocalOwned,
                         });
-                    } else {
-                        kept.push(staged);
                     }
-                } else {
-                    kept.push(staged);
+                    Some(bundle_dir) => to_overwrite.push(MirrorReplacement {
+                        staged,
+                        bundle_dir,
+                        register_binding: true,
+                    }),
+                    None => kept.push(staged),
                 }
             }
             Some(existing) => {

--- a/crates/orbit-store/src/workflow/task/tests/owner_wins.rs
+++ b/crates/orbit-store/src/workflow/task/tests/owner_wins.rs
@@ -428,6 +428,61 @@ fn owner_wins_repairs_an_unbound_existing_bundle_and_lands_the_rest() {
 }
 
 #[test]
+fn owner_wins_leaves_an_unbound_locally_owned_bundle_untouched() {
+    let src = TempDir::new().unwrap();
+    let dst = TempDir::new().unwrap();
+    let ws = "orbit-owner-acacac";
+
+    // The peer's archive carries a stale mirror of our task. Locally that task
+    // has lost its registry binding (a partial index rebuild) but its bundle
+    // is still on disk — the unbound repair path must not let the mirror
+    // overwrite it.
+    let archive = src.path().join("tasks.tar.zst");
+    export_owner_archive(
+        src.path(),
+        ws,
+        &archive,
+        &[make_bundle(
+            "DANI-00042",
+            "stale mirror of our task",
+            Vec::new(),
+        )],
+    );
+
+    let registry = open_mirror_registry(dst.path());
+    let binding = bind(&registry, dst.path(), ws);
+    let store = bundle_store(&registry, &binding);
+    let local = make_bundle("DANI-00042", "local truth", Vec::new());
+    seed(&store, &registry, ws, &local);
+    registry
+        .unregister_task_bundle("DANI-00042", ws)
+        .expect("remove only our task's registry binding");
+    assert!(
+        registry
+            .canonical_task_bundle_path(ws, "DANI-00042")
+            .unwrap()
+            .is_dir()
+    );
+
+    let outcome =
+        import_tasks(&registry, &archive, None, ImportConflictPolicy::OwnerWins).expect("sync");
+
+    assert_eq!(outcome.tasks.len(), 1);
+    assert_eq!(outcome.tasks[0].source_id, "DANI-00042");
+    assert_eq!(outcome.tasks[0].final_id, "DANI-00042");
+    assert_eq!(outcome.tasks[0].action, ImportAction::SkippedLocalOwned);
+    assert_eq!(
+        landed_bundle(&registry, ws, "DANI-00042"),
+        local,
+        "the local bundle's contents are preserved"
+    );
+    assert!(
+        registry.find_task_binding("DANI-00042").unwrap().is_none(),
+        "a skipped local task is not rebound by the sync"
+    );
+}
+
+#[test]
 fn owner_wins_preserves_foreign_relation_targets() {
     let first_export = TempDir::new().unwrap();
     let second_export = TempDir::new().unwrap();

--- a/docs/design/task-migration/1_overview.md
+++ b/docs/design/task-migration/1_overview.md
@@ -225,8 +225,10 @@ algorithm:
   `updated`), a colliding local-prefix bundle is left untouched (reported
   `skipped-local-owned`), and nothing is ever renumbered ([ORB-12126]). If the
   task id has no registry binding but its canonical bundle directory remains,
-  owner-wins refreshes that orphaned mirror and restores its binding; `reindex`
-  remains the recovery command for other index drift. Because it never mints,
+  owner-wins refreshes that orphaned mirror and restores its binding — but only
+  for a foreign-prefix id, because a local-prefix bundle is locally owned
+  whether or not the index still binds it ([ORB-12164]); `reindex` remains the
+  recovery command for other index drift. Because it never mints,
   foreign relation targets survive verbatim, no `.idmap.json` is written, and
   re-running the same archive reports every task as `already-present` — so it
   is safe on a timer:
@@ -248,5 +250,6 @@ in [4_decisions](./4_decisions.md).
 - [ORB-00034] — task migration tooling: `orbit task export/import/reindex`, `tasks.id_start` allocator config.
 - [ORB-10721] — per-host `task_prefix` in `host.toml`, projected into the allocator.
 - [ORB-12126] — owner-wins cross-host sync: import policy that overwrites only foreign-prefix bundles.
+- [ORB-12164] — the unbound-bundle repair path honors the local-prefix guard.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-12164](https://orbit-cli.com/tasks/ORB-12164) — [code-review] owner-wins import overwrites a local-prefix task whose registry binding is missing

### Description

`import_tasks` with `--on-conflict=owner-wins` gained a repair path for a canonical bundle that exists on disk without a registry binding (ORB-12152). That path skips the local-prefix guard every other owner-wins decision applies, so an incoming archive can destroy a locally owned task.

## Evidence

- `crates/orbit-store/src/workflow/task/mod.rs:378-395` — when `find_task_binding` returns `None` and the policy is `OwnerWins`, an existing canonical directory is pushed straight onto `to_overwrite` with `register_binding: true`. `local_prefix` (computed at `:370`) is never consulted.
- `crates/orbit-store/src/workflow/task/mod.rs:615-632` — `owner_wins_verdict`, the bound path, returns `MirrorVerdict::LocalOwned` for any id under the local prefix, and the caller records `ImportAction::SkippedLocalOwned` (`:431-435`) instead of replacing anything.
- `crates/orbit-store/src/workflow/task/mod.rs:33-40` and `docs/design/task-migration/1_overview.md:223-228` both state the invariant: "a colliding local-prefix bundle is left untouched (reported `skipped-local-owned`), and nothing is ever renumbered".
- The replacement is destructive: `crates/orbit-store/src/workflow/task/mod.rs:546-556` calls `replace_bundle_at(&replacement.bundle_dir, &staged.bundle, &staged.staging_dir)`, and rollback deliberately does not restore an owner-wins replacement (`:462-466`, `WriteGuard::rollback` at `:829-845`).

## Failure scenario

Two hosts mint under the same `task_prefix` (a copied or hand-edited `~/.orbit/host.toml` — exactly the case the `LocalOwned` branch exists to cover). Host B runs an owner-wins sync of host A's archive on a timer. B's task index is lost or partially rebuilt, so B's own `ORB-00042` still has its canonical bundle on disk but no `task_bundle_bindings` row — the precise state ORB-12151 and ORB-12152 were written for.

On the next sync, `find_task_binding("ORB-00042")` returns `None`, the directory exists, and the incoming archive's `ORB-00042` replaces B's bundle contents and takes the binding. B's local task is reported `updated` rather than `skipped-local-owned`, its description/criteria/comments are gone, and neither rollback nor `orbit task reindex` can recover them (the bytes were overwritten).

## Expected

The unbound branch should reach the same verdict as the bound branch: an id under `registry.local_task_prefix()` is local-owned and must be reported `skipped-local-owned` without touching the directory. Only a foreign-prefix id should be repaired in place.

### Acceptance Criteria

- An owner-wins import whose archive carries a local-prefix id that has a canonical bundle on disk but no registry binding leaves that bundle's contents unchanged and reports it as skipped-local-owned.
- An owner-wins import whose archive carries a foreign-prefix id in the same unbound state still replaces the bundle and restores its registry binding (the ORB-12152 behavior is preserved).
- A regression test covers the local-prefix unbound case and fails against the current code.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed the owner-wins unbound-bundle repair path so it honors the local-prefix guard.

Change (uncommitted, HEAD 7271e03c88c2c0857ae55b335dc9c734e2573b51):
- crates/orbit-store/src/workflow/task/mod.rs:378-404 — in `import_tasks`, the `find_task_binding == None` arm now computes the orphan canonical directory only for `OwnerWins`, and when that directory exists it consults `task_id_prefix(source_id) == local_prefix` first: a local-prefix id is recorded as `ImportAction::SkippedLocalOwned` with no write, a foreign-prefix id still becomes a `MirrorReplacement { register_binding: true }` (ORB-12152 behavior), and a missing directory still falls through to `kept`. The module doc (:33-40) now states that only a foreign-prefix orphan is repaired.
- crates/orbit-store/src/workflow/task/tests/owner_wins.rs — new `owner_wins_leaves_an_unbound_locally_owned_bundle_untouched`: destination host mints `DANI`, its `DANI-00042` bundle is seeded then unbound via `unregister_task_bundle`, the peer archive carries a stale `DANI-00042`. Asserts the action is `SkippedLocalOwned`, the on-disk bundle still equals the local copy, and the task is not rebound.
- docs/design/task-migration/1_overview.md:222-230, 253 — owner-wins bullet now says the orphan repair applies only to foreign-prefix ids, with a task-reference entry. Appended to context_files (unlisted file) because it restated the repair rule the fix narrows; leaving it would have documented the defect as intended behavior.

Acceptance criteria:
1. Local-prefix unbound bundle left unchanged and reported skipped-local-owned — met; asserted by the new test (bundle contents equal the local copy, action `SkippedLocalOwned`, binding still absent).
2. Foreign-prefix unbound bundle still replaced and rebound — met; `owner_wins_repairs_an_unbound_existing_bundle_and_lands_the_rest` still passes unchanged.
3. Regression test fails against current code — met; before the fix the new test failed at the action assertion with `left: Updated, right: SkippedLocalOwned` (run captured pre-fix).

Validation:
- `cargo test -p orbit-store --lib owner_wins_leaves_an_unbound_locally_owned_bundle_untouched` (pre-fix): FAILED as designed.
- `cargo test -p orbit-store --lib owner_wins`: passed, 8/8.
- `cargo test -p orbit-store`: passed, 525 passed / 0 failed / 7 ignored.
- `cargo fmt --all` then `make ci-fast`: passed (one sandbox skip reported by the suite itself: `test-compiler-cache-namespaces` skipped — kernel denies unprivileged user namespaces).
- `make ci-lint`: passed, no warnings.
- `git diff --check`: clean; `git status --short` shows only the three files above.

Risks/deviations: none known. The behavior is exercised through `import_tasks` at the crate boundary with real archives and registries on Linux; no cross-OS claim is made. `make ci` was not run locally per workspace policy (CI owns it).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12164-6aa3cc60`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus