### PR TITLE
[qa-sweep] `make test` fails at HEAD: ORB-12215 changed three MCP tool parameter descriptions without regenerating `mcp_tools_list.json`

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,6 +25,8 @@ Pre-1.0 semver: `0.<minor>.<patch>`.
 
 - Validation tightening that rejects inputs that were already invalid by spec.
 - New guards that match documented behavior (e.g. MCP surface catching up to CLI).
+- MCP tool description-only wording changes that leave tool and parameter names,
+  types, requiredness, and input/output shape unchanged.
 - Internal module decomposition or refactors with no external API change.
 - Performance changes.
 - New optional fields with safe defaults.

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -640,7 +640,7 @@
               "type": "string"
             }
           ],
-          "description": "Optional task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:`, `dir:`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically."
+          "description": "Optional task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:`, `dir:`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically. Existence checks verify the filesystem anchor only; a `symbol:` name and kind are not looked up."
         },
         "crew": {
           "description": "Optional named crew to use when running this task",
@@ -1067,7 +1067,7 @@
           "type": "string"
         },
         "context": {
-          "description": "Legacy alias for `context_files`. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files that are only relevant background context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`.",
+          "description": "Legacy alias for `context_files`. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files that are only relevant background context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`. Existence checks verify the filesystem anchor only; a `symbol:` name and kind are not looked up.",
           "type": "string"
         },
         "context_files": {
@@ -1082,7 +1082,7 @@
               "type": "string"
             }
           ],
