### PR TITLE
[qa-sweep] `orbit.task.add` still validates context selectors against a workspace sub-path, so the MCP tool both stores dead selectors and rejects valid ones

### DIFF
--- a/crates/orbit-core/src/adapter/tool_host/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/task_tools.rs
@@ -26,11 +26,14 @@ pub(super) fn add(
 ) -> Result<Value, OrbitError> {
     let title = required_string(&input, &["title"], "title")?;
     let description = required_string(&input, &["description"], "description")?;
-    let workspace = required_string(&input, &["workspace"], "workspace")?;
+    // `workspace` is required for the existing MCP/CLI routing that selects
+    // this runtime before dispatch reaches here; context selectors always
+    // canonicalize against the repository root regardless of its value.
+    required_string(&input, &["workspace"], "workspace")?;
     let raw_context_files =
         optional_csv_or_string_list_alias(&input, &["context_files"])?.unwrap_or_default();
     if !allows_missing_context(&input)? {
-        runtime.ensure_context_selectors_exist(&raw_context_files, Some(workspace.as_str()))?;
+        runtime.ensure_context_selectors_exist(&raw_context_files, None)?;
     }
     let task = runtime.add_task_with_identity(
         TaskAddParams {
@@ -57,7 +60,7 @@ pub(super) fn add(
             plan: String::new(),
             comment: None,
             context_files: raw_context_files.clone(),
-            workspace_path: Some(workspace),
+            workspace_path: None,
             priority: optional_string(&input, "priority")?
                 .map(|value| parse_task_priority("priority", &value))
                 .transpose()?

--- a/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
@@ -165,6 +165,68 @@ fn task_add_tool_creates_proposed_tasks_for_agents() {
     );
 }
 
+/// ORB-12208: `orbit.task.add` must validate `context_files` against the same
+/// root `add_task` stores them relative to (the repository root), not against
+/// a sub-directory path-form `workspace` selector. `orbit.task.update`
+/// (ORB-12197) already passes `None`; this covers the tool that was left
+/// behind, in both directions: a selector valid only relative to the
+/// sub-directory must be rejected rather than stored dead, and a selector
+/// valid at the repository root must be accepted rather than false-rejected.
+#[test]
+fn task_add_tool_validates_context_selectors_against_repo_root_not_workspace_subdir() {
+    let (_root, runtime, repo_root) = test_runtime();
+    fs::create_dir_all(repo_root.join("src")).expect("create repo-root src dir");
+    fs::write(repo_root.join("src/main.rs"), "fn main() {}\n").expect("write repo-root file");
+    let sub_dir = repo_root.join("crates").join("orbit-cli").join("src");
+    fs::create_dir_all(&sub_dir).expect("create workspace sub-directory");
+    fs::write(sub_dir.join("lib.rs"), "pub fn ok() {}\n").expect("write sub-directory file");
+    let workspace = repo_root.join("crates").join("orbit-cli");
+
+    // A selector that only resolves relative to the sub-directory workspace
+    // (`crates/orbit-cli/src/lib.rs` as `file:src/lib.rs`) does not exist at
+    // the repository root `add_task` stores it against, so it must be
+    // rejected rather than accepted and stored dead.
+    let message = invalid_input_message(runtime.execute_tool_command(
+        "orbit.task.add",
+        json!({
+            "title": "Rejects sub-directory-only selector",
+            "description": "file:src/lib.rs only resolves under the workspace sub-directory.",
+            "complexity": "low",
+            "workspace": workspace.to_string_lossy(),
+            "context_files": ["file:src/lib.rs"],
+        }),
+        Some("codex".to_string()),
+        Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+    ));
+    assert!(
+        message.contains("file:src/lib.rs") && message.contains("does not resolve"),
+        "{message}"
+    );
+
+    // A selector valid at the repository root (`file:src/main.rs`) must be
+    // accepted even though the call's `workspace` is a sub-directory, because
+    // `add_task` canonicalizes and stores selectors relative to the
+    // repository root.
+    let output = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Accepts repo-root selector",
+                "description": "file:src/main.rs resolves at the repository root.",
+                "complexity": "low",
+                "workspace": workspace.to_string_lossy(),
+                "context_files": ["file:src/main.rs"],
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("repo-root-valid selector is accepted from a sub-directory workspace");
+    assert_eq!(
+        output.get("context_files"),
+        Some(&json!(["file:src/main.rs"]))
+    );
+}
+
 #[test]
 fn mcp_task_add_uses_session_workspace_from_worktree_cwd() {
     let (_root, runtime, repo_root) = test_runtime();


### PR DESCRIPTION
## Task

[ORB-12208](https://orbit-cli.com/tasks/ORB-12208) — [qa-sweep] `orbit.task.add` still validates context selectors against a workspace sub-path, so the MCP tool both stores dead selectors and rejects valid ones

### Description

## Summary

ORB-12197 (74424c589) made task context selectors always canonicalize against the
**repository root** and removed the `--workspace-path` sub-directory hint from
`orbit task add`. It updated the CLI (`crates/orbit-cli/src/command/task/add.rs`)
and the dashboard (`crates/orbit-web/src/api/tasks.rs`) to call the guard with
`None`. ORB-12199 (cf4fe6d47) wired the dashboard handlers up the same way.

One call site was left behind: the tool host's `orbit.task.add`.

`crates/orbit-core/src/adapter/tool_host/task_tools.rs:33`

```rust
let workspace = required_string(&input, &["workspace"], "workspace")?;
...
runtime.ensure_context_selectors_exist(&raw_context_files, Some(workspace.as_str()))?;
```

and `task_tools.rs:60` still passes `workspace_path: Some(workspace)` into
`TaskAddParams`, a field ORB-12197 documented as deprecated and that `add_task`
now ignores.

Every other guard call site passes `None`:

- `crates/orbit-cli/src/command/task/add.rs:85`
- `crates/orbit-cli/src/command/task/update.rs:211`
- `crates/orbit-web/src/api/tasks.rs:578`, `:644`
- `crates/orbit-core/src/adapter/tool_host/task_tools.rs:309` (`orbit.task.update`)

`orbit.task.add` is the only surface left validating against a different root
than the one storage uses.

## Why the wrong root reaches the guard

`workspace` on the tool input is a *workspace selector*, not a path. When it is
a registered name or a `ws_*` id, `crates/orbit-cmd/src/registry_runtime.rs`
(`resolve_cli_workspace_target`, `rewrite_to_repo_root: true`) rewrites the
input to the checkout repo root, so the guard happens to use the right root.

When the selector is a **path**, `resolve_cli_workspace_path` returns
`rewrite_to_repo_root: false` and the raw path is left in the input verbatim.
A path pointing at a sub-directory of the checkout is accepted as a selector
(it resolves through `find_checkout_for_git_common_dir`), so the guard then
runs `normalize_workspace_path` on that sub-directory and validates every
selector relative to it — while `add_task` canonicalizes and stores them
relative to the repository root.

## Evidence (reproduced at cf39037c7, `orbit 0.21.0`, Linux)

Scratch Orbit root + checkout (nothing touches the real `~/.orbit`):

```
mkdir -p /tmp/qa12207/root /tmp/qa12207/repo
cd /tmp/qa12207/repo && git init -q .
mkdir -p src crates/orbit-cli/src && echo fn > src/main.rs && echo x > crates/orbit-cli/src/lib.rs
git add -A && git -c user.email=a@b -c user.name=a commit -qm init
HOME=/tmp/qa12207/home orbit --root /tmp/qa12207/root init --non-interactive --host-name qa12207 --task-prefix QAX
HOME=/tmp/qa12207/home orbit --root /tmp/qa12207/root workspace init
```

All of the following run from `/tmp/qa12207/repo` with
`HOME=/tmp/qa12207/home orbit --root /tmp/qa12207/root ...` and with
`ORBIT_WORKSPACE` / `ORBIT_REGISTRY_ROOT` / `ORBIT_RUN_ID` cleared.

**A. False accept — a dead selector is stored.**

```
orbit tool run orbit.task.add --input '{"title":"T5 subdir","description":"d","complexity":"low",
  "workspace":"/tmp/qa12207/repo/crates/orbit-cli","context_files":["file:src/lib.rs"]}'
```

exit 0, creates `QAX-00003`. `orbit task show QAX-00003 --format json` reports

```
"context_files": ["file:src/lib.rs"]
```

`/tmp/qa12207/repo/src/lib.rs` does not exist. The guard checked
`crates/orbit-cli/src/lib.rs`; storage recorded a repo-root-relative selector
that resolves to nothing — exactly the "dead on arrival" context ORB-12168 and
ORB-12197 were meant to stop.

**B. False reject — a valid repo-root selector is refused.**

```
orbit tool run orbit.task.add --input '{"title":"T6","description":"d","complexity":"low",
  "workspace":"/tmp/qa12207/repo/crates/orbit-cli","context_files":["file:src/main.rs"]}'
```

exit 1:

```
{"code":"invalid_input","error":"invalid input: selector `file:src/main.rs` does not resolve to an existing in-workspace target"}
```

`src/main.rs` exists at the repository root and is precisely what `add_task`
would have stored.

**C. `orbit.task.update` on the identical input behaves correctly** (it passes
`None`), so the two tools disagree about the same selector:

```
orbit tool run orbit.task.update --input '{"id":"QAX-00000",
  "workspace":"/tmp/qa12207/repo/crates/orbit-cli","context_files":["file:src/lib.rs"]}'
-> exit 1: selector `file:src/lib.rs` does not resolve to an existing in-workspace target
```

**Control:** with `"workspace":"repo"` or `"workspace":"ws_repo"` (name/id
forms, which the registry rewrites to the repo root) `file:src/main.rs` is
accepted and `file:src/nope.rs` is rejected — correct behavior. The defect is
specific to a path-form selector that is not the checkout root.

## Expected

`orbit.task.add` validates against the same root storage uses. Passing `None`
matches every other surface and makes A fail and B succeed.

## Suggested fix

In `crates/orbit-core/src/adapter/tool_host/task_tools.rs::add`:

- call `runtime.ensure_context_selectors_exist(&raw_context_files, None)?`
- drop `workspace_path: Some(workspace)` in favour of `None` (the field is
  deprecated and ignored by `add_task` since ORB-12197); `workspace` is then
  only needed for the existing routing/`required_string` validation.

Add a regression test at the tool-host boundary covering a sub-directory
path-form `workspace` selector for both the accept and the reject case.

## Scope

Production defect on an agent-facing tool. Not a validation blocker: `make
ci-fast` and the workspace test suite do not cover a path-form sub-directory
workspace selector for `orbit.task.add`.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed `orbit.task.add` (`crates/orbit-core/src/adapter/tool_host/task_tools.rs::add`) to validate `context_files` against the repository root instead of the path-form `workspace` sub-directory selector, matching every other guard call site (CLI add/update, dashboard handlers, `orbit.task.update`).

Changes:
- `runtime.ensure_context_selectors_exist(&raw_context_files, Some(workspace.as_str()))` -> `..., None`.
- `TaskAddParams.workspace_path: Some(workspace)` -> `None` (field is deprecated and already ignored by `add_task` since ORB-12197).
- `workspace` is still required via `required_string` (still needed for existing MCP/CLI routing that selects the runtime before dispatch reaches this handler) but its value is no longer bound/used inside the handler.

Regression test added at the tool-host boundary in the sibling test file `crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs`: `task_add_tool_validates_context_selectors_against_repo_root_not_workspace_subdir`. It reproduces both defect modes from the task's evidence using a real sub-directory workspace path (no registry/CLI routing needed, since `execute_tool_command` in these unit tests calls the handler directly with the raw `workspace` string):
- False accept (dead selector): a selector valid only relative to the sub-directory (`file:src/lib.rs` under `crates/orbit-cli/`) is now rejected with "does not resolve to an existing in-workspace target" instead of being silently stored.
- False reject: a selector valid at the repository root (`file:src/main.rs`) is now accepted and stored as `file:src/main.rs` even though `workspace` in the call is a sub-directory path.

Acceptance criteria: none were declared on the task; the suggested fix and regression test from the description were implemented as specified.

Validation:
- `cargo test -p orbit-core --lib adapter::tool_host::tests::task_tools` — passed, 72/72 tests including the new regression test.
- `make ci-fast` — passed (fmt-check + guardrail scripts).
- `make ci-lint` — passed (workspace-wide, all-target clippy, warnings denied).
- `git status --short` / `git diff --check` — clean; only the two in-scope files changed (handler + its sibling test file, per this crate's test-layout convention — no new files, no scope declaration needed).

No blockers, no deviations, no friction filed (this was a straightforward, well-specified fix with reproduction steps already provided in the task description).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12208-6aa40761`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus