### PR TITLE
[qa-sweep] The ORB-12168 context-selector guard skips the dashboard API: POST/PATCH /api/tasks still accept selectors the CLI and MCP tools reject

### DIFF
--- a/crates/orbit-core/src/application/task/paths.rs
+++ b/crates/orbit-core/src/application/task/paths.rs
@@ -107,11 +107,13 @@ impl OrbitRuntime {
     /// workspace the task write will use.
     ///
     /// This is an operator-surface guard: `orbit task add` / `orbit task
-    /// update` and the `orbit.task.add` / `orbit.task.update` tools call it so
-    /// a mistyped selector cannot ship a task whose context is dead on
-    /// arrival. Both surfaces expose an explicit escape for the deliberate
-    /// not-yet-created target. `add_task` and `update_task` themselves stay
-    /// permissive so internal callers are unaffected.
+    /// update`, the `orbit.task.add` / `orbit.task.update` tools, and the
+    /// dashboard `POST /api/tasks` / `PATCH /api/tasks/:id` handlers all call
+    /// it so a mistyped selector cannot ship a task whose context is dead on
+    /// arrival. Every surface exposes an explicit `allow_missing_context`
+    /// escape for the deliberate not-yet-created target. `add_task` and
+    /// `update_task` themselves stay permissive so internal callers are
+    /// unaffected.
     pub fn ensure_context_selectors_exist(
         &self,
         selectors: &[String],

--- a/crates/orbit-web/src/api/tasks.rs
+++ b/crates/orbit-web/src/api/tasks.rs
@@ -122,6 +122,12 @@ pub(super) struct CreateTaskBody {
     plan: String,
     #[serde(default)]
     context_files: Vec<String>,
+    /// Escape for a `context_files` selector that names a target this task is
+    /// about to create, mirroring `orbit task add --allow-missing-context` and
+    /// the `orbit.task.add` tool's `allow_missing_context` input. See
+    /// [`OrbitRuntime::ensure_context_selectors_exist`](orbit_core::OrbitRuntime::ensure_context_selectors_exist).
+    #[serde(default)]
+    allow_missing_context: bool,
     #[serde(default)]
     external_refs: Vec<ExternalRef>,
     /// Trap field (ORB-00042): `workspace` is a *workspace selector* and this
@@ -264,6 +270,10 @@ pub(super) struct UpdateTaskBody {
     pr_status: Option<Option<String>>,
     #[serde(default)]
     context_files: Option<Vec<String>>,
+    /// Escape for a `context_files` selector that names a target this task is
+    /// about to create. See [`CreateTaskBody::allow_missing_context`].
+    #[serde(default)]
+    allow_missing_context: bool,
     #[serde(default, deserialize_with = "deserialize_nullable_string_patch_field")]
     crew: Option<Option<String>>,
     #[serde(default, deserialize_with = "deserialize_nullable_string_patch_field")]
@@ -539,6 +549,7 @@ pub(super) async fn create_task_action(
         Err(message) => return bad_request(message),
     };
     let model = body.model.as_deref().and_then(non_empty_string);
+    let allow_missing_context = body.allow_missing_context;
     let params = TaskAddParams {
         parent_id: body.parent_id,
         title: body.title,
@@ -563,6 +574,9 @@ pub(super) async fn create_task_action(
         orchestrator: body.orchestrator,
     };
     task_mutation_response(runtime, "task creation", move |runtime| {
+        if !allow_missing_context {
+            runtime.ensure_context_selectors_exist(&params.context_files, None)?;
+        }
         runtime.add_task_with_identity(params, None, model)
     })
     .await
@@ -599,6 +613,7 @@ pub(super) async fn update_task_action(
         Err(message) => return bad_request(message),
     };
     let model = body.model.as_deref().and_then(non_empty_string);
+    let allow_missing_context = body.allow_missing_context;
     let params = TaskUpdateParams {
         title: body.title,
         description: body.description,
@@ -625,6 +640,9 @@ pub(super) async fn update_task_action(
     };
     let id = id.to_string();
     task_mutation_response(runtime, "task update", move |runtime| {
+        if !allow_missing_context && let Some(candidates) = params.context_files.as_deref() {
+            runtime.ensure_context_selectors_exist(candidates, None)?;
+        }
         runtime.update_task_with_identity(&id, params, None, model)
     })
     .await

--- a/crates/orbit-web/src/api/tests/tasks.rs
+++ b/crates/orbit-web/src/api/tests/tasks.rs
@@ -1676,6 +1676,7 @@ async fn update_task_response_fields_survive_a_read_back() {
             "complexity": "hard",
             "task_type": "bug",
             "context_files": ["file:src/lib.rs"],
+            "allow_missing_context": true,
         }),
     )
     .await;
@@ -1844,6 +1845,117 @@ async fn update_task_requires_assessed_complexity() {
         Some(TaskComplexity::Medium),
         "a rejected update leaves the stored complexity alone"
     );
+}
+
+/// ORB-12199: the dashboard API applies the same operator-surface guard as
+/// `orbit task add` and `orbit.task.add` — a `context_files` selector with no
+/// existing in-workspace target is a 400, not a task whose context is dead on
+/// arrival.
+#[tokio::test]
+async fn create_task_rejects_a_dead_context_selector() {
+    let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
+
+    let response = post_task(
+        runtime.clone(),
+        json!({
+            "title": "dash ctx",
+            "description": "d",
+            "complexity": "low",
+            "context_files": ["file:does/not/exist.rs"],
+        }),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let message = body_json(response).await["error"]
+        .as_str()
+        .expect("error message")
+        .to_string();
+    assert!(
+        message.contains("file:does/not/exist.rs"),
+        "error must name the dead selector: {message}"
+    );
+    assert!(
+        runtime.list_tasks().expect("list tasks").is_empty(),
+        "a rejected create writes nothing"
+    );
+}
+
+/// ORB-12199: `allow_missing_context` is the same escape as the CLI's
+/// `--allow-missing-context` and the tool's `allow_missing_context` input, for
+/// the deliberate not-yet-created target.
+#[tokio::test]
+async fn create_task_allow_missing_context_permits_a_dead_selector() {
+    let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
+
+    let response = post_task(
+        runtime.clone(),
+        json!({
+            "title": "dash ctx",
+            "description": "d",
+            "complexity": "low",
+            "context_files": ["file:does/not/exist.rs"],
+            "allow_missing_context": true,
+        }),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let created = body_json(response).await;
+    assert_eq!(created["context_files"], json!(["file:does/not/exist.rs"]));
+}
+
+/// ORB-12199: `PATCH /api/tasks/:id` carries the same guard as create.
+#[tokio::test]
+async fn update_task_rejects_a_dead_context_selector() {
+    let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
+    let task = seed_backlog_task(&runtime, "Untouched context task");
+
+    let response = patch_task(
+        runtime.clone(),
+        &task.id,
+        json!({ "context_files": ["file:also/missing.rs"] }),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let message = body_json(response).await["error"]
+        .as_str()
+        .expect("error message")
+        .to_string();
+    assert!(
+        message.contains("file:also/missing.rs"),
+        "error must name the dead selector: {message}"
+    );
+    assert!(
+        runtime
+            .get_task(&task.id)
+            .expect("read task")
+            .context_files
+            .is_empty(),
+        "a rejected update leaves stored context_files alone"
+    );
+}
+
+/// ORB-12199: the same escape applies to update.
+#[tokio::test]
+async fn update_task_allow_missing_context_permits_a_dead_selector() {
+    let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
+    let task = seed_backlog_task(&runtime, "Escaped context task");
+
+    let response = patch_task(
+        runtime.clone(),
+        &task.id,
+        json!({
+            "context_files": ["file:also/missing.rs"],
+            "allow_missing_context": true,
+        }),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let patched = body_json(response).await;
+    assert_eq!(patched["context_files"], json!(["file:also/missing.rs"]));
 }
 
 /// ORB-10648: the same contract on create — `POST /api/tasks` no longer absorbs


### PR DESCRIPTION
## Task

[ORB-12199](https://orbit-cli.com/tasks/ORB-12199) — [qa-sweep] The ORB-12168 context-selector guard skips the dashboard API: POST/PATCH /api/tasks still accept selectors the CLI and MCP tools reject

### Description

## Summary

ORB-12168 / ORB-12184 added an operator-surface guard that rejects
`context_files` selectors with no existing in-workspace target, plus an explicit
`--allow-missing-context` / `allow_missing_context` escape. It is wired into the
CLI (`orbit task add`, `orbit task update`) and the tool host
(`orbit.task.add`, `orbit.task.update`). The dashboard HTTP API
(`POST /api/tasks`, `PATCH /api/tasks/:id`) calls `add_task` / `update_task`
directly, which stayed deliberately permissive, so an API client can still write
a task whose context is dead on arrival — with no escape flag needed and no way
for the caller to opt into the check.

`crates/orbit-core/src/application/task/paths.rs:104-112` documents the intended
callers: "`orbit task add` / `orbit task update` and the `orbit.task.add` /
`orbit.task.update` tools call it". The dashboard is neither named as a caller
nor documented as a deliberate exemption.

## Reproduction (orbit 0.21.0, HEAD `6e9db4a1d`, Linux 6.8)

```sh
orbit --root /tmp/qa12189/root --workspace /tmp/qa12189/work web serve --port 18921 &

# CLI rejects it
orbit --root /tmp/qa12189/root --workspace /tmp/qa12189/work task add \
  --complexity low --description d --title x --context file:does/not/exist.rs --json
# {"code":"invalid_input",
#  "error":"invalid input: selector `file:does/not/exist.rs` does not resolve to an existing in-workspace target"}

# the dashboard API accepts the same selector
curl -s -X POST http://127.0.0.1:18921/api/tasks \
  -H 'content-type: application/json' -H 'Origin: http://127.0.0.1:18921' \
  -d '{"title":"dash ctx","description":"d","complexity":"low",
       "context_files":["file:does/not/exist.rs"]}'
# 200 -> {"id":"QAQA-00061", ... "context_files":["file:does/not/exist.rs"] ...}

curl -s -X PATCH http://127.0.0.1:18921/api/tasks/QAQA-00062 \
  -H 'content-type: application/json' -H 'Origin: http://127.0.0.1:18921' \
  -d '{"context_files":["file:also/missing.rs"]}'
# 200 -> context_files: ["file:also/missing.rs"]
```

## Scope

Production impact: moderate. The current dashboard UI only renders
`context_files`; it has no create-form input for them
(`crates/orbit-web/assets/dashboard/tasks.js:857`), so the exposure today is
programmatic API clients rather than a human typing into the dashboard. Those
clients get exactly the failure mode ORB-12168 was filed about — a task whose
context files silently do not exist — while the same payload through the CLI or
MCP is refused. The inconsistency also makes the guard easy to bypass
accidentally.

Validation impact: none — `make test` passes; no test asserts selector
validation on the HTTP surface either way.

## Suggested direction

Decide and document one rule. Either call `ensure_context_selectors_exist` from
`create_task_action` / the task PATCH handler and accept an
`allow_missing_context` body field mirroring the CLI/tool escape (returning 400
on a dead selector), or state in `paths.rs` and the API docs that the HTTP
surface is intentionally permissive and why. A test on the chosen behaviour
should accompany it.

### Acceptance Criteria

- The dashboard task create/update API either validates context selectors like the CLI and MCP surfaces or documents a deliberate exemption
- If validated, an allow_missing_context body field provides the same escape and a dead selector returns 400
- A test covers the chosen HTTP-surface behaviour

## Execution Summary

<details>
<summary>Click to expand</summary>

## Chosen direction
Validated context selectors on the dashboard API the same way as CLI/MCP, rather than documenting a permissive exemption: `POST /api/tasks` and `PATCH /api/tasks/:id` now call `OrbitRuntime::ensure_context_selectors_exist` and accept the same `allow_missing_context` body field as `orbit task add --allow-missing-context` / `orbit.task.add`'s `allow_missing_context` input.

## Changes
- `crates/orbit-web/src/api/tasks.rs`: added `allow_missing_context: bool` (`#[serde(default)]`) to `CreateTaskBody` and `UpdateTaskBody`. `create_task_action` / `update_task_action` now call `runtime.ensure_context_selectors_exist(...)` inside the `task_mutation_response` blocking closure (mirroring `orbit-core`'s InvalidInput -> 400 mapping already used for mutation errors) unless the flag is set. Update only validates when `context_files` is present in the PATCH body, matching the `orbit.task.update` tool's behavior.
- `crates/orbit-core/src/application/task/paths.rs`: updated the `ensure_context_selectors_exist` doc comment to name the dashboard handlers as intended callers, alongside the CLI and tool surfaces, and to name the `allow_missing_context` escape explicitly.
- `crates/orbit-web/src/api/tests/tasks.rs`: added `create_task_rejects_a_dead_context_selector`, `create_task_allow_missing_context_permits_a_dead_selector`, `update_task_rejects_a_dead_context_selector`, `update_task_allow_missing_context_permits_a_dead_selector`. Also added `allow_missing_context: true` to the existing `update_task_response_fields_survive_a_read_back` fixture body, since it asserted on a `context_files` selector (`file:src/lib.rs`) that does not exist in the in-memory test runtime's repo root and would otherwise now be rejected by the new guard.

## Acceptance criteria
1. "Dashboard task create/update API either validates context selectors like the CLI and MCP surfaces or documents a deliberate exemption" — met: validation chosen and wired via `ensure_context_selectors_exist`, doc updated in `paths.rs`.
2. "If validated, an `allow_missing_context` body field provides the same escape and a dead selector returns 400" — met: field added to both bodies; `OrbitError::InvalidInput` from the guard maps to HTTP 400 via the existing `map_runtime_error`/`task_mutation_response` path (same mapping used for every other mutation-time validation error on these endpoints).
3. "A test covers the chosen HTTP-surface behaviour" — met: 4 new tests plus the fixed existing test.

## Validation
- `cargo build -p orbit-web -p orbit-core`: passed.
- `cargo test -p orbit-web --lib api::tests::tasks::`: 48 passed, 0 failed (includes new/fixed tests).
- `cargo test -p orbit-web -p orbit-core --lib`: 1420 passed (orbit-core) + 385 passed (orbit-web), 0 failed.
- `cargo fmt --check -p orbit-web -p orbit-core`: passed (after `cargo fmt` normalized the new code).
- `cargo clippy -p orbit-web -p orbit-core --all-targets -- -D warnings`: passed, 0 warnings.
- `make ci-fast`: passed.
- `make ci-lint` (workspace-wide clippy, all targets, warnings denied — required before moving to review): passed.
- `git status --short` / `git diff --check`: only the 3 intended files changed, no whitespace issues, nothing untracked.

## Scope
No `context_files` selectors were appended for this task; only files already in `context_files` (`crates/orbit-web/src/api/tasks.rs`, `crates/orbit-core/src/application/task/paths.rs`) plus their existing sibling test file (`crates/orbit-web/src/api/tests/tasks.rs`, already covered by the `tasks.rs` context selector as its test module) were touched. No new source files were created.

## Remaining risk
None identified. Changes are left uncommitted per pipeline ownership of commit/PR/merge.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12199-6aa3f189`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus