### PR TITLE
task.update --context accepts file: selectors that do not exist in the checkout, so a typo silently ships a task with dead context

### DIFF
--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -2740,6 +2740,79 @@ fn mcp_serve_error_paths_return_tool_errors_and_keep_serving() {
 }
 
 #[test]
+fn mcp_task_add_and_update_validate_context_selectors() {
+    let workspace = McpWorkspace::init();
+    let mut client = workspace.serve();
+
+    // 1. Task add with missing context file fails
+    let add_err = client.call_tool_err(
+        "orbit_task_add",
+        json!({
+            "title": "Add with invalid context",
+            "description": "testing invalid context rejection",
+            "context_files": ["file:does/not/exist.rs"],
+            "complexity": "low",
+            "model": "codex"
+        }),
+    );
+    assert_eq!(add_err["code"], "invalid_input");
+    assert!(
+        add_err["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("file:does/not/exist.rs")),
+        "error should name missing selector: {add_err}"
+    );
+
+    // 2. Task add with valid context succeeds
+    std::fs::write(workspace.work.join("existing.rs"), "pub fn run() {}\n").expect("write file");
+    let added = client.call_tool_ok(
+        "orbit_task_add",
+        json!({
+            "title": "Add with valid context",
+            "description": "testing valid context acceptance",
+            "context_files": ["file:existing.rs", "symbol:existing.rs#run:function"],
+            "complexity": "low",
+            "model": "codex"
+        }),
+    );
+    let task_id = added["id"].as_str().expect("task id");
+    assert_eq!(
+        added["context_files"],
+        json!(["file:existing.rs", "symbol:existing.rs#run:function"])
+    );
+
+    // 3. Task update with missing context file fails and leaves task unchanged
+    let update_err = client.call_tool_err(
+        "orbit_task_update",
+        json!({
+            "id": task_id,
+            "context_files": ["file:does/not/exist.rs"],
+            "model": "codex"
+        }),
+    );
+    assert_eq!(update_err["code"], "invalid_input");
+    assert!(
+        update_err["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("file:does/not/exist.rs")),
+        "error should name missing selector: {update_err}"
+    );
+
+    let shown = client.call_tool_ok(
+        "orbit_task_show",
+        json!({
+            "id": task_id,
+            "model": "codex"
+        }),
+    );
+    assert_eq!(
+        shown["context_files"],
+        json!(["file:existing.rs", "symbol:existing.rs#run:function"]),
+        "task context_files must remain unchanged"
+    );
+}
+
+#[test]
 fn mcp_hybrid_search_without_companion_returns_lexical_results() {
     let workspace = McpWorkspace::init();
     let companion_state = workspace.home.join(".orbit").join("embed");

--- a/crates/orbit-cli/tests/task_trimmed_surface.rs
+++ b/crates/orbit-cli/tests/task_trimmed_surface.rs
@@ -85,6 +85,7 @@ fn task_update_repeats_dependencies_and_clears_context() {
     let dependency_a = workspace.add_task("First dependency");
     let dependency_b = workspace.add_task("Second dependency");
     let id = workspace.add_task("List update");
+    fs::write(workspace.work.join("one.rs"), "// one\n").expect("write one file");
 
     workspace.run(
         &[
@@ -109,6 +110,90 @@ fn task_update_repeats_dependencies_and_clears_context() {
     let context =
         workspace.task_json(&["task", "show", &id, "--fields", "context_files", "--json"]);
     assert_eq!(context, json!([]));
+}
+
+#[test]
+fn task_update_rejects_missing_context_file_and_leaves_task_unchanged() {
+    let workspace = TestWorkspace::new();
+    let id = workspace.add_task("Target task");
+    let before = workspace.task_json(&["task", "show", &id, "--json"]);
+
+    let output = workspace.run_raw(&["task", "update", &id, "--context", "file:does/not/exist.rs"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("file:does/not/exist.rs"),
+        "stderr must name selector: {stderr}"
+    );
+
+    let after = workspace.task_json(&["task", "show", &id, "--json"]);
+    assert_eq!(
+        before, after,
+        "task must be unchanged after rejected context update"
+    );
+}
+
+#[test]
+fn task_add_rejects_missing_context_file() {
+    let workspace = TestWorkspace::new();
+    let output = workspace.run_raw(&[
+        "task",
+        "add",
+        "--title",
+        "Add with missing context",
+        "--complexity",
+        "low",
+        "--context",
+        "file:does/not/exist.rs",
+    ]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("file:does/not/exist.rs"),
+        "stderr must name selector: {stderr}"
+    );
+}
+
+#[test]
+fn task_update_and_add_accept_valid_context_selectors() {
+    let workspace = TestWorkspace::new();
+    fs::write(
+        workspace.work.join("existing.rs"),
+        "pub fn my_symbol() {}\n",
+    )
+    .expect("write existing file");
+    fs::create_dir_all(workspace.work.join("existing_dir")).expect("create existing dir");
+
+    let added = workspace.task_json(&[
+        "task",
+        "add",
+        "--title",
+        "Add with valid context",
+        "--complexity",
+        "low",
+        "--context",
+        "file:existing.rs,dir:existing_dir,symbol:existing.rs#my_symbol:function",
+        "--json",
+    ]);
+    assert_eq!(
+        added["context_files"],
+        json!([
+            "file:existing.rs",
+            "dir:existing_dir",
+            "symbol:existing.rs#my_symbol:function"
+        ])
+    );
+
+    let id = added["id"].as_str().unwrap();
+    let updated = workspace.task_json(&[
+        "task",
+        "update",
+        id,
+        "--context",
+        "file:existing.rs",
+        "--json",
+    ]);
+    assert_eq!(updated["context_files"], json!(["file:existing.rs"]));
 }
 
 #[test]

--- a/crates/orbit-core/src/application/task/add.rs
+++ b/crates/orbit-core/src/application/task/add.rs
@@ -1,5 +1,4 @@
 use orbit_common::OrbitError;
-use orbit_common::fs::task_io::prune_missing_context_files;
 use orbit_common::security::redaction::redact_all;
 use orbit_store::contracts::TaskCreateParams as StoreTaskCreateParams;
 use orbit_types::record::OrbitEvent;
@@ -8,14 +7,12 @@ use orbit_types::task::{
     normalize_task_tags,
 };
 
-use super::TaskRecordUpdateParams;
 use crate::OrbitRuntime;
 
 use super::helpers::{authored_role_value, build_task_comments, effective_actor_label};
 use super::params::TaskAddParams;
 use super::paths::{
-    context_files_pruned_history_entry, context_workspace_root, normalize_context_files_for_write,
-    normalize_workspace_path,
+    context_workspace_root, normalize_context_files_for_write, normalize_workspace_path,
 };
 
 const AUTO_TASK_TITLE_PREFIX: &str = "[auto-task] ";
@@ -100,11 +97,10 @@ impl OrbitRuntime {
             )));
         }
 
-        let prune_root = context_workspace_root(&self.paths().repo_root, workspace_path.as_deref());
-        let normalized_context_files =
-            normalize_context_files_for_write(params.context_files.clone(), &prune_root)?;
-        let (kept_context_files, dropped_context_files) =
-            prune_missing_context_files(&prune_root, normalized_context_files);
+        let context_root =
+            context_workspace_root(&self.paths().repo_root, workspace_path.as_deref());
+        let context_files =
+            normalize_context_files_for_write(params.context_files.clone(), &context_root)?;
 
         let task = self.with_mutation(|| {
             let task = self.stores().task_records().create_with_key(
@@ -120,7 +116,7 @@ impl OrbitRuntime {
                     required_tools: normalize_required_tools(params.required_tools.clone()),
                     plan: params.plan.clone(),
                     execution_summary: String::new(),
-                    context_files: kept_context_files.clone(),
+                    context_files,
                     workspace_path: workspace_path.clone(),
                     repo_root: None,
                     created_by: Some(create_label.clone()),
@@ -145,22 +141,6 @@ impl OrbitRuntime {
                 },
             ))
         })?;
-
-        let task = if dropped_context_files.is_empty() {
-            task
-        } else {
-            self.stores().task_records().update(
-                &task.id,
-                TaskRecordUpdateParams {
-                    actor: create_label.clone(),
-                    append_history: vec![context_files_pruned_history_entry(
-                        &create_label,
-                        &dropped_context_files,
-                    )],
-                    ..Default::default()
-                },
-            )?
-        };
 
         Ok(task)
     }

--- a/crates/orbit-core/src/application/task/paths.rs
+++ b/crates/orbit-core/src/application/task/paths.rs
@@ -4,6 +4,7 @@ use orbit_common::fs::selector::{
     anchor_path, canonical_selector_in_workspace, exists_in_workspace,
 };
 use orbit_types::task::{TaskHistoryEntry, TaskType};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 pub(super) fn normalize_workspace_path(
@@ -82,13 +83,72 @@ pub(crate) fn normalize_context_files_for_write(
     candidates: Vec<String>,
     workspace_root: &Path,
 ) -> Result<Vec<String>, OrbitError> {
-    candidates
-        .into_iter()
-        .map(|entry| {
-            canonical_selector_in_workspace(entry.as_str(), workspace_root)
-                .map_err(|error| OrbitError::InvalidInput(error.to_string()))
-        })
-        .collect()
+    let canonical_workspace = workspace_root.canonicalize().map_err(|error| {
+        OrbitError::InvalidInput(format!(
+            "failed to resolve workspace root '{}': {error}",
+            workspace_root.display()
+        ))
+    })?;
+
+    let mut seen = BTreeSet::new();
+    let mut normalized = Vec::with_capacity(candidates.len());
+
+    for entry in candidates {
+        let trimmed = entry.trim();
+        if trimmed.is_empty() {
+            return Err(OrbitError::InvalidInput(
+                "selector input must not be empty".to_string(),
+            ));
+        }
+
+        if trimmed.starts_with("module:") || trimmed.starts_with("command:") {
+            return Err(OrbitError::InvalidInput(format!(
+                "selector `{entry}` must use file:, dir:, or symbol:"
+            )));
+        }
+
+        let canonical =
+            canonical_selector_in_workspace(trimmed, &canonical_workspace).map_err(|error| {
+                OrbitError::InvalidInput(format!("selector `{entry}` is invalid: {error}"))
+            })?;
+
+        if canonical.starts_with("module:") || canonical.starts_with("command:") {
+            return Err(OrbitError::InvalidInput(format!(
+                "selector `{entry}` must use file:, dir:, or symbol:"
+            )));
+        }
+
+        if !exists_in_workspace(&canonical, &canonical_workspace) {
+            return Err(OrbitError::InvalidInput(format!(
+                "selector `{entry}` does not resolve to an existing in-workspace target"
+            )));
+        }
+
+        let anchor = anchor_path(&canonical).map_err(|error| {
+            OrbitError::InvalidInput(format!(
+                "selector `{entry}` has no filesystem anchor: {error}"
+            ))
+        })?;
+
+        let resolved = canonical_workspace.join(anchor);
+        let correct_kind = if canonical.starts_with("dir:") {
+            resolved.is_dir()
+        } else {
+            resolved.is_file()
+        };
+
+        if !correct_kind {
+            return Err(OrbitError::InvalidInput(format!(
+                "selector `{entry}` does not match the target's file/directory kind"
+            )));
+        }
+
+        if seen.insert(canonical.clone()) {
+            normalized.push(canonical);
+        }
+    }
+
+    Ok(normalized)
 }
 
 pub(crate) use crate::runtime::task::canonicalize_context_files_for_read;

--- a/crates/orbit-core/src/application/task/tests/add.rs
+++ b/crates/orbit-core/src/application/task/tests/add.rs
@@ -351,3 +351,63 @@ fn task_add_preserves_auto_task_title_prefix_behavior() {
         assert_eq!(task.title, "[auto-task] Scheduled work");
     }
 }
+
+#[test]
+fn task_add_validates_context_files_rejecting_missing_selectors() {
+    let (_root, runtime) = test_runtime();
+
+    let error = runtime
+        .add_task(TaskAddParams {
+            title: "Missing context".to_string(),
+            context_files: vec!["file:does/not/exist.rs".to_string()],
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect_err("task add must reject missing file selector");
+
+    match error {
+        OrbitError::InvalidInput(msg) => {
+            assert!(
+                msg.contains("file:does/not/exist.rs"),
+                "error must name missing selector: {msg}"
+            );
+        }
+        other => panic!("expected InvalidInput, got {other:?}"),
+    }
+
+    let tasks = runtime.list_tasks().expect("list tasks");
+    assert!(
+        tasks.is_empty(),
+        "no task should be created on invalid context"
+    );
+}
+
+#[test]
+fn task_add_accepts_valid_context_selectors() {
+    let (root, runtime) = test_runtime();
+    let repo_dir = root.path().join("repo");
+    std::fs::create_dir_all(repo_dir.join("src")).expect("create src");
+    std::fs::write(repo_dir.join("src/lib.rs"), b"pub fn run() {}\n").expect("write lib.rs");
+
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Valid context".to_string(),
+            context_files: vec![
+                "file:src/lib.rs".to_string(),
+                "dir:src".to_string(),
+                "symbol:src/lib.rs#run:function".to_string(),
+            ],
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("task add with valid selectors succeeds");
+
+    assert_eq!(
+        task.context_files,
+        vec![
+            "file:src/lib.rs".to_string(),
+            "dir:src".to_string(),
+            "symbol:src/lib.rs#run:function".to_string(),
+        ]
+    );
+}

--- a/crates/orbit-core/src/application/task/tests/paths.rs
+++ b/crates/orbit-core/src/application/task/tests/paths.rs
@@ -6,8 +6,7 @@ use orbit_common::OrbitError;
 use tempfile::tempdir;
 
 use crate::application::task::paths::{
-    canonicalize_context_files_for_read, normalize_context_files_for_write,
-    normalize_workspace_path, task_path_exists,
+    normalize_context_files_for_write, normalize_workspace_path, task_path_exists,
 };
 
 fn expect_invalid_input(result: Result<Option<String>, OrbitError>) -> String {
@@ -132,23 +131,148 @@ fn path_to_a_file_is_rejected_as_not_a_directory() {
 }
 
 #[test]
-fn symbol_context_validation_uses_only_the_workspace_file_anchor() {
+fn normalize_context_files_accepts_valid_selectors() {
     let workspace = tempdir().expect("create workspace");
     std::fs::create_dir_all(workspace.path().join("src")).expect("create src");
     std::fs::write(workspace.path().join("src/lib.rs"), b"pub fn run() {}\n")
         .expect("write anchor");
-    let selector = "symbol:src/lib.rs#not::a::real::symbol:invented-kind";
 
-    let normalized =
-        normalize_context_files_for_write(vec![selector.to_string()], workspace.path())
-            .expect("opaque symbol metadata must not be resolved");
+    let selectors = vec![
+        "file:src/lib.rs".to_string(),
+        "dir:src".to_string(),
+        "symbol:src/lib.rs#run:function".to_string(),
+    ];
 
-    assert_eq!(normalized, vec![selector]);
-    assert!(task_path_exists(workspace.path(), selector));
-    assert_eq!(
-        canonicalize_context_files_for_read(&normalized, workspace.path()),
-        normalized
-    );
+    let normalized = normalize_context_files_for_write(selectors.clone(), workspace.path())
+        .expect("valid selectors must be accepted");
+
+    assert_eq!(normalized, selectors);
+}
+
+#[test]
+fn normalize_context_files_rejects_missing_selectors() {
+    let workspace = tempdir().expect("create workspace");
+
+    let error = normalize_context_files_for_write(
+        vec!["file:does/not/exist.rs".to_string()],
+        workspace.path(),
+    )
+    .expect_err("missing file must be rejected");
+
+    match error {
+        OrbitError::InvalidInput(msg) => {
+            assert!(
+                msg.contains("file:does/not/exist.rs"),
+                "error must name selector: {msg}"
+            );
+        }
+        other => panic!("expected InvalidInput, got {other:?}"),
+    }
+
+    let symbol_error = normalize_context_files_for_write(
+        vec!["symbol:does/not/exist.rs#run:function".to_string()],
+        workspace.path(),
+    )
+    .expect_err("missing symbol anchor must be rejected");
+
+    match symbol_error {
+        OrbitError::InvalidInput(msg) => {
+            assert!(
+                msg.contains("symbol:does/not/exist.rs#run:function"),
+                "error must name selector: {msg}"
+            );
+        }
+        other => panic!("expected InvalidInput, got {other:?}"),
+    }
+}
+
+#[test]
+fn normalize_context_files_rejects_target_kind_mismatch() {
+    let workspace = tempdir().expect("create workspace");
+    std::fs::create_dir_all(workspace.path().join("src")).expect("create src");
+    std::fs::write(workspace.path().join("src/lib.rs"), b"pub fn run() {}\n")
+        .expect("write anchor");
+
+    // file: pointing to a directory
+    let error = normalize_context_files_for_write(vec!["file:src".to_string()], workspace.path())
+        .expect_err("file: targeting a directory must be rejected");
+    match error {
+        OrbitError::InvalidInput(msg) => {
+            assert!(msg.contains("file:src"), "{msg}");
+            assert!(msg.contains("file/directory kind"), "{msg}");
+        }
+        other => panic!("expected InvalidInput, got {other:?}"),
+    }
+
+    // dir: pointing to a file
+    let error =
+        normalize_context_files_for_write(vec!["dir:src/lib.rs".to_string()], workspace.path())
+            .expect_err("dir: targeting a file must be rejected");
+    match error {
+        OrbitError::InvalidInput(msg) => {
+            assert!(msg.contains("dir:src/lib.rs"), "{msg}");
+            assert!(msg.contains("file/directory kind"), "{msg}");
+        }
+        other => panic!("expected InvalidInput, got {other:?}"),
+    }
+
+    // symbol: pointing to a directory
+    let error = normalize_context_files_for_write(
+        vec!["symbol:src#run:function".to_string()],
+        workspace.path(),
+    )
+    .expect_err("symbol: targeting a directory must be rejected");
+    match error {
+        OrbitError::InvalidInput(msg) => {
+            assert!(msg.contains("symbol:src#run:function"), "{msg}");
+            assert!(msg.contains("file/directory kind"), "{msg}");
+        }
+        other => panic!("expected InvalidInput, got {other:?}"),
+    }
+}
+
+#[test]
+fn normalize_context_files_rejects_unsupported_kinds_and_malformed_selectors() {
+    let workspace = tempdir().expect("create workspace");
+
+    // module: selector is rejected
+    let error = normalize_context_files_for_write(
+        vec!["module:orbit_core::task".to_string()],
+        workspace.path(),
+    )
+    .expect_err("module: selector must be rejected");
+    match error {
+        OrbitError::InvalidInput(msg) => {
+            assert!(msg.contains("module:orbit_core::task"), "{msg}");
+            assert!(msg.contains("must use file:, dir:, or symbol:"), "{msg}");
+        }
+        other => panic!("expected InvalidInput, got {other:?}"),
+    }
+
+    // command: selector is rejected
+    let error =
+        normalize_context_files_for_write(vec!["command:task".to_string()], workspace.path())
+            .expect_err("command: selector must be rejected");
+    match error {
+        OrbitError::InvalidInput(msg) => {
+            assert!(msg.contains("command:task"), "{msg}");
+            assert!(msg.contains("must use file:, dir:, or symbol:"), "{msg}");
+        }
+        other => panic!("expected InvalidInput, got {other:?}"),
+    }
+
+    // malformed symbol selector is rejected
+    let error = normalize_context_files_for_write(
+        vec!["symbol:serve_throttled_response".to_string()],
+        workspace.path(),
+    )
+    .expect_err("malformed symbol: must be rejected");
+    match error {
+        OrbitError::InvalidInput(msg) => {
+            assert!(msg.contains("symbol:serve_throttled_response"), "{msg}");
+        }
+        other => panic!("expected InvalidInput, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/orbit-core/src/application/task/tests/update.rs
+++ b/crates/orbit-core/src/application/task/tests/update.rs
@@ -392,3 +392,86 @@ fn concurrent_explicit_edit_preserves_the_newer_status() {
         "the serialized edit must not restore its earlier status snapshot"
     );
 }
+
+#[test]
+fn task_update_rejects_missing_context_files_and_leaves_task_unchanged() {
+    let (root, runtime) = test_runtime();
+    let repo_dir = root.path().join("repo");
+    std::fs::create_dir_all(repo_dir.join("src")).expect("create src");
+    std::fs::write(repo_dir.join("src/lib.rs"), b"pub fn run() {}\n").expect("write lib.rs");
+
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Original context".to_string(),
+            context_files: vec!["file:src/lib.rs".to_string()],
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("add task succeeds");
+
+    let error = runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                context_files: Some(vec!["file:does/not/exist.rs".to_string()]),
+                ..Default::default()
+            },
+        )
+        .expect_err("update must reject missing context file");
+
+    match error {
+        orbit_common::OrbitError::InvalidInput(msg) => {
+            assert!(
+                msg.contains("file:does/not/exist.rs"),
+                "error must name missing selector: {msg}"
+            );
+        }
+        other => panic!("expected InvalidInput, got {other:?}"),
+    }
+
+    let reread = runtime.get_task(&task.id).expect("get task");
+    assert_eq!(
+        reread.context_files,
+        vec!["file:src/lib.rs".to_string()],
+        "task context_files must remain unchanged"
+    );
+}
+
+#[test]
+fn task_update_accepts_valid_context_selectors() {
+    let (root, runtime) = test_runtime();
+    let repo_dir = root.path().join("repo");
+    std::fs::create_dir_all(repo_dir.join("src")).expect("create src");
+    std::fs::write(repo_dir.join("src/lib.rs"), b"pub fn run() {}\n").expect("write lib.rs");
+
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Initial task".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("add task succeeds");
+
+    let updated = runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                context_files: Some(vec![
+                    "file:src/lib.rs".to_string(),
+                    "dir:src".to_string(),
+                    "symbol:src/lib.rs#run:function".to_string(),
+                ]),
+                ..Default::default()
+            },
+        )
+        .expect("update with valid context selectors succeeds");
+
+    assert_eq!(
+        updated.context_files,
+        vec![
+            "file:src/lib.rs".to_string(),
+            "dir:src".to_string(),
+            "symbol:src/lib.rs#run:function".to_string(),
+        ]
+    );
+}

--- a/crates/orbit-core/src/application/task/update.rs
+++ b/crates/orbit-core/src/application/task/update.rs
@@ -176,7 +176,6 @@ impl OrbitRuntime {
             params.context_files.take()
         {
             let normalized = normalize_context_files_for_write(candidates, &prune_root)?;
-            // L-0030: explicit replacements preserve draft/future selectors; pruning stays read-time.
             params.context_files = Some(normalized);
             Vec::new()
         } else {


### PR DESCRIPTION
## Task

[ORB-12168](https://orbit-cli.com/tasks/ORB-12168) — task.update --context accepts file: selectors that do not exist in the checkout, so a typo silently ships a task with dead context

### Description

## Observed (2026-09-11 on-call shift)

`orbit task update ORB-12167 --context "file:crates/orbit-automation/src/ci_failure_sweep/mod.rs"` succeeded and persisted the selector, although no such file exists (the real module is `crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs`). The task then sat in `backlog` as "ready" with context that resolves to nothing; a worker would have started with no file reservations and no reading list.

By contrast the task-pilot apply step rejects malformed selectors (`selector "symbol:serve_throttled_response" is invalid`) — so validation exists but is not applied on the operator/agent `task.update` and `task.add` surfaces.

## Wanted

On `orbit.task.update` / `orbit.task.add` (CLI and MCP), validate `context_files` selectors the same way task-pilot apply does:
- a `file:` selector must resolve to an existing path in the workspace checkout at HEAD (directories allowed only if the selector grammar allows them);
- `symbol:`/other selector kinds must parse and resolve;
- reject with a message naming the bad selector(s), or — behind an explicit `--allow-missing-context` flag for deliberate future-file references — accept and record a warning in the task history.

### Acceptance Criteria

- `orbit task update <id> --context file:does/not/exist.rs` fails with an error naming the selector and leaves the task unchanged; a CLI test covers it.
- The same validation applies to `orbit task add --context` and to the MCP `orbit.task.update`/`orbit.task.add` tools.
- Valid selectors (existing files, valid symbol selectors) continue to be accepted unchanged.

## Execution Summary

<details>
<summary>Click to expand</summary>

### Summary of Changes

#### Root Cause
Previously, `normalize_context_files_for_write` only canonicalized selector strings without verifying whether the targets existed in the workspace or matched their expected target kinds (regular file vs. directory). In `add.rs`, missing context files were silently pruned rather than rejected, while `update.rs` accepted and persisted invalid/missing selectors directly.

#### Implementation
1. **Context Selector Validation (`crates/orbit-core/src/application/task/paths.rs`)**:
   - Enhanced `normalize_context_files_for_write` to reject empty tokens and unsupported kinds (`module:`, `command:`).
   - Validated that canonical workspace anchors exist via `exists_in_workspace`. Invalid or missing selectors return `OrbitError::InvalidInput` explicitly naming the problematic selector.
   - Enforced target kind checks: `file:` and `symbol:` selectors must resolve to regular files; `dir:` selectors must resolve to directories.
   - Preserved input ordering and deduplicated canonical selectors.
2. **Task Creation (`crates/orbit-core/src/application/task/add.rs`)**:
   - Removed silent write-time pruning of missing context files (`prune_missing_context_files`).
   - Added upfront context selector validation before record generation or storage mutations.
3. **Task Updates (`crates/orbit-core/src/application/task/update.rs`)**:
   - Validated context file inputs through `normalize_context_files_for_write` prior to mutating records, ensuring failures abort immediately and leave the persisted task unchanged.

#### Verification & Acceptance Criteria
- **Acceptance Criterion 1 (CLI task update rejection)**: Verified by `task_update_rejects_missing_context_file_and_leaves_task_unchanged` in `task_trimmed_surface.rs` and `task_update_rejects_missing_context_files_and_leaves_task_unchanged` in `orbit-core`.
- **Acceptance Criterion 2 (CLI task add & MCP validation)**: Verified by `task_add_rejects_missing_context_file` in `task_trimmed_surface.rs` and `mcp_task_add_and_update_validate_context_selectors` in `mcp_roundtrip.rs`.
- **Acceptance Criterion 3 (Valid selectors accepted)**: Verified by `task_update_and_add_accept_valid_context_selectors` (CLI), `mcp_task_add_and_update_validate_context_selectors` (MCP), and unit tests in `paths.rs`, `add.rs`, and `update.rs`.
- **Quality Checks**:
  - `cargo test -p orbit-core application::task::tests` (58/58 passed)
  - `cargo test -p orbit-cli --test task_trimmed_surface` (16/16 passed)
  - `cargo test -p orbit-cli --test mcp_roundtrip -- mcp_task_add_and_update_validate_context_selectors` (passed)
  - `make ci-fast` (passed)
  - `make ci-lint` (passed)
  - `git diff --check` (clean)

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12168-6aa3d17b`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus