### PR TITLE
[qa-sweep] `orbit task list` reports a lost task index as `invalid_input`, rendering "invalid input:" inside the recovery sentence

### DIFF
--- a/crates/orbit-cli/src/command/task/list.rs
+++ b/crates/orbit-cli/src/command/task/list.rs
@@ -119,7 +119,7 @@ impl Execute for TaskListArgs {
         if tasks.is_empty() {
             let count = runtime.unindexed_task_bundle_count()?;
             if count > 0 {
-                return Err(OrbitError::InvalidInput(format!(
+                return Err(OrbitError::Store(format!(
                     "task index is missing {count} on-disk bundle(s); run `orbit task reindex` to recover them"
                 )));
             }

--- a/crates/orbit-cli/tests/mcp_setup_root.rs
+++ b/crates/orbit-cli/tests/mcp_setup_root.rs
@@ -220,8 +220,30 @@ fn external_root_task_index_loss_is_reported_and_reindexed() {
         .orbit(&fixture.checkout, &fixture.rooted(&["task", "list"]))
         .failure();
     let stderr = String::from_utf8_lossy(&listed.get_output().stderr);
-    assert!(stderr.contains("on-disk bundle"), "stderr: {stderr}");
-    assert!(stderr.contains("task reindex"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("error: store error: task index is missing 1 on-disk bundle(s); run `orbit task reindex` to recover them"),
+        "stderr: {stderr}"
+    );
+    assert!(!stderr.contains("invalid input"), "stderr: {stderr}");
+
+    let listed_json = fixture
+        .orbit(
+            &fixture.checkout,
+            &fixture.rooted(&["task", "list", "--format", "json"]),
+        )
+        .failure();
+    let stderr_json = String::from_utf8_lossy(&listed_json.get_output().stderr);
+    let error_payload: Value = serde_json::from_str(stderr_json.trim()).expect("error json");
+    assert_eq!(error_payload["code"], "store_error", "json: {stderr_json}");
+    assert_eq!(
+        error_payload["error"],
+        "store error: task index is missing 1 on-disk bundle(s); run `orbit task reindex` to recover them",
+        "json: {stderr_json}"
+    );
+    assert!(
+        !stderr_json.contains("invalid_input"),
+        "json: {stderr_json}"
+    );
 
     fixture
         .orbit(&fixture.checkout, &fixture.rooted(&["task", "reindex"]))


### PR DESCRIPTION
## Task

[ORB-12172](https://orbit-cli.com/tasks/ORB-12172) — [qa-sweep] `orbit task list` reports a lost task index as `invalid_input`, rendering "invalid input:" inside the recovery sentence

### Description

## Summary

ORB-12151 (`7001a6878`) made `orbit task list` refuse to report an empty list
while the partition holds unindexed bundles — the right call. It raises that
condition as `OrbitError::InvalidInput`
(`crates/orbit-cli/src/command/task/list.rs:119-125`), so the user-facing text
carries the error-kind prefix and the machine-readable code says the caller's
input was wrong:

```
$ orbit task list
error: invalid input: task index is missing 3 on-disk bundle(s); run `orbit task reindex` to recover them

$ orbit task list --format json
{"code":"invalid_input","error":"invalid input: task index is missing 3 on-disk bundle(s); run `orbit task reindex` to recover them"}
```

Nothing about the invocation is invalid: this is a store-integrity condition
detected while serving a valid command. ORB-12037 treated the same shape — an
error-kind prefix rendered inside a user-facing remediation sentence, in
`orbit update` — as a defect and fixed it; this reintroduces it in a new place,
and additionally mislabels the `code` that scripts branch on.

## Reproduction (orbit 0.21.0 built from `f9122f5a1`, Linux)

Disposable `HOME` under `/tmp`, every `orbit_common::test_env::INHERITED_AUTHORITY_ENV`
variable cleared, routing verified with `orbit workspace show --format json`
before any mutation.

```sh
orbit --root /tmp/qa/roota init --non-interactive --host-name qa-a --task-prefix AAA
cd /tmp/qa/repoa && orbit --root /tmp/qa/roota workspace init
orbit --root /tmp/qa/roota task add --title "First task"  --description d --complexity low
orbit --root /tmp/qa/roota task add --title "Second task" --description d --complexity low
orbit --root /tmp/qa/roota task add --title "Third task"  --description d --complexity low

mv /tmp/qa/roota/tasks/index.sqlite /tmp/qa/index.bak     # the documented drift state

orbit --root /tmp/qa/roota task list              # exit 1, message above
orbit --root /tmp/qa/roota task list --format json # exit 1, {"code":"invalid_input", …}
orbit --root /tmp/qa/roota task reindex           # recovers: 3 bundle(s)
```

The rest of ORB-12151 works as intended and was verified in the same sweep:
`reindex` rebuilds the binding in the external-root layout, the tasks come back,
and the allocator continues at the next free id. The guard also does not misfire
— `task list --status done` and `task list --tag nope` against a healthy index
still exit 0 with an empty result.

## Impact

Production impact: cosmetic-plus — the operator is told their input was invalid
when it was not, and a JSON consumer that branches on `code` sees
`invalid_input` for a recoverable store-integrity condition, which is
indistinguishable from a genuine bad-argument error.

Validation impact: none.

## Suggested direction

Raise the condition with an error kind that describes it (a `Store`/state
variant, or the same treatment ORB-12037 applied: keep the refusal, but render
the remediation sentence without the error-kind prefix), and assert the rendered
text and JSON `code` in the ORB-12151 regression test rather than only the
message substring.

### Acceptance Criteria

- orbit task list raises OrbitError::Store rather than OrbitError::InvalidInput when unindexed task bundles exist and task listing returns empty
- Human-readable error rendering produces `error: store error: task index is missing ...; run `orbit task reindex` to recover them` without an `invalid input:` prefix
- JSON-formatted error output produces machine-readable `code: "store_error"` instead of `"invalid_input"`
- Regression test external_root_task_index_loss_is_reported_and_reindexed verifies both the rendered error text and the JSON error payload

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Changed `orbit task list` unindexed bundle guard in `crates/orbit-cli/src/command/task/list.rs` to return `OrbitError::Store` rather than `OrbitError::InvalidInput`.
- Rendered user-facing error text now reads `error: store error: task index is missing {count} on-disk bundle(s); run `orbit task reindex` to recover them` without leaking `invalid input:` into the recovery sentence.
- JSON error reporting now produces machine-readable `code: "store_error"` rather than `"invalid_input"`.
- Updated regression test `external_root_task_index_loss_is_reported_and_reindexed` in `crates/orbit-cli/tests/mcp_setup_root.rs` to assert the rendered error text without `invalid input` and assert JSON `code: "store_error"`.

Acceptance criteria:
- `orbit task list` raises `OrbitError::Store` rather than `OrbitError::InvalidInput` when unindexed task bundles exist and task listing returns empty: passed.
- Human-readable error rendering produces `error: store error: task index is missing ...; run `orbit task reindex` to recover them` without an `invalid input:` prefix: passed.
- JSON-formatted error output produces machine-readable `code: "store_error"` instead of `"invalid_input"`: passed.
- Regression test `external_root_task_index_loss_is_reported_and_reindexed` verifies both the rendered error text and the JSON error payload: passed.

Validation:
- `cargo test -p orbit-cli --test mcp_setup_root external_root_task_index_loss_is_reported_and_reindexed`: passed.
- `cargo test -p orbit-cli --test mcp_setup_root`: passed (8 tests).
- `cargo test -p orbit-cli --test task_publication --test task_tags --test task_trimmed_surface --test shared_root_task_isolation`: passed (17 tests).
- `cargo fmt --all -- --check`: passed.
- `make ci-fast`: passed.
- `make ci-lint`: passed (workspace-wide clippy with -D warnings).
- `git diff --check`: passed (clean).
- `git status --short`: only declared context files modified (`crates/orbit-cli/src/command/task/list.rs` and `crates/orbit-cli/tests/mcp_setup_root.rs`).

Assessment: Targeted fix aligning error classification with store-integrity reality and eliminating the misleading `invalid input:` error prefix and code. No known remaining risks or deviations.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12172-6aa3d00e`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus