### PR TITLE
[friction-curation] Warn task authors that an acceptance criterion outside the task's workspace cannot be satisfied in a managed run

### DIFF
--- a/crates/orbit-core/assets/skills/orbit/references/task-authoring.md
+++ b/crates/orbit-core/assets/skills/orbit/references/task-authoring.md
@@ -60,6 +60,18 @@ empty** — the list is what conflict detection reads, so a wrong entry actively
 misleads. When an orchestrator needs selectors prepared at scale, the task-pilot
 job fills them from real inspection. → [orchestration.md](orchestration.md)
 
+### Acceptance criteria outside the workspace
+
+An acceptance criterion cannot require a change outside the task's own
+workspace. A managed run mounts everything outside its own worktree
+read-only, and the delivery boundary refuses untracked paths — so there is no
+place for a cross-workspace edit to land, no matter how the criterion is
+worded. This holds for any out-of-workspace path, not one particular
+companion repository. If the work genuinely spans two workspaces, file the
+companion change as its own task in its own workspace and relate the two
+(for example, a `related_to` relation) instead of asking one task to reach
+outside its root.
+
 ## Operating rules
 
 - Never edit task files directly; never invent task IDs (`orbit.task.add`

--- a/plugin/skills/orbit/references/task-authoring.md
+++ b/plugin/skills/orbit/references/task-authoring.md
@@ -60,6 +60,18 @@ empty** — the list is what conflict detection reads, so a wrong entry actively
 misleads. When an orchestrator needs selectors prepared at scale, the task-pilot
 job fills them from real inspection. → [orchestration.md](orchestration.md)
 
+### Acceptance criteria outside the workspace
+
+An acceptance criterion cannot require a change outside the task's own
+workspace. A managed run mounts everything outside its own worktree
+read-only, and the delivery boundary refuses untracked paths — so there is no
+place for a cross-workspace edit to land, no matter how the criterion is
+worded. This holds for any out-of-workspace path, not one particular
+companion repository. If the work genuinely spans two workspaces, file the
+companion change as its own task in its own workspace and relate the two
+(for example, a `related_to` relation) instead of asking one task to reach
+outside its root.
+
 ## Operating rules
 
 - Never edit task files directly; never invent task IDs (`orbit.task.add`


### PR DESCRIPTION
## Task

[ORB-12227](https://orbit-cli.com/tasks/ORB-12227) — [friction-curation] Warn task authors that an acceptance criterion outside the task's workspace cannot be satisfied in a managed run

### Description

## Problem

The task-authoring reference (`crates/orbit-core/assets/skills/orbit/references/task-authoring.md`) tells an author that `context_files` must resolve inside the target workspace's root, but says nothing about acceptance criteria that require a change *outside* that workspace. Nothing warns that such a criterion is unsatisfiable by the lane that will run it.

## Reproduction (F2026-09-130, run jrun-20260911-0621-c6 on ORB-12126)

ORB-12126's final criterion required an edit to a companion repository's document as well as the CLI help in this workspace. Inside the managed run everything outside the run's own worktree is mounted read-only:

```
$ touch <companion-repo>/.write-probe
touch: cannot touch '...': Read-only file system
$ mount | head -1
/dev/mapper/... on / type ext4 (ro,nosuid,nodev,relatime)
```

The directory is owned and writable on the host, so this is the run sandbox, not a permission problem — and the denial only appears at write time, after the work to compose the change is already done. The delivery boundary also refuses untracked paths, so there is no in-worktree place for a cross-repo change to ride along. The executor worked around it by attaching the change as a patch artifact and reporting the criterion as prepared-but-not-applied.

## Why It Matters

An author writes such a criterion in good faith; the cost lands on the implementing run, which cannot satisfy it without reaching for a sandbox bypass. The cheap repair is at authoring time: file the companion change as its own task in its own workspace and relate the two.

## Constraints / Notes

- Keep the guidance domain-neutral: it is about any path outside the task's workspace, not about one particular companion repository.
- `crates/orbit-core/assets/skills/**` is canonical and `plugin/skills/**` is its byte-identical mirror, checked by `scripts/sync-plugin-skills.sh --check` in `make ci-fast`; update both (running the sync script is the intended route).
- This task changes authoring guidance only. Do not add an admission-time rejection for out-of-workspace criteria: that is a separate, heavier decision that F2026-09-130 records as an alternative direction.

### Acceptance Criteria

- `crates/orbit-core/assets/skills/orbit/references/task-authoring.md` states that an acceptance criterion requiring a change outside the task's own workspace cannot be satisfied by a managed run (everything outside the run's worktree is read-only and the delivery boundary refuses untracked paths), and names the repair: file the companion change as its own task in its own workspace and relate the two.
- The guidance sits with the existing workspace-scoping rules (near the `context_files` section) rather than as an unrelated aside, and stays domain-neutral.
- `plugin/skills/orbit/references/task-authoring.md` is byte-identical to the canonical copy: `./scripts/sync-plugin-skills.sh --check` exits 0.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Added a new "Acceptance criteria outside the workspace" subsection to
`crates/orbit-core/assets/skills/orbit/references/task-authoring.md`, placed
immediately after the `context_files` guidance (before "## Operating
rules") so it sits with the existing workspace-scoping rules rather than as
an unrelated aside. It states, domain-neutrally, that a criterion requiring
a change outside the task's own workspace cannot be satisfied by a managed
run — everything outside the run's worktree is read-only and the delivery
boundary refuses untracked paths — and names the repair: file the companion
change as its own task in its own workspace and relate the two (e.g. a
`related_to` relation). Ran `./scripts/sync-plugin-skills.sh` to regenerate
the byte-identical `plugin/skills/orbit/references/task-authoring.md`
mirror (it does not auto-sync; `--check` confirmed drift beforehand and a
clean pass afterward). No admission-time rejection was added, per the
task's explicit constraint.

Criteria:
1. Canonical file states the unsatisfiability and repair — done (new
   subsection, quoted above in spirit).
2. Guidance sits near `context_files` section, domain-neutral — done,
   verified by reading the rendered file.
3. `./scripts/sync-plugin-skills.sh --check` exits 0 — verified directly,
   exit code 0.
4. `make ci-fast` passes — ran to completion, exit code 0 (includes the
   sync-plugin-skills check, dependency-direction guard, and other
   guardrails; one unrelated sub-check, test-compiler-cache-namespaces,
   self-reported "skip" due to sandbox mount-namespace restrictions, not a
   failure).

Validation commands run:
- `./scripts/sync-plugin-skills.sh --check` (before edit): exit 1, reported
  drift in task-authoring.md — expected, confirms the check catches drift.
- `./scripts/sync-plugin-skills.sh` (apply sync): succeeded.
- `./scripts/sync-plugin-skills.sh --check` (after sync): exit 0.
- `git status --short`: only the two intended files modified.
- `git diff --check`: clean, no whitespace issues.
- `make ci-fast`: exit 0.

Scope: only the two context_files-listed files were touched; no scope
expansion needed. Changes are left uncommitted per pipeline ownership of
commit/push/PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12227-6aa4ab42`
- Behind base: 0
- Ahead of base: 1