-          "description": "Task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically."
+          "description": "Task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically. Existence checks verify the filesystem anchor only; a `symbol:` name and kind are not looked up."
         },
         "crew": {
           "description": "Named crew to use when running this task (empty string clears)",


### PR DESCRIPTION
## Task

[ORB-12221](https://orbit-cli.com/tasks/ORB-12221) — [qa-sweep] `make test` fails at HEAD: ORB-12215 changed three MCP tool parameter descriptions without regenerating `mcp_tools_list.json`

### Description

## Summary

`make test` fails at HEAD (`79aad9db4`). ORB-12215 (`79aad9db4`) appended the
sentence "Existence checks verify the filesystem anchor only; a `symbol:` name
and kind are not looked up." to three MCP tool parameter descriptions but did
not regenerate the checked-in `tools/list` snapshot, so the production-surface
snapshot test now fails.

Changed in `79aad9db4`:

- `crates/orbit-tools/src/builtin/orbit/task/add.rs` — `context_files`
- `crates/orbit-tools/src/builtin/orbit/task/update.rs` — `context_files`
- `crates/orbit-tools/src/builtin/orbit/task/update.rs` — `context` (legacy alias)

Not updated: `crates/orbit-cli/tests/snapshots/mcp_tools_list.json`. The snapshot
still carries the pre-ORB-12215 text (verified: `grep -c "filesystem anchor"
crates/orbit-cli/tests/snapshots/mcp_tools_list.json` -> `0`, while `orbit tool
show orbit.task.add` prints the new sentence).

## Reproduction (orbit 0.21.0 built from `79aad9db4`, Linux 6.8, debug profile)

```
$ make test
...
test mcp_serve_tools_list_matches_production_snapshot ... FAILED
test result: FAILED. 53 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.83s
error: test failed, to rerun pass `-p orbit-cli --test mcp_roundtrip`
make: *** [Makefile:124: test] Error 2        (wrapper exit code 2)
```

Isolated, same result:

```
$ ./scripts/build-budget.py -- cargo test -p orbit-cli --test mcp_roundtrip \
      mcp_serve_tools_list_matches_production_snapshot
running 1 test
test mcp_serve_tools_list_matches_production_snapshot ... FAILED

thread 'mcp_serve_tools_list_matches_production_snapshot' panicked at
crates/orbit-cli/tests/mcp_roundtrip.rs:493:5:
assertion `left == right` failed: tools/list drifted from
tests/snapshots/mcp_tools_list.json. MCP tool schema changes are BREAKING (see
RELEASING.md). If the change is intentional, regenerate the snapshot with
`ORBIT_MCP_UPDATE_SNAPSHOT=1 cargo test -p orbit-cli --test mcp_roundtrip` and
call the release breaking.
```

Every other test target in the workspace passed in the same run; this is the
only failure. `make ci-fast` passes (exit 0) — it does not compile or run the
test suite, so it does not catch this.

## Impact

**Validation impact (blocking).** The repository's standard suite cannot
complete: `make test` exits non-zero, and `make ci` runs the same `cargo test`
pass, so the canonical PR merge gate is red for every branch off `79aad9db4`
until the snapshot is regenerated.

**Production impact (none observed).** The served MCP surface is correct — the
new description text is the intended ORB-12215 wording and is what `orbit tool
show orbit.task.add` and a live `tools/list` return. Only the checked-in
expectation is stale. No tool name, parameter name, type, or required-ness
changed; the drift is description text only.

## Suggested direction

Regenerate with `ORBIT_MCP_UPDATE_SNAPSHOT=1 cargo test -p orbit-cli --test
mcp_roundtrip`, then diff the snapshot and confirm the only changes are the
three description strings. The test's panic message tells the regenerator to
"call the release breaking"; decide and record explicitly whether a
description-only change meets the RELEASING.md MCP-break bar, since blanket
compliance with that message would mark a non-breaking release breaking.

### Acceptance Criteria

- `cargo test -p orbit-cli --test mcp_roundtrip mcp_serve_tools_list_matches_production_snapshot` passes at HEAD, so `make test` / `make ci` can complete.
- The snapshot matches the live `tools/list` payload the MCP server serves for `orbit.task.add` and `orbit.task.update` after ORB-12215.
- The change is explicitly classified against the RELEASING.md MCP-schema-break rule (description-only text change vs. schema shape change) and that classification is recorded where a release reader will see it.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Regenerated `crates/orbit-cli/tests/snapshots/mcp_tools_list.json`; the diff is exactly three ORB-12215 description updates for `orbit.task.add.context_files`, `orbit.task.update.context`, and `orbit.task.update.context_files`.
- Added the release-facing rule in `RELEASING.md` that MCP description-only wording changes are non-breaking when tool/parameter names, types, requiredness, and input/output shape are unchanged. This classifies ORB-12215 as non-breaking.
Criteria:
- Criterion 1: passed — the required production snapshot test passed at HEAD.
- Criterion 2: passed — the snapshot test compared the live `tools/list` payload and the reviewed diff contains only the three expected description changes.
- Criterion 3: passed — the classification is recorded under `RELEASING.md`'s MCP breaking-change guidance.
Validation:
- Passed: `ORBIT_MCP_UPDATE_SNAPSHOT=1 ./scripts/build-budget.py -- cargo test -p orbit-cli --test mcp_roundtrip mcp_serve_tools_list_matches_production_snapshot`.
- Passed: `cargo test -p orbit-cli --test mcp_roundtrip mcp_serve_tools_list_matches_production_snapshot`.
- Passed: `make ci-fast` (its compiler-cache mount-namespace subcheck reported an environment-limited skip because unprivileged user namespaces are unavailable).
- Passed: `make ci-lint`.
- Failed, unrelated baseline drift: `make test` reported 538 passed and 2 failures in `friction_help_matches_the_shipped_surface` and `operation_help_matches_the_shipped_surface`; both expected older `--workspace` help text and neither touches this task's files.
- Passed: `git diff --check`.
- Passed: `GIT_OPTIONAL_LOCKS=0 git status --short`; only `RELEASING.md` and the MCP snapshot are modified.
- Not run: `make ci`, per workspace guidance that the full CI merge gate is run by the PR workflow rather than per task locally.
Assessment: The scoped MCP snapshot drift is fixed and the release classification is explicit. Remaining risk is limited to the two unrelated stale CLI help snapshots and the environment-limited ci-fast subcheck.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12221-6aa4a78b`
- Behind base: 0
- Ahead of base: 1