### PR TITLE
[friction-curation] Correct the QA-sweep guidance that produces unusable or false validation evidence

### DIFF
--- a/.orbit/auto_tasks/qa-sweep.yaml
+++ b/.orbit/auto_tasks/qa-sweep.yaml
@@ -23,22 +23,42 @@ template:
 
     Root `init` hangs on stdin without `--non-interactive`. `workspace init`
     does not need that flag and does not prompt non-interactively in
-    practice.
+    practice. Keep disposable Orbit roots and scratch checkouts under `/tmp`,
+    but build in the worktree's gitignored `target/` (or another disk-backed
+    path), naming the 14 GiB tmpfs and the ~11-14 GiB workspace target directory
+    as the reason: building in `/tmp` exhausts the tmpfs and breaks the harness.
+    `cargo clean` — not `rm -rf` — is the cleanup and an emptied `target/` is
+    the expected end state.
 
     Similarly, in agent-executor sandboxes and linked job-run worktrees, the
     repository's managed `.git` mount is read-only by design and must not be
-    worked around by chmod or host-side gitdir writes. Commands that write to
-    `.git` fail (such as `git worktree add` or `git checkout --`).
+    worked around by chmod or host-side gitdir writes. In a job-run worktree,
+    `git rm`, `git mv` and `git add` fail because `.git/worktrees/<id>/` is
+    read-only. A tracked deletion is made with `rm <path>`, which `git status --short`
+    still reports as `D <path>`. Other commands that write to `.git` fail as well
+    (such as `git worktree add` or `git checkout --`).
     Instead:
     - To build an arbitrary baseline revision without writing `.git` or creating
       `.git/worktrees/*`, extract an archive to a scratch directory:
       `mkdir -p /tmp/base && git archive <sha> | tar -x -C /tmp/base`,
-      then build there with a separate `CARGO_TARGET_DIR`.
+      then build there with a disk-backed `CARGO_TARGET_DIR` (such as
+      `<worktree>/target/scratch-base`), keeping multi-gigabyte build output
+      out of `/tmp`.
     - To revert a modified tracked file when `git checkout -- <path>` fails
       because it cannot acquire `index.lock`, restore it from the commit tree:
       `git show HEAD:<path> > <path>`.
     - Read-only inspection commands such as `git status --short` succeed with
       `GIT_OPTIONAL_LOCKS=0`.
+
+    The session's granted `orbit.*` MCP tools run the machine's installed binary
+    rather than the build under test; tool behavior at HEAD is validated with
+    `<worktree>/target/debug/orbit tool run <tool.name>` against a scratch `/tmp`
+    Orbit root, with MCP output treated as bookkeeping.
+
+    A long build or test command's completion must be confirmed by a positive
+    marker in its captured output (`test result:`, `Finished`, or the target's
+    own final line), with its absence treated as "did not run" regardless of the
+    reported exit status.
 
     Before filing anything, search open Orbit tasks tagged `qa-sweep`. For each
     real issue that is not already filed, create an Orbit task yourself through

--- a/crates/orbit-core/assets/auto_tasks/qa-sweep.yaml
+++ b/crates/orbit-core/assets/auto_tasks/qa-sweep.yaml
@@ -16,7 +16,8 @@ template:
     sandbox or other environment constraint makes the usual local state
     unwritable, put scratch checkouts, caches, and other ephemeral state in a
     writable temporary location rather than the machine's real home directory
-    or the product's live data root.
+    or the product's live data root. A writable temporary location may be too
+    small for build output; choose the build cache location for capacity.
 
     In agent-executor sandboxes and linked job-run worktrees, the repository's
     managed `.git` mount is read-only by design and must not be worked around by
@@ -32,6 +33,11 @@ template:
       `git show HEAD:<path> > <path>`.
     - Read-only inspection commands such as `git status --short` succeed with
       `GIT_OPTIONAL_LOCKS=0`.
+
+    A long build or test command's completion must be confirmed by a positive
+    marker in its captured output (`test result:`, `Finished`, or the target's
+    own final line), with its absence treated as "did not run" regardless of the
+    reported exit status.
 
     Before reporting anything, search the workspace's configured task or issue surface
     for open work covering the same problem. For each real issue that is not already


### PR DESCRIPTION
## Task

[ORB-12229](https://orbit-cli.com/tasks/ORB-12229) — [friction-curation] Correct the QA-sweep guidance that produces unusable or false validation evidence

### Description

## Problem

The QA-sweep auto-task guidance sends sweeps into four traps that cost real time and, in one case, nearly produced a false green. Three of the four are caused by the guidance itself.

### 1. Scratch guidance sends multi-gigabyte build output to a 14 GiB tmpfs (F2026-09-132, duplicate F2026-09-138)

`.orbit/auto_tasks/qa-sweep.yaml` says to put the Orbit root and any scratch git checkouts under `/tmp` and to build "there with a separate `CARGO_TARGET_DIR`". On this host `/tmp` is a **14 GiB tmpfs**, and a workspace `cargo test` target directory reaches ~11-14 GiB. Two sweeps filled it mid-run:

```
error: failed to write file /tmp/orbit-qa-12213-target/debug/incremental/.../dep-graph.part.bin: No space left on device (os error 28)
$ df -h /tmp
tmpfs  14G  14G  148M  99% /tmp
```

The failure is self-obscuring: the agent harness writes every tool's stdout under `/tmp/claude-1000/...`, so *every subsequent command* — including `df` — returned `Command output was lost: the temp filesystem ... is full`. Recovery required deleting the incremental cache blind, which corrupted the in-flight build into compiler-looking errors. The worktree's own `target/` is gitignored and on the real disk (`/dev/mapper/...`, ~300 GiB free), so it is both writable and safe.

### 2. Tracked-file mutations fail in job-run worktrees (F2026-09-134)

The guidance covers `git worktree add` and `git checkout --`, but not the rest: `.git/worktrees/<id>/` is read-only in this execution environment, so `git rm`, `git mv` and `git add` all fail at the lock-file step (`fatal: Unable to create '.git/worktrees/<id>/index.lock': Read-only file system`). Deleting the file with `rm` works, and `git status --short` still reports it as a tracked deletion (`D <path>`), which the delivery boundary reads correctly.

### 3. Granted `orbit.*` MCP tools run the installed release, not the build under test (F2026-09-136)

A sweep reached for the granted MCP tools as the natural "exercise it as a user would" surface. Those tools are served by the machine's installed `orbit`, not the worktree build, so their output described a different binary and a different checkout; ~15 minutes went into tracing a phantom defect (a `context_files_pruned` history entry that no code at HEAD could produce). `<worktree>/target/debug/orbit tool run <tool.name>` routes through the same registry and allowlist but exercises the build under test.

### 4. A shell-backgrounded validation command reports exit 0 without running (F2026-09-127)

`nohup make test > log 2>&1 &` came back as "completed, exit code 0" with a log truncated mid-compile: the process was killed when the tool call returned, and the reported status was the backgrounding shell's. Re-running the same command through the harness's own background mechanism surfaced a genuine failing test (ORB-12123) that the false green had hidden. The detection rule that works is to require a positive completion marker in the captured output (`test result:` for cargo test, `Finished` for cargo build/clippy, the make target's own final line) and treat its absence as "did not run", whatever the exit status says.

## Why It Matters

A QA sweep's durable output is the issues it files. Guidance that leads a sweep to exhaust the host's tmpfs, to read an installed binary's behavior as evidence about HEAD, or to record a suite as passing when it never ran turns that output into noise or into a false all-clear.

## Constraints / Notes

- Host-specific facts (the 14 GiB `/tmp` tmpfs, the read-only `.git/worktrees/<id>/`, the machine's installed `orbit`) belong in the workspace copy `.orbit/auto_tasks/qa-sweep.yaml`. Keep the shipped default `crates/orbit-core/assets/auto_tasks/qa-sweep.yaml` domain-neutral: a temporary location may be small, so a build cache needs a location chosen for capacity, and a long validation command's completion must be confirmed from its output rather than from a reported exit status.
- Keep the existing structure and the existing correct guidance (disposable Orbit roots and scratch checkouts under `/tmp` remain right; they are a few MB each).
- Do not change `enabled`, the schedule, the crew, the task type, or the acceptance criteria of the auto-task template beyond what these corrections require.
- `qa-sweep.yaml` is not in `.orbit/auto_tasks/.orbit-managed-assets.json`, so the workspace copy is locally owned and is not overwritten by managed-asset reconciliation; the two files are intentionally not byte-identical.

### Acceptance Criteria

- `.orbit/auto_tasks/qa-sweep.yaml` tells a sweep to keep disposable Orbit roots and scratch checkouts under `/tmp` but to build in the worktree's gitignored `target/` (or another disk-backed path), naming the 14 GiB tmpfs and the ~11-14 GiB workspace target directory as the reason, and stating that `cargo clean` — not `rm -rf` — is the cleanup and that an emptied `target/` is the expected end state.
- `.orbit/auto_tasks/qa-sweep.yaml` states that `git rm`, `git mv` and `git add` fail in a job-run worktree because `.git/worktrees/<id>/` is read-only, and that a tracked deletion is made with `rm <path>`, which `git status --short` still reports as `D <path>`.
- `.orbit/auto_tasks/qa-sweep.yaml` states that the session's granted `orbit.*` MCP tools run the machine's installed binary rather than the build under test, and that tool behavior at HEAD is validated with `<worktree>/target/debug/orbit tool run <tool.name>` against a scratch `/tmp` Orbit root, with MCP output treated as bookkeeping.
- Both `.orbit/auto_tasks/qa-sweep.yaml` and `crates/orbit-core/assets/auto_tasks/qa-sweep.yaml` require a long build or test command's completion to be confirmed by a positive marker in its captured output (`test result:`, `Finished`, or the target's own final line), with its absence treated as "did not run" regardless of the reported exit status.
- `crates/orbit-core/assets/auto_tasks/qa-sweep.yaml` gains the domain-neutral capacity warning (a writable temporary location may be too small for build output; choose the build cache location for capacity) without acquiring any host-specific or repository-specific detail.
- Both files still parse as auto-task definitions and `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

### Acceptance Criteria Mapping
- Criterion 1: `.orbit/auto_tasks/qa-sweep.yaml` advises keeping disposable Orbit roots and scratch checkouts under `/tmp` while building in the worktree's gitignored `target/` (or another disk-backed path), explicitly citing the 14 GiB tmpfs vs ~11-14 GiB workspace target size, and stating that `cargo clean` — not `rm -rf` — is the cleanup with an emptied `target/` as the expected end state.
- Criterion 2: `.orbit/auto_tasks/qa-sweep.yaml` states that `git rm`, `git mv` and `git add` fail in a job-run worktree because `.git/worktrees/<id>/` is read-only, and that tracked deletions are made with `rm <path>`, which `git status --short` still reports as `D <path>`.
- Criterion 3: `.orbit/auto_tasks/qa-sweep.yaml` states that session-granted `orbit.*` MCP tools run the machine's installed binary rather than the build under test, tool behavior at HEAD is validated with `<worktree>/target/debug/orbit tool run <tool.name>` against a scratch `/tmp` Orbit root, and MCP output is treated as bookkeeping.
- Criterion 4: Both `.orbit/auto_tasks/qa-sweep.yaml` and `crates/orbit-core/assets/auto_tasks/qa-sweep.yaml` require long build or test command completion to be confirmed by a positive marker in captured output (`test result:`, `Finished`, or the target's own final line), with absence treated as "did not run" regardless of reported exit status.
- Criterion 5: `crates/orbit-core/assets/auto_tasks/qa-sweep.yaml` gained the domain-neutral capacity warning ("A writable temporary location may be too small for build output; choose the build cache location for capacity") without host- or repo-specific detail.
- Criterion 6: Both files parse cleanly as auto-task definitions and pass `make ci-fast`.

### Validation Commands
- `make ci-fast`: PASSED
- `cargo test -p orbit-core --lib auto_tasks::tests::shipped`: PASSED (9/9 tests passed, verifying parser and definition invariants)
- `cargo clippy -p orbit-core --tests`: PASSED (no warnings)
- `git diff --check`: PASSED (clean)
- `cargo clean`: FAILED with os error 16 (Device or resource busy) due to mounted target directory; recorded bounded leftover per instructions.

### Remaining Risks or Deviations
None.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12229-6aa4ab05`
- Behind base: 0
- Ahead of base: 1