### PR TITLE
[code-review] ci-failure-sweep: a completed repair silently suppresses a later recurrence of the same named test for 30 days

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -1199,7 +1199,7 @@ impl FailureCluster {
             )];
             fingerprints.extend(self.provenance_fingerprints());
             return DuplicateCandidate::new(exact_tag, fingerprints)
-                .with_completed_fingerprints(self.provenance_fingerprints());
+                .with_completed_fingerprints(self.completed_provenance_fingerprints());
         }
         let mut fingerprints = if self.signature_is_step_fallback {
             // A step-name fallback contains no diagnostic. It is sufficient
@@ -1242,10 +1242,21 @@ impl FailureCluster {
         }
         fingerprints.extend(self.provenance_fingerprints());
         DuplicateCandidate::new(exact_tag, fingerprints)
-            .with_completed_fingerprints(self.provenance_fingerprints())
+            .with_completed_fingerprints(self.completed_provenance_fingerprints())
     }
 
     fn provenance_fingerprints(&self) -> Vec<CoverageFingerprint> {
+        self.provenance_fingerprints_with_test_names(true)
+    }
+
+    fn completed_provenance_fingerprints(&self) -> Vec<CoverageFingerprint> {
+        self.provenance_fingerprints_with_test_names(false)
+    }
+
+    fn provenance_fingerprints_with_test_names(
+        &self,
+        include_test_names: bool,
+    ) -> Vec<CoverageFingerprint> {
         let mut fingerprints = Vec::new();
         let mut seen = BTreeSet::new();
         for run in &self.runs {
@@ -1268,12 +1279,14 @@ impl FailureCluster {
                     ));
                 }
             }
-            for name in failure_test_names(run) {
-                if seen.insert(("test_name", name.clone())) {
-                    fingerprints.push(CoverageFingerprint::new(
-                        "ci_failure_test_name",
-                        vec![CoverageAnchor::new("test_name", name)],
-                    ));
+            if include_test_names {
+                for name in failure_test_names(run) {
+                    if seen.insert(("test_name", name.clone())) {
+                        fingerprints.push(CoverageFingerprint::new(
+                            "ci_failure_test_name",
+                            vec![CoverageAnchor::new("test_name", name)],
+                        ));
+                    }
                 }
             }
         }

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -666,7 +666,7 @@ fn a_second_sweep_over_a_still_red_run_does_not_file_a_second_task() {
 #[test]
 fn a_closed_task_does_not_suppress_a_recurrence() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
-    let log = "ci\tbuild\t2026-08-30T01:00:00Z error: expected 3 arguments, found 2\n";
+    let log = "ci\tbuild\t2026-08-30T01:00:00Z test suite::probe_case ... FAILED\nci\tbuild\t2026-08-30T01:00:01Z error: assertion failed: left == right\n";
     let evidence = snapshot(vec![failure(
         10,
         "ci",
@@ -699,6 +699,26 @@ fn a_closed_task_does_not_suppress_a_recurrence() {
             },
         )
         .expect("close the first task");
+
+    let same_run = file(&runtime, json!({"ci_evidence": evidence.clone()}));
+    assert_eq!(same_run["filed_count"], json!(0));
+    assert_eq!(
+        same_run["skipped_existing"][0]["match_evidence"]["fingerprint"],
+        json!("ci_failure_run_id")
+    );
+
+    let mut same_commit = failure(12, "ci", "build", "cargo build", log, CHECKOUT);
+    same_commit["event_reported_head_sha"] = json!(NEXT_HEAD);
+    same_commit["current_ref_head_sha"] = json!(NEXT_HEAD);
+    let same_commit = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![same_commit])}),
+    );
+    assert_eq!(same_commit["filed_count"], json!(0));
+    assert_eq!(
+        same_commit["skipped_existing"][0]["match_evidence"]["fingerprint"],
+        json!("ci_failure_head_sha")
+    );
 
     let mut second_failure = failure(11, "ci", "build", "cargo build", log, NEXT_HEAD);
     second_failure["event_reported_head_sha"] = json!(NEXT_HEAD);


### PR DESCRIPTION
## Task

[ORB-12181](https://orbit-cli.com/tasks/ORB-12181) — [code-review] ci-failure-sweep: a completed repair silently suppresses a later recurrence of the same named test for 30 days

### Description

`file_ci_failure_tasks` no longer files a repair task when a **completed** task mentions the failing test's name, even though the recurrence is a new run on a new commit. Red CI is then reported as `filed_count: 0` / `skipped_existing` and nothing is filed for up to 30 days.

## Mechanism

- ORB-12167 added provenance fingerprints and attached them as the *completed*-task fingerprint set: `crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs:1200-1204` and `:1243-1245` (`with_completed_fingerprints(self.provenance_fingerprints())`).
- `provenance_fingerprints` (`ci_failure_tasks.rs:1247-1281`) emits `ci_failure_run_id`, `ci_failure_head_sha` **and `ci_failure_test_name`**. Run id and head SHA identify one incident; a test name does not — it matches any future failure of the same test.
- `find_covering_task` now scans recently completed tasks too and matches them with that set: `crates/orbit-core/src/adapter/engine_host/v2_host/duplicate_tasks.rs:153-157` (`is_open_status(task.status) || recently_completed(task)`), `:161-176` (completed tasks use `completed_fingerprints`), `:387-390` (`recently_completed` = `Done` and `updated_at` within 30 days).
- The filed task's description embeds the failed-step log excerpt (`ci_failure_tasks.rs:1450-1470`), so the completed repair task always contains the test name that the next failure of that test fingerprints on.

## Reproduction (run in this checkout)

Added to `crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs`, modelled exactly on the existing `a_closed_task_does_not_suppress_a_recurrence` but with a libtest-style log line:

```rust
let log = "ci\tbuild\t2026-08-30T01:00:00Z test suite::probe_case ... FAILED\nci\tbuild\t2026-08-30T01:00:01Z error: assertion failed: left == right\n";
// file run 10 at CHECKOUT, admit it, close it as Done
// then file run 11 at NEXT_HEAD with event_reported_head_sha/current_ref_head_sha = NEXT_HEAD
assert_eq!(second["filed_count"], json!(1));
```

`cargo test -p orbit-core --lib` on that probe fails with:

```
left: Number(0)  right: Number(1)
"skipped_existing":[{"match_evidence":{"fingerprint":"ci_failure_test_name",
  "matched_fields":[{"field":"test_name","value":"suite::probe_case"}]},
  "match_kind":"material_coverage","task_id":"ORB-00000"}]
```

The probe was reverted; the checkout is unchanged.

The existing guard test `a_closed_task_does_not_suppress_a_recurrence` (`tests/ci_failure_tasks.rs:666-712`) still passes only because its fixture log is a compiler error with no test name, so nothing exercises the new completed-task path for a test-name fingerprint.

## Suggested direction

Keep the incident-scoped anchors (`ci_failure_run_id`, `ci_failure_head_sha`) in `completed_fingerprints` and drop `ci_failure_test_name` from that set — it remains correct for still-open tasks, where "someone is already working on this test" is the intended match.

### Acceptance Criteria

- A CI failure of a test named in a recently completed repair task, observed on a new run and a new commit, is filed as a new repair task rather than reported under skipped_existing.
- A replay of the same run id or the same tested commit as a recently completed repair task is still suppressed.
- A regression test with a libtest-style log line (`test <name> ... FAILED`) covers the recurrence case and fails against the current behavior.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Split CI provenance fingerprints into open-task and recently-completed-task sets. Recently completed tasks retain only run-id and tested-head anchors, so a future failure of the same named test on a new run and commit is filed again while same-run and same-commit replays remain suppressed.
- Expanded `a_closed_task_does_not_suppress_a_recurrence` with a libtest-style `test suite::probe_case ... FAILED` log and assertions for same-run suppression, same-tested-commit suppression, and new-run/new-commit filing.
Criteria:
- Criterion 1: passed — the regression test files one task for run 11 on `NEXT_HEAD` after run 10 was completed, with no completed-task test-name fingerprint available to suppress it.
- Criterion 2: passed — the same test asserts run 10 is skipped by `ci_failure_run_id` and a distinct run on the original `CHECKOUT` is skipped by `ci_failure_head_sha`.
- Criterion 3: passed — the focused regression uses the required libtest-style FAILED line and passes after the fix; against the prior implementation, the completed task's test-name fingerprint would have produced `filed_count: 0`.
Assessment: The change is limited to the authoritative duplicate-candidate construction and its focused regression coverage; open-task matching still includes test-name fingerprints.
Validation:
- `cargo fmt --all`: passed.
- `cargo test -p orbit-core --lib a_closed_task_does_not_suppress_a_recurrence`: passed.
- `make ci-fast`: passed; its compiler-cache namespace subcheck reported an environment limitation (`bwrap: No permissions to create new namespace`) and explicitly skipped that subcheck.
- `make ci-lint`: passed.
- `git diff --check`: passed.
- `cargo test -p orbit-core --lib`: failed with 5 unrelated existing fixture-selector failures (`1411 passed, 5 failed, 2 ignored`); the changed regression and affected CI-failure test module passed. The failures cite missing fixture targets such as `Cargo.toml`, `crates/leaf_0/src/lib.rs`, `file:src/future.rs`, and `src/lib.rs`.
- `GIT_OPTIONAL_LOCKS=0 git status --short`: passed; only the two declared task files are modified.
Remaining risk: The full orbit-core lib suite remains red for unrelated workspace fixture setup failures; no failure occurred in the affected CI-failure tests.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12181-6aa3d9c6`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus