### PR TITLE
[code-review] ORB-12170 left two `orbit_dir` descriptions of the task-partition evidence rule stale, one of them inside the runbook it updated

### DIFF
--- a/crates/orbit-cmd/src/task_store.rs
+++ b/crates/orbit-cmd/src/task_store.rs
@@ -66,9 +66,9 @@ pub struct TaskStorePartitions {
     pub scanned: usize,
     /// Unclaimed and empty of task bundles: nothing to lose by deleting them.
     pub removable: Vec<UnclaimedPartition>,
-    /// Partitions whose task-registry checkout binding points at an orbit
-    /// directory confirmed absent. That the checkout is gone is sufficient
-    /// evidence to remove the partition, including its bundles.
+    /// Partitions whose task-registry checkout binding points at a repository
+    /// root (`repo_root`) confirmed absent. That the checkout is gone is
+    /// sufficient evidence to remove the partition, including its bundles.
     pub stale: Vec<UnclaimedPartition>,
     /// Unclaimed but still holding task bundles, which `orbit task reindex`
     /// can rebind from the bundles themselves. Never deleted automatically.

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -143,7 +143,7 @@ permissions that hide the checkout — and re-run `orbit doctor`. A reachable ch
 claim again and the row clears itself; a checkout that is genuinely gone once its parent is
 readable becomes a confirmed-stale binding, which the repair can then remove.
 
-For a partition whose binding is confirmed stale, the missing `orbit_dir` is the evidence that the
+For a partition whose binding is confirmed stale, the missing `repo_root` is the evidence that the
 checkout is gone. The confirmed repair removes that partition, including its task bundles, and
 retires the stale registry rows — as it does for every empty unclaimed partition. If the deleted
 checkout is still listed in the workspace catalog, first deregister it with its name, `ws_*` id, or


### PR DESCRIPTION
## Task

[ORB-12183](https://orbit-cli.com/tasks/ORB-12183) — [code-review] ORB-12170 left two `orbit_dir` descriptions of the task-partition evidence rule stale, one of them inside the runbook it updated

### Description

ORB-12170 moved the orphan-task-store evidence rule from the bound `orbit_dir` to the checkout's `repo_root` (`crates/orbit-cmd/src/task_store.rs:380-397`), because a shared external Orbit root is not per-checkout evidence. Two descriptions of that rule still name `orbit_dir` and now describe behavior the code no longer has:

- `crates/orbit-cmd/src/task_store.rs:69-71` — the `TaskStorePartitions::stale` field doc still reads "Partitions whose task-registry checkout binding points at an orbit directory confirmed absent". This is the doc for the field whose population rule the same commit changed.
- `docs/runbooks/health-checks.md:146` — "For a partition whose binding is confirmed stale, the missing `orbit_dir` is the evidence that the checkout is gone." The same file's paragraph at `:104-117` was updated by the same commit to `repo_root` and explicitly says the shared external Orbit root is *not* used as checkout evidence, so the runbook now contradicts itself.

This matters beyond wording: the rule governs a destructive repair (`orbit doctor --fix-orphan-task-stores --confirm` deletes populated partitions and their task bundles), and an operator following the runbook would check the wrong path before confirming.

### Acceptance Criteria

- The `TaskStorePartitions::stale` field doc describes the evidence path the implementation actually stats.
- `docs/runbooks/health-checks.md` names one evidence path consistently in both the classification paragraph and the stale-partition remediation paragraph.
- No remaining current description of the orphan-task-store evidence rule refers to `orbit_dir`.

## Execution Summary

<details>
<summary>Click to expand</summary>

### Acceptance Criteria Mapping
- **Criterion 1 (TaskStorePartitions::stale field doc describes evidence path stat-ed)**: Passed. Updated `TaskStorePartitions::stale` doc comment in `crates/orbit-cmd/src/task_store.rs` to refer to repository root (`repo_root`), which is the path stat-ed by `checkout_evidence`.
- **Criterion 2 (docs/runbooks/health-checks.md names one evidence path consistently)**: Passed. Replaced `orbit_dir` with `repo_root` at line 146 of `docs/runbooks/health-checks.md`, aligning the stale-partition remediation paragraph with the classification and evidence paragraphs (lines 107-124).
- **Criterion 3 (No remaining current description of the orphan-task-store evidence rule refers to `orbit_dir`)**: Passed. Verified via codebase search that no remaining current descriptions of the orphan-task-store evidence rule refer to `orbit_dir`.

### Validation Commands
- `make ci-fast`: Passed (guardrails and formatting checks passed).
- `cargo test -p orbit-cmd`: Passed (152 tests passed, 0 failed).
- `make ci-lint`: Passed (workspace-wide clippy with warnings denied).
- `git diff --check`: Passed (no whitespace or formatting issues).
- `git status --short`: Passed (only the two scoped context files modified).

### Remaining Risks or Deviations
- None. Changes are confined to doc comments and runbook documentation aligned with the implementation in ORB-12170.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12183-6aa3d9c7`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus