### PR TITLE
[qa-sweep] The ORB-12168 selector guard validates against the registered checkout, so a job-run worktree agent cannot declare a file it just created

### DIFF
--- a/crates/orbit-cli/tests/context_selector_worktree.rs
+++ b/crates/orbit-cli/tests/context_selector_worktree.rs
@@ -1,0 +1,345 @@
+#![allow(missing_docs)]
+// Tests use unwrap/expect to keep fixture setup readable.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+//! ORB-12201: the operator-surface context-selector guard validates against the
+//! checkout the caller stands in, not only the registered one. Managed job runs
+//! execute inside a linked worktree, so a file such a run just created exists
+//! only there — declaring it must not require `--allow-missing-context`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command as StdCommand, Output};
+
+use assert_cmd::Command as AssertCommand;
+use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
+use serde_json::{Value, json};
+use tempfile::{TempDir, tempdir};
+
+/// A registered checkout with its own disposable Orbit home.
+struct Workspace {
+    temp: TempDir,
+    home: PathBuf,
+    repo: PathBuf,
+}
+
+impl Workspace {
+    /// Initialize a Git repository, register it with Orbit, and confirm the
+    /// child process really routes to these disposable paths before any task
+    /// is written.
+    fn init() -> Self {
+        let temp = tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&home).expect("create home");
+        fs::create_dir_all(repo.join("src")).expect("create repo src");
+
+        run_git(&repo, &["init"]);
+        run_git(&repo, &["config", "user.name", "Orbit Test"]);
+        run_git(&repo, &["config", "user.email", "orbit-test@example.com"]);
+        run_git(&repo, &["config", "commit.gpgsign", "false"]);
+        fs::write(repo.join("src/lib.rs"), "pub fn run() {}\n").expect("write committed file");
+        run_git(&repo, &["add", "src/lib.rs"]);
+        run_git(&repo, &["commit", "-m", "initial"]);
+
+        let workspace = Self {
+            temp,
+            home,
+            repo: fs::canonicalize(&repo).expect("canonicalize repo"),
+        };
+        workspace.run_success(&workspace.repo, &["workspace", "init"]);
+        workspace.assert_routes_to_repo(&workspace.repo);
+        workspace
+    }
+
+    fn temp_path(&self) -> &Path {
+        self.temp.path()
+    }
+
+    fn run_success(&self, cwd: &Path, args: &[&str]) -> Output {
+        let output = self.orbit(cwd, args).output().expect("run orbit");
+        assert!(
+            output.status.success(),
+            "`orbit {}` in {} failed\nstdout:\n{}\nstderr:\n{}",
+            args.join(" "),
+            cwd.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output
+    }
+
+    fn run_failure(&self, cwd: &Path, args: &[&str]) -> String {
+        let output = self.orbit(cwd, args).output().expect("run orbit");
+        assert!(
+            !output.status.success(),
+            "`orbit {}` in {} unexpectedly succeeded\nstdout:\n{}",
+            args.join(" "),
+            cwd.display(),
+            String::from_utf8_lossy(&output.stdout)
+        );
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    }
+
+    fn orbit(&self, cwd: &Path, args: &[&str]) -> AssertCommand {
+        let mut command = cargo_bin_cmd!("orbit");
+        // ORB-11300: scrub inherited managed-run authority before pinning this
+        // fixture's own routing, so an ambient envelope cannot redirect writes.
+        test_env::clear_inherited_authority(|name| {
+            command.env_remove(name);
+        });
+        command.env_remove("LLVM_PROFILE_FILE");
+        command
+            .current_dir(cwd)
+            .env("HOME", &self.home)
+            .env("USERPROFILE", &self.home)
+            .env("ORBIT_AGENT_NAME", "claude")
+            .env("ORBIT_AGENT_MODEL", "claude")
+            .args(args);
+        command
+    }
+
+    /// Child processes report physical paths, so compare against canonicalized
+    /// fixture paths.
+    fn assert_routes_to_repo(&self, cwd: &Path) {
+        let shown = self.json(cwd, &["workspace", "show", "--format", "json"]);
+        let checkout = &shown["checkout"];
+        assert_eq!(
+            checkout["repo_root"].as_str(),
+            self.repo.to_str(),
+            "fixture must bind the disposable checkout: {shown}"
+        );
+        assert_eq!(
+            checkout["orbit_dir"].as_str(),
+            self.repo.join(".orbit").to_str(),
+            "fixture must bind the disposable Orbit directory: {shown}"
+        );
+    }
+
+    fn json(&self, cwd: &Path, args: &[&str]) -> Value {
+        let output = self.run_success(cwd, args);
+        serde_json::from_slice(&output.stdout).expect("orbit json output")
+    }
+
+    /// File a task from the registered checkout and return its ID.
+    fn author_task(&self, title: &str) -> String {
+        let created = self.json(
+            &self.repo,
+            &[
+                "task",
+                "add",
+                "--title",
+                title,
+                "--description",
+                "Context selector guard fixture",
+                "--complexity",
+                "low",
+                "--context",
+                "file:src/lib.rs",
+                "--json",
+            ],
+        );
+        created["id"]
+            .as_str()
+            .unwrap_or_else(|| panic!("task id in {created}"))
+            .to_string()
+    }
+
+    fn stored_context_files(&self, task_id: &str) -> Vec<String> {
+        let task = self.json(&self.repo, &["task", "show", task_id, "--json"]);
+        task["context_files"]
+            .as_array()
+            .unwrap_or_else(|| panic!("context_files in {task}"))
+            .iter()
+            .map(|entry| entry.as_str().unwrap_or_default().to_string())
+            .collect()
+    }
+
+    /// Add a linked worktree at `path` holding a file that exists nowhere
+    /// else, and return the worktree's canonical path.
+    fn add_worktree_with_new_file(&self, path: &Path, branch: &str, new_file: &str) -> PathBuf {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create worktree parent");
+        }
+        run_git(
+            &self.repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                path.to_str().expect("utf8 worktree path"),
+            ],
+        );
+        let worktree = fs::canonicalize(path).expect("canonicalize linked worktree");
+        fs::write(worktree.join(new_file), "pub fn brand_new() {}\n")
+            .expect("write worktree-only file");
+        worktree
+    }
+}
+
+#[test]
+fn linked_worktree_caller_can_declare_a_file_that_exists_only_there() {
+    let workspace = Workspace::init();
+    let task_id = workspace.author_task("Worktree context selector");
+    let worktree = workspace.add_worktree_with_new_file(
+        &workspace.temp_path().join("linked-worktree"),
+        "orbit-context-selector",
+        "src/brand_new.rs",
+    );
+
+    // The worktree binds the registered checkout, which is exactly why the
+    // guard used to reject its own new files.
+    workspace.assert_routes_to_repo(&worktree);
+    assert!(
+        !workspace.repo.join("src/brand_new.rs").exists(),
+        "the fixture file must exist only in the linked worktree"
+    );
+
+    workspace.run_success(
+        &worktree,
+        &[
+            "task",
+            "update",
+            &task_id,
+            "--context",
+            "file:src/brand_new.rs",
+            "--json",
+        ],
+    );
+    assert_eq!(
+        workspace.stored_context_files(&task_id),
+        vec!["file:src/brand_new.rs".to_string()],
+        "`orbit task update --context` must accept a worktree-local file"
+    );
+
+    let tool_input = json!({
+        "id": task_id,
+        "context_files": ["file:src/lib.rs", "file:src/brand_new.rs"],
+    })
+    .to_string();
+    workspace.run_success(
+        &worktree,
+        &["tool", "run", "orbit.task.update", "--input", &tool_input],
+    );
+    assert_eq!(
+        workspace.stored_context_files(&task_id),
+        vec![
+            "file:src/lib.rs".to_string(),
+            "file:src/brand_new.rs".to_string()
+        ],
+        "`orbit.task.update` must accept a worktree-local file alongside a shared one"
+    );
+
+    // The guard is relaxed for the caller's own checkout only: the same
+    // selector from the registered checkout still names nothing.
+    let rejected = workspace.run_failure(
+        &workspace.repo,
+        &[
+            "task",
+            "update",
+            &task_id,
+            "--context",
+            "file:src/brand_new.rs",
+        ],
+    );
+    assert!(
+        rejected.contains("file:src/brand_new.rs"),
+        "a caller outside the worktree must still be refused: {rejected}"
+    );
+}
+
+#[test]
+fn selector_missing_from_both_checkouts_is_rejected_from_a_worktree() {
+    let workspace = Workspace::init();
+    let task_id = workspace.author_task("Worktree context selector typo");
+    let worktree = workspace.add_worktree_with_new_file(
+        &workspace.temp_path().join("typo-worktree"),
+        "orbit-context-typo",
+        "src/brand_new.rs",
+    );
+
+    let rejected = workspace.run_failure(
+        &worktree,
+        &["task", "update", &task_id, "--context", "file:src/typo.rs"],
+    );
+    assert!(
+        rejected.contains("file:src/typo.rs")
+            && rejected.contains("does not resolve to an existing in-workspace target"),
+        "`orbit task update --context` must still reject a dead selector: {rejected}"
+    );
+
+    let tool_input = json!({
+        "id": task_id,
+        "context_files": ["file:src/typo.rs"],
+    })
+    .to_string();
+    let rejected = workspace.run_failure(
+        &worktree,
+        &["tool", "run", "orbit.task.update", "--input", &tool_input],
+    );
+    assert!(
+        rejected.contains("file:src/typo.rs"),
+        "`orbit.task.update` must still reject a dead selector: {rejected}"
+    );
+
+    assert_eq!(
+        workspace.stored_context_files(&task_id),
+        vec!["file:src/lib.rs".to_string()],
+        "a refused declaration must leave the stored selectors untouched"
+    );
+}
+
+/// Managed job-run worktrees live under `<repo>/.orbit/state/worktrees/**`, so
+/// they sit inside the registered checkout's directory tree while being
+/// separate checkouts: a path-prefix test cannot tell them apart.
+#[test]
+fn worktree_nested_under_the_registered_checkout_can_declare_its_own_file() {
+    let workspace = Workspace::init();
+    let task_id = workspace.author_task("Nested worktree context selector");
+    let worktree = workspace.add_worktree_with_new_file(
+        &workspace.repo.join(".orbit/state/worktrees/jrun-fixture"),
+        "orbit-context-nested",
+        "src/brand_new.rs",
+    );
+
+    workspace.run_success(
+        &worktree,
+        &[
+            "task",
+            "update",
+            &task_id,
+            "--context",
+            "file:src/brand_new.rs",
+            "--json",
+        ],
+    );
+
+    assert_eq!(
+        workspace.stored_context_files(&task_id),
+        vec!["file:src/brand_new.rs".to_string()],
+        "a job-run-shaped nested worktree must be able to declare its own file"
+    );
+}
+
+fn run_git(cwd: &Path, args: &[&str]) {
+    let output = StdCommand::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git -C {} {} failed\nstdout:\n{}\nstderr:\n{}",
+        cwd.display(),
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/orbit-core/src/application/task/paths.rs
+++ b/crates/orbit-core/src/application/task/paths.rs
@@ -7,6 +7,7 @@ use orbit_types::task::{TaskHistoryEntry, TaskType};
 use std::path::{Path, PathBuf};
 
 use crate::OrbitRuntime;
+use crate::paths::find_linked_worktree_root;
 
 pub(super) fn normalize_workspace_path(
     repo_root: &Path,
@@ -120,26 +121,83 @@ impl OrbitRuntime {
             return Ok(());
         }
 
+        let roots = self.context_selector_roots(workspace_path)?;
+
+        selectors
+            .iter()
+            .try_for_each(|selector| ensure_selector_resolves(selector, &roots))
+    }
+
+    /// Resolve the checkouts this call may validate selectors against.
+    fn context_selector_roots(
+        &self,
+        workspace_path: Option<&str>,
+    ) -> Result<ContextSelectorRoots, OrbitError> {
         let repo_root = &self.paths().repo_root;
+        let canonical_repo_root = repo_root.canonicalize().map_err(|error| {
+            OrbitError::InvalidInput(format!(
+                "failed to resolve repository root '{}': {error}",
+                repo_root.display()
+            ))
+        })?;
+
         let normalized_workspace = normalize_workspace_path(repo_root, workspace_path)?;
-        let workspace_root = context_workspace_root(repo_root, normalized_workspace.as_deref());
-        let canonical_workspace = workspace_root.canonicalize().map_err(|error| {
+        let workspace_root =
+            context_workspace_root(&canonical_repo_root, normalized_workspace.as_deref());
+        let workspace = workspace_root.canonicalize().map_err(|error| {
             OrbitError::InvalidInput(format!(
                 "failed to resolve workspace root '{}': {error}",
                 workspace_root.display()
             ))
         })?;
 
-        selectors
-            .iter()
-            .try_for_each(|selector| ensure_selector_resolves(selector, &canonical_workspace))
+        let caller_worktree = std::env::current_dir()
+            .ok()
+            .and_then(|cwd| find_linked_worktree_root(&cwd, &canonical_repo_root))
+            .and_then(|worktree| {
+                mirrored_workspace_root(&workspace, &canonical_repo_root, &worktree)
+            });
+
+        Ok(ContextSelectorRoots {
+            workspace,
+            caller_worktree,
+        })
     }
 }
 
-/// Check one operator-supplied selector against the canonicalized workspace:
-/// it must be a supported kind, name an existing anchor, and match that
+/// The checkouts an operator-supplied context selector may resolve against.
+struct ContextSelectorRoots {
+    /// Workspace root inside the registered checkout.
+    workspace: PathBuf,
+    /// The same workspace root inside the linked worktree the call runs in,
+    /// when the caller is in one and that directory exists there. A managed
+    /// job run executes in such a worktree, so a file it just created exists
+    /// only here until the work merges.
+    caller_worktree: Option<PathBuf>,
+}
+
+/// Place the registered checkout's workspace root at the same relative
+/// position inside `worktree`, so a sub-directory workspace keeps its meaning
+/// there. Returns `None` when that directory does not exist in the worktree.
+fn mirrored_workspace_root(
+    workspace: &Path,
+    canonical_repo_root: &Path,
+    worktree: &Path,
+) -> Option<PathBuf> {
+    let relative = workspace.strip_prefix(canonical_repo_root).ok()?;
+    let mirrored = worktree.join(relative).canonicalize().ok()?;
+    mirrored.is_dir().then_some(mirrored)
+}
+
+/// Check one operator-supplied selector against the checkouts this call may
+/// use: it must be a supported kind, name an existing anchor, and match that
 /// target's file/directory kind.
-fn ensure_selector_resolves(entry: &str, canonical_workspace: &Path) -> Result<(), OrbitError> {
+///
+/// The registered checkout answers first, so its message is the one an
+/// operator sees for a genuinely dead selector. The caller's worktree answers
+/// second: a file created there does not exist in the registered checkout yet,
+/// and declaring it must not require turning the guard off for the whole call.
+fn ensure_selector_resolves(entry: &str, roots: &ContextSelectorRoots) -> Result<(), OrbitError> {
     let trimmed = entry.trim();
     if trimmed.is_empty() {
         return Err(OrbitError::InvalidInput(
@@ -151,6 +209,24 @@ fn ensure_selector_resolves(entry: &str, canonical_workspace: &Path) -> Result<(
         return Err(unsupported_selector_kind(entry));
     }
 
+    match resolve_selector_in(entry, trimmed, &roots.workspace) {
+        Ok(()) => Ok(()),
+        Err(registered_failure) => match roots.caller_worktree.as_deref() {
+            Some(worktree) => {
+                resolve_selector_in(entry, trimmed, worktree).map_err(|_| registered_failure)
+            }
+            None => Err(registered_failure),
+        },
+    }
+}
+
+/// Resolve one already-screened selector against a single canonicalized
+/// checkout root.
+fn resolve_selector_in(
+    entry: &str,
+    trimmed: &str,
+    canonical_workspace: &Path,
+) -> Result<(), OrbitError> {
     let canonical =
         canonical_selector_in_workspace(trimmed, canonical_workspace).map_err(|error| {
             OrbitError::InvalidInput(format!("selector `{entry}` is invalid: {error}"))

--- a/crates/orbit-core/src/paths.rs
+++ b/crates/orbit-core/src/paths.rs
@@ -81,6 +81,34 @@ pub(crate) fn find_git_worktree_root(start: &Path) -> Option<PathBuf> {
     })
 }
 
+/// Resolve the linked worktree a call is running in, when that worktree is a
+/// *different* checkout of the repository rooted at `canonical_repo_root`.
+///
+/// Returns `None` when the caller stands in the registered checkout itself,
+/// outside any Git checkout, or in a checkout of another repository. A path
+/// prefix test cannot answer this: managed job-run worktrees live under
+/// `<repo>/.orbit/state/worktrees/**`, so they sit inside the registered
+/// checkout's directory tree while being separate checkouts. Git's shared
+/// directory is the identity that actually distinguishes the two.
+pub(crate) fn find_linked_worktree_root(
+    start: &Path,
+    canonical_repo_root: &Path,
+) -> Option<PathBuf> {
+    let checkout = find_git_worktree_root(start)?.canonicalize().ok()?;
+    if checkout == canonical_repo_root {
+        return None;
+    }
+
+    let caller_git_dir = shared_git_dir(&checkout)?;
+    let registered_git_dir = shared_git_dir(canonical_repo_root)?;
+    (caller_git_dir == registered_git_dir).then_some(checkout)
+}
+
+fn shared_git_dir(checkout: &Path) -> Option<PathBuf> {
+    let common_dir = orbit_common::fs::git::git_common_dir(checkout).ok()?;
+    Some(common_dir.canonicalize().unwrap_or(common_dir))
+}
+
 pub(crate) fn find_git_main_worktree_root(start: &Path) -> Option<PathBuf> {
     find_git_main_worktree_root_with_git(start)
         .or_else(|| find_git_main_worktree_root_from_gitfile(start))


### PR DESCRIPTION
## Task

[ORB-12201](https://orbit-cli.com/tasks/ORB-12201) — [qa-sweep] The ORB-12168 selector guard validates against the registered checkout, so a job-run worktree agent cannot declare a file it just created

### Description

## Summary

The ORB-12168 / ORB-12184 guard (`bbdf77499`, `6e9db4a1d`) validates
`context_files` selectors against the **registered workspace's** `repo_root`,
not against the checkout the caller is actually working in. An agent running in
a linked Git worktree — which is exactly what the managed job-run lane gives
every executor — therefore cannot declare a file it just created in that
worktree: the guard resolves the selector against the main checkout, where the
file does not exist, and rejects it.

This collides head-on with the handoff step the execution envelope mandates:
"After creating an intended new source file, append its exact `file:` selector
through `orbit.task.update`." The only way past the guard is
`--allow-missing-context` / `allow_missing_context: true`, which switches the
check off entirely for that call — so the guard is bypassed precisely in the
lane it was meant to protect.

Code path: `crates/orbit-core/src/application/task/paths.rs:113-134`
(`ensure_context_selectors_exist`) takes its root from
`self.paths().repo_root`, then `normalize_workspace_path` /
`context_workspace_root` canonicalize under it. Nothing consults the process
working directory or the caller's worktree.

## Observed during this sweep (real workspace, not a fixture)

`orbit task add` filing ORB-12200 from this job-run worktree passed two
selectors:

```
--context file:crates/orbit-cli/src/command/task/list.rs
--context file:crates/orbit-cli/src/command/task/tests/list.rs
```

Only the first was stored. The second file exists in the worktree — it was added
by `1c8a57de2` — but not in the checkout the CLI bound to:

```
$ orbit workspace show --format json | python3 -c 'import json,sys;print(json.load(sys.stdin)["checkout"]["repo_root"])'
/home/daniel/workspace/constellation/codebases/orbit

$ ls /home/daniel/workspace/constellation/codebases/orbit/crates/orbit-cli/src/command/task/tests/
add.rs  artifact.rs  command.rs  flow.rs  mod.rs  output.rs  publication.rs  show.rs  update.rs
# no list.rs

$ ls crates/orbit-cli/src/command/task/tests/list.rs   # inside the worktree
crates/orbit-cli/src/command/task/tests/list.rs
```

(The installed 0.20.0 CLI used for that call dropped the selector silently;
0.21.0 at HEAD hard-rejects it instead. Both outcomes lose the declaration.)

## Reproduction at HEAD (orbit 0.21.0, `6e9db4a1d`, Linux 6.8)

```sh
# scratch root + registered checkout at /tmp/qa12189/work, then a linked worktree
cd /tmp/qa12189/work && git worktree add -q /tmp/qa12189/wt -b wtbranch
cd /tmp/qa12189/wt && echo 'fn newthing(){}' > src/brand_new.rs
ls -l src/brand_new.rs      # the file is right here

orbit --root /tmp/qa12189/root task add --complexity low --description d \
  --title wt3 --context file:src/brand_new.rs --json
# {"code":"invalid_input",
#  "error":"invalid input: selector `file:src/brand_new.rs` does not resolve to an existing in-workspace target"}

orbit --root /tmp/qa12189/root task add --complexity low --description d \
  --title wt4 --context file:src/brand_new.rs --allow-missing-context --json
# succeeds -> context_files: ["file:src/brand_new.rs"]   (guard fully disabled for the call)
```

Passing `--workspace /tmp/qa12189/wt` does not help: the worktree is not a
registered workspace (`workspace show` reports `registered: false`), so the
runtime still binds the parent checkout.

## Scope

Production impact: yes, and it is concentrated in the managed execution lane.
Every job-run worktree agent that creates a file and then declares it — the
documented delivery requirement for untracked paths — hits either a hard
rejection (0.21.0) or a silent drop (0.20.0). Reaching for
`allow_missing_context` to get unblocked disables the typo protection the guard
exists for, so the guard ends up weakest where dead selectors matter most.
Callers working directly in the registered checkout are unaffected.

Validation impact: none — `make test` passes (5529 passed, 0 failed at
`6e9db4a1d`); no test exercises the guard from a linked worktree.

## Suggested direction

Resolve selectors against the checkout the call is actually running in. Options,
smallest first:

- Have `ensure_context_selectors_exist` accept the caller's working checkout
  (the CLI already knows its `cwd`; the tool host has the `workspace` argument)
  and validate there when it is a Git worktree of the registered `repo_root`.
- Or treat "exists in the registered repo_root **or** in the caller's worktree"
  as satisfying the guard, so a not-yet-merged new file is accepted without
  disabling the check for every other selector in the same call.

Add a test that creates a file in a linked worktree and declares it through both
`orbit task update --context` and `orbit.task.update`.

### Acceptance Criteria

- A caller in a linked worktree of the registered checkout can declare a context selector for a file that exists only in that worktree, without allow_missing_context
- The guard still rejects a selector that exists in neither the registered checkout nor the caller's worktree
- A test exercises the guard from a linked worktree through orbit task update and orbit.task.update

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed the ORB-12168/12184 context-selector guard so it validates against the checkout the caller is standing in, falling back to the registered repo_root.

Change
- crates/orbit-core/src/paths.rs: new `find_linked_worktree_root(start, canonical_repo_root)` — resolves the caller's Git checkout (`--show-toplevel`) and accepts it only when its `--git-common-dir` matches the registered checkout's. A path-prefix test is deliberately not used: managed job-run worktrees live under `<repo>/.orbit/state/worktrees/**`, i.e. inside the registered checkout's directory tree while being separate checkouts.
- crates/orbit-core/src/application/task/paths.rs: `ensure_context_selectors_exist` now resolves a `ContextSelectorRoots { workspace, caller_worktree }` pair (the caller's worktree mirrored at the same workspace-relative position, when that directory exists there) and accepts a selector that resolves in either. The registered checkout is tried first so its message is what an operator sees for a genuinely dead selector; `ensure_selector_resolves` keeps the kind/empty screening and delegates per-root resolution to the new `resolve_selector_in`. Error texts are unchanged. Internal write paths, read-time pruning, and `allow_missing_context` behavior are untouched.
- crates/orbit-cli/tests/context_selector_worktree.rs (new): CLI integration coverage from a real linked worktree.

Criteria
1. "A caller in a linked worktree ... can declare a file that exists only in that worktree, without allow_missing_context" — met. `linked_worktree_caller_can_declare_a_file_that_exists_only_there` declares `file:src/brand_new.rs` (present only in the worktree) via `orbit task update --context` and via `orbit tool run orbit.task.update`, then asserts the stored `context_files`. Also covered from a worktree nested under `<repo>/.orbit/state/worktrees/**` (the production job-run shape) by `worktree_nested_under_the_registered_checkout_can_declare_its_own_file`.
2. "The guard still rejects a selector that exists in neither checkout" — met. `selector_missing_from_both_checkouts_is_rejected_from_a_worktree` asserts both surfaces refuse `file:src/typo.rs` with the unchanged "does not resolve to an existing in-workspace target" message and that stored selectors are untouched; the first test also asserts the worktree-only file is still refused when the caller stands in the registered checkout.
3. "A test exercises the guard from a linked worktree through orbit task update and orbit.task.update" — met by the same file; both surfaces run as child processes with cwd inside the worktree, disposable HOME, `clear_inherited_authority`, and a `orbit workspace show --format json` routing assertion before any task write.

Regression evidence: with only the test file present and both source files restored from HEAD (`git show HEAD:<path>`), tests 1 and 3 fail with `invalid input: selector 'file:src/brand_new.rs' does not resolve to an existing in-workspace target`; the rejection test passes in both states. Fix restored afterwards.

Validation (all in this worktree, Linux 6.8, HEAD 6e9db4a1d)
- `cargo test -p orbit-cli --test context_selector_worktree` — passed (3 tests).
- `cargo test -p orbit-core --lib` — passed (1419 passed, 0 failed, 2 ignored).
- `cargo test -p orbit-cli --test task_trimmed_surface --test output_goldens --test task_list --test workspace_selector --test worktree_resolution` — passed (44 tests).
- `cargo test -p orbit-cli --test mcp_roundtrip` — passed (54 tests).
- `make ci-fast` — passed (one environment skip: compiler-cache namespace test cannot create a user namespace here).
- `make ci-lint` — passed, no warnings.
- `cargo fmt --all`, `git diff --check`, `git status --short` — clean; only the three intended paths changed.
- Full `make test` not run (per workspace policy `make ci` is the merge gate).

Risks / notes
- The guard now runs up to three short `git rev-parse` probes per operator call that carries selectors, and only when the caller is outside the registered checkout root or in a different checkout; callers in the registered checkout pay one `--show-toplevel` probe.
- Unchanged and out of scope: `orbit.task.add`'s required `workspace` argument must still name a path inside the registered repo_root, so a worktree located outside the registered checkout cannot be passed there (production job-run worktrees are nested inside it and are unaffected).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12201-6aa3eae4`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus