### PR TITLE
[code-review] `orbit tool run orbit.task.list --fields id,title` returns `{}`: the ORB-12195 envelope broke top-level field projection

### DIFF
--- a/crates/orbit-cli/src/command/tool/run.rs
+++ b/crates/orbit-cli/src/command/tool/run.rs
@@ -30,7 +30,10 @@ pub struct ToolRunArgs {
     /// Validate without executing
     #[arg(long)]
     pub dry_run: bool,
-    /// Comma-separated top-level fields to keep from object output
+    /// Comma-separated top-level fields to keep from object output. For an
+    /// envelope-shaped result (e.g. `orbit.task.list`'s `{tasks, total,
+    /// truncated}`), fields project each record inside the envelope's
+    /// record array instead of the envelope's own top-level keys.
     #[arg(long, value_delimiter = ',', conflicts_with = "full")]
     pub fields: Vec<String>,
     /// Return the tool's full unfiltered JSON output
@@ -207,12 +210,15 @@ pub(super) fn shape_tool_output(
     }
 
     if !fields.is_empty() {
+        if tool_name == "orbit.task.list" {
+            return project_task_list_output(output, fields);
+        }
         return filter_top_level_fields(output, fields);
     }
 
     if should_project_minimal_task_output(tool_name) {
         if tool_name == "orbit.task.list" {
-            return project_task_list_output(output);
+            return project_task_list_output(output, MINIMAL_TASK_FIELDS);
         }
         return filter_top_level_fields(
             output,
@@ -237,16 +243,18 @@ fn should_project_minimal_task_output(tool_name: &str) -> bool {
     true
 }
 
-fn project_task_list_output(value: Value) -> Value {
+/// Projects `--fields` (or the default minimal set) inside the `tasks` array
+/// of an `orbit.task.list` envelope, leaving `total`/`truncated` intact.
+fn project_task_list_output<S: AsRef<str>>(value: Value, fields: &[S]) -> Value {
     let Value::Object(mut object) = value else {
         return value;
     };
     let Some(Value::Array(tasks)) = object.get_mut("tasks") else {
         return Value::Object(object);
     };
-    let fields = MINIMAL_TASK_FIELDS
+    let fields = fields
         .iter()
-        .map(|field| (*field).to_string())
+        .map(|field| field.as_ref().to_string())
         .collect::<Vec<_>>();
     let projected = std::mem::take(tasks)
         .into_iter()

--- a/crates/orbit-cli/src/command/tool/tests/run.rs
+++ b/crates/orbit-cli/src/command/tool/tests/run.rs
@@ -78,6 +78,37 @@ fn list_output_uses_minimal_task_projection() {
 }
 
 #[test]
+fn list_output_projects_explicit_fields_inside_envelope() {
+    let shaped = shape_tool_output(
+        "orbit.task.list",
+        json!({
+            "tasks": [{
+                "id": "T20260422-0001",
+                "title": "Backlog task",
+                "status": "backlog",
+                "description": "should be filtered out"
+            }],
+            "total": 1,
+            "truncated": false
+        }),
+        false,
+        &["id".to_string(), "title".to_string()],
+    );
+
+    assert_eq!(
+        shaped,
+        json!({
+            "tasks": [{
+                "id": "T20260422-0001",
+                "title": "Backlog task"
+            }],
+            "total": 1,
+            "truncated": false
+        })
+    );
+}
+
+#[test]
 fn show_output_preserves_task_details_by_default() {
     let output = json!({
         "id": "T20260422-0001",


### PR DESCRIPTION
## Task

[ORB-12205](https://orbit-cli.com/tasks/ORB-12205) — [code-review] `orbit tool run orbit.task.list --fields id,title` returns `{}`: the ORB-12195 envelope broke top-level field projection

### Description

`58f7295d4` (ORB-12195) changed `orbit.task.list` from a bare task array to a `{tasks, total, truncated}` envelope (`crates/orbit-core/src/adapter/tool_host/task_tools.rs:154-166`). The `orbit tool run` projection was updated for the *default* minimal shape only — `shape_tool_output` gained `project_task_list_output` for the no-flags path (`crates/orbit-cli/src/command/tool/run.rs:213-216`, `:240-260`) — but the explicit `--fields` path runs first and was left untouched (`crates/orbit-cli/src/command/tool/run.rs:203-205`).

`filter_top_level_fields` (`crates/orbit-cli/src/command/tool/run.rs:262-277`) projects an `Array` element-wise and an `Object` key-wise. While the tool returned an array, `--fields id,title` projected each task; against the envelope it now selects the top-level keys `id`/`title`, which the envelope does not have, so the command prints `{}` — exit code 0, no warning, every task silently gone. `--fields` is documented as "Comma-separated top-level fields to keep from object output" (`crates/orbit-cli/src/command/tool/run.rs:32-34`), so callers have no signal that the meaning of the flag moved.

## Reproduction (binary built from `cf39037c7`, disposable `HOME`/checkout fixture, three tasks)

```
$ orbit tool run orbit.task.list --input '{"model":"claude-opus-5"}'
{ "tasks": [ {...FIX-00002...}, {...FIX-00001...}, {...FIX-00000...} ], "total": 3, "truncated": false }

$ orbit tool run orbit.task.list --input '{"model":"claude-opus-5"}' --fields id,title
{}

$ orbit tool run orbit.task.list --input '{"model":"claude-opus-5"}' --fields tasks
{ "tasks": [ ...full unprojected task records... ] }
```

The only way to get records back is `--fields tasks`, which defeats the projection (it returns whole task bodies, the opposite of what the flag is for).

Related, same root cause: `orbit tool run orbit.task.list --format ndjson` now emits one envelope line instead of one record per line, because `ndjson_records` treats a non-array document as a single record (`crates/orbit-cli/src/output/render.rs:92-98`). `crates/orbit-cli/tests/output_goldens.rs:605-616` was updated to assert the new one-line shape, so the change is pinned but undocumented for callers.

## No coverage

No test exercises `tool run orbit.task.list` with `--fields`; the projection tests in `crates/orbit-cli/src/command/tool/tests/run.rs:33-80` only cover the default minimal path, which is why the regression landed green.

## Suggested direction

Have the `--fields` path project inside `tasks` for `orbit.task.list` the same way `project_task_list_output` does for the default shape (keeping `total`/`truncated` intact), and pin it with a test.

### Acceptance Criteria

- `orbit tool run orbit.task.list --fields id,title` returns the envelope with each element of `tasks` projected to the requested fields instead of an empty object.
- A test in the orbit-cli tool-run suite fails if `--fields` on `orbit.task.list` drops the task records again.
- The `--fields` help text and any affected docs state how projection applies to an envelope-shaped tool result.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed `orbit tool run orbit.task.list --fields ...` returning `{}` for the envelope shape introduced by ORB-12195.

Root cause: `shape_tool_output` (crates/orbit-cli/src/command/tool/run.rs) ran `filter_top_level_fields` for the explicit `--fields` path before the tool-specific envelope projection, so `--fields id,title` selected nonexistent top-level keys on the `{tasks, total, truncated}` envelope instead of projecting inside `tasks`.

Fix: `project_task_list_output` (was default-path-only) is now generic over the field list (`fn project_task_list_output<S: AsRef<str>>(value: Value, fields: &[S]) -> Value`) and is called from both the explicit `--fields` branch and the default minimal-projection branch when `tool_name == "orbit.task.list"`, preserving `total`/`truncated` while projecting each `tasks[]` element to the requested fields.

Criteria:
1. `orbit tool run orbit.task.list --fields id,title` now returns the full envelope with each task projected to `{id, title}` instead of `{}` — verified via unit test and by tracing the code path (shape_tool_output -> project_task_list_output on the --fields branch).
2. Added `list_output_projects_explicit_fields_inside_envelope` in crates/orbit-cli/src/command/tool/tests/run.rs, asserting `--fields id,title` on an envelope-shaped `orbit.task.list` output preserves `total`/`truncated` and projects only `id`/`title` inside `tasks`; this test fails against the pre-fix code (which returned `{}`).
3. Updated the `--fields` clap doc comment on `ToolRunArgs::fields` (crates/orbit-cli/src/command/tool/run.rs) to state that for an envelope-shaped result like `orbit.task.list`'s `{tasks, total, truncated}`, fields project each record inside the envelope's array rather than the envelope's own top-level keys. No other docs reference `orbit tool run --fields` semantics (checked website/src/content/docs and docs/ — only `orbit task show --fields` is documented elsewhere, a different command/path).

Scope: touched only the two files already in context_files (run.rs, tests/run.rs); no unlisted files changed.

Validation:
- `cargo test -p orbit-cli --bins run` — 127 passed, 0 failed (includes both the new regression test and the existing default-path test).
- `cargo fmt -- --check` on both changed files — clean.
- `make ci-fast` — passed.
- `make ci-lint` (workspace clippy, all targets, warnings denied) — passed, exit 0.
- `git diff --check` — clean; `git status --short` shows only the two intended files modified.

Not addressed (out of scope per task description, noted only as related context): the `--format ndjson` envelope-vs-per-record behavior mentioned in the task description as "related, same root cause" is a separate, already-pinned behavior (crates/orbit-cli/tests/output_goldens.rs) and not covered by this task's acceptance criteria.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12205-6aa40760`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus