### PR TITLE
[code-review] The `orbit task list` truncation notice now prints above the table instead of after it

### DIFF
--- a/crates/orbit-cli/src/output/render.rs
+++ b/crates/orbit-cli/src/output/render.rs
@@ -36,16 +36,24 @@ pub fn emit(output: CommandOutput, sink: &OutputSink) -> Result<(), OrbitError> 
         return stream(sink, &mut stdout);
     }
 
-    // A list's trailing notices (a truncation count, say) are not a record,
-    // so they belong on stderr in every mode (spec §5) — not only the human
-    // one that happens to render the table carrying them (ORB-12203).
-    for notice in table_notices(&view) {
-        eprintln!("{notice}");
-    }
-
     match sink.mode() {
-        OutputMode::Json => emit_json(&doc, sink.pretty_json()),
-        OutputMode::Ndjson => emit_ndjson(&doc),
+        // A list's trailing notices (a truncation count, say) belong on
+        // stderr in every mode (spec §5). In table and plain modes,
+        // `Table::emit` prints them after the table body (ORB-12206). In
+        // machine-readable modes, `Table::emit` is not called, so we print
+        // them here (ORB-12203).
+        OutputMode::Json => {
+            for notice in table_notices(&view) {
+                eprintln!("{notice}");
+            }
+            emit_json(&doc, sink.pretty_json())
+        }
+        OutputMode::Ndjson => {
+            for notice in table_notices(&view) {
+                eprintln!("{notice}");
+            }
+            emit_ndjson(&doc)
+        }
         OutputMode::Table | OutputMode::Plain => emit_human(doc, view, sink),
     }
 }

--- a/crates/orbit-cli/src/output/table.rs
+++ b/crates/orbit-cli/src/output/table.rs
@@ -12,6 +12,8 @@
 //! (ADR-0306): a zero-width sink truncates nothing, and a sink that disallows
 //! color renders the same bytes a file redirect would.
 
+use std::io::Write;
+
 use comfy_table::{
     Attribute, Cell, CellAlignment, ColumnConstraint, ContentArrangement, Row, Table as Grid,
     Width, presets,
@@ -152,20 +154,18 @@ impl Table {
         self
     }
 
-    /// Add a trailing notice — a truncation count, say — for the renderer to
-    /// print to stderr. Not printed by [`Table::emit`] itself: `output::render`
-    /// reads it via [`Table::trailing_notices`] before mode dispatch, so it
-    /// reaches a `json`/`ndjson` caller too, not only the human table view
-    /// (ORB-12203).
+    /// Add a trailing notice — a truncation count, say — to print to stderr
+    /// after the table in human modes, or for the renderer to print on
+    /// machine-readable paths.
     #[must_use]
     pub fn trailing_notice(mut self, notice: impl Into<String>) -> Self {
         self.trailing_notices.push(notice.into());
         self
     }
 
-    /// Notices for the renderer to print to stderr in every mode, ahead of
-    /// this table's own render (which may add further, rendering-specific
-    /// notices such as dropped columns).
+    /// Notices for the renderer to print to stderr in machine-readable modes
+    /// (where [`Table::emit`] is not called), or printed after the table in
+    /// human modes.
     pub(crate) fn trailing_notices(&self) -> &[String] {
         &self.trailing_notices
     }
@@ -179,9 +179,8 @@ impl Table {
     /// Write the list to stdout in the sink's mode, or the empty-state line to
     /// stderr when there are no records. Notices about dropped columns go to
     /// stderr so that they never land in a consumer's record stream. This
-    /// table's own trailing notices (a truncation count, say) are not printed
-    /// here — `output::render` prints those in every mode, human or not, so
-    /// this only handles rendering-specific notices discovered at this width.
+    /// table's own trailing notices (a truncation count, say) are printed to
+    /// stderr after the body in both table and plain modes (ORB-12206).
     ///
     /// Called only by `output::render`; a command hands its table back inside a
     /// payload rather than emitting one itself.
@@ -192,6 +191,10 @@ impl Table {
         }
         if sink.mode() == OutputMode::Plain {
             println!("{}", self.render_plain(sink));
+            std::io::stdout().flush().ok();
+            for notice in &self.trailing_notices {
+                eprintln!("{notice}");
+            }
             return;
         }
         let rendered = self.render_at(
@@ -203,6 +206,10 @@ impl Table {
             eprintln!("{notice}");
         }
         println!("{}", rendered.body);
+        std::io::stdout().flush().ok();
+        for notice in &self.trailing_notices {
+            eprintln!("{notice}");
+        }
     }
 
     /// The plain form: the same visible columns and the same cell values as

--- a/crates/orbit-cli/tests/task_list.rs
+++ b/crates/orbit-cli/tests/task_list.rs
@@ -94,6 +94,32 @@ impl TestWorkspace {
         );
         output
     }
+
+    fn run_merged(&self, args: &[&str], label: &str) -> String {
+        let temp_file = tempfile::NamedTempFile::new().expect("temp file for merged output");
+        let stdout_file = temp_file
+            .as_file()
+            .try_clone()
+            .expect("clone file for stdout");
+        let stderr_file = temp_file
+            .as_file()
+            .try_clone()
+            .expect("clone file for stderr");
+        let mut command = std::process::Command::new(assert_cmd::cargo::cargo_bin!("orbit"));
+        test_env::clear_inherited_authority(|name| {
+            command.env_remove(name);
+        });
+        command
+            .current_dir(&self.work)
+            .env("HOME", &self.home)
+            .env("USERPROFILE", &self.home)
+            .stdout(stdout_file)
+            .stderr(stderr_file)
+            .args(args);
+        let status = command.status().expect("run orbit");
+        assert!(status.success(), "{label} failed with status {status:?}");
+        fs::read_to_string(temp_file.path()).expect("read merged output")
+    }
 }
 
 fn run_orbit(cwd: &Path, home: &Path, args: &[&str]) -> Output {
@@ -312,4 +338,94 @@ fn existing_filters_keep_behaviour() {
     let limit_payload: Value = serde_json::from_slice(&limit_filter.stdout).expect("limit json");
     let limit_tasks = limit_payload.as_array().expect("tasks array");
     assert_eq!(limit_tasks.len(), 1);
+}
+
+/// ORB-12206: in human modes (`table` and `plain`), the truncation notice
+/// must be emitted after the table body, not before it.
+#[test]
+fn task_list_truncation_notice_emitted_after_table_body_in_human_modes() {
+    let workspace = TestWorkspace::new();
+    for i in 0..5 {
+        workspace.add_task(&format!("Task {i:02}"));
+    }
+    let truncation_notice = "showing 2 of 5 tasks";
+
+    // 1. Table mode: merged streams must have header and rows before the trailing notice.
+    let table_output = workspace.run_merged(
+        &["task", "list", "--limit", "2", "--format", "table"],
+        "task list --limit 2 --format table",
+    );
+    let table_header_idx = table_output
+        .find("ID")
+        .expect("table output must contain ID header");
+    let table_last_row_idx = table_output
+        .rfind("Task 0")
+        .expect("table output must contain task row");
+    let table_notice_idx = table_output
+        .find(truncation_notice)
+        .expect("table output must contain truncation notice");
+    assert!(
+        table_header_idx < table_notice_idx,
+        "table header must appear before truncation notice in table mode, but was below it:\n{table_output}"
+    );
+    assert!(
+        table_last_row_idx < table_notice_idx,
+        "table rows must appear before truncation notice in table mode, but were below it:\n{table_output}"
+    );
+
+    // 2. Plain mode: non-tty default resolves to plain mode.
+    // Merged streams must have records before the trailing notice.
+    let plain_output = workspace.run_merged(
+        &["task", "list", "--limit", "2"],
+        "task list --limit 2 plain",
+    );
+    let plain_last_record_idx = plain_output
+        .rfind("Task 0")
+        .expect("plain output must contain task record");
+    let plain_notice_idx = plain_output
+        .find(truncation_notice)
+        .expect("plain output must contain truncation notice");
+    assert!(
+        plain_last_record_idx < plain_notice_idx,
+        "plain records must appear before truncation notice in plain mode, but were below it:\n{plain_output}"
+    );
+
+    // 3. Independent streams: stdout contains the table body and stderr contains the notice.
+    let table_cmd = workspace.run(
+        &["task", "list", "--limit", "2", "--format", "table"],
+        "task list --limit 2 --format table streams",
+    );
+    let table_stdout = String::from_utf8_lossy(&table_cmd.stdout);
+    let table_stderr = String::from_utf8_lossy(&table_cmd.stderr);
+    assert!(
+        table_stdout.contains("ID") && table_stdout.contains("Task 0"),
+        "table stdout must contain table body:\n{table_stdout}"
+    );
+    assert!(
+        !table_stdout.contains("showing"),
+        "table stdout must not contain truncation notice:\n{table_stdout}"
+    );
+    assert!(
+        table_stderr.contains(truncation_notice),
+        "table stderr must contain truncation notice:\n{table_stderr}"
+    );
+
+    let plain_cmd = workspace.run(
+        &["task", "list", "--limit", "2"],
+        "task list --limit 2 plain streams",
+    );
+    let plain_stdout = String::from_utf8_lossy(&plain_cmd.stdout);
+    let plain_stderr = String::from_utf8_lossy(&plain_cmd.stderr);
+    assert!(
+        plain_stdout.contains("Task 0"),
+        "plain stdout must contain records:\n{plain_stdout}"
+    );
+    assert!(
+        !plain_stdout.contains("showing"),
+        "plain stdout must not contain truncation notice:\n{plain_stdout}"
+    );
+    assert!(
+        plain_stderr.contains(truncation_notice),
+        "plain stderr must contain truncation notice:\n{plain_stderr}"
+    );
 }


### PR DESCRIPTION
## Task

[ORB-12206](https://orbit-cli.com/tasks/ORB-12206) — [code-review] The `orbit task list` truncation notice now prints above the table instead of after it

### Description

`cf39037c7` (ORB-12203) fixed the real defect — a `json`/`ndjson` caller never saw the truncation count — by moving the notice out of `Table::emit` and into `output::render::emit`, where it runs *before* mode dispatch (`crates/orbit-cli/src/output/render.rs:39-43`, `:54-68`) and `Table::emit` no longer prints it (`crates/orbit-cli/src/output/table.rs:192-205`). A side effect of that placement is that the human modes lost the notice's position: it is now written to stderr before the table body reaches stdout.

The count is the discoverability ORB-12177 added. On the default 50-row listing it now scrolls off the top of the terminal before the caller has finished reading the rows, which is where the eye lands after a list. The API still calls these "trailing" notices (`crates/orbit-cli/src/output/table.rs:155-170`), so the name and the rendered order disagree.

## Reproduction (binary built from `cf39037c7`, disposable `HOME`/checkout fixture, 3 tasks)

```
$ orbit task list --limit 2 --format table 2>&1
showing 2 of 3 tasks (non-terminal tasks first, then terminal, each newest first); use --limit N or a filter to see more
ID         TITLE           STATUS    PRIORITY  TYPE
FIX-00002  Fixture task 3  proposed  medium    chore
FIX-00001  Fixture task 2  proposed  medium    chore
```

Before `cf39037c7` the same command printed the two rows first and the notice last. `--format plain` shows the same inversion. The `json`/`ndjson` behaviour that the commit set out to fix is correct and must stay: both now carry the notice on stderr with stdout untouched (verified in the same fixture, and pinned by `crates/orbit-cli/tests/task_list.rs:160-212`).

Only `crates/orbit-cli/src/command/task/list.rs:165-169` uses `Table::trailing_notice`, so the change is contained to this one message. No test asserts the human-mode position — the notice and the table travel on different streams, so the existing assertions pass either way.

## Suggested direction

Keep the notice on stderr in every mode, but emit it after the human table body (for example, let `emit_human` print the notices it owns and have `render::emit` print them only on the machine-readable paths), and add a test that pins ordering for the human modes.

### Acceptance Criteria

- In `table` and `plain` modes the truncation notice is printed after the table body again, while `json` and `ndjson` still receive it on stderr with stdout carrying only records.
- A test fails if the human-mode notice moves back above the table.

## Execution Summary

<details>
<summary>Click to expand</summary>

### Criteria to Results
1. In `table` and `plain` modes the truncation notice is printed after the table body again, while `json` and `ndjson` still receive it on stderr with stdout carrying only records:
   - In `crates/orbit-cli/src/output/table.rs`, restored printing `self.trailing_notices` to stderr after the body is printed to stdout (with `stdout().flush()` ensuring stdout output precedes stderr notices) in both table and plain modes in `Table::emit`.
   - In `crates/orbit-cli/src/output/render.rs`, moved `table_notices` printing to the `Json` and `Ndjson` branches of `render::emit` so machine-readable modes continue receiving the notice on stderr without interfering with stdout records.
2. A test fails if the human-mode notice moves back above the table:
   - In `crates/orbit-cli/tests/task_list.rs`, added `task_list_truncation_notice_emitted_after_table_body_in_human_modes` asserting that both table headers and rows precede the truncation notice in merged stream output for both table and plain modes, and that stdout/stderr separation is preserved. Confirmed this test fails on the pre-fix codebase and passes with the fix.

### Validation Commands
- `cargo test -p orbit-cli --test task_list task_list_truncation_notice_emitted_after_table_body_in_human_modes`: PASSED (verified failure on pre-fix code, verified pass on fixed code).
- `cargo test -p orbit-cli --test task_list`: PASSED (6 passed, 0 failed).
- `cargo test -p orbit-cli --bin orbit`: PASSED (539 passed, 0 failed).
- `make ci-fast`: PASSED (fmt-check and CI guardrails passed).
- `make ci-lint`: PASSED (workspace clippy passed with -D warnings).
- `git diff --check`: PASSED (no whitespace issues or conflicts).
- `git status --short`: PASSED (clean working copy with only the 3 declared context files modified).

### Deviations and Remaining Risks
- None.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12206-6aa40760`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: opus