### PR TITLE
[qa-sweep] Flaky under load: `update::tests::stage::rollback_replaces_a_running_executable_atomically` spawns a freshly copied executable without the ETXTBSY retry ORB-11340 added elsewhere

### DIFF
--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -21,13 +21,13 @@ use std::sync::mpsc::{Receiver, channel};
 use std::time::{Duration, Instant};
 
 use orbit_common::test_env;
+#[cfg(target_os = "linux")]
+use orbit_common::test_process::retry_executable_busy;
 use rusqlite::Connection;
 use serde_json::{Value, json};
 use tempfile::{TempDir, tempdir};
 
 const RESPONSE_TIMEOUT: Duration = Duration::from_secs(120);
-#[cfg(target_os = "linux")]
-const EXEC_BUSY_RETRY_WINDOW: Duration = Duration::from_secs(2);
 #[cfg(target_os = "linux")]
 const REQUIRE_PROTECTED_SSH_REGRESSION_ENV: &str = "ORBIT_REQUIRE_PROTECTED_SSH_REGRESSION";
 
@@ -1006,31 +1006,6 @@ struct GeneratedForcedCommand {
     argv: Vec<String>,
     forced_command: String,
     acceptance_token: String,
-}
-
-/// Retry a freshly copied test launcher while another parallel test's child
-/// still has its writable descriptor inherited across `fork`.
-///
-/// The descriptor is close-on-exec, but Linux can reject a concurrent exec
-/// with `ETXTBSY` during that short pre-exec window. This is the same bounded
-/// transient the production updater handles when it launches a newly written
-/// binary; all other errors remain immediate test failures.
-#[cfg(target_os = "linux")]
-fn retry_executable_busy<T>(
-    mut operation: impl FnMut() -> std::io::Result<T>,
-) -> std::io::Result<T> {
-    let deadline = Instant::now() + EXEC_BUSY_RETRY_WINDOW;
-    loop {
-        match operation() {
-            Err(error)
-                if error.kind() == std::io::ErrorKind::ExecutableFileBusy
-                    && Instant::now() < deadline =>
-            {
-                std::thread::sleep(Duration::from_millis(25));
-            }
-            result => return result,
-        }
-    }
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/orbit-cmd/src/update/tests/stage.rs
+++ b/crates/orbit-cmd/src/update/tests/stage.rs
@@ -59,6 +59,7 @@ fn a_failed_atomic_restore_keeps_both_complete_files_and_cleans_staging() {
 #[test]
 fn rollback_replaces_a_running_executable_atomically() {
     use crate::update::stage::restore_backup;
+    use orbit_common::test_process::retry_executable_busy;
     use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
     use std::time::{Duration, Instant};
@@ -78,16 +79,17 @@ fn rollback_replaces_a_running_executable_atomically() {
     std::fs::set_permissions(&backup, std::fs::Permissions::from_mode(0o751))
         .expect("make previous executable runnable");
 
-    let mut running = Command::new(&destination)
+    let mut command = Command::new(&destination);
+    command
         .args([
             "--ignored",
             "--exact",
             "update::tests::stage::running_replacement_process_fixture",
         ])
         .env("ORBIT_TEST_REPLACEMENT_READY", &ready)
-        .env("ORBIT_TEST_REPLACEMENT_RELEASE", &release)
-        .spawn()
-        .expect("launch installed replacement");
+        .env("ORBIT_TEST_REPLACEMENT_RELEASE", &release);
+    let mut running =
+        retry_executable_busy(|| command.spawn()).expect("launch installed replacement");
     wait_for_path(&ready, Duration::from_secs(5));
 
     restore_backup(&destination, &backup).expect("atomically restore previous executable");

--- a/crates/orbit-common/Cargo.toml
+++ b/crates/orbit-common/Cargo.toml
@@ -16,9 +16,9 @@ clap = ["orbit-types/clap"]
 # Shared SQLite connection defaults (utility::sqlite). Optional so that
 # non-SQLite consumers (orbit-policy, orbit-exec, ...) do not pull rusqlite.
 sqlite = ["dep:rusqlite"]
-# Exposes `test_fixtures` (frozen model-name constants) and `test_env` (scoped
-# environment guards) to integration tests in sibling crates, which cannot see
-# this crate's `#[cfg(test)]` items.
+# Exposes `test_fixtures` (frozen model-name constants), `test_env` (scoped
+# environment guards), and `test_process` (spawn-retry helpers) to integration
+# tests in sibling crates, which cannot see this crate's `#[cfg(test)]` items.
 test-util = []
 
 [dependencies]

--- a/crates/orbit-common/src/lib.rs
+++ b/crates/orbit-common/src/lib.rs
@@ -30,6 +30,9 @@ pub mod test_env;
 #[cfg(any(test, feature = "test-util"))]
 pub mod test_fixtures;
 
+#[cfg(any(test, feature = "test-util"))]
+pub mod test_process;
+
 pub use error::{
     ArtifactOrigin, ArtifactOriginMode, DependencyNotDelivered, FrictionNotLocal, NotFoundKind,
     OrbitError, RecoverableVcsConflict, WorkspaceClaimHeld,

--- a/crates/orbit-common/src/test_process.rs
+++ b/crates/orbit-common/src/test_process.rs
@@ -1,0 +1,43 @@
+//! Spawn helpers for tests that launch a freshly written executable.
+//!
+//! A test that copies an executable into a tempdir and immediately spawns it
+//! races every other parallel test-process `fork()` in the suite: a sibling
+//! spawn can briefly inherit a writable descriptor on *this* file across
+//! `fork` before close-on-exec runs, and Linux rejects a concurrent exec of a
+//! file that still looks open for writing with `ETXTBSY` (ORB-11340).
+//! [`retry_executable_busy`] absorbs that bounded, load-dependent transient so
+//! the fixture fails only on a real spawn error.
+//!
+//! Exposed behind the `test-util` feature so integration tests in sibling
+//! crates, which cannot see this crate's `#[cfg(test)]` items, share one
+//! implementation rather than each re-deriving the retry.
+
+use std::io;
+use std::time::{Duration, Instant};
+
+/// How long [`retry_executable_busy`] keeps retrying before giving up.
+#[cfg(target_os = "linux")]
+const EXEC_BUSY_RETRY_WINDOW: Duration = Duration::from_secs(2);
+
+/// Retry a freshly copied test launcher while another parallel test's child
+/// still has its writable descriptor inherited across `fork`.
+///
+/// The descriptor is close-on-exec, but Linux can reject a concurrent exec
+/// with `ETXTBSY` during that short pre-exec window. This is the same bounded
+/// transient the production updater handles when it launches a newly written
+/// binary; all other errors remain immediate test failures.
+#[cfg(target_os = "linux")]
+pub fn retry_executable_busy<T>(mut operation: impl FnMut() -> io::Result<T>) -> io::Result<T> {
+    let deadline = Instant::now() + EXEC_BUSY_RETRY_WINDOW;
+    loop {
+        match operation() {
+            Err(error)
+                if error.kind() == io::ErrorKind::ExecutableFileBusy
+                    && Instant::now() < deadline =>
+            {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            result => return result,
+        }
+    }
+}


### PR DESCRIPTION
## Task

[ORB-12174](https://orbit-cli.com/tasks/ORB-12174) — [qa-sweep] Flaky under load: `update::tests::stage::rollback_replaces_a_running_executable_atomically` spawns a freshly copied executable without the ETXTBSY retry ORB-11340 added elsewhere

### Description

## Summary

`crates/orbit-cmd/src/update/tests/stage.rs:82-90` copies the current test
executable into a tempdir and immediately `spawn()`s it. Under a full-workspace
parallel test run that spawn intermittently fails with Linux `ETXTBSY`, failing
`cargo test -p orbit-cmd --lib` and therefore `make test`:

```
---- update::tests::stage::rollback_replaces_a_running_executable_atomically stdout ----
thread '...' panicked at crates/orbit-cmd/src/update/tests/stage.rs:90:10:
launch installed replacement: Os { code: 26, kind: ExecutableFileBusy, message: "Text file busy" }
test result: FAILED. 150 passed; 1 failed; 1 ignored; 0 measured
```

This is the same race ORB-11340 diagnosed and repaired — "parallel test-process
forks can briefly inherit a writable launcher descriptor before close-on-exec,
so Linux rejects a concurrent exec with ETXTBSY" — but that repair added its
bounded retry only in `crates/orbit-cli/tests/mcp_roundtrip.rs`. This call site
has no retry.

## Reproduction (orbit 0.21.0, HEAD `f9122f5a1`, Linux 6.8, 64-thread host)

```sh
cargo test --workspace --no-fail-fast        # failed once, at the run above
cargo test -q -p orbit-cmd --lib update::tests::stage::rollback_replaces_a_running_executable_atomically   # 3/3 passed
cargo test -q -p orbit-cmd --lib             # 3/3 passed (151 passed each time)
```

Load-dependent, not deterministic: it reproduced during the workspace-wide run
(many test binaries executing concurrently) and did not reproduce in six
isolated runs of the test and of its whole crate suite.

## Impact

Validation impact: `make test` / `cargo test --workspace` fails
nondeterministically; without `--no-fail-fast` the failure aborts the rest of
the suite. The same flake in CI (`Check / Clippy / Test`, `Coverage`) is
indistinguishable from a real regression and, per ORB-11341, tends to be refiled
by the CI failure sweep.

Production impact: none. ORB-11340 recorded that the production updater already
retries ETXTBSY; only this fixture's spawn does not.

## Suggested direction

Apply the established fix at this call site: wrap the `Command::spawn` of the
freshly copied executable in the same Linux-only, bounded ETXTBSY retry the
repository already uses (`crates/orbit-cli/tests/mcp_roundtrip.rs`, added by
ORB-11340), retrying only `ErrorKind::ExecutableFileBusy`. If a second site
needs it, the retry helper is worth moving somewhere both fixtures can share
rather than copying a third time. Auditing other test fixtures that copy and
then spawn an executable is in scope for the same change.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Root cause: `rollback_replaces_a_running_executable_atomically` (crates/orbit-cmd/src/update/tests/stage.rs) copies `current_exe()` into a tempdir and immediately `Command::spawn()`s it, unguarded against the Linux ETXTBSY race ORB-11340 diagnosed (a sibling test's fork() can briefly inherit a writable descriptor on this file before close-on-exec runs).

Fix: wrapped that spawn in a bounded, Linux-only ETXTBSY retry, matching the pattern ORB-11340 already established.

Audit (task's suggested scope): grepped the whole workspace for `Command::new(std::env::current_exe()...)`. Found 9 other call sites (orbit-common/storage/tests/sqlite.rs; orbit-exec linux_sandbox.rs and macos_sandbox/provider_dirs.rs; orbit-engine vcs/worktree gc.rs, vcs/commit git_ops.rs, vcs/tests/mod.rs x2, activity_job/cli_runner/tests/inspection.rs, activity_job/tests/workspace.rs). All of them re-exec the already-linked test binary directly with no preceding `fs::copy`/`fs::write` to a new path, so the process never holds a write descriptor on the exec target and they are not subject to this race. Left unchanged — no retry needed there. The only other site matching the vulnerable "copy a fresh executable, then spawn it" shape was `crates/orbit-cli/tests/mcp_roundtrip.rs`, which already carried its own `retry_executable_busy` from ORB-11340.

Since a second call site now needed the same retry, moved it to a shared location per the task's suggested direction rather than copying a third time: added `orbit_common::test_process::retry_executable_busy` (new file `crates/orbit-common/src/test_process.rs`), declared in `crates/orbit-common/src/lib.rs` behind the pre-existing `test-util` feature (comment in `crates/orbit-common/Cargo.toml` updated to mention it). Both `orbit-cmd` and `orbit-cli` already depend on `orbit-common` with `test-util` in `[dev-dependencies]`, so this adds no new cross-crate dependency edge. `stage.rs` and `mcp_roundtrip.rs` now both call the shared helper; `mcp_roundtrip.rs`'s local `retry_executable_busy` fn and `EXEC_BUSY_RETRY_WINDOW` const were deleted (dead code after the move).

Validation:
- `cargo test -q -p orbit-cmd --lib update::tests::stage` — passed (target test + siblings, incl. the ignored fixture run explicitly).
- `cargo test -q -p orbit-cli --test mcp_roundtrip --no-run` — compiles clean after the extraction.
- `cargo fmt --check -p orbit-cmd -p orbit-cli -p orbit-common` — passed, no diffs.
- `cargo clippy -p orbit-cmd -p orbit-cli -p orbit-common --all-targets --tests -- -D warnings` — passed, zero warnings.
- `make ci-fast` — passed (one guardrail, test-compiler-cache-namespaces, skipped for lack of user-namespace permission in this sandbox — unrelated to this change, pre-existing sandbox limitation).
- `git diff --check` — clean. `git status --short` — only the 4 modified files plus the new `test_process.rs`, all declared in context_files.
- Did not run full `cargo test --workspace` (the original nondeterministic repro requires many parallel test binaries; workspace policy is that `make ci` is the canonical merge gate, not a per-task local run). Residual risk: cannot deterministically reproduce the original ETXTBSY failure locally to prove the fix defeats it directly, since it was load-dependent and unreproducible even before the fix in isolated runs — the fix applies the same mechanism already validated by ORB-11340's own regression test (`a_fresh_test_launcher_waits_for_a_writer_to_close`, which still passes).

No acceptance criteria were set on this task; the description's reproduction and suggested direction were treated as the scope. Changes left uncommitted per pipeline ownership.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12174-6aa3cc61`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus