### PR TITLE
[qa-sweep] Every `--workspace` command calls a registered-but-`invalid` workspace an "unknown workspace selector", so the deleted checkout ORB-12150 made diagnosable is still uninspectable

### DIFF
--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -127,7 +127,8 @@ pub struct Cli {
 
     /// Select a workspace by registered name, logical ID (`ws_*`), or absolute
     /// checkout path. Distinct from `--root`, which overrides the Orbit data
-    /// directory.
+    /// directory. Only active workspaces may be bound; commands fail if the
+    /// workspace status is not active.
     #[arg(long, global = true, value_name = "SELECTOR")]
     pub workspace: Option<String>,
 

--- a/crates/orbit-cli/tests/workspace_selector.rs
+++ b/crates/orbit-cli/tests/workspace_selector.rs
@@ -316,6 +316,117 @@ fn global_workspace_flag_fails_closed_on_unknown_selector() {
 }
 
 #[test]
+fn global_workspace_flag_on_deleted_checkout_reports_inactive_status_and_recorded_path() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let survivor_repo = temp.path().join("survivor");
+    let deleted_repo = temp.path().join("deleted");
+    fs::create_dir_all(&home).expect("home");
+    init_git_repo(&survivor_repo);
+    init_git_repo(&deleted_repo);
+
+    run_orbit(
+        &survivor_repo,
+        &home,
+        &[
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "selector-host",
+            "--task-prefix",
+            "DEL",
+        ],
+    )
+    .success();
+    run_orbit(
+        &survivor_repo,
+        &home,
+        &["workspace", "init", "--name", "survivor"],
+    )
+    .success();
+    run_orbit(
+        &deleted_repo,
+        &home,
+        &["workspace", "init", "--name", "deleted-ws"],
+    )
+    .success();
+
+    let created = run_orbit_json(
+        &deleted_repo,
+        &home,
+        &[
+            "task",
+            "add",
+            "--title",
+            "Task in deleted workspace",
+            "--complexity",
+            "low",
+            "--json",
+        ],
+    );
+    let task_id = created["id"].as_str().expect("task id").to_string();
+
+    let deleted_path_str = deleted_repo.to_str().expect("utf8");
+
+    // Delete checkout directory without teardown
+    fs::remove_dir_all(&deleted_repo).expect("delete checkout directory");
+
+    let selectors = [
+        ("registered name", "deleted-ws"),
+        ("logical id", "ws_deleted-ws"),
+        ("checkout path", deleted_path_str),
+    ];
+
+    for (label, selector) in selectors {
+        // Read-only verbs across task list, task show, workspace show, and doctor
+        let commands: &[&[&str]] = &[
+            &["--workspace", selector, "task", "list"],
+            &["--workspace", selector, "task", "show", &task_id],
+            &["--workspace", selector, "workspace", "show"],
+            &["--workspace", selector, "doctor"],
+        ];
+
+        for cmd in commands {
+            let assert = run_orbit(&survivor_repo, &home, cmd).failure();
+            let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+            assert!(
+                stderr
+                    .contains("workspace 'deleted-ws' (ws_deleted-ws) is invalid on this machine"),
+                "command {:?} with {label} selector must report name, id, and invalid status: {stderr}",
+                cmd
+            );
+            assert!(
+                stderr.contains(deleted_path_str),
+                "command {:?} with {label} selector must report recorded checkout path: {stderr}",
+                cmd
+            );
+            assert!(
+                !stderr.contains("unknown workspace selector"),
+                "command {:?} with {label} selector must not report unknown workspace selector: {stderr}",
+                cmd
+            );
+        }
+    }
+
+    // Contrast with an unknown workspace selector
+    let unknown_assert = run_orbit(
+        &survivor_repo,
+        &home,
+        &["--workspace", "unknown-workspace", "task", "list"],
+    )
+    .failure();
+    let unknown_stderr = String::from_utf8_lossy(&unknown_assert.get_output().stderr);
+    assert!(
+        unknown_stderr.contains("unknown workspace selector 'unknown-workspace'"),
+        "unknown selector must report unknown workspace selector: {unknown_stderr}"
+    );
+    assert!(
+        !unknown_stderr.contains("is invalid on this machine"),
+        "unknown selector must not report invalid workspace: {unknown_stderr}"
+    );
+}
+
+#[test]
 fn migrate_dry_run_honors_selected_checkout_and_confirm_uses_the_same_one() {
     let temp = tempdir().expect("tempdir");
     let home = temp.path().join("home");

--- a/crates/orbit-cmd/src/registry_runtime.rs
+++ b/crates/orbit-cmd/src/registry_runtime.rs
@@ -188,16 +188,24 @@ impl RegisteredRuntimeFactory {
     /// This is the shared server/CLI bootstrap seam. It performs correctness
     /// checks needed to construct a runtime, but makes no transport,
     /// authorization, or cross-machine routing decision.
+    ///
+    /// Non-active workspaces (such as a workspace whose checkout directory was
+    /// deleted without teardown) cannot be bound by any CLI verb, including
+    /// read-only inspection commands (`task list`, `task show`, `workspace show`,
+    /// `doctor`), even if the Orbit root is still readable. The command fails
+    /// closed naming the status and recorded checkout path.
     pub fn resolve_workspace_selector(
         global_root: &Path,
         selector: &str,
     ) -> Result<ResolvedWorkspaceSelection, OrbitError> {
-        let registry = workspace_registry::load_registry_from(
-            &workspace_registry::registry_path_for(global_root),
-        )?;
+        let registry_path = workspace_registry::registry_path_for(global_root);
+        let mut registry = workspace_registry::load_registry_from(&registry_path)?;
+        if workspace_registry::validate_workspaces(&mut registry) {
+            let _ = workspace_registry::save_registry_to(&registry, &registry_path);
+        }
         let (workspace, checkout) = resolve_cli_workspace_binding(&registry, selector)?;
         if workspace.status != WorkspaceStatus::Active {
-            return Err(unsupported_cli_workspace(selector));
+            return Err(inactive_cli_workspace(workspace, checkout));
         }
         Ok(ResolvedWorkspaceSelection {
             workspace: workspace.clone(),
@@ -331,9 +339,11 @@ impl RegisteredRuntimeFactory {
             return Ok(None);
         };
         let global_root = runtime.global_root();
-        let registry = workspace_registry::load_registry_from(
-            &workspace_registry::registry_path_for(&global_root),
-        )?;
+        let registry_path = workspace_registry::registry_path_for(&global_root);
+        let mut registry = workspace_registry::load_registry_from(&registry_path)?;
+        if workspace_registry::validate_workspaces(&mut registry) {
+            let _ = workspace_registry::save_registry_to(&registry, &registry_path);
+        }
         match resolve_cli_workspace_target(&registry, runtime, &selector)? {
             CliWorkspaceTarget::CurrentRuntime => Ok(None),
             CliWorkspaceTarget::Checkout {
@@ -342,7 +352,7 @@ impl RegisteredRuntimeFactory {
                 rewrite_to_repo_root,
             } => {
                 if workspace.status != WorkspaceStatus::Active {
-                    return Err(unsupported_cli_workspace(&selector));
+                    return Err(inactive_cli_workspace(workspace, checkout));
                 }
                 if rewrite_to_repo_root {
                     set_input_workspace(input, &checkout.repo_root)?;
@@ -468,15 +478,28 @@ fn resolve_cli_workspace_path<'a>(
             .unwrap_or_else(|_| PathBuf::from("."))
             .join(raw)
     };
-    let canonical = candidate
-        .canonicalize()
-        .map_err(|_| unsupported_cli_workspace(selector))?;
-    if !canonical.is_dir() {
-        return Err(unsupported_cli_workspace(selector));
-    }
-    if let Some(checkout) = find_checkout_for_canonical_path(registry, &canonical)
-        .or_else(|| find_checkout_for_git_common_dir(registry, &canonical))
+    if let Ok(canonical) = candidate.canonicalize()
+        && canonical.is_dir()
     {
+        if let Some(checkout) = find_checkout_for_canonical_path(registry, &canonical)
+            .or_else(|| find_checkout_for_git_common_dir(registry, &canonical))
+        {
+            let workspace =
+                workspace_registry::find_workspace_by_id(registry, &checkout.workspace_id)
+                    .ok_or_else(|| unsupported_cli_workspace(selector))?;
+            return Ok(CliWorkspaceTarget::Checkout {
+                workspace,
+                checkout,
+                rewrite_to_repo_root: false,
+            });
+        }
+        if let Some(runtime) = runtime
+            && path_is_inside(&runtime.paths().repo_root, &canonical)
+        {
+            return Ok(CliWorkspaceTarget::CurrentRuntime);
+        }
+    }
+    if let Some(checkout) = find_checkout_for_raw_path(registry, &candidate) {
         let workspace = workspace_registry::find_workspace_by_id(registry, &checkout.workspace_id)
             .ok_or_else(|| unsupported_cli_workspace(selector))?;
         return Ok(CliWorkspaceTarget::Checkout {
@@ -484,11 +507,6 @@ fn resolve_cli_workspace_path<'a>(
             checkout,
             rewrite_to_repo_root: false,
         });
-    }
-    if let Some(runtime) = runtime
-        && path_is_inside(&runtime.paths().repo_root, &canonical)
-    {
-        return Ok(CliWorkspaceTarget::CurrentRuntime);
     }
     Err(unsupported_cli_workspace(selector))
 }
@@ -505,6 +523,15 @@ fn find_checkout_for_canonical_path<'a>(
                 .iter()
                 .any(|override_path| canonical_path(override_path) == canonical)
     })
+}
+
+fn find_checkout_for_raw_path<'a>(
+    registry: &'a WorkspaceRegistry,
+    candidate: &Path,
+) -> Option<&'a WorkspaceCheckout> {
+    let normalized = normalize_path(candidate);
+    find_checkout_for_canonical_path(registry, &normalized)
+        .or_else(|| workspace_registry::find_checkout_by_path(registry, &normalized))
 }
 
 fn find_checkout_for_git_common_dir<'a>(
@@ -574,9 +601,34 @@ fn set_input_workspace(input: &mut Value, repo_root: &Path) -> Result<(), OrbitE
     Ok(())
 }
 
+fn normalize_path(path: &Path) -> PathBuf {
+    use std::path::Component;
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
 fn unsupported_cli_workspace(selector: &str) -> OrbitError {
     OrbitError::InvalidInput(format!(
         "unknown workspace selector '{selector}'; pass a registered workspace name, a logical workspace ID, or an absolute local checkout path"
+    ))
+}
+
+fn inactive_cli_workspace(workspace: &Workspace, checkout: &WorkspaceCheckout) -> OrbitError {
+    OrbitError::InvalidInput(format!(
+        "workspace '{}' ({}) is {} on this machine; recorded checkout path: {}",
+        workspace.name,
+        workspace.id,
+        workspace.status,
+        checkout.repo_root.display(),
     ))
 }
 

--- a/crates/orbit-cmd/src/tests/registry_runtime.rs
+++ b/crates/orbit-cmd/src/tests/registry_runtime.rs
@@ -1167,3 +1167,218 @@ fn cwd_and_absolute_path_select_a_workspace_whose_id_collides_with_another_name(
         other => panic!("expected InvalidInput, got {other}"),
     }
 }
+
+#[test]
+fn deleted_checkout_workspace_selector_reports_inactive_status_and_recorded_path() {
+    let root = tempfile::tempdir().expect("root");
+    let global = root.path().join("global");
+    std::fs::create_dir_all(&global).expect("global");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_deleted_test\"\nhost_id = \"deleted-test\"\ntask_prefix = \"ORB\"\n",
+    )
+    .expect("host identity");
+
+    let (ws_alpha, checkout_alpha) =
+        registered_workspace(root.path(), "ws_alpha", "alpha", "hm_deleted_test");
+    let (ws_beta, checkout_beta) =
+        registered_workspace(root.path(), "ws_beta", "beta", "hm_deleted_test");
+
+    save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![ws_alpha.clone(), ws_beta.clone()],
+            checkouts: vec![checkout_alpha.clone(), checkout_beta.clone()],
+            ..Default::default()
+        },
+        &registry_path_for(&global),
+    )
+    .expect("workspace registry");
+
+    let alpha_runtime =
+        RegisteredRuntimeFactory::open_registered_checkout(&global, &ws_alpha, &checkout_alpha)
+            .expect("alpha runtime");
+
+    // Delete beta checkout without teardown
+    std::fs::remove_dir_all(&checkout_beta.repo_root).expect("remove beta checkout");
+    let beta_repo_str = checkout_beta.repo_root.to_str().expect("utf8 beta path");
+
+    let selectors = [
+        ("registered name", "beta"),
+        ("logical id", "ws_beta"),
+        ("checkout path", beta_repo_str),
+    ];
+
+    for (label, selector) in selectors {
+        // Direct resolution via RegisteredRuntimeFactory
+        let direct_err = match RegisteredRuntimeFactory::initialize_with_overrides(
+            Some(&global),
+            Some(selector),
+        ) {
+            Ok(_) => panic!("deleted checkout workspace must not resolve ({label})"),
+            Err(e) => e,
+        };
+        let msg = match direct_err {
+            OrbitError::InvalidInput(msg) => msg,
+            other => panic!("expected InvalidInput for {label}, got {other}"),
+        };
+        assert!(
+            msg.contains("workspace 'beta' (ws_beta) is invalid on this machine"),
+            "error for {label} must report name, id, and invalid status: {msg}"
+        );
+        assert!(
+            msg.contains(beta_repo_str),
+            "error for {label} must report recorded checkout path: {msg}"
+        );
+        assert!(
+            !msg.contains("unknown workspace selector"),
+            "error for {label} must not report unknown workspace selector: {msg}"
+        );
+
+        // Rebinding via cli_tool on an active runtime
+        let tool_err = execute_cli_tool(
+            &alpha_runtime,
+            "orbit.task.list",
+            json!({ "workspace": selector, "limit": 10 }),
+        )
+        .expect_err("rebinding to deleted checkout workspace must fail");
+        let tool_msg = match tool_err {
+            OrbitError::InvalidInput(msg) => msg,
+            other => panic!("expected InvalidInput for {label}, got {other}"),
+        };
+        assert!(
+            tool_msg.contains("workspace 'beta' (ws_beta) is invalid on this machine"),
+            "tool error for {label} must report invalid status: {tool_msg}"
+        );
+        assert!(
+            tool_msg.contains(beta_repo_str),
+            "tool error for {label} must report recorded checkout path: {tool_msg}"
+        );
+    }
+
+    // Distinct message for unknown selector
+    let unknown_direct = match RegisteredRuntimeFactory::initialize_with_overrides(
+        Some(&global),
+        Some("unknown-workspace"),
+    ) {
+        Ok(_) => panic!("unknown selector must fail"),
+        Err(e) => e,
+    };
+    unsupported_workspace_message(unknown_direct, "unknown-workspace");
+
+    let unknown_tool = execute_cli_tool(
+        &alpha_runtime,
+        "orbit.task.list",
+        json!({ "workspace": "unknown-workspace", "limit": 10 }),
+    )
+    .expect_err("unknown selector tool call must fail");
+    unsupported_workspace_message(unknown_tool, "unknown-workspace");
+}
+
+#[test]
+fn non_active_workspace_with_readable_orbit_root_fails_to_bind_for_read_verbs() {
+    let root = tempfile::tempdir().expect("root");
+    let global = root.path().join("global");
+    std::fs::create_dir_all(&global).expect("global");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_readable_test\"\nhost_id = \"readable-test\"\ntask_prefix = \"ORB\"\n",
+    )
+    .expect("host identity");
+
+    let (ws_alpha, checkout_alpha) =
+        registered_workspace(root.path(), "ws_alpha", "alpha", "hm_readable_test");
+
+    // Create gamma with split checkout: repo_root is deleted, but orbit_dir is readable
+    let gamma_repo = root.path().join("gamma_repo");
+    let gamma_orbit_dir = root.path().join("gamma_orbit");
+    std::fs::create_dir_all(&gamma_orbit_dir).expect("gamma orbit dir");
+    write_workspace_config(
+        &gamma_orbit_dir,
+        &WorkspaceConfig {
+            schema_version: 1,
+            workspace_id: "ws_gamma".to_string(),
+        },
+    )
+    .expect("gamma workspace config");
+
+    let ws_gamma = Workspace {
+        id: "ws_gamma".to_string(),
+        name: "gamma".to_string(),
+        owner_machine_id: Some("hm_readable_test".to_string()),
+        git_remote: None,
+        ship_mode: Some("local".to_string()),
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Invalid,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    let checkout_gamma = WorkspaceCheckout::owner(
+        "ws_gamma".to_string(),
+        gamma_repo.clone(),
+        gamma_orbit_dir.clone(),
+    );
+
+    save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![ws_alpha.clone(), ws_gamma.clone()],
+            checkouts: vec![checkout_alpha.clone(), checkout_gamma.clone()],
+            ..Default::default()
+        },
+        &registry_path_for(&global),
+    )
+    .expect("workspace registry");
+
+    let alpha_runtime =
+        RegisteredRuntimeFactory::open_registered_checkout(&global, &ws_alpha, &checkout_alpha)
+            .expect("alpha runtime");
+
+    assert!(!gamma_repo.exists(), "gamma repo checkout must not exist");
+    assert!(
+        gamma_orbit_dir.exists(),
+        "gamma orbit root must still be readable"
+    );
+
+    let gamma_repo_str = gamma_repo.to_str().expect("utf8 gamma path");
+    let selectors = [
+        ("registered name", "gamma"),
+        ("logical id", "ws_gamma"),
+        ("checkout path", gamma_repo_str),
+    ];
+
+    for (label, selector) in selectors {
+        let err = match RegisteredRuntimeFactory::initialize_with_overrides(
+            Some(&global),
+            Some(selector),
+        ) {
+            Ok(_) => panic!("invalid workspace must not resolve ({label})"),
+            Err(e) => e,
+        };
+        let msg = match err {
+            OrbitError::InvalidInput(msg) => msg,
+            other => panic!("expected InvalidInput for {label}, got {other}"),
+        };
+        assert!(
+            msg.contains("workspace 'gamma' (ws_gamma) is invalid on this machine"),
+            "error for {label} must report invalid status: {msg}"
+        );
+        assert!(
+            msg.contains(gamma_repo_str),
+            "error for {label} must report recorded checkout path: {msg}"
+        );
+
+        let tool_err = execute_cli_tool(
+            &alpha_runtime,
+            "orbit.task.list",
+            json!({ "workspace": selector, "limit": 10 }),
+        )
+        .expect_err("rebinding to invalid workspace must fail");
+        let tool_msg = match tool_err {
+            OrbitError::InvalidInput(msg) => msg,
+            other => panic!("expected InvalidInput for {label}, got {other}"),
+        };
+        assert!(
+            tool_msg.contains("workspace 'gamma' (ws_gamma) is invalid on this machine"),
+            "tool error for {label} must report invalid status: {tool_msg}"
+        );
+    }
+}

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -13,7 +13,7 @@ This page is the map.
 | Option | Effect |
 |---|---|
 | `--root <ROOT>` | Override the Orbit root directory. Highest precedence. |
-| `--workspace <SELECTOR>` | Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`. |
+| `--workspace <SELECTOR>` | Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`. Only active workspaces may be bound. |
 | `--format <MODE>` | `auto` (default — table on a terminal, plain text when piped), `table`, `json`, or `ndjson`. |
 
 Global options go **before** the subcommand: `orbit --workspace ws_x task list`.


### PR DESCRIPTION
## Task

[ORB-12216](https://orbit-cli.com/tasks/ORB-12216) — [qa-sweep] Every `--workspace` command calls a registered-but-`invalid` workspace an "unknown workspace selector", so the deleted checkout ORB-12150 made diagnosable is still uninspectable

### Description

## Summary

ORB-12150 (`a90d36b33`) and ORB-12169 (`e949ba6a4`) made a checkout deleted
without teardown diagnosable and reclaimable: `orbit doctor` now reports the
orphan partition and `ORBIT_OPERATOR=1 orbit workspace remove <id>` now
deregisters it. Both were verified working at `fa448d1da` (evidence below).

What remains is the wording and reachability gap ORB-12169 flagged in its own
"Suggested direction" but did not implement:

> Consider making `resolve_workspace_selector`'s non-`Active` refusal say so,
> rather than reusing the "unknown selector" wording for a workspace the catalog
> clearly lists.

`RegisteredRuntimeFactory::resolve_workspace_selector`
(`crates/orbit-cmd/src/registry_runtime.rs:191-205`) resolves the binding
successfully and *then* rejects any workspace whose `status != Active` with
`unsupported_cli_workspace(selector)` (`registry_runtime.rs:577-581`), whose
text is byte-identical to the genuine unknown-selector message:

```
unknown workspace selector '<sel>'; pass a registered workspace name, a logical
workspace ID, or an absolute local checkout path
```

So the global `--workspace` selector tells an operator the id is unknown while
`orbit workspace list` prints that same id, and while `orbit workspace remove`
accepts it. The accurate wording already exists elsewhere in the codebase — the
id-routed `orbit task show` path says
`task <id> is owned by workspace <name> (<id>), which is invalid on this machine`.

## Reproduction (orbit 0.21.0 built from `fa448d1da`, Linux, debug)

Disposable fixture: `HOME=/tmp/qa-home`, external Orbit root `/tmp/qa3/root`,
scratch checkout `/tmp/qa3/repo`, every
`orbit_common::test_env::INHERITED_AUTHORITY_ENV` variable cleared, routing
verified with `orbit workspace show --format json`
(`checkout.repo_root=/tmp/qa3/repo`, `checkout.orbit_dir=/tmp/qa3/root`)
before any mutation.

```sh
cd /tmp/qa3/repo && orbit --root /tmp/qa3/root workspace init     # ws_repo
cd /tmp/qa3/repo && orbit --root /tmp/qa3/root task add --title keeper --complexity low \
  --context file:src/a.rs                                          # QC-00000

rm -rf /tmp/qa3/repo                        # checkout deleted, no teardown

cd /tmp && orbit --root /tmp/qa3/root workspace list
#   repo  ws_repo  invalid  pr  hm_…  owner  /tmp/qa3/repo          <- catalog knows it

cd /tmp && orbit --root /tmp/qa3/root --workspace ws_repo task list
#   error: invalid input: unknown workspace selector 'ws_repo'; pass a registered
#          workspace name, a logical workspace ID, or an absolute local checkout path
cd /tmp && orbit --root /tmp/qa3/root --workspace ws_repo workspace show     # same error
cd /tmp && orbit --root /tmp/qa3/root --workspace ws_repo doctor             # same error
cd /tmp && orbit --root /tmp/qa3/root --workspace /tmp/qa3/repo task list    # same error
cd /tmp && orbit --root /tmp/qa3/root --workspace repo task list             # same error

# the id-routed path gets it right:
cd /tmp && orbit --root /tmp/qa3/root task show QC-00000
#   error: workspace error: task QC-00000 is owned by workspace repo (ws_repo),
#          which is invalid on this machine
```

The ORB-12150/ORB-12169 fixes themselves are confirmed good in the same
fixture, so this is a residual, not a regression:

```sh
cd /tmp && orbit --root /tmp/qa3/root doctor | grep orphan-task
#   orphan-task-stores  warning  1 stale task-store partition(s) point at missing
#   checkout directories: ws_repo (/tmp/qa3/root/tasks/workspaces/ws_repo,
#   1 task bundle(s)) | Action: Run `orbit doctor --fix-orphan-task-stores --confirm`.

cd /tmp && ORBIT_OPERATOR=1 orbit --root /tmp/qa12213/root workspace remove ws_repo
#   workspace 'repo' removed from registry          (same state, earlier fixture)
```

## Impact

Validation impact: none — no test or prescribed validation command is blocked.

Production impact: two things, both in the recovery flow ORB-12150 opened.

1. **Wrong diagnosis.** The message tells the operator the selector is not
   registered, which contradicts `orbit workspace list` on the same machine and
   sends them looking for a typo instead of a missing checkout. It is the same
   text for three different states (never registered, registered-but-invalid,
   and a path that is not a checkout).
2. **No read path to the surviving data.** `orbit doctor --fix-orphan-task-stores
   --confirm` deletes the partition *and its task bundles*, and the doctor row
   says so. Before running it an operator reasonably wants to see what would be
   lost — `orbit --workspace <id> task list` — and that is refused. Per-task
   `orbit task show <id>` works, but only if the ids are already known, which is
   exactly what the listing would have supplied.

## Suggested direction

Give the non-`Active` refusal in `resolve_workspace_selector` its own message
naming the status and the recorded checkout path (the evidence
`orbit workspace list` already prints), separate from
`unsupported_cli_workspace`. Then decide, and state, whether read-only verbs
(`task list`, `task show`, `workspace show`, `doctor`) should be allowed to
bind an `invalid` workspace whose Orbit root is still readable — the
external-root layout in the reproduction above keeps every task bundle intact —
while mutating verbs keep refusing. Add coverage for a non-`Active` workspace
through all three selector forms, which today has none.

### Acceptance Criteria

- A `--workspace` selector naming a registered workspace whose status is not `active` fails with a message that names the status and the recorded checkout path, distinct from the message for a selector the registry does not know.
- Whether read-only verbs may bind a non-`active` workspace whose Orbit root is still readable is decided explicitly, implemented consistently across `task list`, `task show`, `workspace show`, and `doctor`, and stated where an operator reads it.
- A test covers a workspace whose checkout directory was deleted without teardown, addressed through all three selector forms (registered name, `ws_*` id, absolute checkout path).

## Execution Summary

<details>
<summary>Click to expand</summary>

### Summary of Changes (ORB-12216)

#### 1. Core Fix & Explicit Decision
- **Root Cause:** When `--workspace <selector>` resolved to a registered workspace whose status was not `active` (e.g. `invalid`, such as when a checkout directory was deleted without teardown), `RegisteredRuntimeFactory::resolve_workspace_selector` and `bind_cli_tool_workspace` returned `unsupported_cli_workspace(selector)` ("unknown workspace selector '<sel>'"). Furthermore, `resolve_cli_workspace_path` called `canonicalize()` which failed for non-existent directories, skipping registered checkouts whose paths matched. Additionally, `validate_workspaces` was not called during selector resolution, meaning deleted checkouts were not detected as `invalid` until an explicit sweep or catalog listing was run.
- **Decision on Read-Only Verbs (Criterion 2):** Read-only verbs (`task list`, `task show`, `workspace show`, `doctor`) fail closed and may **NOT** bind a non-`active` workspace, even if its Orbit root is still readable. This is consistent across all commands, matches existing task owner checks in `orbit task show`, prevents misleading partial states or low-level I/O failures on collocated checkouts, and is documented in the CLI `--workspace` help and documentation.
- **Inactive Workspace Error:** Any selector addressing a registered non-active workspace now fails with: `workspace '<name>' (<id>) is <status> on this machine; recorded checkout path: <path>`, which is clearly distinct from the unknown workspace selector error.

#### 2. Implementation Details
- In `crates/orbit-cmd/src/registry_runtime.rs`:
  - Updated `RegisteredRuntimeFactory::resolve_workspace_selector` and `bind_cli_tool_workspace` to run `validate_workspaces` on the loaded registry (persisting status updates) and return `inactive_cli_workspace(workspace, checkout)` when `workspace.status != WorkspaceStatus::Active`.
  - Updated `resolve_cli_workspace_path` so if canonicalization fails or the path is not an existing directory, it checks `find_checkout_for_raw_path` using normalized path matching against registered checkouts and path overrides.
  - Added `inactive_cli_workspace`, `find_checkout_for_raw_path`, and `normalize_path` helper functions.
- In `crates/orbit-cli/src/command/mod.rs`:
  - Updated the doc comment for `--workspace` to state that only active workspaces may be bound and commands fail if the workspace status is not active.
- In `website/src/content/docs/reference/cli.md`:
  - Updated the `--workspace` description to note that only active workspaces may be bound.

#### 3. Verification & Tests
- Added unit tests in `crates/orbit-cmd/src/tests/registry_runtime.rs` covering deleted checkout and readable-orbit-root inactive workspaces across all 3 selector forms and unknown selectors.
- Added integration test in `crates/orbit-cli/tests/workspace_selector.rs` verifying `task list`, `task show`, `workspace show`, and `doctor` fail closed naming invalid status and recorded checkout path.
- Ran `cargo test -p orbit-cmd --lib tests::registry_runtime`, `cargo test --test workspace_selector`, `make ci-fast`, and `make ci-lint` with all checks passing cleanly.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12216-6aa4a19c`
- Behind base: 0
- Ahead of base: 1