### PR TITLE
[code-review] `orbit mcp init/remove --claude --scope home` rewrites all of `~/.claude.json` with an unlocked, non-atomic write

### DIFF
--- a/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/dispatch.rs
@@ -68,6 +68,7 @@ pub(super) struct ConfigTarget {
     pub(super) mcp_path: PathBuf,
     pub(super) legacy_mcp_path: Option<PathBuf>,
     pub(super) settings_path: Option<PathBuf>,
+    pub(super) scope: ScopeArg,
 }
 
 impl ConfigTarget {
@@ -84,12 +85,14 @@ impl ConfigTarget {
                     mcp_path: home.join(".claude.json"),
                     legacy_mcp_path: Some(home.join(".claude").join(".mcp.json")),
                     settings_path: Some(home.join(".claude").join("settings.json")),
+                    scope,
                 })
             }
             (ScopeArg::Workspace, McpProvider::Claude) => Ok(Self {
                 mcp_path: repo_root.join(".mcp.json"),
                 legacy_mcp_path: Some(repo_root.join(".claude.json")),
                 settings_path: Some(repo_root.join(".claude").join("settings.json")),
+                scope,
             }),
             (ScopeArg::Home, McpProvider::Codex) => {
                 let home = require_home_dir(home_dir)?;
@@ -97,12 +100,14 @@ impl ConfigTarget {
                     mcp_path: home.join(".codex").join("config.toml"),
                     legacy_mcp_path: None,
                     settings_path: None,
+                    scope,
                 })
             }
             (ScopeArg::Workspace, McpProvider::Codex) => Ok(Self {
                 mcp_path: repo_root.join(".codex").join("config.toml"),
                 legacy_mcp_path: None,
                 settings_path: None,
+                scope,
             }),
             (ScopeArg::Home, McpProvider::Gemini) => {
                 let home = require_home_dir(home_dir)?;
@@ -110,12 +115,14 @@ impl ConfigTarget {
                     mcp_path: home.join(".gemini").join("settings.json"),
                     legacy_mcp_path: None,
                     settings_path: None,
+                    scope,
                 })
             }
             (ScopeArg::Workspace, McpProvider::Gemini) => Ok(Self {
                 mcp_path: repo_root.join(".gemini").join("settings.json"),
                 legacy_mcp_path: None,
                 settings_path: None,
+                scope,
             }),
             (ScopeArg::Home, McpProvider::Antigravity) => {
                 let home = require_home_dir(home_dir)?;
@@ -123,12 +130,14 @@ impl ConfigTarget {
                     mcp_path: home.join(".gemini").join("config").join("mcp_config.json"),
                     legacy_mcp_path: None,
                     settings_path: None,
+                    scope,
                 })
             }
             (ScopeArg::Workspace, McpProvider::Antigravity) => Ok(Self {
                 mcp_path: repo_root.join(".agents").join("mcp_config.json"),
                 legacy_mcp_path: None,
                 settings_path: None,
+                scope,
             }),
             (ScopeArg::Home, McpProvider::Grok) => {
                 let home = require_home_dir(home_dir)?;
@@ -136,12 +145,14 @@ impl ConfigTarget {
                     mcp_path: home.join(".grok").join("config.toml"),
                     legacy_mcp_path: None,
                     settings_path: None,
+                    scope,
                 })
             }
             (ScopeArg::Workspace, McpProvider::Grok) => Ok(Self {
                 mcp_path: repo_root.join(".grok").join("config.toml"),
                 legacy_mcp_path: None,
                 settings_path: None,
+                scope,
             }),
             (ScopeArg::Home, McpProvider::Cursor) => {
                 let home = require_home_dir(home_dir)?;
@@ -149,12 +160,14 @@ impl ConfigTarget {
                     mcp_path: home.join(".cursor").join("mcp.json"),
                     legacy_mcp_path: None,
                     settings_path: None,
+                    scope,
                 })
             }
             (ScopeArg::Workspace, McpProvider::Cursor) => Ok(Self {
                 mcp_path: repo_root.join(".cursor").join("mcp.json"),
                 legacy_mcp_path: None,
                 settings_path: None,
+                scope,
             }),
             (ScopeArg::Home, McpProvider::Vscode) => {
                 let home = require_home_dir(home_dir)?;
@@ -162,12 +175,14 @@ impl ConfigTarget {
                     mcp_path: vscode_home_user_dir(home).join("mcp.json"),
                     legacy_mcp_path: None,
                     settings_path: None,
+                    scope,
                 })
             }
             (ScopeArg::Workspace, McpProvider::Vscode) => Ok(Self {
                 mcp_path: repo_root.join(".vscode").join("mcp.json"),
                 legacy_mcp_path: None,
                 settings_path: None,
+                scope,
             }),
             (ScopeArg::Home, McpProvider::Windsurf) => {
                 let home = require_home_dir(home_dir)?;
@@ -178,6 +193,7 @@ impl ConfigTarget {
                         .join("mcp_config.json"),
                     legacy_mcp_path: None,
                     settings_path: None,
+                    scope,
                 })
             }
             (ScopeArg::Workspace, McpProvider::Windsurf) => Ok(Self {
@@ -187,6 +203,7 @@ impl ConfigTarget {
                     .join("mcp_config.json"),
                 legacy_mcp_path: None,
                 settings_path: None,
+                scope,
             }),
         }
     }

--- a/crates/orbit-cli/src/command/mcp/setup/format/json.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/format/json.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::Path;
 
+use orbit_common::fs::io::atomic_write_text;
 use orbit_core::OrbitError;
 use serde_json::{Map as JsonMap, Value as JsonValue};
 
@@ -73,6 +74,23 @@ pub(in crate::command::mcp::setup) fn write_json_object(
     rendered.push('\n');
     fs::write(path, rendered)
         .map_err(|err| OrbitError::Io(format!("failed to write '{}': {err}", path.display())))
+}
+
+pub(in crate::command::mcp::setup) fn write_json_object_atomic(
+    path: &Path,
+    root: &JsonMap<String, JsonValue>,
+) -> Result<(), OrbitError> {
+    let mut rendered =
+        serde_json::to_string_pretty(&JsonValue::Object(root.clone())).map_err(|err| {
+            OrbitError::Execution(format!("serialize JSON '{}': {err}", path.display()))
+        })?;
+    rendered.push('\n');
+    atomic_write_text(path, &rendered).map_err(|err| {
+        OrbitError::Io(format!(
+            "failed to atomically write '{}': {err}",
+            path.display()
+        ))
+    })
 }
 
 pub(in crate::command::mcp::setup) fn write_or_remove_json_object(

--- a/crates/orbit-cli/src/command/mcp/setup/providers/claude.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/claude.rs
@@ -1,12 +1,14 @@
 use std::fs;
 use std::path::Path;
 
+use orbit_common::fs::io::with_exclusive_file_lock;
 use orbit_core::OrbitError;
 use orbit_types::tool::mcp_advertised_tool_name;
 use serde_json::{Map as JsonMap, Value as JsonValue};
 
 use crate::command::mcp::{ORBIT_MCP_SERVER_ID, safe_mcp_tool_names};
 
+use super::super::args::ScopeArg;
 use super::super::dispatch::ConfigTarget;
 use super::super::format::*;
 use super::common::{ServerLaunch, server_args, server_id};
@@ -18,10 +20,21 @@ pub(in crate::command::mcp::setup) fn apply_claude_init(
     let server_id = server_id(launch);
     cleanup_legacy_mcp_path(target, server_id)?;
 
-    let mut root = load_json_object(&target.mcp_path)?;
-    let mcp_servers = ensure_json_object(&mut root, "mcpServers")?;
-    mcp_servers.insert(server_id.to_string(), claude_mcp_server_value(launch));
-    write_json_object(&target.mcp_path, &root)?;
+    let update_mcp = || {
+        let mut root = load_json_object(&target.mcp_path)?;
+        let mcp_servers = ensure_json_object(&mut root, "mcpServers")?;
+        mcp_servers.insert(server_id.to_string(), claude_mcp_server_value(launch));
+        if target.scope == ScopeArg::Home {
+            write_json_object_atomic(&target.mcp_path, &root)
+        } else {
+            write_json_object(&target.mcp_path, &root)
+        }
+    };
+    if target.scope == ScopeArg::Home {
+        with_exclusive_file_lock(&target.mcp_path, "Claude Code main settings", update_mcp)?;
+    } else {
+        update_mcp()?;
+    }
 
     if let Some(settings_path) = &target.settings_path {
         let mut settings = load_json_object(settings_path)?;
@@ -37,17 +50,31 @@ pub(in crate::command::mcp::setup) fn apply_claude_remove(
     target: &ConfigTarget,
     server_id: &str,
 ) -> Result<(), OrbitError> {
-    let mut root = load_json_object(&target.mcp_path)?;
-    if let Some(mcp_servers) = root
-        .get_mut("mcpServers")
-        .and_then(JsonValue::as_object_mut)
-    {
-        mcp_servers.remove(server_id);
-        if mcp_servers.is_empty() {
-            root.remove("mcpServers");
+    let remove_mcp = || {
+        let mut root = load_json_object(&target.mcp_path)?;
+        if let Some(mcp_servers) = root
+            .get_mut("mcpServers")
+            .and_then(JsonValue::as_object_mut)
+        {
+            mcp_servers.remove(server_id);
+            if mcp_servers.is_empty() {
+                root.remove("mcpServers");
+            }
         }
+        if target.scope == ScopeArg::Home {
+            if target.mcp_path.exists() {
+                write_json_object_atomic(&target.mcp_path, &root)?;
+            }
+            Ok(())
+        } else {
+            write_or_remove_json_object(&target.mcp_path, &root)
+        }
+    };
+    if target.scope == ScopeArg::Home {
+        with_exclusive_file_lock(&target.mcp_path, "Claude Code main settings", remove_mcp)?;
+    } else {
+        remove_mcp()?;
     }
-    write_or_remove_json_object(&target.mcp_path, &root)?;
     cleanup_legacy_mcp_path(target, server_id)?;
 
     if let Some(settings_path) = &target.settings_path {

--- a/crates/orbit-cli/src/command/mcp/setup/providers/tests/claude.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/tests/claude.rs
@@ -1,5 +1,7 @@
 use tempfile::tempdir;
 
+use orbit_common::fs::io::{atomic_write_text, with_exclusive_file_lock};
+
 use super::super::super::args::{McpAction, McpProvider, ProviderSelectionMode, ScopeArg};
 use super::super::super::dispatch::run_action;
 use super::super::claude::*;
@@ -117,6 +119,11 @@ fn claude_home_scope_uses_documented_user_file_and_cleans_legacy_file() {
     let home = tempdir().expect("home tempdir");
     std::fs::create_dir_all(home.path().join(".claude")).expect("create claude home");
     std::fs::write(
+        home.path().join(".claude.json"),
+        "{\n  \"userState\": \"preserve-me\"\n}\n",
+    )
+    .expect("write existing Claude state");
+    std::fs::write(
         home.path().join(".claude").join(".mcp.json"),
         "{\n  \"mcpServers\": {\n    \"orbit\": {\"command\": \"orbit\"},\n    \"legacy-other\": {\"command\": \"demo\"}\n  }\n}\n",
     )
@@ -138,6 +145,7 @@ fn claude_home_scope_uses_documented_user_file_and_cleans_legacy_file() {
         &std::fs::read_to_string(home.path().join(".claude.json")).expect("read user mcp"),
     )
     .expect("parse user mcp");
+    assert_eq!(mcp["userState"], "preserve-me");
     assert!(mcp["mcpServers"]["orbit"].is_object());
 
     let legacy: serde_json::Value = serde_json::from_str(
@@ -158,7 +166,13 @@ fn claude_home_scope_uses_documented_user_file_and_cleans_legacy_file() {
     )
     .expect("remove claude home scope");
 
-    assert!(!home.path().join(".claude.json").exists());
+    let mcp: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(home.path().join(".claude.json"))
+            .expect("read preserved user mcp after remove"),
+    )
+    .expect("parse preserved user mcp after remove");
+    assert_eq!(mcp["userState"], "preserve-me");
+    assert!(mcp.get("mcpServers").is_none());
     let legacy: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(home.path().join(".claude").join(".mcp.json"))
             .expect("read legacy user mcp after remove"),
@@ -166,6 +180,66 @@ fn claude_home_scope_uses_documented_user_file_and_cleans_legacy_file() {
     .expect("parse legacy user mcp after remove");
     assert!(legacy["mcpServers"]["orbit"].is_null());
     assert!(legacy["mcpServers"]["legacy-other"].is_object());
+}
+
+#[test]
+fn claude_home_scope_waits_for_concurrent_state_update_before_reading() {
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    let orbit_root = repo.path().join(".orbit");
+    std::fs::create_dir_all(&orbit_root).expect("create orbit root");
+    let mcp_path = home.path().join(".claude.json");
+    std::fs::write(&mcp_path, "{\n  \"userState\": \"before\"\n}\n")
+        .expect("write initial Claude state");
+
+    let (lock_ready_tx, lock_ready_rx) = std::sync::mpsc::sync_channel(0);
+    let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+    let held_path = mcp_path.clone();
+    let holder = std::thread::spawn(move || {
+        with_exclusive_file_lock(&held_path, "test Claude Code writer", || {
+            lock_ready_tx
+                .send(())
+                .expect("notify that Claude lock is held");
+            release_rx.recv().expect("wait for test release");
+            Ok::<(), std::io::Error>(())
+        })
+        .expect("hold Claude lock");
+    });
+    lock_ready_rx.recv().expect("wait for Claude lock holder");
+
+    let worker_repo = repo.path().to_path_buf();
+    let worker_home = home.path().to_path_buf();
+    let worker_orbit_root = orbit_root.clone();
+    let worker = std::thread::spawn(move || {
+        run_action(
+            McpAction::Init(ServerLaunch::default()),
+            &worker_repo,
+            &worker_orbit_root,
+            ProviderSelectionMode::Explicit(vec![McpProvider::Claude]),
+            Some(worker_home),
+            ScopeArg::Home,
+        )
+    });
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    assert!(
+        !worker.is_finished(),
+        "Claude init must wait for the state-file lock before reading"
+    );
+    atomic_write_text(&mcp_path, "{\n  \"userState\": \"during\"\n}\n")
+        .expect("write concurrent Claude state update");
+    release_tx.send(()).expect("release Claude lock");
+    holder.join().expect("join Claude lock holder");
+    worker
+        .join()
+        .expect("join Claude init")
+        .expect("Claude init after concurrent update");
+
+    let mcp: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&mcp_path).expect("read final Claude state"))
+            .expect("parse final Claude state");
+    assert_eq!(mcp["userState"], "during");
+    assert!(mcp["mcpServers"]["orbit"].is_object());
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-12165](https://orbit-cli.com/tasks/ORB-12165) — [code-review] `orbit mcp init/remove --claude --scope home` rewrites all of `~/.claude.json` with an unlocked, non-atomic write

### Description

ORB-12149 repointed Claude home-scope MCP setup from `~/.claude/.mcp.json` (a file Orbit solely owned) to `~/.claude.json` — Claude Code's live main state file. Orbit writes it with a plain read-modify-`fs::write`, ignoring the lock and atomic-rename protocol Claude Code uses, so a concurrent Claude Code write is clobbered or Orbit's registration is silently lost.

## Evidence

- `crates/orbit-cli/src/command/mcp/setup/dispatch.rs:82-88` — home-scope Claude now targets `mcp_path: home.join(".claude.json")`.
- `crates/orbit-cli/src/command/mcp/setup/providers/claude.rs:14-34` and `:36-52` — init and remove do `load_json_object(&target.mcp_path)` → mutate → `write_json_object` / `write_or_remove_json_object`. No lock is taken anywhere between the read and the write.
- `crates/orbit-cli/src/command/mcp/setup/format/json.rs:36-57` reads the whole file; `:60-76` serializes the whole root and calls `fs::write(path, rendered)` — truncate-in-place, no temp file, no rename, no `.lock`.
- This repository already documents the conflicting protocol: `crates/orbit-exec/src/macos_sandbox/provider_dirs.rs:232-260` and `docs/design/policy-sandbox/4_decisions.md:226-239` state that "Claude Code persists its main settings to `$HOME/.claude.json` — a sibling *file* at the home root, with `.lock` and atomic-write `.tmp.<pid>.<ms_ts>` companions", and that tool calls wait on that state-file lock.
- `crates/orbit-cli/src/command/mcp/setup/format/json.rs:78-91` — on `remove`, an empty root deletes the file outright; the new test `claude_home_scope_uses_documented_user_file_and_cleans_legacy_file` asserts exactly that (`providers/tests/claude.rs`), so `orbit mcp remove --claude --scope home` can delete `~/.claude.json` rather than only its `mcpServers` entry.

## Failure scenario

A user runs `orbit mcp init --claude --scope home` from inside a running Claude Code session (the most likely place to run it). Orbit reads `~/.claude.json`, adds `mcpServers.orbit`, and rewrites the whole file. Claude Code then flushes its own in-memory state under its lock and overwrites the file — Orbit's registration disappears with no error, which is the same class of "the Orbit MCP server is never registered" symptom ORB-12149 set out to fix. In the opposite interleaving Orbit's truncating write lands after Claude's, discarding whatever Claude just persisted (project history, onboarding and account state). The `fs::write` is not atomic, so a crash mid-write leaves a truncated `~/.claude.json`.

## Expected

Home-scope Claude writes should respect the file's owner: take the `~/.claude.json.lock` Claude Code uses, write via a temp file plus rename, and never remove the file when only Orbit's `mcpServers` entry was deleted.

### Acceptance Criteria

- Home-scope `orbit mcp init --claude` updates `~/.claude.json` without a plain truncating whole-file `fs::write`: the update is serialized against Claude Code's lock file and published by an atomic rename.
- Home-scope `orbit mcp remove --claude` removes only Orbit's `mcpServers` entry and never deletes a `~/.claude.json` that Orbit did not create.
- A test demonstrates that a concurrent modification of `~/.claude.json` between Orbit's read and write is not silently discarded.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added scope metadata to MCP config targets so Claude home state is handled distinctly.
- Added an atomic JSON writer backed by orbit-common's rename-based atomic filesystem primitive.
- Wrapped home-scope Claude `~/.claude.json` read-modify-write operations in the documented sibling lock and preserved the file on remove, while leaving workspace and other-provider behavior unchanged.
- Extended Claude provider coverage for preserving existing home state, removing only Orbit's entry, and waiting through a concurrent locked state update.

Acceptance criteria:
- Home init uses `~/.claude.json.lock` via `with_exclusive_file_lock` and publishes through `atomic_write_text`; no home-state path uses the truncating generic writer.
- Home remove atomically rewrites an existing state file after removing only Orbit's `mcpServers` entry and does not delete the file.
- `claude_home_scope_waits_for_concurrent_state_update_before_reading` holds the lock, verifies init waits, applies a concurrent atomic state update, then verifies both the update and Orbit registration survive.

Validation:
- PASSED: `cargo test -p orbit-cli claude_home_scope -- --nocapture` (2 passed).
- PASSED: `cargo test -p orbit-cli command::mcp::setup::providers::tests::claude -- --nocapture` (7 passed).
- PASSED: `cargo fmt --all -- --check`.
- PASSED: `make ci-fast`; its existing unprivileged bubblewrap mount-namespace check reported a bounded environment skip.
- PASSED: `make ci-lint` (workspace clippy with warnings denied).
- PASSED: `git diff --check`.
- PASSED: `GIT_OPTIONAL_LOCKS=0 git status --short`; only the four task-scoped context files are modified.

Assessment: The repair is narrow, uses the repository's established lock and atomic-write primitives, and covers preservation, non-deletion, and lock serialization. Remaining risk is limited to platform-specific Claude Code behavior not directly exercised on macOS; the lock filename and atomic-write protocol match the repository's documented contract.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12165-6aa3cdbf`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus