### PR TITLE
[qa-sweep] `orbit workspace remove` still refuses a deleted checkout: its positional collides with the global `--workspace` arg, so the runtime binds to the workspace being removed

### DIFF
--- a/crates/orbit-cli/src/command/workspace/remove.rs
+++ b/crates/orbit-cli/src/command/workspace/remove.rs
@@ -10,6 +10,7 @@ use crate::command::{CommandOut, CommandOutput, Execute};
 #[derive(Args)]
 pub struct WorkspaceRemoveArgs {
     /// Workspace name, id, or absolute checkout path
+    #[arg(value_name = "WORKSPACE", id = "workspace_selector")]
     pub workspace: String,
 }
 

--- a/crates/orbit-cli/tests/workspace_selector.rs
+++ b/crates/orbit-cli/tests/workspace_selector.rs
@@ -11,6 +11,93 @@ use serde_json::Value;
 use tempfile::tempdir;
 
 #[test]
+fn workspace_remove_deregisters_deleted_checkout_by_name_id_and_path() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let survivor_repo = temp.path().join("survivor");
+    let deleted_by_name = temp.path().join("deleted-by-name");
+    let deleted_by_id = temp.path().join("deleted-by-id");
+    let deleted_by_path = temp.path().join("deleted-by-path");
+    fs::create_dir_all(&home).expect("home");
+
+    for repo in [
+        &survivor_repo,
+        &deleted_by_name,
+        &deleted_by_id,
+        &deleted_by_path,
+    ] {
+        init_git_repo(repo);
+    }
+
+    run_orbit(
+        &survivor_repo,
+        &home,
+        &[
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "remove-host",
+            "--task-prefix",
+            "REM",
+        ],
+    )
+    .success();
+    run_orbit(
+        &survivor_repo,
+        &home,
+        &["workspace", "init", "--name", "survivor"],
+    )
+    .success();
+
+    for (repo, name) in [
+        (&deleted_by_name, "deleted-by-name"),
+        (&deleted_by_id, "deleted-by-id"),
+        (&deleted_by_path, "deleted-by-path"),
+    ] {
+        run_orbit(repo, &home, &["workspace", "init", "--name", name]).success();
+    }
+
+    fs::remove_dir_all(&deleted_by_name).expect("delete name-selected checkout");
+    fs::remove_dir_all(&deleted_by_id).expect("delete id-selected checkout");
+    fs::remove_dir_all(&deleted_by_path).expect("delete path-selected checkout");
+
+    run_orbit_as_operator(
+        &survivor_repo,
+        &home,
+        &["workspace", "remove", "deleted-by-name"],
+    )
+    .success();
+    run_orbit_as_operator(
+        &survivor_repo,
+        &home,
+        &["workspace", "remove", "ws_deleted-by-id"],
+    )
+    .success();
+    run_orbit_as_operator(
+        &survivor_repo,
+        &home,
+        &[
+            "workspace",
+            "remove",
+            deleted_by_path.to_str().expect("deleted path is utf8"),
+        ],
+    )
+    .success();
+
+    let registry: Value = serde_json::from_slice(
+        &fs::read(home.join(".orbit/workspaces.json")).expect("read workspace registry"),
+    )
+    .expect("parse workspace registry");
+    let workspace_names = registry["workspaces"]
+        .as_array()
+        .expect("workspace array")
+        .iter()
+        .filter_map(|workspace| workspace["name"].as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(workspace_names, vec!["survivor"]);
+}
+
+#[test]
 fn global_workspace_flag_selects_by_name_and_id_from_a_foreign_checkout() {
     let temp = tempdir().expect("tempdir");
     let home = temp.path().join("home");
@@ -613,7 +700,11 @@ fn checkout_path_and_cwd_resolve_an_id_that_collides_with_another_workspace_name
         ["workspace", "remove", "ws_alpha"].as_slice(),
         ["workspace", "role", "ws_alpha", "owner"].as_slice(),
     ] {
-        let assert = run_orbit(&alpha_repo, &home, args).failure();
+        let assert = if args[1] == "remove" {
+            run_orbit_as_operator(&alpha_repo, &home, args).failure()
+        } else {
+            run_orbit(&alpha_repo, &home, args).failure()
+        };
         let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
         let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
         let combined = format!("{stdout}{stderr}");
@@ -1052,6 +1143,20 @@ fn run_orbit(cwd: &Path, home: &Path, args: &[&str]) -> assert_cmd::assert::Asse
         .current_dir(cwd)
         .env("HOME", home)
         .env("USERPROFILE", home)
+        .args(args);
+    command.assert()
+}
+
+fn run_orbit_as_operator(cwd: &Path, home: &Path, args: &[&str]) -> assert_cmd::assert::Assert {
+    let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("ORBIT_OPERATOR", "1")
         .args(args);
     command.assert()
 }


### PR DESCRIPTION
## Task

[ORB-12169](https://orbit-cli.com/tasks/ORB-12169) — [qa-sweep] `orbit workspace remove` still refuses a deleted checkout: its positional collides with the global `--workspace` arg, so the runtime binds to the workspace being removed

### Description

## Summary

ORB-12150 (`a90d36b33`, PR #1952) added absolute-path selector support to
`orbit workspace remove` and a runbook section telling operators to deregister a
deleted checkout with
`ORBIT_OPERATOR=1 orbit workspace remove <name|ws_*|absolute path>`
(`docs/runbooks/health-checks.md:142-157`). That command still fails for every
selector form, in both the repo-local and external-root layouts, so the
documented recovery does not work and the new code in
`crates/orbit-cli/src/command/workspace/remove.rs` is unreachable for the case
it was written for.

## Root cause

`WorkspaceRemoveArgs` declares a **positional** field named `workspace`
(`crates/orbit-cli/src/command/workspace/remove.rs:11-14`), which collides with
the clap-derive id of the global `--workspace <SELECTOR>` flag
(`crates/orbit-cli/src/command/mod.rs:131-132`, `#[arg(long, global = true)]`).
The positional therefore *is* the global arg: its value lands in `cli.workspace`
and `main.rs:223,255` passes it to
`RegisteredRuntimeFactory::initialize_with_overrides(root, selector)` before
dispatch. `resolve_workspace_selector`
(`crates/orbit-cmd/src/registry_runtime.rs:191-205`) rejects any workspace whose
catalog `status != Active` with `unsupported_cli_workspace`, whose text is
identical to `unknown_workspace_selector`
(`registry_runtime.rs:577-581`). A checkout deleted without teardown is flipped
to `status: invalid` by `validate_workspaces`
(`crates/orbit-registry/src/workspace_registry/catalog.rs:547-570`) — exactly the
workspace an operator needs to remove.

Three independent proofs that the positional is the global selector:

1. `orbit workspace remove --help` lists **no** `--workspace` option, while every
   sibling subcommand (`workspace show --help`, …) does.
2. `orbit workspace remove <live-workspace-name>` succeeds when run from a
   directory that is not inside any workspace (`/tmp`) — impossible unless the
   positional supplied the runtime's workspace selection.
3. A bogus name returns `invalid input: unknown workspace selector 'zzz-nope'`
   (the bootstrap message) instead of `remove_workspace`'s
   `OrbitError::not_found` ("workspace not found: zzz-nope").

## Reproduction (orbit 0.21.0 built from `f9122f5a1`, Linux)

Disposable `HOME` under `/tmp`, every `orbit_common::test_env::INHERITED_AUTHORITY_ENV`
variable cleared, routing verified with `orbit workspace show --format json`
before any mutation.

```sh
# repo-local layout — the same layout as the ORB-12150 report
orbit init --non-interactive --host-name qa-d --task-prefix DDD    # HOME=/tmp/qa/home-d
cd /tmp/qa/repod2 && orbit workspace init        # id ws_repod2, orbit_dir /tmp/qa/repod2/.orbit
orbit task add --title "D2 one" --description d --complexity low   # DDD-00000
rm -rf /tmp/qa/repod2                             # checkout deleted, no teardown

cd /tmp/qa/repod1 && orbit workspace list
#   repod2  ws_repod2  invalid  pr  hm_…  owner  /tmp/qa/repod2

cd /tmp/qa/repod1 && ORBIT_OPERATOR=1 orbit workspace remove repod2
#   error: invalid input: unknown workspace selector 'repod2'; pass a registered
#          workspace name, a logical workspace ID, or an absolute local checkout path
ORBIT_OPERATOR=1 orbit workspace remove ws_repod2            # same error
ORBIT_OPERATOR=1 orbit workspace remove /tmp/qa/repod2       # same error
```

The identical three failures reproduce in the external-root layout
(`orbit --root /tmp/qa/roota workspace init`).

Flipping the catalog entry's `status` back to `active` by hand in
`<root>/workspaces.json` makes the same command succeed immediately
(`workspace 'repob' removed from registry`), which isolates the status gate as
the only blocker; the removal logic itself is fine.

## Impact

Production impact: an operator cannot deregister a workspace whose checkout was
deleted without `orbit workspace teardown` — the state the `orphan-task-stores`
doctor check exists to diagnose. `workspace teardown` takes no target argument
(it acts on the current directory, which no longer exists), so the catalog row
is permanent. `docs/runbooks/health-checks.md` documents a command that always
fails.

Validation impact: none — no test covers `workspace remove` against a
non-`active` workspace, which is why ORB-12150 shipped green.

## Suggested direction

Rename the positional's clap id so it stops shadowing the global selector (for
example `#[arg(value_name = "WORKSPACE", id = "workspace_selector")]`, or rename
the field), and add a regression test that removes a workspace whose checkout
directory is gone through all three selector forms. Consider making
`resolve_workspace_selector`'s non-`Active` refusal say so, rather than reusing
the "unknown selector" wording for a workspace the catalog clearly lists.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Assigned the workspace remove positional a distinct Clap argument ID (workspace_selector), preventing it from shadowing the global --workspace selector during runtime bootstrap.
- Added an end-to-end regression that initializes three workspaces, deletes their checkout directories, and deregisters them by name, logical ws_* ID, and recorded absolute path.
- Updated the existing ambiguous-selector regression to grant the operator capability for workspace removal, so it reaches the intended command-level ambiguity check after the parser fix.
Assessment: The fix is minimal and preserves the existing removal implementation while covering the documented deleted-checkout recovery workflow at the real CLI boundary.

Acceptance criteria and task mandate:
- Deleted checkout removal through all three supported selector forms: passed by the new integration test.
- Positional and global workspace selectors remain distinct: passed by the end-to-end test and full workspace-selector suite.

Validation:
- cargo fmt --all -- --check: passed.
- cargo test -p orbit-cli --test workspace_selector workspace_remove_deregisters_deleted_checkout_by_name_id_and_path -- --exact: passed.
- cargo test -p orbit-cli --test workspace_selector: passed, 9 tests.
- make ci-fast: passed; its compiler-cache namespace subcheck reported the expected bubblewrap permission skip in this environment.
- make ci-lint: passed with workspace all-target clippy and warnings denied.
- git diff --check: passed; final status contains only the two intended tracked test/source modifications.

Remaining risks: Validation exercised Linux only; no platform-specific behavior was changed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12169-6aa3cc61`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus