### PR TITLE
[code-review] `orbit task list --json` truncates silently again: the truncation notice never reaches a json/ndjson caller

### DIFF
--- a/crates/orbit-cli/src/output/render.rs
+++ b/crates/orbit-cli/src/output/render.rs
@@ -9,7 +9,8 @@
 //! from the sink `main` already resolved.
 //!
 //! Everything that is not a record goes to stderr in every mode (spec §5):
-//! empty-state lines, dropped-column notices, and progress.
+//! empty-state lines, dropped-column notices, trailing notices such as a
+//! truncation count, and progress.
 
 use std::io::Write;
 
@@ -35,11 +36,36 @@ pub fn emit(output: CommandOutput, sink: &OutputSink) -> Result<(), OrbitError> 
         return stream(sink, &mut stdout);
     }
 
+    // A list's trailing notices (a truncation count, say) are not a record,
+    // so they belong on stderr in every mode (spec §5) — not only the human
+    // one that happens to render the table carrying them (ORB-12203).
+    for notice in table_notices(&view) {
+        eprintln!("{notice}");
+    }
+
     match sink.mode() {
         OutputMode::Json => emit_json(&doc, sink.pretty_json()),
         OutputMode::Ndjson => emit_ndjson(&doc),
         OutputMode::Table | OutputMode::Plain => emit_human(doc, view, sink),
     }
+}
+
+/// The trailing notices carried by a payload's table, if it has one. Read
+/// here rather than inside `Table::emit` so a `json`/`ndjson` caller — which
+/// never reaches `emit_human` — still receives them.
+fn table_notices(view: &View) -> Vec<&str> {
+    let View::Blocks(blocks) = view else {
+        return Vec::new();
+    };
+    blocks
+        .iter()
+        .filter_map(|block| match block {
+            Block::Table(table) => Some(table.trailing_notices()),
+            Block::Text(_) => None,
+        })
+        .flatten()
+        .map(String::as_str)
+        .collect()
 }
 
 /// One document, pretty-printed only for a human (spec §3).

--- a/crates/orbit-cli/src/output/table.rs
+++ b/crates/orbit-cli/src/output/table.rs
@@ -152,16 +152,21 @@ impl Table {
         self
     }
 
-    /// Add a trailing notice to print to stderr after the table.
+    /// Add a trailing notice — a truncation count, say — for the renderer to
+    /// print to stderr. Not printed by [`Table::emit`] itself: `output::render`
+    /// reads it via [`Table::trailing_notices`] before mode dispatch, so it
+    /// reaches a `json`/`ndjson` caller too, not only the human table view
+    /// (ORB-12203).
     #[must_use]
     pub fn trailing_notice(mut self, notice: impl Into<String>) -> Self {
         self.trailing_notices.push(notice.into());
         self
     }
 
-    /// Notices to be printed to stderr after the table.
-    #[cfg(test)]
-    pub fn trailing_notices(&self) -> &[String] {
+    /// Notices for the renderer to print to stderr in every mode, ahead of
+    /// this table's own render (which may add further, rendering-specific
+    /// notices such as dropped columns).
+    pub(crate) fn trailing_notices(&self) -> &[String] {
         &self.trailing_notices
     }
 
@@ -173,7 +178,10 @@ impl Table {
 
     /// Write the list to stdout in the sink's mode, or the empty-state line to
     /// stderr when there are no records. Notices about dropped columns go to
-    /// stderr so that they never land in a consumer's record stream.
+    /// stderr so that they never land in a consumer's record stream. This
+    /// table's own trailing notices (a truncation count, say) are not printed
+    /// here — `output::render` prints those in every mode, human or not, so
+    /// this only handles rendering-specific notices discovered at this width.
     ///
     /// Called only by `output::render`; a command hands its table back inside a
     /// payload rather than emitting one itself.
@@ -184,9 +192,6 @@ impl Table {
         }
         if sink.mode() == OutputMode::Plain {
             println!("{}", self.render_plain(sink));
-            for notice in &self.trailing_notices {
-                eprintln!("{notice}");
-            }
             return;
         }
         let rendered = self.render_at(
@@ -198,9 +203,6 @@ impl Table {
             eprintln!("{notice}");
         }
         println!("{}", rendered.body);
-        for notice in &self.trailing_notices {
-            eprintln!("{notice}");
-        }
     }
 
     /// The plain form: the same visible columns and the same cell values as

--- a/crates/orbit-cli/tests/task_list.rs
+++ b/crates/orbit-cli/tests/task_list.rs
@@ -157,6 +157,61 @@ fn task_list_truncation_notice_and_bare_json_array_with_60_tasks() {
     );
 }
 
+/// ORB-12203: the truncation notice on a machine-readable mode must reach
+/// stderr, and stdout must stay exactly the records — a bare array for
+/// `--format json`, one record per line for `--format ndjson` — with no
+/// notice mixed in.
+#[test]
+fn task_list_truncation_notice_reaches_stderr_in_json_and_ndjson_modes() {
+    let workspace = TestWorkspace::new();
+    for i in 0..60 {
+        workspace.add_task(&format!("Task {i:02}"));
+    }
+    let truncation_notice = "showing 50 of 60 tasks (non-terminal tasks first, then terminal, each newest first); use --limit N or a filter to see more";
+
+    let json = workspace.run(
+        &["task", "list", "--format", "json"],
+        "task list --format json",
+    );
+    let json_stdout = String::from_utf8_lossy(&json.stdout);
+    let json_stderr = String::from_utf8_lossy(&json.stderr);
+    assert!(
+        json_stderr.contains(truncation_notice),
+        "--format json must report truncation on stderr:\n{json_stderr}"
+    );
+    let tasks: Value = serde_json::from_slice(&json.stdout).expect("bare json array");
+    assert_eq!(
+        tasks.as_array().expect("tasks array").len(),
+        50,
+        "--format json stdout must stay the bare array, untouched by the notice"
+    );
+    assert!(
+        !json_stdout.contains("showing"),
+        "stdout must not carry the truncation notice:\n{json_stdout}"
+    );
+
+    let ndjson = workspace.run(
+        &["task", "list", "--format", "ndjson"],
+        "task list --format ndjson",
+    );
+    let ndjson_stdout = String::from_utf8_lossy(&ndjson.stdout);
+    let ndjson_stderr = String::from_utf8_lossy(&ndjson.stderr);
+    assert!(
+        ndjson_stderr.contains(truncation_notice),
+        "--format ndjson must report truncation on stderr:\n{ndjson_stderr}"
+    );
+    let lines: Vec<&str> = ndjson_stdout.lines().collect();
+    assert_eq!(
+        lines.len(),
+        50,
+        "--format ndjson stdout must stay one record per line, untouched by the notice:\n{ndjson_stdout}"
+    );
+    for line in &lines {
+        let record: Value = serde_json::from_str(line).expect("ndjson line is a JSON object");
+        assert!(record.is_object(), "each ndjson line is one task record");
+    }
+}
+
 #[test]
 fn older_someday_task_discoverable_ahead_of_50_newer_done_tasks() {
     let workspace = TestWorkspace::new();


### PR DESCRIPTION
## Task

[ORB-12203](https://orbit-cli.com/tasks/ORB-12203) — [code-review] `orbit task list --json` truncates silently again: the truncation notice never reaches a json/ndjson caller

### Description

## Summary

ORB-12198 (`ca38d5ba3`, #1975) restored the frozen bare-array shape of `orbit task list --json` by replacing the `{tasks,total,truncated}` document with `Payload::list(records, table)` (`crates/orbit-cli/src/command/task/list.rs:237`). That revert was the right call for the byte contract, but it removed the *only* truncation signal a machine consumer had, and it did not put one back on any other channel. `orbit task list --json` (and `--format json` / `--format ndjson`) now returns a silently capped page with nothing in the payload and nothing on stderr — exactly the defect ORB-12177 was filed to fix ("silently truncates at --limit (default 50) with no notice or total, hiding older open tasks"), restored for every non-human caller.

The notice survives only on the human path: it is attached to the `Table` (`crates/orbit-cli/src/command/task/list.rs:221-235`), and a table's stderr notices are printed by `Table::emit` (`crates/orbit-cli/src/output/table.rs:180-203`), which is reached only from `emit_human` (`crates/orbit-cli/src/output/render.rs:77-86`). `render::emit` dispatches json/ndjson to `emit_json`/`emit_ndjson` (`crates/orbit-cli/src/output/render.rs:38-42`), which take the document and discard the view entirely, so no block — and no trailing notice — is ever emitted in those modes.

This contradicts the output-modes spec, which is explicit that this class of output is mode-independent: "stdout carries the payload and nothing else. Progress, warnings, counts, empty-state prose, and diagnostics go to stderr, **in every mode**" (`docs/design/terminal-interface/specs/output-modes.md:65`). A truncation count is precisely such a count, and `render.rs:11-12` repeats the same rule in the module docs.

Nothing pins the behavior either way: `crates/orbit-cli/tests/task_list.rs:138-152` now asserts only array lengths for `--json`, and the notice assertions at `:122-127` and `:183-190` exercise the default (human) sink only.

## Reproduction (built from `ca38d5ba3`, Linux 6.8, disposable HOME + checkout)

Three tasks in a scratch workspace, `--limit 2`:

```
$ orbit task list --limit 2 >/dev/null
# stderr: showing 2 of 3 tasks (non-terminal tasks first, then terminal, each newest first); use --limit N or a filter to see more

$ orbit task list --limit 2 --json 2>stderr.txt | python3 -c 'import json,sys; d=json.load(sys.stdin); print(type(d).__name__, len(d))'
list 2
$ cat stderr.txt
            # empty — one task hidden, nothing says so

$ orbit task list --limit 2 --format json 2>&1 >/dev/null   # empty
$ orbit task list --limit 2 --format ndjson 2>&1 >/dev/null  # empty
```

(The same run confirms ndjson streaming is fixed: `--format ndjson` writes one line per task, so ORB-12196 is genuinely closed by this commit. Only the truncation signal is missing.)

## Suggested direction

Emit the truncation notice to stderr in every mode rather than only from the table. Spec §3 ("`json` for a list command emits a single array") rules out re-introducing a stdout envelope, and §5 already says where the count belongs; the gap is that a payload's non-record output is currently unreachable outside `emit_human`. Whatever the mechanism, the fix belongs in the renderer so every truncating list command benefits, not as a second code path in `task list`.

## Relation to existing work

ORB-12195 (in-progress) covers the *MCP* `orbit.task.list` surface having no total/truncated. This is the CLI surface and a different file; ORB-12195's description also now mis-describes the CLI (it says `--json` carries `total`/`truncated`, which `ca38d5ba3` reverted), so whoever takes it should read this one first.

### Acceptance Criteria

- `orbit task list --limit N --json`, `--format json`, and `--format ndjson` on a truncated result all report the truncation on stderr while stdout stays exactly the records (a bare array / one record per line).
- The mechanism lives in the output renderer, so a list payload's stderr notices are emitted in every mode rather than only on the human path.
- `orbit task list --json` on a truncated result still emits a bare JSON array on stdout, byte-identical to today (the ORB-12198 contract is not reopened).
- A regression test asserts both the stderr notice and the untouched stdout records for at least one machine-readable mode.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Fix

The truncation notice was stored on `Table::trailing_notices` and only printed by `Table::emit` (`output/table.rs`), which is reached exclusively from `emit_human` (`output/render.rs`) — so `--json`, `--format json`, and `--format ndjson` never saw it, silently re-introducing the ORB-12177 defect for every non-human caller.

Moved the printing to the renderer itself, before mode dispatch, so it fires in every mode:
- `output/render.rs`: `emit()` now reads a payload's `View::Blocks` for any `Block::Table` and prints its `trailing_notices()` to stderr, once, before the `json`/`ndjson`/`table`/`plain` match. Added a `table_notices()` helper for the extraction.
- `output/table.rs`: `Table::emit` (human/table/plain path) no longer prints `trailing_notices` itself, since the renderer now does it for every mode including human — avoids double-printing. `trailing_notices()` changed from `#[cfg(test)]` to `pub(crate)` so the renderer can read it outside tests. Doc comments updated to describe the new split (dropped-column notices stay render-time/human-only inside `Table::emit`; trailing notices like a truncation count are renderer-owned and mode-independent).
- `command/task/list.rs`: unchanged — it still just calls `table.trailing_notice(...)`; the fix is a single mechanism in the renderer that benefits every truncating list command, not a second code path in `task list` (per the task's suggested direction).

## Acceptance criteria

1. **Notice reaches stderr in every mode, stdout untouched** — verified by new integration test `task_list_truncation_notice_reaches_stderr_in_json_and_ndjson_modes` (`crates/orbit-cli/tests/task_list.rs`): with 60 tasks/limit 50, both `--format json` and `--format ndjson` show the truncation notice on stderr, `--format json` stdout is still a 50-element bare array with no "showing" text, `--format ndjson` stdout is still exactly 50 JSON-object lines.
2. **Mechanism lives in the renderer** — done; see above. `command/task/list.rs` has no new branching.
3. **`--json` stays a byte-identical bare array** — unchanged: `Payload::list` still builds `Value::Array(records)` as `doc`; existing test `task_list_truncation_notice_and_bare_json_array_with_60_tasks` (asserting array length 50/60/60 across `--json` variants) still passes untouched.
4. **Regression test asserts both stderr notice and untouched stdout for a machine-readable mode** — the new test above covers this for both `--format json` and `--format ndjson`.

## Scope deviation

`context_files` named `crates/orbit-cli/tests/json_output_surface.rs`, which does not exist in this repo (confirmed via `git log --all`). Used the existing `crates/orbit-cli/tests/task_list.rs` instead (already the home of this exact truncation-notice coverage) and updated `context_files` accordingly via `orbit.task.update`, along with the two source files actually touched (`output/render.rs`, `output/table.rs`).

## Unresolved discrepancy (flagged via task comment, not blocking)

A task comment (2026-09-11T12:10:53Z) asks for an opt-in `--format json --envelope`/`--with-meta` flag returning `{tasks,total,truncated}`. This is not reflected in any of the four acceptance_criteria, and contradicts the description's own "Suggested direction" (fix belongs in the renderer, not a new flag/second code path). Implemented per the acceptance_criteria as written (stderr-only, no new flag); left a comment flagging this for whoever owns the envelope idea, if it's still wanted, as separate scope.

## Validation

- `cargo build -p orbit-cli` — passed.
- `cargo test -p orbit-cli --bin orbit output::` (56 tests) — passed.
- `cargo test -p orbit-cli --bin orbit command::task::tests::list::` (4 tests, incl. `table_trailing_notices_are_stored_and_rendered`) — passed.
- `cargo test -p orbit-cli --test task_list` (5 tests, incl. new regression test) — passed.
- `cargo test -p orbit-cli --test output_goldens` (8 tests) — passed, no golden drift.
- `make ci-fast` — passed (after `cargo fmt -p orbit-cli`).
- `make ci-lint` (workspace clippy, warnings denied) — passed, no warnings.
- `git diff --check` and `git status --short` — clean; only the three intended files modified, no stray artifacts.

## Remaining risk

None identified. The change is renderer-only and additive to stderr; no stdout byte shape changed for any existing mode.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12203-6aa3f36f`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus