### PR TITLE
Fix red CI on agent-main: ORB-12168 context-selector validation runs inside core add_task/update_task and breaks 5 orbit-core tests that seed fixture tasks

### DIFF
--- a/crates/orbit-cli/src/command/task/add.rs
+++ b/crates/orbit-cli/src/command/task/add.rs
@@ -46,6 +46,9 @@ pub struct TaskAddArgs {
     /// Prefer `file:`, `dir:`, or `symbol:` forms; legacy raw paths are accepted and upgraded.
     #[arg(long, action = ArgAction::Append, value_delimiter = ',')]
     pub context: Vec<String>,
+    /// Accept context selectors whose target does not exist yet (for work that creates the file)
+    #[arg(long)]
+    pub allow_missing_context: bool,
     /// Workspace path for the task, relative to the selected workspace
     #[arg(long = "workspace-path")]
     pub workspace_path: Option<String>,
@@ -81,6 +84,10 @@ pub struct TaskAddArgs {
 impl Execute for TaskAddArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
         let (agent, model) = super::mutation_identity(self.model);
+        if !self.allow_missing_context {
+            runtime
+                .ensure_context_selectors_exist(&self.context, self.workspace_path.as_deref())?;
+        }
         if let Some(parent_id) = self.parent_id.as_deref()
             && runtime.get_task(parent_id).is_err()
         {

--- a/crates/orbit-cli/src/command/task/update.rs
+++ b/crates/orbit-cli/src/command/task/update.rs
@@ -69,6 +69,9 @@ pub struct TaskUpdateArgs {
     /// Prefer `file:`, `dir:`, or `symbol:` forms; legacy raw paths are accepted and upgraded.
     #[arg(long = "context", alias = "context-files", action = ArgAction::Append, value_delimiter = ',')]
     pub context_files: Vec<String>,
+    /// Accept context selectors whose target does not exist yet (for work that creates the file)
+    #[arg(long)]
+    pub allow_missing_context: bool,
     /// Task artifact write in `path=content` form. Repeat for multiple artifacts.
     #[arg(long = "artifact")]
     pub artifacts: Vec<String>,
@@ -139,6 +142,7 @@ impl Execute for TaskUpdateArgs {
             crew,
             orchestrator,
             context_files,
+            allow_missing_context,
             artifacts,
             model,
             approve,
@@ -202,6 +206,10 @@ impl Execute for TaskUpdateArgs {
         let dependencies = parse_replacement_list(dependencies);
         let tags = (!tags.is_empty()).then_some(tags);
         let upsert_artifacts = parse_artifact_args(&artifacts)?;
+        let context_files = parse_replacement_list(context_files);
+        if !allow_missing_context && let Some(candidates) = context_files.as_deref() {
+            runtime.ensure_context_selectors_exist(candidates, None)?;
+        }
         let (agent, model) = super::mutation_identity(model);
 
         let task = runtime.update_task_with_identity(
@@ -225,7 +233,7 @@ impl Execute for TaskUpdateArgs {
                 job_run_id,
                 crew,
                 orchestrator,
-                context_files: parse_replacement_list(context_files),
+                context_files,
                 upsert_artifacts,
                 ..Default::default()
             },

--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -811,6 +811,12 @@
         "required": false
       },
       {
+        "description": "Optional. Set true to accept `context_files` selectors whose target does not exist yet, for work that creates the file. Missing selectors are rejected by default.",
+        "name": "allow_missing_context",
+        "param_type": "boolean",
+        "required": false
+      },
+      {
         "description": "Optional priority level",
         "name": "priority",
         "param_type": "string",
@@ -1274,6 +1280,12 @@
         "description": "Task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically.",
         "name": "context_files",
         "param_type": "string_list",
+        "required": false
+      },
+      {
+        "description": "Optional. Set true to accept `context_files` selectors whose target does not exist yet, for work that creates the file. Missing selectors are rejected by default.",
+        "name": "allow_missing_context",
+        "param_type": "boolean",
         "required": false
       },
       {

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -615,6 +615,10 @@
           ],
           "description": "Optional acceptance criteria as a string or array of strings"
         },
+        "allow_missing_context": {
+          "description": "Optional. Set true to accept `context_files` selectors whose target does not exist yet, for work that creates the file. Missing selectors are rejected by default.",
+          "type": "boolean"
+        },
         "complexity": {
           "description": "Task complexity level (low, medium, or hard)",
           "enum": [
@@ -1049,6 +1053,10 @@
             }
           ],
           "description": "New acceptance criteria as an array of strings or a single string"
+        },
+        "allow_missing_context": {
+          "description": "Optional. Set true to accept `context_files` selectors whose target does not exist yet, for work that creates the file. Missing selectors are rejected by default.",
+          "type": "boolean"
         },
         "comment": {
           "description": "Task comment to append",

--- a/crates/orbit-cli/tests/task_trimmed_surface.rs
+++ b/crates/orbit-cli/tests/task_trimmed_surface.rs
@@ -196,6 +196,42 @@ fn task_update_and_add_accept_valid_context_selectors() {
     assert_eq!(updated["context_files"], json!(["file:existing.rs"]));
 }
 
+/// The existence guard is an operator-surface default, not a wall: work that
+/// creates a file records its selector with the explicit escape.
+#[test]
+fn allow_missing_context_accepts_a_not_yet_existing_selector() {
+    let workspace = TestWorkspace::new();
+
+    let added = workspace.task_json(&[
+        "task",
+        "add",
+        "--title",
+        "Create a new module",
+        "--complexity",
+        "low",
+        "--context",
+        "file:src/future.rs",
+        "--allow-missing-context",
+        "--json",
+    ]);
+    assert_eq!(added["context_files"], json!(["file:src/future.rs"]));
+
+    let id = added["id"].as_str().expect("task id");
+    let updated = workspace.task_json(&[
+        "task",
+        "update",
+        id,
+        "--context",
+        "file:src/other_future.rs",
+        "--allow-missing-context",
+        "--json",
+    ]);
+    assert_eq!(
+        updated["context_files"],
+        json!(["file:src/other_future.rs"])
+    );
+}
+
 #[test]
 fn locks_list_projects_files_held_by_active_tasks() {
     let workspace = TestWorkspace::new();

--- a/crates/orbit-core/src/adapter/tool_host/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/task_tools.rs
@@ -29,6 +29,9 @@ pub(super) fn add(
     let workspace = required_string(&input, &["workspace"], "workspace")?;
     let raw_context_files =
         optional_csv_or_string_list_alias(&input, &["context_files"])?.unwrap_or_default();
+    if !allows_missing_context(&input)? {
+        runtime.ensure_context_selectors_exist(&raw_context_files, Some(workspace.as_str()))?;
+    }
     let task = runtime.add_task_with_identity(
         TaskAddParams {
             parent_id: None,
@@ -292,6 +295,12 @@ pub(super) fn update(
         ));
     }
     let id = required_string(&input, &["id"], "id")?;
+    let context_files = optional_csv_or_string_list_alias(&input, &["context_files", "context"])?;
+    if !allows_missing_context(&input)?
+        && let Some(candidates) = context_files.as_deref()
+    {
+        runtime.ensure_context_selectors_exist(candidates, None)?;
+    }
     let task = runtime.update_task_with_owner(
         &id,
         TaskUpdateParams {
@@ -349,10 +358,7 @@ pub(super) fn update(
             job_run_id: optional_raw_string(&input, "job_run_id")?.map(empty_string_to_none),
             crew: optional_raw_string(&input, "crew")?.map(empty_string_to_none),
             orchestrator: optional_raw_string(&input, "orchestrator")?.map(empty_string_to_none),
-            context_files: optional_csv_or_string_list_alias(
-                &input,
-                &["context_files", "context"],
-            )?,
+            context_files,
             upsert_artifacts: parse_artifacts(&input)?,
         },
         agent,
@@ -360,6 +366,17 @@ pub(super) fn update(
         owner.map(|owner| owner.owner_run_id),
     )?;
     serialize_task(runtime, &task)
+}
+
+/// Whether the caller explicitly opted out of the operator-surface check that
+/// every `context_files` selector already exists. Internal callers never reach
+/// these handlers, so the escape is the only way for an agent to record a
+/// target the task is about to create.
+fn allows_missing_context(input: &Value) -> Result<bool, OrbitError> {
+    Ok(
+        optional_bool_alias(input, &["allow_missing_context", "allowMissingContext"])?
+            .unwrap_or(false),
+    )
 }
 
 fn optional_raw_string_alias(input: &Value, keys: &[&str]) -> Result<Option<String>, OrbitError> {

--- a/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
@@ -1823,12 +1823,16 @@ fn task_update_tool_replaces_context_files_and_keeps_future_paths() {
         .expect("created updated_at")
         .to_string();
 
+    // `file:src/future.rs` does not exist yet, so the tool's default existence
+    // guard would refuse it; the explicit escape is how a caller records a
+    // target the task is about to create.
     let output = runtime
         .execute_tool_command(
             "orbit.task.update",
             json!({
                 "id": task_id,
                 "context_files": ["[\"file:src/main.rs\", \"file:src/future.rs\"]"],
+                "allow_missing_context": true,
             }),
             Some("codex".to_string()),
             Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
@@ -1868,6 +1872,79 @@ fn task_update_tool_replaces_context_files_and_keeps_future_paths() {
             .iter()
             .any(|event| event.payload["data"]["id"] == shown["id"]),
         "{events:#?}"
+    );
+}
+
+/// The existence guard lives on the tool surface, not in `add_task` /
+/// `update_task`: an agent typo must not ship a task whose context is dead on
+/// arrival, and the rejected write must leave the task untouched.
+#[test]
+fn task_tools_reject_context_selectors_that_do_not_exist() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let src_dir = repo_root.join("src");
+    fs::create_dir_all(&src_dir).expect("create src dir");
+    fs::write(src_dir.join("lib.rs"), "pub fn before() {}\n").expect("write source file");
+
+    let add_error = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Missing context",
+                "description": "Exercise the tool-surface existence guard.",
+                "complexity": "low",
+                "workspace": repo_root.to_string_lossy(),
+                "context_files": ["file:src/typo.rs"],
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect_err("task add tool must reject a missing selector");
+    assert!(
+        add_error.to_string().contains("file:src/typo.rs"),
+        "{add_error}"
+    );
+    assert!(
+        runtime.list_tasks().expect("list tasks").is_empty(),
+        "a rejected add must not create a task"
+    );
+
+    let added = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Existing context",
+                "description": "Exercise the tool-surface existence guard.",
+                "complexity": "low",
+                "workspace": repo_root.to_string_lossy(),
+                "context_files": ["file:src/lib.rs"],
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("task add tool accepts an existing selector");
+    let task_id = added["id"].as_str().expect("task id").to_string();
+
+    let update_error = runtime
+        .execute_tool_command(
+            "orbit.task.update",
+            json!({
+                "id": task_id,
+                "context_files": ["file:src/typo.rs"],
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect_err("task update tool must reject a missing selector");
+    assert!(
+        update_error.to_string().contains("file:src/typo.rs"),
+        "{update_error}"
+    );
+
+    let preserved = runtime.get_task(&task_id).expect("reload task");
+    assert_eq!(
+        preserved.context_files,
+        vec!["file:src/lib.rs".to_string()],
+        "a rejected update must leave context_files unchanged"
     );
 }
 

--- a/crates/orbit-core/src/application/task/paths.rs
+++ b/crates/orbit-core/src/application/task/paths.rs
@@ -4,8 +4,9 @@ use orbit_common::fs::selector::{
     anchor_path, canonical_selector_in_workspace, exists_in_workspace,
 };
 use orbit_types::task::{TaskHistoryEntry, TaskType};
-use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+
+use crate::OrbitRuntime;
 
 pub(super) fn normalize_workspace_path(
     repo_root: &Path,
@@ -79,76 +80,117 @@ pub(super) fn context_files_pruned_history_entry(
     }
 }
 
+/// Canonicalize context selectors for a task write, leaving selectors that do
+/// not exist yet in place.
+///
+/// The core write path stays permissive on purpose: task-pilot apply,
+/// automation seeding, and runtime host updates legitimately record targets the
+/// task is about to create, and read paths prune what is missing. Operator
+/// surfaces guard typos separately through
+/// [`OrbitRuntime::ensure_context_selectors_exist`].
 pub(crate) fn normalize_context_files_for_write(
     candidates: Vec<String>,
     workspace_root: &Path,
 ) -> Result<Vec<String>, OrbitError> {
-    let canonical_workspace = workspace_root.canonicalize().map_err(|error| {
-        OrbitError::InvalidInput(format!(
-            "failed to resolve workspace root '{}': {error}",
-            workspace_root.display()
-        ))
-    })?;
+    candidates
+        .into_iter()
+        .map(|entry| {
+            canonical_selector_in_workspace(entry.as_str(), workspace_root)
+                .map_err(|error| OrbitError::InvalidInput(error.to_string()))
+        })
+        .collect()
+}
 
-    let mut seen = BTreeSet::new();
-    let mut normalized = Vec::with_capacity(candidates.len());
-
-    for entry in candidates {
-        let trimmed = entry.trim();
-        if trimmed.is_empty() {
-            return Err(OrbitError::InvalidInput(
-                "selector input must not be empty".to_string(),
-            ));
+impl OrbitRuntime {
+    /// Reject context selectors that do not name an existing target in the
+    /// workspace the task write will use.
+    ///
+    /// This is an operator-surface guard: `orbit task add` / `orbit task
+    /// update` and the `orbit.task.add` / `orbit.task.update` tools call it so
+    /// a mistyped selector cannot ship a task whose context is dead on
+    /// arrival. Both surfaces expose an explicit escape for the deliberate
+    /// not-yet-created target. `add_task` and `update_task` themselves stay
+    /// permissive so internal callers are unaffected.
+    pub fn ensure_context_selectors_exist(
+        &self,
+        selectors: &[String],
+        workspace_path: Option<&str>,
+    ) -> Result<(), OrbitError> {
+        if selectors.is_empty() {
+            return Ok(());
         }
 
-        if trimmed.starts_with("module:") || trimmed.starts_with("command:") {
-            return Err(OrbitError::InvalidInput(format!(
-                "selector `{entry}` must use file:, dir:, or symbol:"
-            )));
-        }
-
-        let canonical =
-            canonical_selector_in_workspace(trimmed, &canonical_workspace).map_err(|error| {
-                OrbitError::InvalidInput(format!("selector `{entry}` is invalid: {error}"))
-            })?;
-
-        if canonical.starts_with("module:") || canonical.starts_with("command:") {
-            return Err(OrbitError::InvalidInput(format!(
-                "selector `{entry}` must use file:, dir:, or symbol:"
-            )));
-        }
-
-        if !exists_in_workspace(&canonical, &canonical_workspace) {
-            return Err(OrbitError::InvalidInput(format!(
-                "selector `{entry}` does not resolve to an existing in-workspace target"
-            )));
-        }
-
-        let anchor = anchor_path(&canonical).map_err(|error| {
+        let repo_root = &self.paths().repo_root;
+        let normalized_workspace = normalize_workspace_path(repo_root, workspace_path)?;
+        let workspace_root = context_workspace_root(repo_root, normalized_workspace.as_deref());
+        let canonical_workspace = workspace_root.canonicalize().map_err(|error| {
             OrbitError::InvalidInput(format!(
-                "selector `{entry}` has no filesystem anchor: {error}"
+                "failed to resolve workspace root '{}': {error}",
+                workspace_root.display()
             ))
         })?;
 
-        let resolved = canonical_workspace.join(anchor);
-        let correct_kind = if canonical.starts_with("dir:") {
-            resolved.is_dir()
-        } else {
-            resolved.is_file()
-        };
+        selectors
+            .iter()
+            .try_for_each(|selector| ensure_selector_resolves(selector, &canonical_workspace))
+    }
+}
 
-        if !correct_kind {
-            return Err(OrbitError::InvalidInput(format!(
-                "selector `{entry}` does not match the target's file/directory kind"
-            )));
-        }
-
-        if seen.insert(canonical.clone()) {
-            normalized.push(canonical);
-        }
+/// Check one operator-supplied selector against the canonicalized workspace:
+/// it must be a supported kind, name an existing anchor, and match that
+/// target's file/directory kind.
+fn ensure_selector_resolves(entry: &str, canonical_workspace: &Path) -> Result<(), OrbitError> {
+    let trimmed = entry.trim();
+    if trimmed.is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "selector input must not be empty".to_string(),
+        ));
     }
 
-    Ok(normalized)
+    if trimmed.starts_with("module:") || trimmed.starts_with("command:") {
+        return Err(unsupported_selector_kind(entry));
+    }
+
+    let canonical =
+        canonical_selector_in_workspace(trimmed, canonical_workspace).map_err(|error| {
+            OrbitError::InvalidInput(format!("selector `{entry}` is invalid: {error}"))
+        })?;
+
+    if canonical.starts_with("module:") || canonical.starts_with("command:") {
+        return Err(unsupported_selector_kind(entry));
+    }
+
+    if !exists_in_workspace(&canonical, canonical_workspace) {
+        return Err(OrbitError::InvalidInput(format!(
+            "selector `{entry}` does not resolve to an existing in-workspace target"
+        )));
+    }
+
+    let anchor = anchor_path(&canonical).map_err(|error| {
+        OrbitError::InvalidInput(format!(
+            "selector `{entry}` has no filesystem anchor: {error}"
+        ))
+    })?;
+    let resolved = canonical_workspace.join(anchor);
+    let matches_target_kind = if canonical.starts_with("dir:") {
+        resolved.is_dir()
+    } else {
+        resolved.is_file()
+    };
+
+    if !matches_target_kind {
+        return Err(OrbitError::InvalidInput(format!(
+            "selector `{entry}` does not match the target's file/directory kind"
+        )));
+    }
+
+    Ok(())
+}
+
+fn unsupported_selector_kind(entry: &str) -> OrbitError {
+    OrbitError::InvalidInput(format!(
+        "selector `{entry}` must use file:, dir:, or symbol:"
+    ))
 }
 
 pub(crate) use crate::runtime::task::canonicalize_context_files_for_read;

--- a/crates/orbit-core/src/application/task/tests/add.rs
+++ b/crates/orbit-core/src/application/task/tests/add.rs
@@ -352,34 +352,24 @@ fn task_add_preserves_auto_task_title_prefix_behavior() {
     }
 }
 
+/// `add_task` is the shared core write path: task-pilot apply, automation
+/// seeding, and the runtime host all create tasks whose context names files
+/// the task will produce. Existence is enforced on the operator surfaces
+/// instead (CLI `task add`, `orbit.task.add`).
 #[test]
-fn task_add_validates_context_files_rejecting_missing_selectors() {
+fn task_add_keeps_context_selectors_that_do_not_exist_yet() {
     let (_root, runtime) = test_runtime();
 
-    let error = runtime
+    let task = runtime
         .add_task(TaskAddParams {
-            title: "Missing context".to_string(),
-            context_files: vec!["file:does/not/exist.rs".to_string()],
+            title: "Future context".to_string(),
+            context_files: vec!["file:src/future.rs".to_string()],
             workspace_path: Some(".".to_string()),
             ..Default::default()
         })
-        .expect_err("task add must reject missing file selector");
+        .expect("core add_task must accept a not-yet-existing file selector");
 
-    match error {
-        OrbitError::InvalidInput(msg) => {
-            assert!(
-                msg.contains("file:does/not/exist.rs"),
-                "error must name missing selector: {msg}"
-            );
-        }
-        other => panic!("expected InvalidInput, got {other:?}"),
-    }
-
-    let tasks = runtime.list_tasks().expect("list tasks");
-    assert!(
-        tasks.is_empty(),
-        "no task should be created on invalid context"
-    );
+    assert_eq!(task.context_files, vec!["file:src/future.rs".to_string()]);
 }
 
 #[test]

--- a/crates/orbit-core/src/application/task/tests/paths.rs
+++ b/crates/orbit-core/src/application/task/tests/paths.rs
@@ -5,9 +5,21 @@
 use orbit_common::OrbitError;
 use tempfile::tempdir;
 
+use super::test_runtime;
+use crate::OrbitRuntime;
 use crate::application::task::paths::{
-    normalize_context_files_for_write, normalize_workspace_path, task_path_exists,
+    canonicalize_context_files_for_read, normalize_context_files_for_write,
+    normalize_workspace_path, task_path_exists,
 };
+
+/// Run one selector through the operator-surface guard and return the
+/// `InvalidInput` message it must produce.
+fn expect_selector_rejection(runtime: &OrbitRuntime, selector: &str) -> String {
+    match runtime.ensure_context_selectors_exist(&[selector.to_string()], Some(".")) {
+        Err(OrbitError::InvalidInput(message)) => message,
+        other => panic!("expected InvalidInput for `{selector}`, got {other:?}"),
+    }
+}
 
 fn expect_invalid_input(result: Result<Option<String>, OrbitError>) -> String {
     match result {
@@ -149,130 +161,104 @@ fn normalize_context_files_accepts_valid_selectors() {
     assert_eq!(normalized, selectors);
 }
 
+/// The core write path canonicalizes without resolving the target: internal
+/// callers record selectors for files the task is about to create, and symbol
+/// metadata is opaque to the filesystem. Existence is an operator-surface rule
+/// (see the `ensure_context_selectors_exist` tests below).
 #[test]
-fn normalize_context_files_rejects_missing_selectors() {
-    let workspace = tempdir().expect("create workspace");
-
-    let error = normalize_context_files_for_write(
-        vec!["file:does/not/exist.rs".to_string()],
-        workspace.path(),
-    )
-    .expect_err("missing file must be rejected");
-
-    match error {
-        OrbitError::InvalidInput(msg) => {
-            assert!(
-                msg.contains("file:does/not/exist.rs"),
-                "error must name selector: {msg}"
-            );
-        }
-        other => panic!("expected InvalidInput, got {other:?}"),
-    }
-
-    let symbol_error = normalize_context_files_for_write(
-        vec!["symbol:does/not/exist.rs#run:function".to_string()],
-        workspace.path(),
-    )
-    .expect_err("missing symbol anchor must be rejected");
-
-    match symbol_error {
-        OrbitError::InvalidInput(msg) => {
-            assert!(
-                msg.contains("symbol:does/not/exist.rs#run:function"),
-                "error must name selector: {msg}"
-            );
-        }
-        other => panic!("expected InvalidInput, got {other:?}"),
-    }
-}
-
-#[test]
-fn normalize_context_files_rejects_target_kind_mismatch() {
+fn normalize_context_files_keeps_selectors_that_do_not_exist_yet() {
     let workspace = tempdir().expect("create workspace");
     std::fs::create_dir_all(workspace.path().join("src")).expect("create src");
     std::fs::write(workspace.path().join("src/lib.rs"), b"pub fn run() {}\n")
         .expect("write anchor");
 
-    // file: pointing to a directory
-    let error = normalize_context_files_for_write(vec!["file:src".to_string()], workspace.path())
-        .expect_err("file: targeting a directory must be rejected");
-    match error {
-        OrbitError::InvalidInput(msg) => {
-            assert!(msg.contains("file:src"), "{msg}");
-            assert!(msg.contains("file/directory kind"), "{msg}");
-        }
-        other => panic!("expected InvalidInput, got {other:?}"),
-    }
+    let selectors = vec![
+        "file:src/future.rs".to_string(),
+        "symbol:src/lib.rs#not::a::real::symbol:invented-kind".to_string(),
+    ];
 
-    // dir: pointing to a file
-    let error =
-        normalize_context_files_for_write(vec!["dir:src/lib.rs".to_string()], workspace.path())
-            .expect_err("dir: targeting a file must be rejected");
-    match error {
-        OrbitError::InvalidInput(msg) => {
-            assert!(msg.contains("dir:src/lib.rs"), "{msg}");
-            assert!(msg.contains("file/directory kind"), "{msg}");
-        }
-        other => panic!("expected InvalidInput, got {other:?}"),
-    }
+    let normalized = normalize_context_files_for_write(selectors.clone(), workspace.path())
+        .expect("not-yet-existing targets must survive the core write path");
 
-    // symbol: pointing to a directory
-    let error = normalize_context_files_for_write(
-        vec!["symbol:src#run:function".to_string()],
+    assert_eq!(normalized, selectors);
+    assert!(task_path_exists(
         workspace.path(),
-    )
-    .expect_err("symbol: targeting a directory must be rejected");
-    match error {
-        OrbitError::InvalidInput(msg) => {
-            assert!(msg.contains("symbol:src#run:function"), "{msg}");
-            assert!(msg.contains("file/directory kind"), "{msg}");
-        }
-        other => panic!("expected InvalidInput, got {other:?}"),
+        "symbol:src/lib.rs#not::a::real::symbol:invented-kind"
+    ));
+    assert_eq!(
+        canonicalize_context_files_for_read(&normalized, workspace.path()),
+        normalized
+    );
+}
+
+#[test]
+fn ensure_context_selectors_exist_accepts_resolvable_selectors() {
+    let (root, runtime) = test_runtime();
+    let repo_root = root.path().join("repo");
+    std::fs::create_dir_all(repo_root.join("src")).expect("create src");
+    std::fs::write(repo_root.join("src/lib.rs"), b"pub fn run() {}\n").expect("write anchor");
+
+    runtime
+        .ensure_context_selectors_exist(
+            &[
+                "file:src/lib.rs".to_string(),
+                "dir:src".to_string(),
+                "symbol:src/lib.rs#run:function".to_string(),
+            ],
+            Some("."),
+        )
+        .expect("resolvable selectors must be accepted");
+}
+
+#[test]
+fn ensure_context_selectors_exist_rejects_missing_selectors() {
+    let (_root, runtime) = test_runtime();
+
+    let message = expect_selector_rejection(&runtime, "file:does/not/exist.rs");
+    assert!(
+        message.contains("file:does/not/exist.rs"),
+        "error must name selector: {message}"
+    );
+
+    let message = expect_selector_rejection(&runtime, "symbol:does/not/exist.rs#run:function");
+    assert!(
+        message.contains("symbol:does/not/exist.rs#run:function"),
+        "error must name selector: {message}"
+    );
+}
+
+#[test]
+fn ensure_context_selectors_exist_rejects_target_kind_mismatch() {
+    let (root, runtime) = test_runtime();
+    let repo_root = root.path().join("repo");
+    std::fs::create_dir_all(repo_root.join("src")).expect("create src");
+    std::fs::write(repo_root.join("src/lib.rs"), b"pub fn run() {}\n").expect("write anchor");
+
+    for selector in ["file:src", "dir:src/lib.rs", "symbol:src#run:function"] {
+        let message = expect_selector_rejection(&runtime, selector);
+        assert!(message.contains(selector), "{message}");
+        assert!(message.contains("file/directory kind"), "{message}");
     }
 }
 
 #[test]
-fn normalize_context_files_rejects_unsupported_kinds_and_malformed_selectors() {
-    let workspace = tempdir().expect("create workspace");
+fn ensure_context_selectors_exist_rejects_unsupported_kinds_and_malformed_selectors() {
+    let (_root, runtime) = test_runtime();
 
-    // module: selector is rejected
-    let error = normalize_context_files_for_write(
-        vec!["module:orbit_core::task".to_string()],
-        workspace.path(),
-    )
-    .expect_err("module: selector must be rejected");
-    match error {
-        OrbitError::InvalidInput(msg) => {
-            assert!(msg.contains("module:orbit_core::task"), "{msg}");
-            assert!(msg.contains("must use file:, dir:, or symbol:"), "{msg}");
-        }
-        other => panic!("expected InvalidInput, got {other:?}"),
+    for selector in ["module:orbit_core::task", "command:task"] {
+        let message = expect_selector_rejection(&runtime, selector);
+        assert!(message.contains(selector), "{message}");
+        assert!(
+            message.contains("must use file:, dir:, or symbol:"),
+            "{message}"
+        );
     }
 
-    // command: selector is rejected
-    let error =
-        normalize_context_files_for_write(vec!["command:task".to_string()], workspace.path())
-            .expect_err("command: selector must be rejected");
-    match error {
-        OrbitError::InvalidInput(msg) => {
-            assert!(msg.contains("command:task"), "{msg}");
-            assert!(msg.contains("must use file:, dir:, or symbol:"), "{msg}");
-        }
-        other => panic!("expected InvalidInput, got {other:?}"),
-    }
-
-    // malformed symbol selector is rejected
-    let error = normalize_context_files_for_write(
-        vec!["symbol:serve_throttled_response".to_string()],
-        workspace.path(),
-    )
-    .expect_err("malformed symbol: must be rejected");
-    match error {
-        OrbitError::InvalidInput(msg) => {
-            assert!(msg.contains("symbol:serve_throttled_response"), "{msg}");
-        }
-        other => panic!("expected InvalidInput, got {other:?}"),
-    }
+    let message = expect_selector_rejection(&runtime, "symbol:serve_throttled_response");
+    assert!(
+        message.contains("symbol:serve_throttled_response"),
+        "{message}"
+    );
 }
 
 #[test]

--- a/crates/orbit-core/src/application/task/tests/update.rs
+++ b/crates/orbit-core/src/application/task/tests/update.rs
@@ -393,8 +393,11 @@ fn concurrent_explicit_edit_preserves_the_newer_status() {
     );
 }
 
+/// An explicit replacement through the core path keeps draft/future
+/// selectors; missing targets are refused on the operator surfaces (CLI `task
+/// update`, `orbit.task.update`) and pruned at read time.
 #[test]
-fn task_update_rejects_missing_context_files_and_leaves_task_unchanged() {
+fn task_update_keeps_context_selectors_that_do_not_exist_yet() {
     let (root, runtime) = test_runtime();
     let repo_dir = root.path().join("repo");
     std::fs::create_dir_all(repo_dir.join("src")).expect("create src");
@@ -409,31 +412,25 @@ fn task_update_rejects_missing_context_files_and_leaves_task_unchanged() {
         })
         .expect("add task succeeds");
 
-    let error = runtime
+    let updated = runtime
         .update_task(
             &task.id,
             TaskUpdateParams {
-                context_files: Some(vec!["file:does/not/exist.rs".to_string()]),
+                context_files: Some(vec![
+                    "file:src/lib.rs".to_string(),
+                    "file:src/future.rs".to_string(),
+                ]),
                 ..Default::default()
             },
         )
-        .expect_err("update must reject missing context file");
+        .expect("core update_task must accept a not-yet-existing file selector");
 
-    match error {
-        orbit_common::OrbitError::InvalidInput(msg) => {
-            assert!(
-                msg.contains("file:does/not/exist.rs"),
-                "error must name missing selector: {msg}"
-            );
-        }
-        other => panic!("expected InvalidInput, got {other:?}"),
-    }
-
-    let reread = runtime.get_task(&task.id).expect("get task");
     assert_eq!(
-        reread.context_files,
-        vec!["file:src/lib.rs".to_string()],
-        "task context_files must remain unchanged"
+        updated.context_files,
+        vec![
+            "file:src/lib.rs".to_string(),
+            "file:src/future.rs".to_string()
+        ]
     );
 }
 

--- a/crates/orbit-core/src/application/task/update.rs
+++ b/crates/orbit-core/src/application/task/update.rs
@@ -176,6 +176,7 @@ impl OrbitRuntime {
             params.context_files.take()
         {
             let normalized = normalize_context_files_for_write(candidates, &prune_root)?;
+            // An explicit replacement preserves draft/future selectors; pruning stays read-time.
             params.context_files = Some(normalized);
             Vec::new()
         } else {

--- a/crates/orbit-tools/src/builtin/orbit/task/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add.rs
@@ -64,6 +64,13 @@ impl Tool for OrbitTaskAddTool {
                 required: false,
             },
             ToolParam {
+                name: "allow_missing_context".to_string(),
+                description: "Optional. Set true to accept `context_files` selectors whose target does not exist yet, for work that creates the file. Missing selectors are rejected by default."
+                    .to_string(),
+                param_type: "boolean".to_string(),
+                required: false,
+            },
+            ToolParam {
                 name: "priority".to_string(),
                 description: "Optional priority level".to_string(),
                 param_type: "string".to_string(),

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
@@ -163,6 +163,7 @@ fn schema_exposes_only_trimmed_create_task_fields() {
             "tags",
             "required_tools",
             "context_files",
+            "allow_missing_context",
             "priority",
             "complexity",
             "type",

--- a/crates/orbit-tools/src/builtin/orbit/task/update.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/update.rs
@@ -148,6 +148,13 @@ impl Tool for OrbitTaskUpdateTool {
                 required: false,
             },
             ToolParam {
+                name: "allow_missing_context".to_string(),
+                description: "Optional. Set true to accept `context_files` selectors whose target does not exist yet, for work that creates the file. Missing selectors are rejected by default."
+                    .to_string(),
+                param_type: "boolean".to_string(),
+                required: false,
+            },
+            ToolParam {
                 name: "context".to_string(),
                 description:
                     "Legacy alias for `context_files`. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files that are only relevant background context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`."

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -397,6 +397,7 @@ fn task_add_schema_uses_trimmed_authoring_surface() {
             "tags",
             "required_tools",
             "context_files",
+            "allow_missing_context",
             "priority",
             "complexity",
             "type",


### PR DESCRIPTION
## Task

[ORB-12184](https://orbit-cli.com/tasks/ORB-12184) — Fix red CI on agent-main: ORB-12168 context-selector validation runs inside core add_task/update_task and breaks 5 orbit-core tests that seed fixture tasks

### Description

## Red CI

Every agent-main CI run that started after PR #1968 (ORB-12168, bbdf7749) merged fails the same five orbit-core tests (1411 passed; 5 failed):

```
adapter::engine_host::tests::runtime_host::apply_task_automation_update_replaces_context_files_when_set
  add task: InvalidInput("selector `Cargo.toml` does not resolve to an existing in-workspace target")
adapter::engine_host::v2_host::tests::workspace_auto::readiness_candidate_pool_parsing_matches_classifier_for_numeric_and_string_one
  seed task: InvalidInput("selector `crates/leaf_0/src/lib.rs` does not resolve …")
adapter::tool_host::tests::task_tools::task_update_tool_replaces_context_files_and_keeps_future_paths
  InvalidInput("selector `file:src/future.rs` does not resolve …")
application::job::tests::exec::completion::an_open_pull_request_reported_as_merged_never_completes_the_pipeline
application::job::tests::exec::completion::completion_merge_failure_routes_to_review_recovery_without_republishing
  seed published task: InvalidInput("selector `src/lib.rs` does not resolve …")
```

Note: the CI workflow checks out `github.ref_name` on push events, so runs attributed to earlier SHAs (920aedef, dc6c48a9, …) actually tested the branch tip once they dequeued — that is why the failure appears "before" bbdf7749 in `gh run list`. Filed separately.

## Cause

ORB-12168 asked for validation of `context_files` selectors on the **operator/agent surfaces** (`orbit task add/update` CLI and the `orbit.task.add/update` MCP tools). The implementation put the check in the core application path (`crates/orbit-core/src/application/task/{add,update,paths}.rs`), so every internal caller — automation seeding, the runtime host's `apply_task_automation_update`, pipeline completion fixtures, and the tool-host test that explicitly asserts future paths are kept — is now rejected too.

## Fix

Move the existence validation to the boundary: the CLI `task add/update` commands and the MCP tool handlers (`crates/orbit-core/src/adapter/tool_host/...task_tools`), keeping the core `add_task`/`update_task` permissive as before (the task-pilot apply step already validates its own selectors). Keep the `--allow-missing-context` escape on the CLI/MCP surfaces. Restore the five tests to green without changing what they assert; `task_update_tool_replaces_context_files_and_keeps_future_paths` documents intended behaviour for the tool surface — if the MCP tool is meant to reject missing paths by default, that test must be updated to pass the allow flag, and the decision stated in the PR.

### Acceptance Criteria

- `cargo test -p orbit-core --lib` passes; the five tests listed above are green without weakening their assertions.
- `orbit task update <id> --context file:does/not/exist.rs` (CLI) and the MCP orbit.task.update tool still reject a non-existent selector by default, with the ORB-12168 tests for that behaviour still passing.
- Internal callers (task-pilot apply, automation seeding, runtime host updates) are not subject to the existence check; a unit test pins that core add_task accepts a not-yet-existing file: selector.
- The agent-main push CI run that starts after this merges is green on Check / Clippy / Test and Coverage.

## Execution Summary

<details>
<summary>Click to expand</summary>

Moved ORB-12168's context-selector existence check off the core write path and onto the operator surfaces.

What changed
- `crates/orbit-core/src/application/task/paths.rs`: `normalize_context_files_for_write` is back to canonicalization only (pre-ORB-12168 behaviour), so `add_task`/`update_task` accept not-yet-existing selectors again. The strict rule now lives in a new `OrbitRuntime::ensure_context_selectors_exist(selectors, workspace_path)` plus a private `ensure_selector_resolves` helper in the same module: unsupported kind (`module:`/`command:`), missing anchor, and file/dir kind mismatch produce the same `InvalidInput` messages as before.
- `crates/orbit-core/src/adapter/tool_host/task_tools.rs`: `orbit.task.add` and `orbit.task.update` call the guard before the runtime write; a new `allows_missing_context` helper reads the `allow_missing_context` / `allowMissingContext` escape. `update` now parses `context_files` once and reuses it.
- `crates/orbit-cli/src/command/task/{add,update}.rs`: same guard, with a new `--allow-missing-context` flag on both commands.
- `crates/orbit-tools/src/builtin/orbit/task/{add,update}.rs`: advertise the optional `allow_missing_context` boolean param.
- `crates/orbit-core/src/application/task/update.rs`: restored the L-0030 comment explaining that an explicit replacement preserves draft/future selectors.

Decision on `task_update_tool_replaces_context_files_and_keeps_future_paths`: acceptance criteria 1 and 2 conflict for that test (it updates context to `file:src/future.rs`, which does not exist, through the MCP tool that criterion 2 requires to reject missing selectors by default). As the task description directs, the MCP tool rejects by default and the test now passes `allow_missing_context: true`. Its assertions are unchanged — it still proves the tool stores and returns the future selector verbatim.

Criteria
1. PASS — `cargo test -p orbit-core --lib`: 1419 passed, 0 failed. All five named tests are green (verified by name), none of their assertions weakened; only the one input flag noted above was added.
2. PASS — CLI `task_update_rejects_missing_context_file_and_leaves_task_unchanged`, `task_add_rejects_missing_context_file`, `task_update_and_add_accept_valid_context_selectors` and MCP `mcp_task_add_and_update_validate_context_selectors` all still pass unmodified. New `task_tools_reject_context_selectors_that_do_not_exist` pins the same rejection at the tool-host boundary, including that a rejected update leaves `context_files` untouched.
3. PASS — new `application::task::tests::add::task_add_keeps_context_selectors_that_do_not_exist_yet` pins core `add_task` accepting `file:src/future.rs`; companion pins at `update_task` (`task_update_keeps_context_selectors_that_do_not_exist_yet`) and at `normalize_context_files_for_write`. The five previously failing internal-caller tests (runtime host, workspace-auto seeding, pipeline completion fixtures) pass unchanged.
4. NOT VERIFIABLE HERE — depends on the post-merge agent-main push run. Local evidence below is the strongest available substitute.

Validation (all run in this worktree, Linux, from HEAD 70e63ced5 + these changes)
- `cargo test -p orbit-core --lib` — passed (1419 passed / 0 failed / 2 ignored).
- `cargo test -p orbit-core` (all targets) — passed.
- `cargo test -p orbit-cli` — passed (all 30 test binaries).
- `cargo test -p orbit-tools` — passed.
- `cargo test -p orbit-web -p orbit-automation -p orbit-engine` — passed.
- `make ci-fast` — passed (exit 0).
- `make ci-lint` — passed (exit 0).
- `git diff --check` clean; `git status --short` shows only the 16 intended modified tracked files, no untracked paths.

Snapshot/golden updates (regenerated deliberately, diffs reviewed — each adds only the new optional param)
- `crates/orbit-cli/tests/snapshots/mcp_tools_list.json` via `ORBIT_MCP_UPDATE_SNAPSHOT=1`.
- `crates/orbit-cli/tests/output_goldens/tool_list.json` via `ORBIT_UPDATE_OUTPUT_GOLDENS=1`.
- Param-order expectations in `crates/orbit-tools/src/builtin/orbit/task/tests/add.rs` and `crates/orbit-tools/tests/public_tool_surface.rs`.
Release classification: per RELEASING.md "What does NOT count as breaking", `allow_missing_context` is a new optional field with a safe default (false = previous ORB-12168 behaviour), so this is not a breaking MCP schema change despite the snapshot guard's generic warning.

Scope note: `context_files` was extended with the orbit-tools schema/test files, the CLI test and golden/snapshot files, and the core task test files, all required by the criteria above.

Residual risk / deviation
- The dashboard task create/update API (`crates/orbit-web/src/api/tasks.rs`) calls the core runtime directly and therefore does not run the existence guard. That matches both pre-ORB-12168 behaviour and this task's stated scope (CLI + MCP), but it means the guard is not universal; a follow-up could route it through the same runtime method.
- `normalize_context_files_for_write` no longer de-duplicates selectors (that dedup arrived with the ORB-12168 strict loop). Pre-ORB-12168 behaviour did not dedup either, and the operator surfaces do not depend on it.
- Criterion 4 cannot be checked before merge.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12184-6aa3df11`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus