### PR TITLE
[qa-sweep] In the shared external-root layout a deleted checkout's task partition is claimed forever: `workspace init` writes no checkout binding, so doctor can never classify it stale

### DIFF
--- a/crates/orbit-cmd/src/task_store.rs
+++ b/crates/orbit-cmd/src/task_store.rs
@@ -261,6 +261,9 @@ struct PartitionClaims {
     /// Registered task workspaces, live workspace catalog ids, and the
     /// synthetic partition every `--root <data-dir>` write lands in.
     claimed: BTreeSet<String>,
+    /// Task-registry bindings that carry their own checkout paths. Their
+    /// evidence takes precedence over a catalog checkout with the same id.
+    checkout_bound: BTreeSet<String>,
     /// Bindings or catalog checkouts that are confirmed absent.
     gone: BTreeSet<String>,
     /// Bindings or catalog checkouts whose filesystem state could not be
@@ -274,6 +277,7 @@ fn partition_claims(global_root: &Path) -> Result<PartitionClaims, OrbitError> {
     let tasks = open_task_registry(global_root)?;
     let mut claims = PartitionClaims {
         claimed: BTreeSet::new(),
+        checkout_bound: BTreeSet::new(),
         gone: BTreeSet::new(),
         unreachable: BTreeMap::new(),
     };
@@ -285,7 +289,8 @@ fn partition_claims(global_root: &Path) -> Result<PartitionClaims, OrbitError> {
             claims.claimed.insert(workspace_id);
             continue;
         };
-        match checkout_evidence(&checkout.orbit_dir) {
+        claims.checkout_bound.insert(workspace_id.clone());
+        match checkout_evidence(&checkout.repo_root) {
             CheckoutEvidence::Present => {
                 claims.claimed.insert(workspace_id);
             }
@@ -325,66 +330,77 @@ fn partition_claims(global_root: &Path) -> Result<PartitionClaims, OrbitError> {
     Ok(claims)
 }
 
-/// Add a catalog checkout's claim without overriding stronger evidence from a
-/// task-registry binding that uses the same partition id.
+/// Add a catalog checkout's claim when the task registry has only a path-free
+/// logical registration for the same partition id.
 fn record_catalog_checkout_evidence(
     claims: &mut PartitionClaims,
     workspace_id: &str,
     checkout: &WorkspaceCheckout,
 ) {
-    match checkout_evidence(&checkout.orbit_dir) {
+    // A task-registry checkout binding has a more specific identity than the
+    // catalog fallback. This matters when legacy or reindexed state names the
+    // same partition with different path metadata.
+    if claims.checkout_bound.contains(workspace_id) {
+        return;
+    }
+
+    match checkout_evidence(&checkout.repo_root) {
         CheckoutEvidence::Present => {
             claims.claimed.insert(workspace_id.to_string());
             claims.gone.remove(workspace_id);
             claims.unreachable.remove(workspace_id);
         }
         CheckoutEvidence::Gone => {
-            if !claims.claimed.contains(workspace_id) {
-                claims.gone.insert(workspace_id.to_string());
-                claims.unreachable.remove(workspace_id);
-            }
+            claims.claimed.remove(workspace_id);
+            claims.gone.insert(workspace_id.to_string());
+            claims.unreachable.remove(workspace_id);
         }
         CheckoutEvidence::Unreachable(reason) => {
-            if !claims.claimed.contains(workspace_id) && !claims.gone.contains(workspace_id) {
-                claims.unreachable.insert(workspace_id.to_string(), reason);
-            }
+            claims.claimed.remove(workspace_id);
+            claims.gone.remove(workspace_id);
+            claims.unreachable.insert(workspace_id.to_string(), reason);
         }
     }
 }
 
 /// What the filesystem can testify about a bound checkout directory.
 enum CheckoutEvidence {
-    /// The bound `orbit_dir` is there: the binding is a live claim.
+    /// The bound checkout root is there: the binding is a live claim.
     Present,
-    /// The bound `orbit_dir` is absent, and a directory we could actually read
-    /// said so: the checkout is gone.
+    /// The bound checkout root is absent, and a directory we could actually
+    /// read said so: the checkout is gone.
     Gone,
     /// Neither answer was available, naming the path and the failure.
     Unreachable(String),
 }
 
-/// Classify one bound checkout directory.
+/// Classify one bound checkout's repository root.
 ///
 /// `Path::exists()` collapses every stat failure into "absent", which made an
 /// unmounted volume or an unsearchable parent directory indistinguishable from
 /// a deleted checkout — and the repair deletes task bundles on that evidence
 /// [ORB-12143]. Absence must therefore be positively confirmed rather than
-/// inferred from a failed stat.
-fn checkout_evidence(orbit_dir: &Path) -> CheckoutEvidence {
-    match std::fs::symlink_metadata(orbit_dir) {
-        Ok(_) => CheckoutEvidence::Present,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => confirm_absence(orbit_dir),
-        Err(error) => CheckoutEvidence::Unreachable(filesystem_failure(orbit_dir, &error)),
+/// inferred from a failed stat. The repository root is the per-checkout path;
+/// `orbit_dir` may be a shared external root.
+fn checkout_evidence(repo_root: &Path) -> CheckoutEvidence {
+    match std::fs::metadata(repo_root) {
+        Ok(metadata) if metadata.is_dir() => CheckoutEvidence::Present,
+        Ok(_) => CheckoutEvidence::Unreachable(format!(
+            "{}: checkout root is not a directory",
+            repo_root.display()
+        )),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => confirm_absence(repo_root),
+        Err(error) => CheckoutEvidence::Unreachable(filesystem_failure(repo_root, &error)),
     }
 }
 
-/// Confirm that an unstat-able `orbit_dir` is genuinely missing by walking up
+/// Confirm that an unstat-able repository root is genuinely missing by walking up
 /// to the nearest ancestor that exists and listing it. Only a directory we can
 /// read can testify that the path beneath it is absent; a stat failure other
 /// than `NotFound` anywhere up the chain — `EACCES` from an unsearchable
 /// parent, `EIO`/`ENOTCONN` from a dropped mount — is not absence.
-fn confirm_absence(orbit_dir: &Path) -> CheckoutEvidence {
-    for ancestor in orbit_dir.ancestors().skip(1) {
+fn confirm_absence(repo_root: &Path) -> CheckoutEvidence {
+    for ancestor in repo_root.ancestors().skip(1) {
         match std::fs::symlink_metadata(ancestor) {
             Ok(_) => {
                 return match std::fs::read_dir(ancestor) {
@@ -402,7 +418,7 @@ fn confirm_absence(orbit_dir: &Path) -> CheckoutEvidence {
     }
     CheckoutEvidence::Unreachable(format!(
         "{}: no readable ancestor directory could confirm it is absent",
-        orbit_dir.display()
+        repo_root.display()
     ))
 }
 

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -7,7 +7,8 @@ use chrono::Utc;
 use fs2::FileExt;
 use orbit_registry::workspace_registry;
 use orbit_store::maintenance::task_registry::{
-    BindWorkspaceParams, TaskRegistryStore, task_registry_path, task_workspaces_dir,
+    BindWorkspaceParams, RegisterWorkspaceParams, TaskRegistryStore, task_registry_path,
+    task_workspaces_dir,
 };
 use orbit_types::workflow::{JobRun, JobRunState};
 use orbit_types::workspace::{Workspace, WorkspaceCheckout, WorkspaceStatus};
@@ -102,6 +103,22 @@ fn write_registered_checkout(global_root: &Path, workspace_id: &str, repo_root: 
 /// directories are named after, which a `<slug>-<hash>` id inhabits and the
 /// workspace catalog's `ws_*` ids do not [ORB-12119].
 fn bind_task_partition(global_root: &Path, workspace_id: &str, slug: &str, repo_root: &Path) {
+    bind_task_partition_at(
+        global_root,
+        workspace_id,
+        slug,
+        repo_root,
+        &repo_root.join(".orbit"),
+    );
+}
+
+fn bind_task_partition_at(
+    global_root: &Path,
+    workspace_id: &str,
+    slug: &str,
+    repo_root: &Path,
+    orbit_dir: &Path,
+) {
     let tasks =
         TaskRegistryStore::open(&task_registry_path(global_root)).expect("open task registry");
     tasks
@@ -110,10 +127,38 @@ fn bind_task_partition(global_root: &Path, workspace_id: &str, slug: &str, repo_
             slug: slug.to_string(),
             repo_root: repo_root.to_path_buf(),
             workspace_path: repo_root.to_path_buf(),
-            orbit_dir: repo_root.join(".orbit"),
+            orbit_dir: orbit_dir.to_path_buf(),
             repo_fingerprint: None,
         })
         .expect("bind task-registry workspace");
+}
+
+fn register_task_workspace(global_root: &Path, workspace_id: &str, slug: &str) {
+    let tasks =
+        TaskRegistryStore::open(&task_registry_path(global_root)).expect("open task registry");
+    tasks
+        .register_workspace(RegisterWorkspaceParams {
+            workspace_id: workspace_id.to_string(),
+            slug: slug.to_string(),
+            repo_fingerprint: None,
+        })
+        .expect("register path-free task workspace");
+}
+
+fn write_registered_shared_root_checkout(global_root: &Path, workspace_id: &str, repo_root: &Path) {
+    let registry_path = workspace_registry::registry_path_for(global_root);
+    let mut registry =
+        workspace_registry::load_registry_from(&registry_path).expect("load registry");
+    workspace_registry::register_checkout(
+        &mut registry,
+        WorkspaceCheckout::owner(
+            workspace_id.to_string(),
+            repo_root.to_path_buf(),
+            global_root.to_path_buf(),
+        ),
+    )
+    .expect("register shared-root checkout");
+    workspace_registry::save_registry_to(&registry, &registry_path).expect("save registry");
 }
 
 fn write_task_bundle(global_root: &Path, workspace_id: &str, task_id: &str) {
@@ -1038,7 +1083,13 @@ fn stale_task_registry_binding_is_reported_and_removed() {
     let deleted_root = temp.path().join("deleted");
     fs::create_dir_all(deleted_root.join(".orbit")).expect("create deleted checkout");
 
-    bind_task_partition(&global_root, "deleted-a1b2c3", "deleted", &deleted_root);
+    bind_task_partition_at(
+        &global_root,
+        "deleted-a1b2c3",
+        "deleted",
+        &deleted_root,
+        &global_root,
+    );
     write_task_bundle(&global_root, "deleted-a1b2c3", "ORB-2");
     fs::remove_dir_all(&deleted_root).expect("delete checkout");
 
@@ -1114,6 +1165,47 @@ fn deleted_catalog_checkout_partition_is_reported_and_removed() {
             .exists()
     );
     assert!(!partition_is_bound(&global_root, "ws_deleted").expect("read binding"));
+}
+
+/// A shared external root is not per-checkout evidence: the catalog's
+/// repository root must be used when `workspace init` supplied only a
+/// path-free task-registry registration.
+#[test]
+fn deleted_shared_root_catalog_checkout_partition_is_reported_and_removed() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let global_root = temp.path().join("global");
+    let deleted_root = temp.path().join("deleted");
+    fs::create_dir_all(&deleted_root).expect("create deleted checkout");
+
+    write_registered_workspace(&global_root, "ws_shared_deleted", "shared-deleted");
+    write_registered_shared_root_checkout(&global_root, "ws_shared_deleted", &deleted_root);
+    register_task_workspace(&global_root, "ws_shared_deleted", "shared-deleted");
+    write_task_bundle(&global_root, "ws_shared_deleted", "ORB-5");
+    fs::remove_dir_all(&deleted_root).expect("delete checkout");
+
+    let results = runtime.doctor_workspace().expect("doctor");
+    let row = status_of(&results, "orphan-task-stores");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Warning, "{row:?}");
+    assert!(row.message.contains("ws_shared_deleted"), "{}", row.message);
+    assert!(row.message.contains("1 task bundle(s)"), "{}", row.message);
+    assert!(
+        row.message.contains("missing checkout directories"),
+        "{}",
+        row.message
+    );
+
+    let removed = runtime
+        .remove_orphan_task_stores()
+        .expect("remove stale shared-root partition");
+    assert_eq!(removed.populated_partitions, 1, "{removed:?}");
+    assert_eq!(removed.task_bundles, 1, "{removed:?}");
+    assert!(
+        !task_workspaces_dir(&global_root)
+            .join("ws_shared_deleted")
+            .exists()
+    );
+    assert!(!partition_is_bound(&global_root, "ws_shared_deleted").expect("read binding"));
 }
 
 /// A catalog checkout that cannot be stat-ed is not evidence of deletion. Its

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -104,14 +104,17 @@ partition's rows in `~/.orbit/tasks/index.sqlite` in the same step.
 A partition directory is normally named for a **task-registry** workspace id
 (`workspace_bindings.workspace_id` in `~/.orbit/tasks/index.sqlite`), minted as `<slug>-<hash>`
 for a checkout that binds without an explicit id. `orbit workspace init` may instead use its
-catalog `ws_*` id directly. A task-registry or catalog checkout claim is live while its recorded
-`orbit_dir` is present on disk; a missing checkout is reported as stale, and an unreadable path is
-reported as unreachable. Checkoutless catalog entries and the synthetic `ws_unbound-data-dir`
-partition every `--root <data-dir>` write lands in remain claims. `orphan-task-stores` names each
+catalog `ws_*` id directly. A task-registry checkout claim is live while its recorded `repo_root`
+is present on disk; a catalog checkout supplies the same per-checkout evidence when `workspace init`
+has only a path-free task-registry registration. The shared external Orbit root (`--root
+<data-dir>`) is not used as checkout evidence because several checkouts may share it. A missing
+checkout is reported as stale, and an unreadable path is reported as unreachable. Checkoutless
+catalog entries and the synthetic `ws_unbound-data-dir` partition every `--root <data-dir>` write
+lands in remain claims. `orphan-task-stores` names each
 reported workspace id, its partition path, and its task-bundle count.
 
 **Evidence rule for deleting task bundles.** A partition that holds task bundles is deleted by the
-repair only when its bound checkout is *confirmed gone*: `orbit_dir` stats as absent, and the
+repair only when its bound checkout is *confirmed gone*: `repo_root` stats as absent, and the
 nearest ancestor directory that does exist is readable and therefore able to testify that the path
 below it is missing. Any other filesystem answer — `EACCES` from an unsearchable parent, `EIO` or
 `ENOTCONN` from a dropped mount, a path that resolves through a non-directory — classifies the


### PR DESCRIPTION
## Task

[ORB-12170](https://orbit-cli.com/tasks/ORB-12170) — [qa-sweep] In the shared external-root layout a deleted checkout's task partition is claimed forever: `workspace init` writes no checkout binding, so doctor can never classify it stale

### Description

## Summary

ORB-12127/ORB-12143/ORB-12150 made `doctor`'s `orphan-task-stores` row classify
a task-store partition by the filesystem evidence for its bound checkout's
`orbit_dir`. That evidence never exists for a workspace created with a shared
external Orbit root (`orbit --root <dir> workspace init`), so a checkout deleted
without teardown stays permanently "claimed": doctor reports `ok`, the repair
never reclaims it, and its task bundles are unreachable. The repo-local layout
(`orbit workspace init` with `orbit_dir = <repo>/.orbit`) is unaffected and was
verified working in the same sweep.

Two independent reasons, both in
`partition_claims` (`crates/orbit-cmd/src/task_store.rs:272-325`):

1. `orbit --root <root> workspace init` registers the workspace in
   `workspace_bindings` but writes **no** `workspace_checkout_bindings` row, so
   `tasks.find_workspace_checkout(...)` returns `None` and the id is
   unconditionally inserted into `claims.claimed` under the "imported task
   archive" branch (`task_store.rs:279-285`).
2. When a checkout binding does get written in this layout — `task reindex` does
   it via `ensure_migration_workspace_binding`
   (`crates/orbit-core/src/bootstrap/task_migration.rs:58-88`) — its recorded
   `orbit_dir` is the **shared root**, not anything that disappears with the
   checkout. `checkout_evidence` therefore always answers `Present`.

Removing the catalog entry does not help: the task-registry claim from (1)
survives, and `orbit workspace remove` refuses the workspace anyway (filed
separately as the `--workspace` positional collision).

## Reproduction (orbit 0.21.0 built from `f9122f5a1`, Linux)

Disposable `HOME` under `/tmp`, every `orbit_common::test_env::INHERITED_AUTHORITY_ENV`
variable cleared, routing verified with `orbit workspace show --format json`
before any mutation.

```sh
orbit --root /tmp/qa/roota init --non-interactive --host-name qa-a --task-prefix AAA
cd /tmp/qa/repoa && orbit --root /tmp/qa/roota workspace init      # ws_repoa
cd /tmp/qa/repob && orbit --root /tmp/qa/roota workspace init      # ws_repob
cd /tmp/qa/repob && orbit --root /tmp/qa/roota task add --title "B one" --description d --complexity low
cd /tmp/qa/repob && orbit --root /tmp/qa/roota task add --title "B two" --description d --complexity low

rm -rf /tmp/qa/repob                                # checkout deleted, no teardown

cd /tmp/qa/repoa && orbit --root /tmp/qa/roota doctor --json | jq '.[]|select(.check=="orphan-task-stores")'
#   { "check": "orphan-task-stores", "status": "ok",
#     "message": "2 task-store partition(s) scanned, all claimed by a workspace binding" }

ls /tmp/qa/roota/tasks/workspaces/ws_repob/         # AAA-00004  AAA-00005  (unreachable)

sqlite3 /tmp/qa/roota/tasks/index.sqlite 'select * from workspace_checkout_bindings;'
#   ws_repoa|/tmp/qa/repoa|/tmp/qa/repoa|/tmp/qa/roota|...      <- only, and only because
#                                                                  `task reindex` ran here
#   (no row for ws_repob or ws_repoc, both created by `workspace init`)
```

Control — the same deletion in the repo-local layout is classified correctly:

```sh
orbit init --non-interactive --host-name qa-d --task-prefix DDD   # HOME=/tmp/qa/home-d
cd /tmp/qa/repod2 && orbit workspace init   # orbit_dir /tmp/qa/repod2/.orbit
… add two tasks …
rm -rf /tmp/qa/repod2
cd /tmp/qa/repod1 && orbit doctor --json | jq '.[]|select(.check=="orphan-task-stores")'
#   warning: "1 stale task-store partition(s) point at missing checkout directories:
#             ws_repod2 (…/tasks/workspaces/ws_repod2, 2 task bundle(s))"
#   remediation: "Run `orbit doctor --fix-orphan-task-stores --confirm`. …"
```

## Impact

Production impact: on any host using a shared Orbit root (the layout Orbit's own
sandbox/CI instructions use, and any `--root` deployment), the state that the
`orphan-task-stores` check was added for is invisible and unreclaimable, and
`docs/runbooks/health-checks.md`'s recovery sequence cannot complete. No data is
destroyed — the bundles remain on disk and `orbit task reindex` can still rebind
them from a live checkout — but a deleted checkout leaks its partition forever.

Validation impact: none. The regression tests for the stale path
(`crates/orbit-cmd/src/tests/doctor.rs`) construct partitions with checkout
bindings whose `orbit_dir` is a per-checkout directory, so they never exercise a
shared-root binding or a `workspace init`-shaped registration without one.

## Suggested direction

Decide what the claim evidence should be for a shared-root checkout —
`workspace_checkout_bindings.repo_root`, or the workspace catalog's checkout
`repo_root`, rather than `orbit_dir`, which is not per-checkout in this layout —
and make `workspace init` register the checkout binding in the task registry so
the two id spaces agree. Cover the shared-root layout in the doctor tests
alongside the existing repo-local cases.

### Acceptance Criteria

- Shared external-root workspaces created by `workspace init` correlate their path-free task-registry workspace binding with the catalog checkout's per-checkout repository root.
- Orphan-task-store detection uses per-checkout repository-root evidence, so a deleted checkout in the shared external-root layout is reported stale rather than claimed/present.
- The confirmed orphan-task-store repair can reclaim the stale shared-root partition while preserving the existing repo-local layout behavior.
- Regression tests cover shared-root catalog-only registration, shared-root task-registry checkout evidence, stale detection after checkout removal, repair, and the existing repo-local control path.
- The health-check runbook accurately describes recovery for the shared external-root layout.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `partition_claims` so task-registry checkout bindings use their per-checkout `repo_root` instead of `orbit_dir`; a shared external root can no longer make a deleted checkout appear live.
- Added explicit precedence tracking so a catalog checkout supplies `repo_root` evidence for `workspace init`'s path-free task-registry registration, while a concrete task-registry checkout binding remains authoritative.
- Preserved safe unreachable behavior for inaccessible or non-directory checkout roots, including symlinked checkout roots that resolve to directories.
- Added doctor regression coverage for a shared-root task-registry binding and a shared-root catalog-only registration, including confirmed repair; existing repo-local and unreachable cases remain covered.
- Updated `docs/runbooks/health-checks.md` to document `repo_root` evidence and shared-root recovery.

Acceptance criteria:
- Shared-root initialization correlation: satisfied by correlating the catalog checkout's per-checkout `repo_root` with its path-free task-registry workspace registration; the unique shared `orbit_dir` schema remains unchanged.
- Per-checkout stale detection: satisfied; both concrete task-registry bindings and catalog fallback claims inspect `repo_root`.
- Confirmed repair: satisfied; the shared-root regression verifies the populated partition and task-registry binding are removed, while existing repo-local repair tests pass.
- Regression coverage: satisfied; the final doctor suite passes 36/36, including shared-root catalog-only and shared-root task-registry evidence cases plus existing controls.
- Runbook: satisfied; recovery guidance now identifies `repo_root` as evidence and explains why shared `--root` is not evidence.

Assessment: The smallest compatible fix uses the existing catalog checkout record for shared-root per-checkout identity and does not weaken the unique `orbit_dir` invariant. No CHANGELOG.md or unrelated files were changed.

Validation:
- PASSED — `cargo test -p orbit-cmd --lib doctor` (final run: 36 passed, 0 failed).
- PASSED — `make ci-fast` (guardrails passed; its compiler-cache namespace subcheck was skipped because bwrap could not create a user namespace: `No permissions to create new namespace`; the related cross-revision check passed).
- PASSED — `make ci-lint` (workspace clippy with `-D warnings`).
- PASSED — `cargo fmt --all -- --check` (final run passed).
- PASSED — `git diff --check` (final run passed).
- PASSED — `GIT_OPTIONAL_LOCKS=0 git status --short` (final run showed only the three task-scoped files: `crates/orbit-cmd/src/task_store.rs`, `crates/orbit-cmd/src/tests/doctor.rs`, and `docs/runbooks/health-checks.md`).

Deviations from original plan:
- No source change was needed in `task_migration.rs` or workspace initialization: shared-root initialization already records the logical task workspace and catalog checkout, while adding another checkout row would conflict with the intentional unique shared `orbit_dir` invariant.

Remaining risk: unit-level doctor tests cover the claim/repair boundary and shared-root data shape; a full CLI subprocess reproduction was not run. The documented namespace subcheck remains unvalidated in this environment due the kernel sandbox restriction.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12170-6aa3cf17`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus