### PR TITLE
[qa-sweep] `orbit doctor --fix-orphan-task-stores` help still promises "partitions that still hold task bundles are never deleted" while the repair deletes them

### DIFF
--- a/crates/orbit-cli/src/command/doctor.rs
+++ b/crates/orbit-cli/src/command/doctor.rs
@@ -36,11 +36,11 @@ pub struct DoctorCommand {
     #[arg(long)]
     pub fix_retired_activity_backends: bool,
 
-    /// Delete empty task-store partitions that no workspace binding on this host claims. Partitions that still hold task bundles are never deleted. Requires --confirm.
+    /// Delete empty unclaimed task-store partitions, and populated partitions whose bound checkout is confirmed absent (including their task bundles). Unowned or unreachable populated partitions are never touched. Requires --confirm.
     #[arg(long)]
     pub fix_orphan_task_stores: bool,
 
-    /// Confirm a destructive repair. Required by --fix-orphan-task-stores, which deletes partition directories.
+    /// Confirm a destructive repair. Required by --fix-orphan-task-stores, which deletes partition directories and their task bundles.
     #[arg(long)]
     pub confirm: bool,
 }
@@ -114,7 +114,7 @@ impl Execute for DoctorCommand {
         if self.fix_orphan_task_stores {
             if !self.confirm {
                 return Err(orbit_core::OrbitError::InvalidInput(
-                    "--fix-orphan-task-stores deletes task-store partition directories. Pass --confirm to proceed."
+                    "--fix-orphan-task-stores deletes task-store partition directories and their task bundles. Pass --confirm to proceed."
                         .to_string(),
                 ));
             }

--- a/crates/orbit-cli/src/command/tests/doctor.rs
+++ b/crates/orbit-cli/src/command/tests/doctor.rs
@@ -1,8 +1,9 @@
+use clap::CommandFactory;
 use orbit_cmd::{OrphanTaskStoreRemoval, WorkspaceDoctorResult, WorkspaceDoctorStatus};
 use orbit_core::OrbitRuntime;
 
 use super::super::doctor::{doctor_row_json, human_detail, orphan_task_store_removal_message};
-use super::super::{CommandOutput, Execute};
+use super::super::{Cli, CommandOutput, Execute};
 
 #[test]
 fn doctor_warning_renders_structured_and_human_remediation() {
@@ -194,5 +195,63 @@ fn orphan_task_store_removal_message_reports_zero_of_both_kinds() {
         message,
         "Removed 0 empty orphaned task-store partition(s) and 0 populated partition(s) \
          (0 task bundle(s))."
+    );
+}
+
+/// [ORB-12171] The help text for `--fix-orphan-task-stores` and `--confirm`
+/// must accurately document that populated partitions whose checkout binding
+/// is confirmed absent are deleted along with their task bundles, rather than
+/// promising that partitions with task bundles are never deleted.
+#[test]
+fn fix_orphan_task_stores_help_documents_bundle_deletion_on_confirmed_absent_checkouts() {
+    let mut command = Cli::command();
+    let doctor = command
+        .find_subcommand_mut("doctor")
+        .expect("doctor subcommand");
+    let help = doctor.render_long_help().to_string();
+
+    assert!(
+        help.contains("--fix-orphan-task-stores"),
+        "expected --fix-orphan-task-stores in doctor help: {help}"
+    );
+    assert!(
+        help.contains("Delete empty unclaimed task-store partitions, and populated partitions whose bound checkout is confirmed absent (including their task bundles)."),
+        "expected accurate fix-orphan-task-stores description in help: {help}"
+    );
+    assert!(
+        help.contains("Unowned or unreachable populated partitions are never touched."),
+        "expected guard documentation in help: {help}"
+    );
+    assert!(
+        !help.contains("Partitions that still hold task bundles are never deleted"),
+        "help must not promise populated partitions are never deleted: {help}"
+    );
+    assert!(
+        help.contains("Required by --fix-orphan-task-stores, which deletes partition directories and their task bundles"),
+        "expected --confirm help to mention task bundle deletion: {help}"
+    );
+}
+
+#[test]
+fn fix_orphan_task_stores_without_confirm_fails_with_bundle_loss_message() {
+    let runtime = OrbitRuntime::in_memory().expect("build in-memory runtime");
+    let err = super::super::doctor::DoctorCommand {
+        json: false,
+        fix_stale_locks: false,
+        fix_stale_task_locks: false,
+        remove_graph: false,
+        fix_stale_artifacts: false,
+        fix_retired_activity_backends: false,
+        fix_orphan_task_stores: true,
+        confirm: false,
+    }
+    .execute(&runtime)
+    .expect_err("fix_orphan_task_stores must require confirm");
+
+    assert!(
+        err.to_string().contains(
+            "--fix-orphan-task-stores deletes task-store partition directories and their task bundles. Pass --confirm to proceed."
+        ),
+        "expected error message to mention bundle loss, got: {err}"
     );
 }


### PR DESCRIPTION
## Task

[ORB-12171](https://orbit-cli.com/tasks/ORB-12171) — [qa-sweep] `orbit doctor --fix-orphan-task-stores` help still promises "partitions that still hold task bundles are never deleted" while the repair deletes them

### Description

## Summary

Clap renders the `--fix-orphan-task-stores` doc comment as the public help for a
destructive repair, and it still describes the pre-ORB-12143 behavior:

```
      --fix-orphan-task-stores
          Delete empty task-store partitions that no workspace binding on this host
          claims. Partitions that still hold task bundles are never deleted.
          Requires --confirm
```

Since ORB-12143 (`ef18bb063`) / ORB-12144 (`cb9809ddd`) / ORB-12150 (`a90d36b33`)
the repair also deletes **populated** partitions whose checkout binding is
confirmed stale, together with their task bundles. That is the documented,
intended behavior — `docs/runbooks/health-checks.md:141-168` and
`RemovedTaskStores` (`crates/orbit-cmd/src/task_store.rs:139-200`) both state it,
and the doctor row's own remediation now says "Populated stale partitions are
deleted along with their task bundles." Only the CLI help still denies it, and
the CLI help is what an operator reads immediately before typing `--confirm`.

## Reproduction (orbit 0.21.0 built from `f9122f5a1`, Linux)

Disposable `HOME` under `/tmp`, every `orbit_common::test_env::INHERITED_AUTHORITY_ENV`
variable cleared, routing verified with `orbit workspace show --format json`
before any mutation.

```sh
orbit init --non-interactive --host-name qa-d --task-prefix DDD
cd /tmp/qa/repod2 && orbit workspace init          # orbit_dir /tmp/qa/repod2/.orbit
orbit task add --title "D2 one" --description d --complexity low     # DDD-00000
orbit task add --title "D2 two" --description d --complexity low     # DDD-00001
rm -rf /tmp/qa/repod2

cd /tmp/qa/repod1 && orbit doctor --help | sed -n '/fix-orphan-task-stores/,+3p'
#   Delete empty task-store partitions that no workspace binding on this host claims.
#   Partitions that still hold task bundles are never deleted. Requires --confirm

cd /tmp/qa/repod1 && orbit doctor --fix-orphan-task-stores --confirm
#   Removed 0 empty orphaned task-store partition(s) and 1 populated partition(s)
#   (2 task bundle(s)).

ls ~/.orbit/tasks/workspaces/        # ws_repod2 and both bundles are gone
```

## Impact

Production impact: an operator who reads the flag's own help believes the repair
cannot lose task data and runs it with `--confirm`; it silently deletes task
bundles for any partition whose checkout is confirmed gone. The task data is not
recoverable from Orbit afterwards. The behavior itself is correct and
intentional; only the advertised contract is wrong.

Validation impact: none — no test asserts the help text.

## Suggested direction

Rewrite the doc comment on `DoctorArgs::fix_orphan_task_stores`
(`crates/orbit-cli/src/command/doctor.rs`) to match the runbook's evidence rule:
empty unclaimed partitions are removed, and populated partitions are removed
only when their bound checkout is confirmed absent — including their task
bundles; unowned or unreachable populated partitions are never touched. While
there, check the sibling `--confirm` help, which describes the repair as
deleting "partition directories" without naming the bundle loss.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Updated `--fix-orphan-task-stores` and `--confirm` flag documentation in `crates/orbit-cli/src/command/doctor.rs` and added test coverage in `crates/orbit-cli/src/command/tests/doctor.rs`.

### Changes
- Rewrote doc comment on `DoctorCommand::fix_orphan_task_stores` in `crates/orbit-cli/src/command/doctor.rs` to accurately describe the evidence rule and data loss: empty unclaimed partitions, and populated partitions whose bound checkout is confirmed absent, are deleted along with their task bundles, while unowned or unreachable populated partitions are preserved.
- Updated doc comment on sibling `--confirm` flag in `DoctorCommand` to explicitly document that `--fix-orphan-task-stores` deletes partition directories and their task bundles.
- Updated runtime error message when `--fix-orphan-task-stores` is passed without `--confirm` to mention that task bundles are deleted along with partition directories.
- Added unit tests in `crates/orbit-cli/src/command/tests/doctor.rs` asserting that `orbit doctor --help` renders the updated documentation without the outdated promise that task bundles are never deleted, and verified error behavior when `--confirm` is omitted.

### Validation
- `cargo test -p orbit-cli --bin orbit doctor`: passed (12 tests passed, including new help and confirmation checks)
- `cargo test -p orbit-cli --bin orbit`: passed (533 tests passed)
- `make ci-fast`: passed
- `make ci-lint`: passed (0 warnings, 0 errors)
- `git diff --check`: passed
- `git status --short`: clean modifications to scoped files only

### Remaining risks
None identified.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12171-6aa3ce01`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus