### PR TITLE
[code-review] ORB-12211 left two vestigial test remnants of the removed `TaskAddParams::workspace_path`: an orphan comment that still promises the field's guarantee, and an assertion that now proves nothing

### DIFF
--- a/crates/orbit-core/src/application/task/tests/add.rs
+++ b/crates/orbit-core/src/application/task/tests/add.rs
@@ -42,8 +42,6 @@ fn task_context_selector_round_trips_from_repository_root() {
             title: "Read back a subdirectory selector".to_string(),
             description: "Keep the selector rooted at the repository.".to_string(),
             context_files: vec!["file:docs/readme.md".to_string()],
-            // Retained for internal parameter compatibility; it must not
-            // change the canonical root used by task selectors.
             ..Default::default()
         })
         .expect("create task with repository-relative context selector");

--- a/crates/orbit-core/src/application/task/tests/params.rs
+++ b/crates/orbit-core/src/application/task/tests/params.rs
@@ -8,12 +8,6 @@ fn task_add_params_preserve_defaults() {
     assert_eq!(defaults.priority, TaskPriority::Medium);
     assert_eq!(defaults.complexity, TaskComplexity::Unassessed);
     assert!(defaults.acceptance_criteria.is_empty());
-
-    let params = TaskAddParams {
-        title: "Workspace-scoped task".to_string(),
-        ..defaults
-    };
-    assert_eq!(params.title, "Workspace-scoped task");
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-12214](https://orbit-cli.com/tasks/ORB-12214) — [code-review] ORB-12211 left two vestigial test remnants of the removed `TaskAddParams::workspace_path`: an orphan comment that still promises the field's guarantee, and an assertion that now proves nothing

### Description

`fa448d1da` (ORB-12211, PR #1984) removed `TaskAddParams::workspace_path` and `TaskCreateParams::workspace_path`. The production removal is complete — `rg workspace_path crates/` shows no task-add remnant — but two test sites kept the scaffolding that only existed to describe the deleted field.

**1. Orphan comment that documents a field that is gone.**
`crates/orbit-core/src/application/task/tests/add.rs:44-47`:

```rust
context_files: vec!["file:docs/readme.md".to_string()],
// Retained for internal parameter compatibility; it must not
// change the canonical root used by task selectors.
..Default::default()
```

The commit deleted the `workspace_path: Some("docs".to_string())` line the comment annotated but left the comment behind, so it now sits directly above `..Default::default()`. A reader is told that some retained compatibility field must not change the canonical selector root, and no such field exists in the literal or in `TaskAddParams` (`crates/orbit-core/src/application/task/params.rs:80-120`). The test name `task_context_selector_round_trips_from_repository_root` is still accurate; only the comment is stale.

**2. Assertion left with nothing to assert.**
`crates/orbit-core/src/application/task/tests/params.rs:5-17`: the test was `task_add_params_preserve_workspace_routing_and_defaults` and its second half existed to check `params.workspace_path.as_deref() == Some("packages/orbit")`. After the removal the block reads:

```rust
let params = TaskAddParams {
    title: "Workspace-scoped task".to_string(),
    ..defaults
};
assert_eq!(params.title, "Workspace-scoped task");
```

That asserts only that Rust's struct-update syntax sets the field the literal just set — it exercises no Orbit behavior and cannot fail for any change to `TaskAddParams`. The fixture title `"Workspace-scoped task"` also still names the deleted concept, while the renamed test `task_add_params_preserve_defaults` is about defaults.

**Why this is a finding, not a nitpick.** The workspace guide requires deleting dead code and its stale documentation together, and lists stale comments as a diff-review blocker. Both remnants actively mislead: the comment asserts a compatibility guarantee for a field a future contributor will look for and not find, and the tautological assertion reads as coverage of `TaskAddParams` construction that does not exist. No runtime behavior is affected.

**Verified against live code at `fa448d1da5ab98b2b53d3601714ce4fc87afe8b9`**, not only the diff: the comment and the assertion are both present in the working tree, and `cargo test -p orbit-core --lib application::task` passes 56/56 with them, which is exactly the point — neither remnant can fail.

### Acceptance Criteria

- The orphan comment above `..Default::default()` in `crates/orbit-core/src/application/task/tests/add.rs` is gone (or rewritten to describe a guarantee the test still enforces), and the test still asserts the repository-root selector round trip.
- `task_add_params_preserve_defaults` in `crates/orbit-core/src/application/task/tests/params.rs` no longer contains an assertion that only restates a field the same literal sets; it either checks a real `TaskAddParams` behavior or keeps only the defaults assertions, with no fixture text naming the removed `workspace_path`.
- `rg -n workspace_path crates/orbit-core/src/application/task` returns no match outside `context_workspace_root`'s live parameter, and `cargo test -p orbit-core --lib application::task` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Criteria Results:
- Criterion 1 (Remove orphan comment in crates/orbit-core/src/application/task/tests/add.rs): Passed. Removed stale comment annotating the deleted workspace_path parameter above ..Default::default(); task_context_selector_round_trips_from_repository_root remains intact and passes.
- Criterion 2 (Clean up task_add_params_preserve_defaults in crates/orbit-core/src/application/task/tests/params.rs): Passed. Removed tautological struct-update assertion and fixture text "Workspace-scoped task", leaving only defaults assertions.
- Criterion 3 (rg check and cargo test): Passed. rg -n workspace_path crates/orbit-core/src/application/task matched only context_workspace_root in paths.rs; cargo test -p orbit-core --lib application::task passed (56 passed, 0 failed).

Validation Commands:
- rg -n workspace_path crates/orbit-core/src/application/task: Passed
- cargo test -p orbit-core --lib application::task: Passed (56 passed, 0 failed)
- make ci-fast: Passed
- make ci-lint: Passed
- git diff --check: Passed
- git status --short: Passed

Deviations & Risks: None.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12214-6aa4a19d`
- Behind base: 0
- Ahead of base: 1