### PR TITLE
[qa-sweep] With a shared external Orbit root, a call from outside the checkout validates context selectors against `parent(<orbit-root>)`, so real selectors are rejected and data-directory paths are stored

### DIFF
--- a/crates/orbit-cli/tests/context_selector_external_root.rs
+++ b/crates/orbit-cli/tests/context_selector_external_root.rs
@@ -1,0 +1,380 @@
+#![allow(missing_docs)]
+// Tests use unwrap/expect to keep fixture setup readable.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+//! ORB-12222: in the shared external-root layout, a call whose cwd is not
+//! inside the registered checkout must still validate context selectors
+//! against that checkout — never against `parent(<orbit-root>)`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command as StdCommand, Output};
+
+use assert_cmd::Command as AssertCommand;
+use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
+use serde_json::{Value, json};
+use tempfile::{TempDir, tempdir};
+
+/// One registered checkout sharing an Orbit data directory outside the repo.
+struct Workspace {
+    temp: TempDir,
+    home: PathBuf,
+    orbit_root: PathBuf,
+    repo: PathBuf,
+    outside: PathBuf,
+}
+
+impl Workspace {
+    fn init() -> Self {
+        let temp = tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        // Nested so `dir:root` names the data directory under its parent —
+        // the selector the pre-fix guard accepted from any cwd.
+        let orbit_root = temp.path().join("orbit-data").join("root");
+        let repo = temp.path().join("repo");
+        let outside = temp.path().join("outside");
+        for directory in [&home, &outside] {
+            fs::create_dir_all(directory).expect("create fixture directory");
+        }
+        fs::create_dir_all(repo.join("src")).expect("create repo src");
+
+        run_git(&repo, &["init"]);
+        run_git(&repo, &["config", "user.name", "Orbit Test"]);
+        run_git(&repo, &["config", "user.email", "orbit-test@example.com"]);
+        run_git(&repo, &["config", "commit.gpgsign", "false"]);
+        fs::write(repo.join("src/main.rs"), "fn main() {}\n").expect("write committed file");
+        run_git(&repo, &["add", "src/main.rs"]);
+        run_git(&repo, &["commit", "-m", "initial"]);
+
+        let workspace = Self {
+            temp,
+            home,
+            orbit_root,
+            repo: fs::canonicalize(&repo).expect("canonicalize repo"),
+            outside: fs::canonicalize(&outside).expect("canonicalize outside cwd"),
+        };
+        let rooted_init = workspace.rooted(&[
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "external-root-host",
+            "--task-prefix",
+            "EXR",
+        ]);
+        workspace.run_success(&workspace.repo, &string_refs(&rooted_init));
+        let rooted_ws = workspace.rooted(&["workspace", "init", "--name", "repo"]);
+        workspace.run_success(&workspace.repo, &string_refs(&rooted_ws));
+        workspace.assert_bound_from_checkout();
+        workspace
+    }
+
+    fn orbit_root(&self) -> PathBuf {
+        fs::canonicalize(&self.orbit_root).expect("canonicalize orbit root")
+    }
+
+    fn rooted(&self, args: &[&str]) -> Vec<String> {
+        let mut rooted = vec![
+            "--root".to_string(),
+            self.orbit_root
+                .to_str()
+                .expect("utf8 orbit root")
+                .to_string(),
+        ];
+        rooted.extend(args.iter().map(|arg| (*arg).to_string()));
+        rooted
+    }
+
+    fn run_success(&self, cwd: &Path, args: &[&str]) -> Output {
+        let output = self.orbit(cwd, args).output().expect("run orbit");
+        assert!(
+            output.status.success(),
+            "`orbit {}` in {} failed\nstdout:\n{}\nstderr:\n{}",
+            args.join(" "),
+            cwd.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output
+    }
+
+    fn run_failure(&self, cwd: &Path, args: &[&str]) -> String {
+        let output = self.orbit(cwd, args).output().expect("run orbit");
+        assert!(
+            !output.status.success(),
+            "`orbit {}` in {} unexpectedly succeeded\nstdout:\n{}",
+            args.join(" "),
+            cwd.display(),
+            String::from_utf8_lossy(&output.stdout)
+        );
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    }
+
+    fn orbit(&self, cwd: &Path, args: &[&str]) -> AssertCommand {
+        let mut command = cargo_bin_cmd!("orbit");
+        test_env::clear_inherited_authority(|name| {
+            command.env_remove(name);
+        });
+        command.env_remove("LLVM_PROFILE_FILE");
+        command
+            .current_dir(cwd)
+            .env("HOME", &self.home)
+            .env("USERPROFILE", &self.home)
+            .env("ORBIT_AGENT_NAME", "claude")
+            .env("ORBIT_AGENT_MODEL", "claude")
+            .args(args);
+        command
+    }
+
+    fn json(&self, cwd: &Path, args: &[&str]) -> Value {
+        let output = self.run_success(cwd, args);
+        serde_json::from_slice(&output.stdout).expect("orbit json output")
+    }
+
+    fn rooted_json(&self, cwd: &Path, args: &[&str]) -> Value {
+        let rooted = self.rooted(args);
+        self.json(cwd, &string_refs(&rooted))
+    }
+
+    fn assert_bound_from_checkout(&self) {
+        let shown = self.rooted_json(&self.repo, &["workspace", "show", "--format", "json"]);
+        let checkout = &shown["checkout"];
+        assert_eq!(
+            checkout["repo_root"].as_str(),
+            self.repo.to_str(),
+            "fixture must bind the disposable checkout: {shown}"
+        );
+        assert_eq!(
+            checkout["orbit_dir"].as_str(),
+            self.orbit_root().to_str(),
+            "fixture must bind the shared Orbit data directory: {shown}"
+        );
+        assert!(!self.repo.join(".orbit").exists());
+    }
+
+    fn assert_unbound_from_outside(&self) {
+        let shown = self.rooted_json(&self.outside, &["workspace", "show", "--format", "json"]);
+        assert_eq!(
+            shown["registered"], false,
+            "cwd outside the checkout must not bind a checkout: {shown}"
+        );
+        assert!(
+            shown["checkout"].is_null(),
+            "cwd outside the checkout must report no checkout: {shown}"
+        );
+    }
+
+    fn stored_context_files(&self, task_id: &str) -> Vec<String> {
+        let task = self.rooted_json(&self.repo, &["task", "show", task_id, "--json"]);
+        task["context_files"]
+            .as_array()
+            .unwrap_or_else(|| panic!("context_files in {task}"))
+            .iter()
+            .map(|entry| entry.as_str().unwrap_or_default().to_string())
+            .collect()
+    }
+
+    fn add_worktree_with_new_file(&self, path: &Path, branch: &str, new_file: &str) -> PathBuf {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create worktree parent");
+        }
+        run_git(
+            &self.repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                path.to_str().expect("utf8 worktree path"),
+            ],
+        );
+        let worktree = fs::canonicalize(path).expect("canonicalize linked worktree");
+        fs::write(worktree.join(new_file), "fn brand_new() {}\n")
+            .expect("write worktree-only file");
+        worktree
+    }
+}
+
+fn string_refs(args: &[String]) -> Vec<&str> {
+    args.iter().map(String::as_str).collect()
+}
+
+#[test]
+fn outside_cwd_validates_against_the_stored_checkout_not_the_orbit_root_parent() {
+    let workspace = Workspace::init();
+    workspace.assert_unbound_from_outside();
+
+    let accepted = workspace.rooted(&[
+        "task",
+        "add",
+        "--title",
+        "Real selector from outside",
+        "--description",
+        "Must resolve against the stored checkout",
+        "--complexity",
+        "low",
+        "--context",
+        "file:src/main.rs",
+        "--json",
+    ]);
+    let created = workspace.json(&workspace.outside, &string_refs(&accepted));
+    let task_id = created["id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("task id in {created}"))
+        .to_string();
+    assert_eq!(
+        workspace.stored_context_files(&task_id),
+        vec!["file:src/main.rs".to_string()],
+        "`orbit task add` from outside the checkout must store the real selector"
+    );
+
+    let rejected_dir = workspace.rooted(&[
+        "task",
+        "add",
+        "--title",
+        "Bogus parent selector",
+        "--description",
+        "Must not resolve against parent(orbit-root)",
+        "--complexity",
+        "low",
+        "--context",
+        "dir:root",
+    ]);
+    let rejected = workspace.run_failure(&workspace.outside, &string_refs(&rejected_dir));
+    assert!(
+        rejected.contains("dir:root")
+            && rejected.contains("does not resolve to an existing in-workspace target"),
+        "`dir:root` names the Orbit data directory under its parent and must be refused: {rejected}"
+    );
+
+    let rejected_file = workspace.rooted(&[
+        "task",
+        "add",
+        "--title",
+        "Bogus data-dir file",
+        "--description",
+        "Must not resolve against the Orbit data directory",
+        "--complexity",
+        "low",
+        "--context",
+        "file:config.toml",
+    ]);
+    let rejected = workspace.run_failure(&workspace.outside, &string_refs(&rejected_file));
+    assert!(
+        rejected.contains("file:config.toml"),
+        "a file that exists only under the Orbit data directory must be refused: {rejected}"
+    );
+
+    let tool_accept = json!({
+        "title": "Tool real selector from outside",
+        "description": "orbit.task.add must share the same guard root",
+        "complexity": "low",
+        "context_files": ["file:src/main.rs"],
+    })
+    .to_string();
+    let tool_add = workspace.rooted(&["tool", "run", "orbit.task.add", "--input", &tool_accept]);
+    let added = workspace.json(&workspace.outside, &string_refs(&tool_add));
+    let tool_task_id = added["id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("tool task id in {added}"))
+        .to_string();
+    assert_eq!(
+        workspace.stored_context_files(&tool_task_id),
+        vec!["file:src/main.rs".to_string()],
+        "`orbit.task.add` from outside the checkout must store the real selector"
+    );
+
+    let tool_reject = json!({
+        "id": tool_task_id,
+        "context_files": ["dir:root"],
+    })
+    .to_string();
+    let tool_update =
+        workspace.rooted(&["tool", "run", "orbit.task.update", "--input", &tool_reject]);
+    let rejected = workspace.run_failure(&workspace.outside, &string_refs(&tool_update));
+    assert!(
+        rejected.contains("dir:root"),
+        "`orbit.task.update` must refuse a parent(orbit-root) selector: {rejected}"
+    );
+    assert_eq!(
+        workspace.stored_context_files(&tool_task_id),
+        vec!["file:src/main.rs".to_string()],
+        "a refused declaration must leave the stored selectors untouched"
+    );
+}
+
+#[test]
+fn linked_worktree_of_an_external_root_checkout_can_declare_its_own_file() {
+    let workspace = Workspace::init();
+    let worktree = workspace.add_worktree_with_new_file(
+        &workspace.temp.path().join("linked-worktree"),
+        "orbit-external-root-wt",
+        "src/brand_new.rs",
+    );
+    assert!(
+        !workspace.repo.join("src/brand_new.rs").exists(),
+        "the fixture file must exist only in the linked worktree"
+    );
+
+    let added = workspace.rooted(&[
+        "task",
+        "add",
+        "--title",
+        "Worktree file under a shared external root",
+        "--description",
+        "Caller-worktree fallback must see the stored checkout as repo_root",
+        "--complexity",
+        "low",
+        "--context",
+        "file:src/brand_new.rs",
+        "--json",
+    ]);
+    let created = workspace.json(&worktree, &string_refs(&added));
+    let task_id = created["id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("task id in {created}"))
+        .to_string();
+    assert_eq!(
+        workspace.stored_context_files(&task_id),
+        vec!["file:src/brand_new.rs".to_string()],
+        "a linked worktree of a shared-root checkout must be able to declare its own file"
+    );
+
+    let tool_input = json!({
+        "id": task_id,
+        "context_files": ["file:src/main.rs", "file:src/brand_new.rs"],
+    })
+    .to_string();
+    let tool_update =
+        workspace.rooted(&["tool", "run", "orbit.task.update", "--input", &tool_input]);
+    workspace.run_success(&worktree, &string_refs(&tool_update));
+    assert_eq!(
+        workspace.stored_context_files(&task_id),
+        vec![
+            "file:src/main.rs".to_string(),
+            "file:src/brand_new.rs".to_string()
+        ],
+        "`orbit.task.update` must accept a worktree-local file alongside a shared one"
+    );
+}
+
+fn run_git(cwd: &Path, args: &[&str]) {
+    let output = StdCommand::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git -C {} {} failed\nstdout:\n{}\nstderr:\n{}",
+        cwd.display(),
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/orbit-core/src/application/task/paths.rs
+++ b/crates/orbit-core/src/application/task/paths.rs
@@ -4,6 +4,7 @@ use orbit_common::fs::selector::{
     anchor_path, canonical_selector_in_workspace, exists_in_workspace,
 };
 use orbit_types::task::{TaskHistoryEntry, TaskType};
+use orbit_types::workspace::WorkspacePaths;
 use std::path::{Path, PathBuf};
 
 use crate::OrbitRuntime;
@@ -82,7 +83,18 @@ impl OrbitRuntime {
 
     /// Resolve the checkouts this call may validate selectors against.
     fn context_selector_roots(&self) -> Result<ContextSelectorRoots, OrbitError> {
-        let repo_root = &self.paths().repo_root;
+        let paths = self.paths();
+        if unbound_explicit_data_dir(paths, self.workspace_runtime_binding().is_some()) {
+            return Err(OrbitError::InvalidInput(format!(
+                "context selectors cannot be validated because this call has no checkout binding; \
+                 the current directory is not inside a registered workspace of Orbit root '{}'. \
+                 Supply a workspace selector (name, id, or checkout path) so selectors can be \
+                 checked against the workspace the task is stored in",
+                paths.orbit_dir.display()
+            )));
+        }
+
+        let repo_root = &paths.repo_root;
         let canonical_repo_root = repo_root.canonicalize().map_err(|error| {
             OrbitError::InvalidInput(format!(
                 "failed to resolve repository root '{}': {error}",
@@ -100,6 +112,27 @@ impl OrbitRuntime {
             workspace: canonical_repo_root,
             caller_worktree,
         })
+    }
+}
+
+/// True when this runtime opened an explicit data directory with no checkout
+/// to validate against. `repo_root` is the data dir itself, not a repository,
+/// so selector checks must refuse rather than treat Orbit state files as
+/// in-workspace targets.
+fn unbound_explicit_data_dir(paths: &WorkspacePaths, has_checkout_binding: bool) -> bool {
+    if has_checkout_binding {
+        return false;
+    }
+    same_path(&paths.repo_root, &paths.orbit_dir) && same_path(&paths.orbit_dir, &paths.global_dir)
+}
+
+fn same_path(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
+    }
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
     }
 }
 

--- a/crates/orbit-core/src/application/task/tests/paths.rs
+++ b/crates/orbit-core/src/application/task/tests/paths.rs
@@ -4,6 +4,9 @@
 //! and kind are not looked up.
 
 use orbit_common::OrbitError;
+use orbit_store::maintenance::task_registry::{
+    BindWorkspaceParams, TaskRegistryStore, task_registry_path, write_workspace_config,
+};
 use tempfile::tempdir;
 
 use super::test_runtime;
@@ -177,4 +180,85 @@ fn symbol_context_validation_rejects_missing_and_outside_anchors() {
         workspace.path(),
         &format!("symbol:{}#run:function", outside_file.display())
     ));
+}
+
+/// Shared-root / `--root` layout: tasks are stored for a registered checkout
+/// even when this runtime open has no cwd binding. The guard must use that
+/// checkout, not `parent(orbit-root)`.
+fn explicit_root_runtime() -> (tempfile::TempDir, OrbitRuntime) {
+    let root = tempdir().expect("create tempdir");
+    let data_dir = root.path().join("orbit-root");
+    let repo = root.path().join("repo");
+    std::fs::create_dir_all(&data_dir).expect("create data dir");
+    std::fs::create_dir_all(repo.join("src")).expect("create repo src");
+    std::fs::write(repo.join("src/main.rs"), b"fn main() {}\n").expect("write source");
+    std::fs::write(data_dir.join("config.toml"), b"[workflow]\n").expect("write orbit config");
+
+    write_workspace_config(
+        &data_dir,
+        &orbit_store::maintenance::task_registry::WorkspaceConfig {
+            schema_version: 1,
+            workspace_id: "ws_repo".to_string(),
+        },
+    )
+    .expect("write workspace identity");
+    TaskRegistryStore::open(&task_registry_path(&data_dir))
+        .expect("open task registry")
+        .bind_workspace(BindWorkspaceParams {
+            workspace_id: Some("ws_repo".to_string()),
+            slug: "repo".to_string(),
+            repo_root: repo,
+            workspace_path: root.path().join("repo"),
+            orbit_dir: data_dir.clone(),
+            repo_fingerprint: None,
+        })
+        .expect("bind stored checkout");
+
+    let runtime =
+        OrbitRuntime::from_roots(&data_dir, &data_dir).expect("build explicit-root runtime");
+    (root, runtime)
+}
+
+#[test]
+fn explicit_root_without_cwd_binding_accepts_the_stored_checkout_selector() {
+    let (_root, runtime) = explicit_root_runtime();
+
+    runtime
+        .ensure_context_selectors_exist(&["file:src/main.rs".to_string()])
+        .expect("a file in the stored checkout must be accepted");
+}
+
+#[test]
+fn explicit_root_without_cwd_binding_rejects_data_dir_and_parent_selectors() {
+    let (_root, runtime) = explicit_root_runtime();
+
+    for selector in ["dir:orbit-root", "dir:repo", "file:config.toml"] {
+        let message = expect_selector_rejection(&runtime, selector);
+        assert!(
+            message.contains(selector),
+            "error must name selector: {message}"
+        );
+        assert!(
+            message.contains("does not resolve to an existing in-workspace target"),
+            "data-dir/parent paths must not be treated as in-workspace targets: {message}"
+        );
+    }
+}
+
+#[test]
+fn unbound_explicit_data_dir_refuses_selector_validation_without_a_checkout_binding() {
+    let root = tempdir().expect("create tempdir");
+    let data_dir = root.path().join("orbit-root");
+    std::fs::create_dir_all(&data_dir).expect("create data dir");
+    let runtime = OrbitRuntime::from_roots(&data_dir, &data_dir).expect("build unbound runtime");
+
+    let message = expect_selector_rejection(&runtime, "file:config.toml");
+    assert!(
+        message.contains("no checkout binding"),
+        "refusal must name the missing binding: {message}"
+    );
+    assert!(
+        message.contains(data_dir.to_str().expect("utf8 data dir")),
+        "refusal must name the Orbit root: {message}"
+    );
 }

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use orbit_policy::PolicyEngine;
@@ -57,16 +57,13 @@ pub(crate) fn build_context_from_roots(
 
     let store = Store::open(&persistence.audit_db)?;
 
-    // workspace_root IS the .orbit dir. For custom roots outside the repo,
-    // prefer the registry's workspace root over the parent-directory fallback.
-    let repo_root = binding
-        .map(|binding| binding.repo_root.clone())
-        .unwrap_or_else(|| {
-            workspace_root
-                .parent()
-                .unwrap_or(workspace_root)
-                .to_path_buf()
-        });
+    // workspace_root IS the .orbit dir. A cwd checkout binding is authoritative.
+    // Without one, an explicit data dir must not mint parent(orbit-dir) as a
+    // synthetic repository: that root is not the workspace tasks are stored in,
+    // so every consumer of `repo_root` (including the context-selector guard)
+    // would validate against the wrong tree. Recover the stored checkout, and
+    // if none exists keep paths inside the data dir itself.
+    let repo_root = repo_root_for_runtime(global_root, workspace_root, binding)?;
     let paths = WorkspacePaths::new_with_local(
         repo_root,
         workspace_root.to_path_buf(),
@@ -372,6 +369,48 @@ fn rebind_candidate_workspace_id(
             paths.orbit_dir.display()
         ))),
     }
+}
+
+/// Resolve `paths.repo_root` for this runtime open.
+///
+/// Repo-local `.orbit` directories still fall back to their parent. Explicit
+/// `--root` data directories do not: `parent(data-dir)` is not a checkout.
+fn repo_root_for_runtime(
+    global_root: &Path,
+    workspace_root: &Path,
+    binding: Option<&WorkspaceRuntimeBinding>,
+) -> Result<PathBuf, OrbitError> {
+    if let Some(binding) = binding {
+        return Ok(binding.repo_root.clone());
+    }
+    if is_explicit_data_dir(global_root, workspace_root) {
+        if let Some(repo_root) = stored_checkout_repo_root(global_root, workspace_root)? {
+            return Ok(repo_root);
+        }
+        return Ok(workspace_root.to_path_buf());
+    }
+    Ok(workspace_root
+        .parent()
+        .unwrap_or(workspace_root)
+        .to_path_buf())
+}
+
+/// Checkout `repo_root` for the workspace this explicit data dir already
+/// stores tasks in (`config.yaml`), when a machine-local checkout exists.
+fn stored_checkout_repo_root(
+    global_root: &Path,
+    workspace_root: &Path,
+) -> Result<Option<PathBuf>, OrbitError> {
+    let Some(config) = read_workspace_config_optional(workspace_root)? else {
+        return Ok(None);
+    };
+    let registry = TaskRegistryStore::open(&task_registry_path(global_root))?;
+    if let Some(checkout) = registry.find_workspace_checkout(&config.workspace_id)? {
+        return Ok(Some(checkout.repo_root));
+    }
+    Ok(registry
+        .find_checkout_by_orbit_dir(workspace_root)?
+        .map(|checkout| checkout.repo_root))
 }
 
 fn is_explicit_data_dir(global_root: &Path, orbit_dir: &Path) -> bool {

--- a/crates/orbit-core/src/runtime/tests/builder.rs
+++ b/crates/orbit-core/src/runtime/tests/builder.rs
@@ -3,7 +3,8 @@
 use std::path::PathBuf;
 
 use orbit_store::maintenance::task_registry::{
-    TaskRegistryStore, read_workspace_config_optional, task_registry_path,
+    BindWorkspaceParams, TaskRegistryStore, read_workspace_config_optional, task_registry_path,
+    write_workspace_config,
 };
 
 use crate::OrbitError;
@@ -87,7 +88,7 @@ fn registry_neutral_binding_rejects_a_conflicting_workspace_config() {
     let workspace_root = root.path().join("repo/.orbit");
     std::fs::create_dir_all(&global_root).expect("create global root");
     std::fs::create_dir_all(&workspace_root).expect("create workspace root");
-    orbit_store::maintenance::task_registry::write_workspace_config(
+    write_workspace_config(
         &workspace_root,
         &orbit_store::maintenance::task_registry::WorkspaceConfig {
             schema_version: 1,
@@ -261,7 +262,7 @@ fn v2_task_backend_adopts_the_bound_workspace_when_the_checkout_identity_drifts(
         .expect("workspace id");
     drop(runtime);
 
-    orbit_store::maintenance::task_registry::write_workspace_config(
+    write_workspace_config(
         &workspace_root,
         &orbit_store::maintenance::task_registry::WorkspaceConfig {
             schema_version: 1,
@@ -290,6 +291,11 @@ fn explicit_data_dir_runtime_does_not_bind_parent_as_a_checkout() {
     std::fs::create_dir_all(&data_dir).expect("create data dir");
 
     let runtime = OrbitRuntime::from_roots(&data_dir, &data_dir).expect("build data-dir runtime");
+    assert_eq!(
+        runtime.context.paths().repo_root,
+        data_dir,
+        "an unbound data-dir open must not treat parent(data-dir) as repo_root"
+    );
     drop(runtime);
 
     assert!(
@@ -307,6 +313,52 @@ fn explicit_data_dir_runtime_does_not_bind_parent_as_a_checkout() {
     assert!(
         candidates.is_empty(),
         "executor-list-style data-dir open must not insert a checkout for parent(data-dir); got {candidates:?}"
+    );
+}
+
+/// ORB-12222: a registered workspace sharing an explicit data dir still has a
+/// checkout row. Opening that data dir without a cwd binding must recover that
+/// checkout instead of minting parent(data-dir) as `repo_root`.
+#[test]
+fn explicit_data_dir_runtime_recovers_the_stored_checkout_repo_root() {
+    let root = tempdir().expect("tempdir");
+    let data_dir = root.path().join("orbit-root");
+    let repo_root = root.path().join("repo");
+    std::fs::create_dir_all(&data_dir).expect("create data dir");
+    std::fs::create_dir_all(repo_root.join("src")).expect("create repo");
+    std::fs::write(repo_root.join("src/main.rs"), b"fn main() {}\n").expect("write source");
+
+    write_workspace_config(
+        &data_dir,
+        &orbit_store::maintenance::task_registry::WorkspaceConfig {
+            schema_version: 1,
+            workspace_id: "ws_repo".to_string(),
+        },
+    )
+    .expect("write workspace config");
+    let registry =
+        TaskRegistryStore::open(&task_registry_path(&data_dir)).expect("open task registry");
+    let bound = registry
+        .bind_workspace(BindWorkspaceParams {
+            workspace_id: Some("ws_repo".to_string()),
+            slug: "repo".to_string(),
+            repo_root: repo_root.clone(),
+            workspace_path: repo_root.clone(),
+            orbit_dir: data_dir.clone(),
+            repo_fingerprint: None,
+        })
+        .expect("bind stored checkout");
+
+    let runtime = OrbitRuntime::from_roots(&data_dir, &data_dir).expect("build data-dir runtime");
+    assert_eq!(
+        runtime.context.paths().repo_root,
+        bound.repo_root,
+        "explicit-root open without a cwd binding must use the stored checkout, not parent(data-dir)"
+    );
+    assert_ne!(
+        runtime.context.paths().repo_root,
+        data_dir.parent().expect("data dir parent"),
+        "parent(data-dir) must not become repo_root for a registered workspace"
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-12222](https://orbit-cli.com/tasks/ORB-12222) — [qa-sweep] With a shared external Orbit root, a call from outside the checkout validates context selectors against `parent(<orbit-root>)`, so real selectors are rejected and data-directory paths are stored

### Description

## Summary

In the shared external-root layout (`orbit --root <dir>` / an Orbit root outside
the checkout), a call whose cwd is not inside a registered checkout still binds
the registered workspace for *storage* but falls back to
`parent(<orbit-root>)` for `paths().repo_root`. The ORB-12168 context-selector
guard reads that root, so on those calls it:

1. **rejects every legitimate selector** for the workspace the task is actually
   written to, and
2. **accepts and stores selectors resolved against the Orbit data directory's
   parent** — the "dead on arrival" context the guard exists to prevent.

Root cause, `crates/orbit-core/src/runtime/builder.rs:62-70`:

```rust
// workspace_root IS the .orbit dir. For custom roots outside the repo,
// prefer the registry's workspace root over the parent-directory fallback.
let repo_root = binding
    .map(|binding| binding.repo_root.clone())
    .unwrap_or_else(|| workspace_root.parent().unwrap_or(workspace_root).to_path_buf());
```

`binding` is `None` whenever `select_workspace_for_cwd_and_roots`
(`crates/orbit-cmd/src/registry_runtime.rs:675-709`) finds no checkout: with an
explicit `--root`, the orbit-dir fallback is deliberately skipped
(`if canonical_or_original(&roots.global_root) == shared { return Ok(None); }`),
and `find_checkout_by_path` (`crates/orbit-registry/src/workspace_registry/catalog.rs:463`)
is a pure path-prefix match, so any cwd outside the checkout tree — including a
linked Git worktree placed outside it — matches nothing. Storage still routes to
the registered partition, because in that layout the task backend resolves the
workspace id from the shared root's `config.yaml`
(`crates/orbit-core/src/runtime/builder.rs:246-266`). Guard root and storage
root therefore disagree.

`ensure_context_selectors_exist`
(`crates/orbit-core/src/application/task/paths.rs:70-101`) also cannot recover
via its caller-worktree fallback here: `find_linked_worktree_root` compares the
caller's git common dir against `canonical_repo_root`, which is now a non-repo
directory, so it returns `None`.

## Reproduction (orbit 0.21.0 built from `79aad9db4`, Linux 6.8)

Everything under `/tmp`; the real `~/.orbit` is never touched.

```sh
mkdir -p /tmp/qarepro/repo/src && cd /tmp/qarepro/repo
git init -q . && echo 'fn main(){}' > src/main.rs
git add -A && git -c user.email=q@e.com -c user.name=q commit -qm init

orbit --root /tmp/qarepro/root init --non-interactive --host-name qa --task-prefix QR
orbit --root /tmp/qarepro/root workspace init          # from /tmp/qarepro/repo -> ws_repo

# routing check, from inside the checkout: bound, repo_root correct
orbit --root /tmp/qarepro/root workspace show --format json
#   registered=True  checkout={'orbit_dir':'/tmp/qarepro/root','repo_root':'/tmp/qarepro/repo',...}

cd /tmp/qarepro                                        # one level out: binds nothing
orbit --root /tmp/qarepro/root workspace show --format json
#   registered=False  checkout=None

# (1) a real file of the owning workspace is rejected
orbit --root /tmp/qarepro/root task add --title A --complexity low --description d \
      --context "file:src/main.rs"
#   error: invalid input: selector `file:src/main.rs` does not resolve to an
#   existing in-workspace target; only the filesystem anchor is verified, not a
#   `symbol:` name or kind

# (2) a path under parent(<orbit-root>) is accepted and stored
orbit --root /tmp/qarepro/root task add --title B --complexity low --description d \
      --context "dir:root"
#   QR-00000

orbit --root /tmp/qarepro/root task list --workspace repo --format json
#   [('QR-00000', 'B', ['dir:root'])]        <- stored in ws_repo, selector names
#                                               the Orbit data dir, not the repo
```

`dir:scratchrepo`, `dir:wt`, `file:<sibling-repo>/src/main.rs` and
`file:root/config.toml` were all accepted the same way in a second scratch root,
confirming the guard root is exactly `parent(<orbit-root>)`.

The same failure appears from a linked worktree in this layout, because such a
worktree is outside the registered checkout tree:

```sh
cd /tmp/qa12218/scratchrepo && git worktree add -q -b feat /tmp/qa12218/wt
echo new > /tmp/qa12218/wt/src/brand_new.rs
cd /tmp/qa12218/wt
orbit --root /tmp/qa12218/root task add --title wt --complexity low --description d \
      --context "file:src/brand_new.rs"      # rejected
orbit --root /tmp/qa12218/root task add --workspace scratchrepo --title wt2 \
      --complexity low --description d --context "file:src/brand_new.rs"   # accepted
```

Passing an explicit `--workspace <name|ws_*|path>` supplies the binding and
restores correct behavior; that is the workaround, not the fix.

## Control — the repo-local layout is unaffected

With `orbit_dir = <repo>/.orbit`, root resolution follows a worktree's `.git`
file to the main checkout, so the binding is always found. Verified on a
disposable `HOME` with every `orbit_common::test_env::INHERITED_AUTHORITY_ENV`
variable cleared, routing asserted with `orbit workspace show --format json`
before any mutation:

- worktree under `<repo>/.orbit/state/worktrees/wt1`: bound; both a
  worktree-only file and a main-checkout file accepted (ORB-12201's
  caller-worktree fallback working).
- worktree *outside* the repo (`/tmp/qamcp/outside-wt`): still bound
  (`registered=True`, `repo_root=/tmp/qamcp/repo`); both selectors accepted.

## Impact

Production impact on shared external-root deployments — the layout Orbit's own
sandbox/CI guidance uses and any `--root` install (see ORB-12170). Any
`orbit task add` / `orbit task update` / `orbit.task.add` / `orbit.task.update`
call made from outside the checkout directory loses the ORB-12168 guarantee in
both directions at once: correct declarations are hard-rejected, and selectors
that can never resolve for any reader are persisted. Nothing in the error text
hints that the guard is using a different root than the workspace the task
lands in, so the message ("does not resolve to an existing in-workspace
target") actively misleads.

Not a duplicate of ORB-12201 (guard used the registered checkout instead of the
caller's linked worktree; fixed, and its fallback is intact) or ORB-12208
(tool host passed a workspace sub-path; fixed). This is the case where the
caller binds *no* checkout at all.

## Suggested direction

Decide what `paths().repo_root` should be when no checkout binds under an
explicit root, and make the selector guard refuse to validate rather than
validate against `parent(<orbit-root>)`. A synthetic non-repository root is a
silent wrong answer for every consumer of `repo_root`, not just this guard;
`builder.rs:62-70` is the single place that mints it.

### Acceptance Criteria

- In the shared external-root layout, an `orbit task add` / `orbit task update` / `orbit.task.add` / `orbit.task.update` call made from outside the registered checkout either validates context selectors against the checkout the task is stored in, or refuses the call with a message naming the missing binding — it never validates against `parent(<orbit-root>)`.
- A selector naming a path that exists only under the Orbit data directory or its parent can no longer be accepted and persisted for a registered workspace.
- The behavior is the same across the CLI, the `orbit.task.*` tools, and the dashboard handlers, since all four share `ensure_context_selectors_exist`.
- Regression tests cover the shared external-root layout from a cwd outside the checkout (both the rejected-real-selector and the accepted-bogus-selector directions), and keep the repo-local control path and the ORB-12201 caller-worktree fallback passing.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `crates/orbit-core/src/runtime/builder.rs`: when an explicit data dir opens with no cwd checkout, `paths().repo_root` is the stored workspace checkout (`config.yaml` + task-registry binding), not `parent(orbit-dir)`. An unbound data dir keeps `repo_root` inside the data dir itself.
- `crates/orbit-core/src/application/task/paths.rs`: `ensure_context_selectors_exist` refuses unbound explicit-root validation with a message that names the missing checkout binding. When a checkout was recovered, the guard validates against that tree and the ORB-12201 caller-worktree fallback still applies.
- Tests: unit coverage in builder/paths; CLI regression `crates/orbit-cli/tests/context_selector_external_root.rs` (outside-cwd accept real / reject `dir:root` and `file:config.toml`, plus linked-worktree fallback). Repo-local ORB-12201 tests in `context_selector_worktree.rs` are unchanged and still pass.
Assessment: the four operator surfaces share `ensure_context_selectors_exist`, so CLI, `orbit.task.*`, and dashboard handlers take the same root. `--workspace` remains a disambiguator, not the required workaround.

Criteria:
1. Outside-checkout `task add`/`update` and `orbit.task.add`/`update` validate against the stored checkout, never `parent(<orbit-root>)` — met (CLI + unit).
2. Selectors that exist only under the Orbit data directory or its parent are refused for a registered workspace — met (`dir:root`, `file:config.toml`).
3. Same behavior across CLI, tools, and dashboard because they share the guard — met (no per-surface fork).
4. Regression tests cover both bug directions and keep the repo-local / ORB-12201 path passing — met.

Validation:
- `cargo test -p orbit-core --lib -- --test-threads=1 explicit_data_dir explicit_root_without unbound_explicit ensure_context_selectors` — passed (10 tests).
- `cargo test -p orbit-cli --test context_selector_external_root --test context_selector_worktree -- --test-threads=1` — passed (2 + 3 tests).
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- `git diff --check` — passed.

Remaining risks: with several checkouts on one shared root, an unbound cwd still stores into the `config.yaml` workspace (pre-existing routing). `workspace show` from outside still reports `registered=false` because it reads the cwd binding, not `paths().repo_root`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12222-6aa4a78c`
- Behind base: 0
- Ahead of base: 1