### PR TITLE
CI push runs check out the branch tip (github.ref_name) instead of github.sha, so queued runs test a different commit than the one they report on

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -53,9 +53,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # PR head SHA, not the branch name GitHub deletes on merge, and
-          # not github.sha (the ephemeral merge commit).
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
+          # On pull_request, use the PR head SHA: not the branch name
+          # GitHub deletes on merge, and not github.sha (the ephemeral
+          # merge commit). On push, use github.sha directly so a run that
+          # sat queued still builds and reports on the commit that
+          # triggered it, not whatever the branch points to once it starts.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-05-07)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # PR head SHA, not the branch name GitHub deletes on merge, and
-          # not github.sha (the ephemeral merge commit).
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
+          # On pull_request, use the PR head SHA: not the branch name
+          # GitHub deletes on merge, and not github.sha (the ephemeral
+          # merge commit). On push, use github.sha directly so a run that
+          # sat queued still builds and reports on the commit that
+          # triggered it, not whatever the branch points to once it starts.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-05-07)
@@ -80,9 +83,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # PR head SHA, not the branch name GitHub deletes on merge, and
-          # not github.sha (the ephemeral merge commit).
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
+          # On pull_request, use the PR head SHA: not the branch name
+          # GitHub deletes on merge, and not github.sha (the ephemeral
+          # merge commit). On push, use github.sha directly so a run that
+          # sat queued still builds and reports on the commit that
+          # triggered it, not whatever the branch points to once it starts.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-05-07)
@@ -135,9 +141,12 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # PR head SHA, not the branch name GitHub deletes on merge, and
-          # not github.sha (the ephemeral merge commit).
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
+          # On pull_request, use the PR head SHA: not the branch name
+          # GitHub deletes on merge, and not github.sha (the ephemeral
+          # merge commit). On push, use github.sha directly so a run that
+          # sat queued still builds and reports on the commit that
+          # triggered it, not whatever the branch points to once it starts.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-05-07)
@@ -218,9 +227,12 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # PR head SHA, not the branch name GitHub deletes on merge, and
-          # not github.sha (the ephemeral merge commit).
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
+          # On pull_request, use the PR head SHA: not the branch name
+          # GitHub deletes on merge, and not github.sha (the ephemeral
+          # merge commit). On push, use github.sha directly so a run that
+          # sat queued still builds and reports on the commit that
+          # triggered it, not whatever the branch points to once it starts.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-05-07)


### PR DESCRIPTION
## Task

[ORB-12185](https://orbit-cli.com/tasks/ORB-12185) — CI push runs check out the branch tip (github.ref_name) instead of github.sha, so queued runs test a different commit than the one they report on

### Description

## Observed (2026-09-11 on-call shift)

`.github/workflows/ci.yml` (three jobs, lines ~51/85/140) checks out

```yaml
ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
```

On a `push` event that resolves to the **branch name**, so a run that sits in the GitHub queue for 20 minutes (as happened 10:05–10:45 UTC today) checks out whatever `agent-main` points to when the job finally starts — not the commit that triggered it. Tonight this made runs recorded against 920aedef, dc6c48a9, 686ae81c and 15246cd9 fail on tests that only broke in the later bbdf7749 (ORB-12168), while d3dd799f/e949ba6a — which dequeued earlier — passed. Attribution by SHA became impossible and the orchestrator spent a wake proving the "first red" commit was innocent. The ci-failure-sweep suffers the same: it keys repairs on `head_sha` of the run.

## Fix

Check out the triggering commit on push events: `github.sha` (with `fetch-depth` as already configured). Keep the pull_request branch using `head.sha`. If some job deliberately needs the branch tip (e.g. a "latest agent-main" nightly), give it its own explicit ref and a comment saying why.

### Acceptance Criteria

- For push events every checkout step in .github/workflows/ci.yml uses `github.sha`; the pull_request branch of the expression is unchanged.
- A push run started after a later push on the same branch still builds and tests its own triggering commit (verify by inspecting the "Checking out" line in the run log).
- Any other workflow in .github/workflows using the same ref expression is updated consistently or has a comment justifying the branch-tip checkout.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Fix
Changed the checkout `ref` expression's push-event branch from `github.ref_name` (the mutable branch tip) to `github.sha` (the fixed commit that triggered the run) in every checkout step using this pattern:
- `.github/workflows/ci.yml`: 4 jobs (linux-sandbox, msrv, coverage, ci) — lines 54/91/149/235 post-edit.
- `.github/workflows/ci-macos.yml`: 1 job (macos-sandbox) — line 61 post-edit. Added to task context_files (see comment) because it has the identical push-triggered pattern and thus the same bug; not scoped in the original context_files.

The `pull_request` branch of each ternary (`github.event.pull_request.head.sha`) is unchanged. Reworded the adjacent comment to explain both branches (PR head SHA rationale unchanged; new sentence on why push uses `github.sha`).

Left unchanged (not checkout-ref, no bug): `ci.yml`'s `REF` env var (`github.ref_name`, informational branch name for the host CI-failure-sweep report) and `release.yml`'s three `github.ref_name` uses (release tag/name and raw-install-URL path segment — release workflow runs on tag push, where `ref_name` is the tag itself, not a moving branch tip).

## Acceptance criteria
1. "Every checkout step in ci.yml uses github.sha on push; pull_request branch unchanged" — met; verified via `git diff` (5 identical edits across the two files) and `python3 -c "yaml.safe_load(...)"` confirming both files remain valid YAML.
2. "A push run started after a later push on the same branch still builds/tests its own triggering commit, verified via the run log" — met by construction: `github.sha` is fixed at workflow-run creation time (the triggering push), unlike `github.ref_name` which `actions/checkout` re-resolves to the branch's current tip at execution time. Could not obtain an actual queued-then-dequeued GitHub Actions run log from this worktree — that requires a real push-triggered run on GitHub after this change merges; not runnable/observable here. Flagging as residual/runtime-only verification.
3. "Any other workflow with the same ref expression is updated consistently or documented" — met: grepped all of `.github/workflows/*.yml` for `github.ref_name`/`github.sha`; only `ci-macos.yml` shared the exact checkout pattern and was fixed identically; `release.yml`'s unrelated `github.ref_name` uses are tag-push-workflow specific (not a moving branch tip in that trigger context) and were left as-is.

## Validation
- `make ci-fast` (fmt-check + guardrail scripts, no compile): **passed**, exit 0. Includes "CI failure reporting guard passed" (scripts/check-ci-failure-reporting.sh), which checks the EVENT_SHA/reporting contract this fix keeps consistent.
- `git diff --check`: passed, no whitespace issues.
- `git status --short`: only `.github/workflows/ci.yml` and `.github/workflows/ci-macos.yml` modified; no untracked files.
- `make ci-lint` (workspace clippy): not run — this change touches only YAML workflow files, no Rust source, so there is nothing for clippy to evaluate differently; skipping is a no-op with respect to this diff.
- actionlint: not available in this environment (binary not installed); relied on `yaml.safe_load` for syntax validity and manual review of the GitHub Actions expression syntax (unchanged operators/functions, only the RHS identifier changed).

## Remaining risk
None identified for the diff itself. The only unverifiable item is criterion 2's live run-log check, which needs an actual GitHub Actions push run post-merge (outside this worktree's authority — commit/push/PR is owned by the pipeline).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12185-6aa3df4e`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus