### PR TITLE
[qa-sweep] The ORB-12168 context-selector guard never checks a `symbol:` selector's symbol, so `symbol:<existing file>#<typo>:fn` ships dead on every surface

### DIFF
--- a/crates/orbit-cli/src/command/task/add.rs
+++ b/crates/orbit-cli/src/command/task/add.rs
@@ -44,6 +44,7 @@ pub struct TaskAddArgs {
     pub external_refs: Vec<String>,
     /// Task context selectors. Repeat or comma-separate for multiple selectors.
     /// Prefer `file:`, `dir:`, or `symbol:` forms; legacy raw paths are accepted and upgraded.
+    /// Existence checks verify the filesystem anchor only; a `symbol:` name and kind are not looked up.
     #[arg(long, action = ArgAction::Append, value_delimiter = ',')]
     pub context: Vec<String>,
     /// Accept context selectors whose target does not exist yet (for work that creates the file)

--- a/crates/orbit-cli/src/command/task/tests/add.rs
+++ b/crates/orbit-cli/src/command/task/tests/add.rs
@@ -170,6 +170,10 @@ fn task_add_status_only_advertises_creation_legal_values() {
         "complexity must be advertised: {rendered}"
     );
     assert!(
+        rendered.contains("filesystem anchor only"),
+        "--context help must document that a `symbol:` name is not verified: {rendered}"
+    );
+    assert!(
         !rendered.contains("Optional task complexity"),
         "complexity must not be described as optional: {rendered}"
     );

--- a/crates/orbit-cli/src/command/task/tests/update.rs
+++ b/crates/orbit-cli/src/command/task/tests/update.rs
@@ -221,6 +221,10 @@ fn task_update_rejects_unassessed_complexity() {
         !rendered.contains("unassessed"),
         "unassessed is reserved for automated creation: {rendered}"
     );
+    assert!(
+        rendered.contains("filesystem anchor only"),
+        "--context help must document that a `symbol:` name is not verified: {rendered}"
+    );
 }
 
 #[test]

--- a/crates/orbit-cli/src/command/task/update.rs
+++ b/crates/orbit-cli/src/command/task/update.rs
@@ -67,6 +67,7 @@ pub struct TaskUpdateArgs {
     pub orchestrator: Option<String>,
     /// Replacement task context selectors. Repeat or comma-separate for multiple selectors (empty string clears).
     /// Prefer `file:`, `dir:`, or `symbol:` forms; legacy raw paths are accepted and upgraded.
+    /// Existence checks verify the filesystem anchor only; a `symbol:` name and kind are not looked up.
     #[arg(long = "context", alias = "context-files", action = ArgAction::Append, value_delimiter = ',')]
     pub context_files: Vec<String>,
     /// Accept context selectors whose target does not exist yet (for work that creates the file)

--- a/crates/orbit-common/src/fs/selector.rs
+++ b/crates/orbit-common/src/fs/selector.rs
@@ -334,7 +334,8 @@ pub fn anchor_path(selector: &str) -> Result<PathBuf, SelectorParseError> {
 ///
 /// Relative anchors are resolved against `workspace`; absolute anchors are
 /// checked as-is. Invalid selector strings and anchor-less selectors return
-/// `false`.
+/// `false`. For `symbol:` this is the backing file only; the `#name:kind`
+/// half is not looked up.
 pub fn exists_in_workspace(selector: &str, workspace: &Path) -> bool {
     let Ok(anchor) = anchor_path(selector) else {
         return false;

--- a/crates/orbit-core/src/application/task/paths.rs
+++ b/crates/orbit-core/src/application/task/paths.rs
@@ -56,17 +56,18 @@ pub(crate) fn normalize_context_files_for_write(
 }
 
 impl OrbitRuntime {
-    /// Reject context selectors that do not name an existing target in the
+    /// Reject context selectors whose filesystem anchor does not exist in the
     /// workspace the task write will use.
     ///
     /// This is an operator-surface guard: `orbit task add` / `orbit task
     /// update`, the `orbit.task.add` / `orbit.task.update` tools, and the
     /// dashboard `POST /api/tasks` / `PATCH /api/tasks/:id` handlers all call
     /// it so a mistyped selector cannot ship a task whose context is dead on
-    /// arrival. Every surface exposes an explicit `allow_missing_context`
-    /// escape for the deliberate not-yet-created target. `add_task` and
-    /// `update_task` themselves stay permissive so internal callers are
-    /// unaffected.
+    /// arrival. Existence is the filesystem anchor only: a `symbol:` name and
+    /// kind are parsed and stored, but not looked up. Every surface exposes an
+    /// explicit `allow_missing_context` escape for the deliberate
+    /// not-yet-created target. `add_task` and `update_task` themselves stay
+    /// permissive so internal callers are unaffected.
     pub fn ensure_context_selectors_exist(&self, selectors: &[String]) -> Result<(), OrbitError> {
         if selectors.is_empty() {
             return Ok(());
@@ -161,7 +162,8 @@ fn resolve_selector_in(
 
     if !exists_in_workspace(&canonical, canonical_workspace) {
         return Err(OrbitError::InvalidInput(format!(
-            "selector `{entry}` does not resolve to an existing in-workspace target"
+            "selector `{entry}` does not resolve to an existing in-workspace target; \
+             only the filesystem anchor is verified, not a `symbol:` name or kind"
         )));
     }
 

--- a/crates/orbit-core/src/application/task/tests/paths.rs
+++ b/crates/orbit-core/src/application/task/tests/paths.rs
@@ -1,6 +1,7 @@
 //! Context selector and path validation coverage. Task context selectors are
 //! always canonicalized against the repository root, and operator surfaces
-//! reject selectors that do not resolve to existing targets.
+//! reject selectors whose filesystem anchor does not exist. A `symbol:` name
+//! and kind are not looked up.
 
 use orbit_common::OrbitError;
 use tempfile::tempdir;
@@ -86,6 +87,19 @@ fn ensure_context_selectors_exist_accepts_resolvable_selectors() {
 }
 
 #[test]
+fn ensure_context_selectors_exist_accepts_symbol_whose_name_is_absent() {
+    let (root, runtime) = test_runtime();
+    let repo_root = root.path().join("repo");
+    std::fs::create_dir_all(repo_root.join("src")).expect("create src");
+    std::fs::write(repo_root.join("src/lib.rs"), b"pub fn real_symbol() {}\n")
+        .expect("write anchor");
+
+    runtime
+        .ensure_context_selectors_exist(&["symbol:src/lib.rs#no_such_symbol:fn".to_string()])
+        .expect("an existing filesystem anchor is enough; the `symbol:` name is not verified");
+}
+
+#[test]
 fn ensure_context_selectors_exist_rejects_missing_selectors() {
     let (_root, runtime) = test_runtime();
 
@@ -94,11 +108,23 @@ fn ensure_context_selectors_exist_rejects_missing_selectors() {
         message.contains("file:does/not/exist.rs"),
         "error must name selector: {message}"
     );
+    assert!(
+        message.contains("only the filesystem anchor is verified"),
+        "error must document that a `symbol:` name is not verified: {message}"
+    );
+    assert!(
+        message.contains("not a `symbol:` name or kind"),
+        "error must name the unverified `symbol:` half: {message}"
+    );
 
     let message = expect_selector_rejection(&runtime, "symbol:does/not/exist.rs#run:function");
     assert!(
         message.contains("symbol:does/not/exist.rs#run:function"),
         "error must name selector: {message}"
+    );
+    assert!(
+        message.contains("only the filesystem anchor is verified"),
+        "error must document that a `symbol:` name is not verified: {message}"
     );
 }
 

--- a/crates/orbit-tools/src/builtin/orbit/task/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add.rs
@@ -58,7 +58,7 @@ impl Tool for OrbitTaskAddTool {
             ToolParam {
                 name: "context_files".to_string(),
                 description:
-                    "Optional task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:`, `dir:`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically."
+                    "Optional task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:`, `dir:`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically. Existence checks verify the filesystem anchor only; a `symbol:` name and kind are not looked up."
                         .to_string(),
                 param_type: "string_list".to_string(),
                 required: false,

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
@@ -225,6 +225,11 @@ fn schema_exposes_only_trimmed_create_task_fields() {
         .find(|p| p.name == "context_files")
         .expect("context_files");
     assert_eq!(context_files.param_type, "string_list");
+    assert!(
+        context_files.description.contains("filesystem anchor only"),
+        "context_files help must document that a `symbol:` name is not verified: {}",
+        context_files.description
+    );
 }
 
 #[test]

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/update.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/update.rs
@@ -106,6 +106,11 @@ fn schema_exposes_context_files() {
             .contains("comma-separated string or array")
     );
     assert!(param.description.contains("file:path"));
+    assert!(
+        param.description.contains("filesystem anchor only"),
+        "context_files help must document that a `symbol:` name is not verified: {}",
+        param.description
+    );
 }
 
 #[test]

--- a/crates/orbit-tools/src/builtin/orbit/task/update.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/update.rs
@@ -142,7 +142,7 @@ impl Tool for OrbitTaskUpdateTool {
             ToolParam {
                 name: "context_files".to_string(),
                 description:
-                    "Task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically."
+                    "Task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically. Existence checks verify the filesystem anchor only; a `symbol:` name and kind are not looked up."
                         .to_string(),
                 param_type: "string_list".to_string(),
                 required: false,
@@ -157,7 +157,7 @@ impl Tool for OrbitTaskUpdateTool {
             ToolParam {
                 name: "context".to_string(),
                 description:
-                    "Legacy alias for `context_files`. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files that are only relevant background context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`."
+                    "Legacy alias for `context_files`. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files that are only relevant background context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`. Existence checks verify the filesystem anchor only; a `symbol:` name and kind are not looked up."
                         .to_string(),
                 param_type: "string".to_string(),
                 required: false,


### PR DESCRIPTION
## Task

[ORB-12215](https://orbit-cli.com/tasks/ORB-12215) — [qa-sweep] The ORB-12168 context-selector guard never checks a `symbol:` selector's symbol, so `symbol:<existing file>#<typo>:fn` ships dead on every surface

### Description

## Summary

ORB-12168 (`bbdf77499`) asked for a guard that rejects `context_files`
selectors that do not resolve, and its "Wanted" list is explicit about two
cases:

> - a `file:` selector must resolve to an existing path in the workspace
>   checkout at HEAD …
> - `symbol:`/other selector kinds **must parse and resolve**

The delivered guard (`OrbitRuntime::ensure_context_selectors_exist`,
`crates/orbit-core/src/application/task/paths.rs:69-180`, extended by
ORB-12184/ORB-12201/ORB-12208/ORB-12211) only checks the selector's
*filesystem anchor*. `orbit_common::fs::selector::exists_in_workspace`
(`crates/orbit-common/src/fs/selector.rs:338-349`) resolves
`anchor_path(selector)` and stats it; for `symbol:path#name:kind` the anchor
is just `path`, so the `#name:kind` half is never looked at. A typo in the
symbol name therefore passes the guard and is persisted, which is exactly the
"dead on arrival context" class the guard was added to stop.

Read-time pruning does not catch it either: `canonicalize_context_files_for_read`
prunes a selector whose *anchor* is missing, and the anchor here exists.

## Reproduction (orbit 0.21.0 built from `fa448d1da`, Linux, debug)

Disposable fixture: own `HOME=/tmp/qa-home`, `--root /tmp/qa2/repo/.orbit`,
scratch git checkout `/tmp/qa2/repo`, every
`orbit_common::test_env::INHERITED_AUTHORITY_ENV` variable cleared, routing
verified with `orbit workspace show --format json`
(`checkout.repo_root=/tmp/qa2/repo`, `checkout.orbit_dir=/tmp/qa2/repo/.orbit`)
before any task write.

```sh
cat /tmp/qa2/repo/src/lib.rs
#   pub fn real_symbol() -> u32 { 1 }

# CLI — accepted, no warning
orbit --root … task add --title s2 --complexity low \
  --context 'symbol:src/lib.rs#no_such_symbol:fn'
#   QB-00005
orbit --root … task show QB-00005 --format json | jq -c '.context_files'
#   ["symbol:src/lib.rs#no_such_symbol:fn"]

# MCP tool — accepted
orbit --root … tool run orbit.task.add --input \
  '{"workspace":"ws_repo","title":"mcp bogus symbol","description":"d","complexity":"low","context_files":["symbol:src/lib.rs#definitely_not_here:fn"]}'
#   QB-00008

# Dashboard API — accepted (HTTP 200)
curl -X POST 'http://127.0.0.1:18215/api/tasks?workspace=ws_repo' \
  -H 'content-type: application/json' -H 'Origin: http://127.0.0.1:18215' \
  -d '{"title":"api bogus symbol","description":"d","complexity":"low","context_files":["symbol:src/lib.rs#nope_api:fn"]}'
#   200  QB-00009  ["symbol:src/lib.rs#nope_api:fn"]
```

Negative control — the anchor *is* checked, so only the symbol half is
unguarded:

```sh
orbit --root … task add --title s3 --complexity low \
  --context 'symbol:src/absent.rs#foo:fn'
#   error: invalid input: selector `symbol:src/absent.rs#foo:fn` does not
#          resolve to an existing in-workspace target
```

The rest of the ORB-12168 guard works as advertised on all three surfaces and
was verified in the same fixture: a missing `file:` target, a `dir:`/file kind
mismatch, a `module:` kind, and out-of-workspace escapes (`file:../outside.rs`,
`file:/etc/hostname`) are all rejected, and `--allow-missing-context` /
`allow_missing_context: true` accepts a deliberate not-yet-created target.

## Impact

Validation impact: none — no test or prescribed validation command is blocked
(`symbol:` symbol resolution has no coverage, which is why the gap shipped
green).

Production impact: a mistyped or renamed symbol name is stored as live task
context. The rejection message ("does not resolve to an existing in-workspace
target") and the CLI/MCP help ("Prefer `file:`, `dir:`, or `symbol:` forms")
both imply symbols are checked, so an operator reasonably reads acceptance as
confirmation the symbol exists. A worker then starts with a reading list and
file reservation that point at a symbol that is not there. The blast radius is
smaller than the original ORB-12168 defect — the anchor file is still correct,
so the worker lands in the right file — which is why this is filed low rather
than high.

## Suggested direction

Pick one and make the surfaces agree with it:

1. Resolve the symbol half where a cheap source of truth exists (the selector
   grammar already carries `#name:kind`), rejecting a `symbol:` selector whose
   named symbol is absent from the anchor file. Note this needs a language-aware
   lookup; a plain substring scan of the anchor file would be a new false-negative
   source and should not be the answer.
2. Or narrow the promise: state in the guard's error text and in the
   `context_files` parameter help that only the selector's filesystem anchor is
   verified, so the acceptance is not read as symbol confirmation.

Either way, add coverage for a `symbol:` selector whose anchor exists and whose
symbol does not, at the boundary that owns the rule
(`ensure_context_selectors_exist`), so the chosen contract stops being untested.

### Acceptance Criteria

- A `symbol:` selector whose anchor file exists but whose named symbol does not is handled by one explicitly chosen contract: either rejected by `ensure_context_selectors_exist` on the CLI, `orbit.task.add`/`orbit.task.update`, and the dashboard `POST`/`PATCH /api/tasks` surfaces, or documented as unverified in the guard's message and the `context_files` parameter help.
- The chosen contract has a test at the boundary that owns the rule, covering a `symbol:` selector with an existing anchor and an absent symbol.
- Existing guard behavior is unchanged: missing `file:` targets, file/directory kind mismatches, `module:`/`command:` kinds, and out-of-workspace anchors stay rejected, and `allow_missing_context` still accepts a deliberate not-yet-created target.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Chose the documented-as-unverified contract (option 2). There is no language-aware symbol lookup in-tree, and a substring scan of the anchor is forbidden, so the guard still checks the filesystem anchor only.
- `ensure_context_selectors_exist` rustdoc and missing-anchor error now state that only the filesystem anchor is verified, not a `symbol:` name or kind. CLI `--context` help (`task add` / `task update`) and MCP `context_files` help (`orbit.task.add` / `orbit.task.update`, plus the `context` alias) say the same. `exists_in_workspace` docs name the same limit.
- Added `ensure_context_selectors_exist_accepts_symbol_whose_name_is_absent` at the owning boundary, and help-text assertions on the CLI/MCP parameter surfaces.
Assessment: surfaces now agree that acceptance is not symbol confirmation. Rejection behavior for missing `file:`, kind mismatch, `module:`/`command:`, out-of-workspace anchors, and `allow_missing_context` is unchanged.
Strategic decisions: document rather than reject. A cheap source of truth for `#name:kind` does not exist; introducing one would be a new language-aware feature, not this QA gap.
Design weaknesses / risks:
- Severity: low. Dashboard POST/PATCH inherit the guard message but have no `context_files` parameter help string; HTTP-only callers see the narrowed promise on rejection, not on the request schema.
- Severity: low. A mistyped symbol name is still persisted by design; workers still land in the right file.
Deviations from original plan: none.

## Criteria
1. Documented as unverified — met. Guard error text and CLI/MCP `context_files` help state that only the filesystem anchor is verified. All three operator surfaces share `ensure_context_selectors_exist`, so CLI, MCP, and dashboard reject/accept the same way.
2. Test at the owning boundary — met. `ensure_context_selectors_exist_accepts_symbol_whose_name_is_absent` covers `symbol:src/lib.rs#no_such_symbol:fn` against an existing file that defines a different function.
3. Existing guard behavior unchanged — met. Unit tests still reject missing `file:`/`symbol:` anchors, file/directory kind mismatches, `module:`/`command:`, and out-of-workspace anchors; `allow_missing_context_accepts_a_not_yet_existing_selector` still passes.

## Validation
- `cargo test -p orbit-core --lib application::task::tests::paths`: passed (8 tests, including the new absent-symbol case)
- `cargo test -p orbit-tools --lib builtin::orbit::task::tests`: passed (29 tests)
- `cargo test -p orbit-cli --bin orbit command::task::tests`: passed (60 tests)
- `cargo test -p orbit-cli --test task_trimmed_surface allow_missing_context`: passed
- `cargo test -p orbit-cli --test context_selector_worktree`: passed (3 tests)
- `make ci-fast`: passed
- `make ci-lint`: passed
- `git diff --check`: passed (no whitespace errors)
- Dashboard HTTP 400/200 paths: not run as a live server; they call the same `ensure_context_selectors_exist` (remaining risk above)

Friction: none filed. Uncommitted; pipeline owns commit/PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12215-6aa4a19c`
- Behind base: 0
- Ahead of base: 1