### PR TITLE
[code-review] `orbit mcp init/remove --claude --scope home` locks `~/..claude.json.lock`, not Claude Code's `~/.claude.json.lock`, so the ORB-12165 lock excludes nothing

### DIFF
--- a/crates/orbit-cli/src/command/mcp/setup/providers/claude.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/claude.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::Path;
 
-use orbit_common::fs::io::with_exclusive_file_lock;
+use orbit_common::fs::io::{LockFileNaming, with_exclusive_file_lock_named};
 use orbit_core::OrbitError;
 use orbit_types::tool::mcp_advertised_tool_name;
 use serde_json::{Map as JsonMap, Value as JsonValue};
@@ -31,7 +31,15 @@ pub(in crate::command::mcp::setup) fn apply_claude_init(
         }
     };
     if target.scope == ScopeArg::Home {
-        with_exclusive_file_lock(&target.mcp_path, "Claude Code main settings", update_mcp)?;
+        // Claude Code itself locks `<mcp_path>.lock` (its own file name with
+        // `.lock` appended), not Orbit's usual dot-prefixed sibling. Locking
+        // anything else lets the two writers race past each other (ORB-12182).
+        with_exclusive_file_lock_named(
+            &target.mcp_path,
+            LockFileNaming::AppendedSuffix,
+            "Claude Code main settings",
+            update_mcp,
+        )?;
     } else {
         update_mcp()?;
     }
@@ -71,7 +79,12 @@ pub(in crate::command::mcp::setup) fn apply_claude_remove(
         }
     };
     if target.scope == ScopeArg::Home {
-        with_exclusive_file_lock(&target.mcp_path, "Claude Code main settings", remove_mcp)?;
+        with_exclusive_file_lock_named(
+            &target.mcp_path,
+            LockFileNaming::AppendedSuffix,
+            "Claude Code main settings",
+            remove_mcp,
+        )?;
     } else {
         remove_mcp()?;
     }

--- a/crates/orbit-cli/src/command/mcp/setup/providers/tests/claude.rs
+++ b/crates/orbit-cli/src/command/mcp/setup/providers/tests/claude.rs
@@ -1,6 +1,8 @@
+use std::path::PathBuf;
+
 use tempfile::tempdir;
 
-use orbit_common::fs::io::{atomic_write_text, with_exclusive_file_lock};
+use orbit_common::fs::io::{FileLockOptions, acquire_exclusive_file_lock, atomic_write_text};
 
 use super::super::super::args::{McpAction, McpProvider, ProviderSelectionMode, ScopeArg};
 use super::super::super::dispatch::run_action;
@@ -192,18 +194,29 @@ fn claude_home_scope_waits_for_concurrent_state_update_before_reading() {
     std::fs::write(&mcp_path, "{\n  \"userState\": \"before\"\n}\n")
         .expect("write initial Claude state");
 
+    // Simulate Claude Code itself, which locks `<mcp_path>.lock` — the full
+    // file name with `.lock` appended, not Orbit's usual dot-prefixed
+    // sibling. Holding that literal path (independent of the production
+    // helper) is what proves Orbit actually waits on Claude Code's own lock
+    // rather than a differently-named file neither process contends on.
+    let mut claude_lock_path = mcp_path.clone().into_os_string();
+    claude_lock_path.push(".lock");
+    let claude_lock_path = PathBuf::from(claude_lock_path);
+
     let (lock_ready_tx, lock_ready_rx) = std::sync::mpsc::sync_channel(0);
     let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
-    let held_path = mcp_path.clone();
+    let held_path = claude_lock_path.clone();
     let holder = std::thread::spawn(move || {
-        with_exclusive_file_lock(&held_path, "test Claude Code writer", || {
-            lock_ready_tx
-                .send(())
-                .expect("notify that Claude lock is held");
-            release_rx.recv().expect("wait for test release");
-            Ok::<(), std::io::Error>(())
-        })
+        let _guard = acquire_exclusive_file_lock(
+            &held_path,
+            "test Claude Code writer",
+            FileLockOptions::default(),
+        )
         .expect("hold Claude lock");
+        lock_ready_tx
+            .send(())
+            .expect("notify that Claude lock is held");
+        release_rx.recv().expect("wait for test release");
     });
     lock_ready_rx.recv().expect("wait for Claude lock holder");
 
@@ -240,6 +253,47 @@ fn claude_home_scope_waits_for_concurrent_state_update_before_reading() {
             .expect("parse final Claude state");
     assert_eq!(mcp["userState"], "during");
     assert!(mcp["mcpServers"]["orbit"].is_object());
+}
+
+#[test]
+fn claude_home_scope_locks_claude_codes_exact_lock_file() {
+    // ORB-12182: the home-scope read-modify-write must serialize against the
+    // literal lock file Claude Code itself uses (`<mcp_path>.lock`), not a
+    // dot-prefixed sibling of Orbit's own invention. Compute the expected
+    // path independently of the production lock-naming helper so a rename of
+    // that helper's convention fails this test instead of passing vacuously.
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    let orbit_root = repo.path().join(".orbit");
+    std::fs::create_dir_all(&orbit_root).expect("create orbit root");
+    let mcp_path = home.path().join(".claude.json");
+
+    run_action(
+        McpAction::Init(ServerLaunch::default()),
+        repo.path(),
+        &orbit_root,
+        ProviderSelectionMode::Explicit(vec![McpProvider::Claude]),
+        Some(home.path().to_path_buf()),
+        ScopeArg::Home,
+    )
+    .expect("init claude home scope");
+
+    let mut expected_lock_path = mcp_path.clone().into_os_string();
+    expected_lock_path.push(".lock");
+    let expected_lock_path = PathBuf::from(expected_lock_path);
+    assert!(
+        expected_lock_path.is_file(),
+        "expected Claude Code's lock file at {}",
+        expected_lock_path.display()
+    );
+
+    let stray_lock_path = home.path().join("..claude.json.lock");
+    assert!(
+        !stray_lock_path.exists(),
+        "must not create the generic dot-prefixed sibling lock file \
+         Claude Code does not recognize: {}",
+        stray_lock_path.display()
+    );
 }
 
 #[test]

--- a/crates/orbit-common/src/fs/io.rs
+++ b/crates/orbit-common/src/fs/io.rs
@@ -428,6 +428,81 @@ where
     F: FnOnce() -> Result<T, E>,
     E: From<io::Error>,
 {
+    with_exclusive_file_lock_named_options(
+        target_path,
+        LockFileNaming::DotPrefixedSibling,
+        label,
+        options,
+        op,
+    )
+}
+
+/// Naming convention for the sibling lock file [`with_exclusive_file_lock`]
+/// and [`with_exclusive_file_lock_named`] acquire relative to a target path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockFileNaming {
+    /// `.{file_name}.lock` — Orbit's own private sibling, invisible to the
+    /// target's other consumers. Correct whenever Orbit owns both ends of the
+    /// lock protocol.
+    DotPrefixedSibling,
+    /// `{file_name}.lock` — the target's exact file name with `.lock`
+    /// appended, no extra leading dot. Required when another process already
+    /// defines the lock file it expects beside a target Orbit does not
+    /// exclusively own (for example Claude Code locking `~/.claude.json.lock`
+    /// beside its own `~/.claude.json`); acquiring anything else lets the two
+    /// writers race past each other.
+    AppendedSuffix,
+}
+
+impl LockFileNaming {
+    fn lock_path_for(self, path: &Path) -> io::Result<PathBuf> {
+        let file_name = path.file_name().and_then(|n| n.to_str()).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("path '{}' has no file name", path.display()),
+            )
+        })?;
+        let lock_name = match self {
+            LockFileNaming::DotPrefixedSibling => format!(".{file_name}.lock"),
+            LockFileNaming::AppendedSuffix => format!("{file_name}.lock"),
+        };
+        Ok(path.with_file_name(lock_name))
+    }
+}
+
+/// [`with_exclusive_file_lock`] with an explicit [`LockFileNaming`] instead of
+/// Orbit's default dot-prefixed sibling.
+pub fn with_exclusive_file_lock_named<T, E, F>(
+    target_path: &Path,
+    naming: LockFileNaming,
+    label: &str,
+    op: F,
+) -> Result<T, E>
+where
+    F: FnOnce() -> Result<T, E>,
+    E: From<io::Error>,
+{
+    with_exclusive_file_lock_named_options(
+        target_path,
+        naming,
+        label,
+        FileLockOptions::default(),
+        op,
+    )
+}
+
+/// [`with_exclusive_file_lock_named`] with an explicit, testable acquisition policy.
+pub fn with_exclusive_file_lock_named_options<T, E, F>(
+    target_path: &Path,
+    naming: LockFileNaming,
+    label: &str,
+    options: FileLockOptions,
+    op: F,
+) -> Result<T, E>
+where
+    F: FnOnce() -> Result<T, E>,
+    E: From<io::Error>,
+{
     let parent = target_path.parent().ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -447,7 +522,7 @@ where
     // indistinguishable, which is why this only ever deadlocked where a symlink
     // sat above the target.
     create_private_dir_all(parent).map_err(|e| classify_lock_io(parent, e))?;
-    let lock_path = resolved_lock_path(target_path)?;
+    let lock_path = resolved_lock_path(target_path, naming)?;
     let Some(_held) = claim_lock_path(&lock_path) else {
         return op();
     };
@@ -507,7 +582,7 @@ where
     if !parent.is_dir() {
         return op();
     }
-    let lock_path = resolved_lock_path(target_path)?;
+    let lock_path = resolved_lock_path(target_path, LockFileNaming::DotPrefixedSibling)?;
     let Some(_held) = claim_lock_path(&lock_path) else {
         return op();
     };
@@ -538,8 +613,8 @@ where
 /// deadlock on a second descriptor to the same file. Resolving the parent
 /// collapses those routes to one key. An unresolvable parent means the
 /// directory does not exist yet, so nothing can be holding a lock inside it.
-fn resolved_lock_path(target_path: &Path) -> io::Result<PathBuf> {
-    let lock_path = lock_path_for(target_path)?;
+fn resolved_lock_path(target_path: &Path, naming: LockFileNaming) -> io::Result<PathBuf> {
+    let lock_path = naming.lock_path_for(target_path)?;
     let Some(file_name) = lock_path.file_name() else {
         return Ok(lock_path);
     };
@@ -547,16 +622,6 @@ fn resolved_lock_path(target_path: &Path) -> io::Result<PathBuf> {
         Some(Ok(parent)) => Ok(parent.join(file_name)),
         _ => Ok(lock_path),
     }
-}
-
-fn lock_path_for(path: &Path) -> io::Result<PathBuf> {
-    let file_name = path.file_name().and_then(|n| n.to_str()).ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("path '{}' has no file name", path.display()),
-        )
-    })?;
-    Ok(path.with_file_name(format!(".{file_name}.lock")))
 }
 
 pub(crate) fn open_private_file(path: &Path, options: &mut OpenOptions) -> io::Result<File> {


### PR DESCRIPTION
## Task

[ORB-12182](https://orbit-cli.com/tasks/ORB-12182) — [code-review] `orbit mcp init/remove --claude --scope home` locks `~/..claude.json.lock`, not Claude Code's `~/.claude.json.lock`, so the ORB-12165 lock excludes nothing

### Description

ORB-12165 wrapped the home-scope `~/.claude.json` read-modify-write in `with_exclusive_file_lock` to stop Orbit and a live Claude Code process from clobbering each other. The lock helper derives a *dot-prefixed* sibling name, so Orbit takes an exclusive flock on `$HOME/..claude.json.lock` (two dots) while Claude Code uses `$HOME/.claude.json.lock` — two different files, so neither writer ever sees the other's lock.

## Evidence

- Lock acquisition: `crates/orbit-cli/src/command/mcp/setup/providers/claude.rs:32-36` and `:71-75` call `with_exclusive_file_lock(&target.mcp_path, "Claude Code main settings", ...)` with `target.mcp_path == $HOME/.claude.json` (`crates/orbit-cli/src/command/mcp/setup/dispatch.rs:82-90`).
- Lock name: `crates/orbit-common/src/fs/io.rs:552-560` — `lock_path_for` returns `path.with_file_name(format!(".{file_name}.lock"))`, i.e. `.claude.json` → `..claude.json.lock`.
- Confirmed by running a probe test through the public helper in this checkout: holding `with_exclusive_file_lock` on `<tmp>/.claude.json` lists the directory as `["..claude.json.lock", ".claude.json"]`. (Probe reverted; checkout unchanged.)
- Claude Code's lock path is documented in this repository as `$HOME/.claude.json.lock`: `crates/orbit-exec/src/macos_sandbox/provider_dirs.rs:232-262` emits `(allow file-write* (literal "$HOME/.claude.json.lock"))`, and `docs/design/policy-sandbox/4_decisions.md:226-239` records the same protocol (`.lock` plus `.tmp.<pid>.<ms_ts>` siblings).
- The regression test added with the fix (`crates/orbit-cli/src/command/mcp/setup/providers/tests/claude.rs:185-243`, `claude_home_scope_waits_for_concurrent_state_update_before_reading`) simulates "Claude Code" with Orbit's own `with_exclusive_file_lock`, so it only proves Orbit excludes Orbit. It would still pass with any lock file name.

## Impact

The atomic rename added in the same change does prevent a torn/truncated file, but the lost-update window ORB-12165 set out to close is still open: Orbit reads `~/.claude.json`, Claude Code commits its own update, Orbit renames its stale copy over it and Claude Code's just-persisted state is gone (or, in the other interleaving, Orbit's `mcpServers` registration is).

A secondary, cosmetic effect: every home-scope `mcp init`/`mcp remove` leaves a stray `~/..claude.json.lock` in the user's home directory, and creates it even when `~/.claude.json` does not exist.

## Suggested direction

Acquire the lock on the path Claude Code actually uses (`<mcp_path>.lock`) for this provider instead of the generic dot-prefixed sibling — e.g. a lock-path override on the helper, or locking `target.mcp_path.with_extension("json.lock")` explicitly — and assert the concrete lock file name in the regression test so the two protocols cannot drift apart again.

### Acceptance Criteria

- Home-scope `orbit mcp init --claude` and `orbit mcp remove --claude` serialize against a holder of `$HOME/.claude.json.lock`, the lock file Claude Code itself uses.
- A test asserts the concrete lock file path used for the Claude home-scope write, so a rename of the helper's lock convention fails the test.
- No stray lock file is left in `$HOME` under a name Claude Code does not recognize.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed the ORB-12165 regression where the Claude home-scope `~/.claude.json` lock used Orbit's generic dot-prefixed sibling (`~/..claude.json.lock`) instead of the literal path Claude Code itself locks (`~/.claude.json.lock`), so the two writers never excluded each other.

Root cause: `orbit_common::fs::io::lock_path_for` unconditionally derives `.{file_name}.lock`, and `crates/orbit-cli/src/command/mcp/setup/providers/claude.rs` had no way to override that convention.

Fix (crates/orbit-common/src/fs/io.rs):
- Added `LockFileNaming` enum with `DotPrefixedSibling` (existing default, used by every other caller unchanged) and `AppendedSuffix` (`{file_name}.lock`, the convention Claude Code hard-codes).
- Added `with_exclusive_file_lock_named` / `with_exclusive_file_lock_named_options`, a second constructor that takes an explicit `LockFileNaming`. `with_exclusive_file_lock_options` now delegates to it with `DotPrefixedSibling`, so no other of the ~15 existing call sites (orbit-store, orbit-registry, orbit-cli host/rename, git fetch lock, etc.) changed behavior.
- `resolved_lock_path` takes the naming enum instead of hardcoding the dot-prefix; the old free-standing `lock_path_for` helper was folded into `LockFileNaming::lock_path_for`.

Fix (crates/orbit-cli/src/command/mcp/setup/providers/claude.rs):
- `apply_claude_init` and `apply_claude_remove` now call `with_exclusive_file_lock_named(&target.mcp_path, LockFileNaming::AppendedSuffix, ...)` for the home scope, so Orbit takes an exclusive flock on the exact `~/.claude.json.lock` path Claude Code uses.

Tests (crates/orbit-cli/src/command/mcp/setup/providers/tests/claude.rs):
- Fixed `claude_home_scope_waits_for_concurrent_state_update_before_reading`, which previously simulated "Claude Code" via Orbit's own `with_exclusive_file_lock` (proving only that Orbit excludes Orbit). It now holds the lock directly via `acquire_exclusive_file_lock` at the literal `<mcp_path>.lock` path, independent of any production helper, so it proves Orbit's home-scope write actually waits behind that exact file.
- Added `claude_home_scope_locks_claude_codes_exact_lock_file`: asserts the concrete `<mcp_path>.lock` file exists after a home-scope init and that the old incorrect `..claude.json.lock` sibling is never created — covers the "no stray lock file" AC and the "init creates the lock even when `~/.claude.json` doesn't exist" case from the bug report.
- Verified both tests actually catch the regression: temporarily reverted the claude.rs fix to `LockFileNaming::DotPrefixedSibling` and confirmed both new/updated tests fail with the original bug, then restored the fix and reconfirmed green.

Acceptance criteria:
1. Home-scope `init`/`remove` now lock `$HOME/.claude.json.lock` (Claude Code's own lock file) — done, verified by the fixed contention test.
2. A test asserts the concrete lock path independently of the helper's derivation — done (`claude_home_scope_locks_claude_codes_exact_lock_file`), and confirmed to fail on a helper-convention rename via the revert check above.
3. No stray `..claude.json.lock` is left in `$HOME` — done, asserted in the same new test, including the case where `~/.claude.json` doesn't pre-exist.

Validation:
- `cargo build -p orbit-common -p orbit-cli` — passed.
- `cargo test -p orbit-cli --bin orbit mcp::setup` (65 tests) — passed.
- `cargo test -p orbit-common fs::tests::io` (26 tests) — passed, no regression in other lock callers/tests.
- `make ci-fast` — passed (after `cargo fmt --all` to satisfy the formatting guardrail).
- `make ci-lint` (workspace clippy, warnings denied) — passed.
- `git diff --check` / `git status --short` — clean; only the three tracked files listed above are modified, no untracked paths.

No new context files were needed beyond the two already scoped (`crates/orbit-common/src/fs/io.rs`, `crates/orbit-cli/src/command/mcp/setup/providers/claude.rs`); the test file edit is a sibling of the second and within existing scope. No cross-crate dependency edges were added — only new public functions on the existing orbit-cli → orbit-common edge.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12182-6aa3d9c7`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus