### PR TITLE
[qa-sweep] `orbit workspace remove` re-hides the orphan task partition ORB-12170 just made visible: doctor flips back to `ok`, the confirmed repair reclaims nothing, and the task bundles are stranded

### DIFF
--- a/crates/orbit-cli/src/command/workspace/remove.rs
+++ b/crates/orbit-cli/src/command/workspace/remove.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use clap::Args;
+use orbit_cmd::retain_task_store_on_catalog_remove;
 use orbit_core::OrbitRuntime;
 use orbit_registry::workspace_registry;
 use orbit_types::workspace::WorkspaceRegistry;
@@ -19,15 +20,39 @@ impl Execute for WorkspaceRemoveArgs {
         let global_root = runtime.global_root();
         let registry_path = workspace_registry::registry_path_for(&global_root);
         let mut registry = workspace_registry::load_registry_from(&registry_path)?;
-        let workspace_id = workspace_id_for_selector(&registry, &self.workspace)?;
-        let removed = match workspace_id {
-            Some(workspace_id) => {
-                workspace_registry::remove_workspace(&mut registry, &workspace_id)?
-            }
-            None => workspace_registry::remove_workspace(&mut registry, &self.workspace)?,
-        };
+        let workspace_id = workspace_id_for_selector(&registry, &self.workspace)?
+            .unwrap_or_else(|| self.workspace.clone());
+        let checkout = registry
+            .checkouts
+            .iter()
+            .find(|checkout| checkout.workspace_id == workspace_id)
+            .cloned();
+        let slug = workspace_registry::find_workspace_by_id(&registry, &workspace_id)
+            .map(|workspace| workspace.name.clone())
+            .unwrap_or_else(|| workspace_id.clone());
+
+        // Retain checkout evidence before the catalog rows disappear so doctor
+        // can still classify a leftover populated partition [ORB-12223].
+        let leftover = retain_task_store_on_catalog_remove(
+            &global_root,
+            &workspace_id,
+            &slug,
+            checkout.as_ref(),
+        )?;
+
+        let removed = workspace_registry::remove_workspace(&mut registry, &workspace_id)?;
         workspace_registry::save_registry_to(&registry, &registry_path)?;
         println!("workspace '{}' removed from registry", removed.name);
+        if let Some(partition) = leftover.filter(|partition| partition.task_bundles > 0) {
+            println!(
+                "left task-store partition {} ({} task bundle(s)); \
+                 the task-registry workspace binding is retained as checkout evidence \
+                 so `orbit doctor` can classify it. Reclaim with \
+                 `orbit doctor --fix-orphan-task-stores --confirm`.",
+                partition.path.display(),
+                partition.task_bundles
+            );
+        }
         Ok(CommandOutput::Silent)
     }
 }

--- a/crates/orbit-cli/src/command/workspace/tests/remove.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/remove.rs
@@ -1,4 +1,7 @@
 use chrono::Utc;
+use orbit_cmd::DoctorCommands;
+use orbit_cmd::WorkspaceDoctorStatus;
+use orbit_cmd::task_store::{partition_is_bound, task_workspaces_dir};
 use orbit_core::OrbitRuntime;
 use orbit_registry::workspace_registry;
 use orbit_types::workspace::{Workspace, WorkspaceCheckout, WorkspaceStatus};
@@ -64,4 +67,141 @@ fn remove_accepts_the_recorded_path_of_a_deleted_checkout() {
             .all(|checkout| checkout.workspace_id != "ws_deleted"),
         "path removal must remove the checkout binding too"
     );
+}
+
+fn register_workspace(
+    global_root: &std::path::Path,
+    workspace_id: &str,
+    name: &str,
+    repo_root: &std::path::Path,
+    orbit_dir: &std::path::Path,
+) {
+    let registry_path = workspace_registry::registry_path_for(global_root);
+    let mut registry =
+        workspace_registry::load_registry_from(&registry_path).expect("load registry");
+    let now = Utc::now();
+    workspace_registry::register_workspace(
+        &mut registry,
+        Workspace {
+            id: workspace_id.to_string(),
+            name: name.to_string(),
+            owner_machine_id: None,
+            git_remote: None,
+            ship_mode: None,
+            base_branch: "main".to_string(),
+            status: WorkspaceStatus::Invalid,
+            created_at: now,
+            updated_at: now,
+        },
+    )
+    .expect("register workspace");
+    workspace_registry::register_checkout(
+        &mut registry,
+        WorkspaceCheckout::owner(
+            workspace_id.to_string(),
+            repo_root.to_path_buf(),
+            orbit_dir.to_path_buf(),
+        ),
+    )
+    .expect("register checkout");
+    workspace_registry::save_registry_to(&registry, &registry_path).expect("save registry");
+}
+
+fn write_task_bundle(global_root: &std::path::Path, workspace_id: &str, task_id: &str) {
+    let bundle = task_workspaces_dir(global_root)
+        .join(workspace_id)
+        .join(task_id);
+    std::fs::create_dir_all(&bundle).expect("create task bundle dir");
+    std::fs::write(bundle.join("task.yaml"), b"id: dummy\n").expect("write bundle file");
+}
+
+fn orphan_row(results: &[orbit_cmd::WorkspaceDoctorResult]) -> &orbit_cmd::WorkspaceDoctorResult {
+    results
+        .iter()
+        .find(|row| row.check_name == "orphan-task-stores")
+        .expect("orphan-task-stores row present")
+}
+
+/// [ORB-12223] Shared external-root layout: deleted checkout → doctor warns →
+/// `workspace remove` → doctor still reports the leftover → repair reclaims it.
+#[test]
+fn shared_root_remove_keeps_a_deleted_checkout_partition_reclaimable() {
+    let temp = tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let survivor = temp.path().join("survivor");
+    let deleted = temp.path().join("deleted");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::create_dir_all(&survivor).expect("create survivor checkout");
+    std::fs::create_dir_all(&deleted).expect("create deleted checkout");
+
+    register_workspace(
+        &global_root,
+        "ws_survivor",
+        "survivor",
+        &survivor,
+        &global_root,
+    );
+    register_workspace(
+        &global_root,
+        "ws_deleted",
+        "deleted",
+        &deleted,
+        &global_root,
+    );
+    write_task_bundle(&global_root, "ws_deleted", "ORB-2");
+    write_task_bundle(&global_root, "ws_deleted", "ORB-3");
+    std::fs::remove_dir_all(&deleted).expect("delete checkout");
+
+    let runtime = OrbitRuntime::from_resolved_roots(&global_root, &global_root, &survivor)
+        .expect("shared-root runtime");
+
+    let results = runtime.doctor_workspace().expect("doctor before remove");
+    let row = orphan_row(&results);
+    assert_eq!(row.status, WorkspaceDoctorStatus::Warning, "{row:?}");
+    assert!(row.message.contains("ws_deleted"), "{}", row.message);
+    assert!(
+        row.message.contains("missing checkout directories"),
+        "{}",
+        row.message
+    );
+
+    WorkspaceRemoveArgs {
+        workspace: "ws_deleted".to_string(),
+    }
+    .execute(&runtime)
+    .expect("remove deleted shared-root workspace");
+
+    assert!(
+        task_workspaces_dir(&global_root)
+            .join("ws_deleted")
+            .join("ORB-2")
+            .is_dir(),
+        "remove must not delete task bundles"
+    );
+
+    let results = runtime.doctor_workspace().expect("doctor after remove");
+    let row = orphan_row(&results);
+    assert_eq!(
+        row.status,
+        WorkspaceDoctorStatus::Warning,
+        "catalog removal must not re-hide the partition as claimed: {row:?}"
+    );
+    assert!(row.message.contains("ws_deleted"), "{}", row.message);
+    assert!(
+        row.message.contains("missing checkout directories"),
+        "{}",
+        row.message
+    );
+
+    let removed = runtime
+        .remove_orphan_task_stores()
+        .expect("repair after workspace remove");
+    assert_eq!(removed.populated_partitions, 1, "{removed:?}");
+    assert_eq!(removed.task_bundles, 2, "{removed:?}");
+    assert!(
+        !task_workspaces_dir(&global_root)
+            .join("ws_deleted")
+            .exists()
+    );
+    assert!(!partition_is_bound(&global_root, "ws_deleted").expect("read binding"));
 }

--- a/crates/orbit-cmd/src/lib.rs
+++ b/crates/orbit-cmd/src/lib.rs
@@ -42,8 +42,9 @@ pub use doctor::{
 };
 pub use migrate::{MigrateCommands, MigrateStatus, migrate_dry_run_at};
 pub use task_store::{
-    TaskStorePartitions, bound_partition_id, inspect_task_store_partitions,
-    remove_checkout_task_stores, remove_unclaimed_task_stores, task_store_partition_path,
+    TaskStorePartitions, UnclaimedPartition, bound_partition_id, inspect_task_store_partitions,
+    remove_checkout_task_stores, remove_unclaimed_task_stores, retain_task_store_on_catalog_remove,
+    task_store_partition_path,
 };
 
 /// One-stop import for every runtime extension trait this crate defines.

--- a/crates/orbit-cmd/src/task_store.rs
+++ b/crates/orbit-cmd/src/task_store.rs
@@ -13,7 +13,9 @@
 //! explicit id. `orbit workspace init` may instead bind the catalog's `ws_*`
 //! id directly. The task registry and the workspace catalog therefore both
 //! contribute claims, using checkout evidence to distinguish live, stale, and
-//! unreachable state [ORB-12119].
+//! unreachable state [ORB-12119]. `workspace remove` drops catalog rows only;
+//! it retains the task-registry binding and copies catalog checkout evidence
+//! so a leftover partition stays classifiable [ORB-12223].
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -22,7 +24,9 @@ use orbit_common::OrbitError;
 use orbit_core::runtime::UNBOUND_DATA_DIR_WORKSPACE_ID;
 use orbit_registry::workspace_registry;
 pub use orbit_store::maintenance::task_registry::task_workspaces_dir;
-use orbit_store::maintenance::task_registry::{TaskRegistryStore, task_registry_path};
+use orbit_store::maintenance::task_registry::{
+    BindWorkspaceParams, TaskRegistryStore, task_registry_path,
+};
 use orbit_types::task::is_valid_orb_task_id;
 use orbit_types::workspace::WorkspaceCheckout;
 
@@ -254,6 +258,73 @@ pub fn partition_is_bound(global_root: &Path, workspace_id: &str) -> Result<bool
     Ok(open_task_registry(global_root)?
         .workspace_ids()?
         .contains(workspace_id))
+}
+
+/// Copy a catalog checkout into the task registry before `workspace remove`
+/// drops the catalog rows, and describe any leftover partition directory.
+///
+/// Catalog removal is not teardown: task bundles stay on disk. The
+/// task-registry workspace binding is retained so `partition_claims` can
+/// still classify that leftover. Dropping the binding would make a populated
+/// partition `unowned`, which the confirmed repair refuses to delete
+/// [ORB-12131]. A path-free binding — the shared-root `workspace init` shape —
+/// is otherwise treated as an imported-archive claim once the catalog
+/// checkout that proved the directory gone is removed [ORB-12223].
+///
+/// When the catalog `orbit_dir` is already bound to another workspace (the
+/// shared external root), evidence is stored under the per-checkout
+/// `repo_root` instead of stealing that binding. `checkout_evidence` reads
+/// `repo_root`.
+pub fn retain_task_store_on_catalog_remove(
+    global_root: &Path,
+    workspace_id: &str,
+    slug: &str,
+    catalog_checkout: Option<&WorkspaceCheckout>,
+) -> Result<Option<UnclaimedPartition>, OrbitError> {
+    let leftover = leftover_task_partition(global_root, workspace_id);
+    if leftover.is_some()
+        && let Some(checkout) = catalog_checkout
+    {
+        ensure_checkout_evidence(global_root, workspace_id, slug, checkout)?;
+    }
+    Ok(leftover)
+}
+
+fn leftover_task_partition(global_root: &Path, workspace_id: &str) -> Option<UnclaimedPartition> {
+    let path = task_store_partition_path(global_root, workspace_id);
+    if !path.is_dir() {
+        return None;
+    }
+    Some(UnclaimedPartition {
+        task_bundles: count_task_bundles(&path),
+        path,
+    })
+}
+
+fn ensure_checkout_evidence(
+    global_root: &Path,
+    workspace_id: &str,
+    slug: &str,
+    checkout: &WorkspaceCheckout,
+) -> Result<(), OrbitError> {
+    let tasks = open_task_registry(global_root)?;
+    if tasks.find_workspace_checkout(workspace_id)?.is_some() {
+        return Ok(());
+    }
+
+    let orbit_dir = match tasks.find_checkout_by_orbit_dir(&checkout.orbit_dir)? {
+        Some(existing) if existing.workspace_id != workspace_id => checkout.repo_root.clone(),
+        _ => checkout.orbit_dir.clone(),
+    };
+    tasks.bind_workspace(BindWorkspaceParams {
+        workspace_id: Some(workspace_id.to_string()),
+        slug: slug.to_string(),
+        repo_root: checkout.repo_root.clone(),
+        workspace_path: checkout.repo_root.clone(),
+        orbit_dir,
+        repo_fingerprint: None,
+    })?;
+    Ok(())
 }
 
 /// Who claims each partition on this host, and why the rest do not.

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -22,7 +22,7 @@ use crate::doctor::{
     DoctorCommands, OrphanTaskStoreRemoval, WorkspaceDoctorResult, WorkspaceDoctorStatus,
     collect_lock_files, disk_space_check, process_is_alive,
 };
-use crate::task_store::partition_is_bound;
+use crate::task_store::{partition_is_bound, retain_task_store_on_catalog_remove};
 
 fn status_of<'a>(results: &'a [WorkspaceDoctorResult], name: &str) -> &'a WorkspaceDoctorResult {
     results
@@ -1206,6 +1206,160 @@ fn deleted_shared_root_catalog_checkout_partition_is_reported_and_removed() {
             .exists()
     );
     assert!(!partition_is_bound(&global_root, "ws_shared_deleted").expect("read binding"));
+}
+
+/// [ORB-12223] Shared external-root layout: deleted checkout → doctor warns →
+/// catalog `workspace remove` → doctor still reports the partition stale →
+/// the confirmed repair reclaims it. A path-free task-registry binding plus a
+/// survivor occupying the shared `orbit_dir` is the production shape.
+#[test]
+fn catalog_remove_keeps_a_deleted_shared_root_partition_stale_and_reclaimable() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let global_root = temp.path().join("global");
+    let survivor_root = temp.path().join("survivor");
+    let deleted_root = temp.path().join("deleted");
+    fs::create_dir_all(&survivor_root).expect("create survivor checkout");
+    fs::create_dir_all(&deleted_root).expect("create deleted checkout");
+
+    write_registered_workspace(&global_root, "ws_survivor", "survivor");
+    write_registered_shared_root_checkout(&global_root, "ws_survivor", &survivor_root);
+    bind_task_partition_at(
+        &global_root,
+        "ws_survivor",
+        "survivor",
+        &survivor_root,
+        &global_root,
+    );
+    write_task_bundle(&global_root, "ws_survivor", "ORB-1");
+
+    write_registered_workspace(&global_root, "ws_shared_deleted", "shared-deleted");
+    write_registered_shared_root_checkout(&global_root, "ws_shared_deleted", &deleted_root);
+    register_task_workspace(&global_root, "ws_shared_deleted", "shared-deleted");
+    write_task_bundle(&global_root, "ws_shared_deleted", "ORB-5");
+    fs::remove_dir_all(&deleted_root).expect("delete checkout");
+
+    let results = runtime.doctor_workspace().expect("doctor before remove");
+    let row = status_of(&results, "orphan-task-stores");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Warning, "{row:?}");
+    assert!(row.message.contains("ws_shared_deleted"), "{}", row.message);
+    assert!(
+        row.message.contains("missing checkout directories"),
+        "{}",
+        row.message
+    );
+
+    let registry_path = workspace_registry::registry_path_for(&global_root);
+    let mut registry =
+        workspace_registry::load_registry_from(&registry_path).expect("load catalog");
+    let checkout = registry
+        .checkouts
+        .iter()
+        .find(|checkout| checkout.workspace_id == "ws_shared_deleted")
+        .cloned()
+        .expect("catalog checkout");
+    let leftover = retain_task_store_on_catalog_remove(
+        &global_root,
+        "ws_shared_deleted",
+        "shared-deleted",
+        Some(&checkout),
+    )
+    .expect("retain leftover");
+    assert_eq!(leftover.expect("leftover partition").task_bundles, 1);
+    workspace_registry::remove_workspace(&mut registry, "ws_shared_deleted")
+        .expect("drop catalog workspace");
+    workspace_registry::save_registry_to(&registry, &registry_path).expect("save catalog");
+
+    let results = runtime.doctor_workspace().expect("doctor after remove");
+    let row = status_of(&results, "orphan-task-stores");
+    assert_eq!(
+        row.status,
+        WorkspaceDoctorStatus::Warning,
+        "catalog removal must not re-hide the partition as claimed: {row:?}"
+    );
+    assert!(row.message.contains("ws_shared_deleted"), "{}", row.message);
+    assert!(
+        row.message.contains("missing checkout directories"),
+        "{}",
+        row.message
+    );
+
+    let removed = runtime
+        .remove_orphan_task_stores()
+        .expect("remove stale shared-root partition after catalog drop");
+    assert_eq!(removed.populated_partitions, 1, "{removed:?}");
+    assert_eq!(removed.task_bundles, 1, "{removed:?}");
+    assert!(
+        !task_workspaces_dir(&global_root)
+            .join("ws_shared_deleted")
+            .exists()
+    );
+    assert!(
+        task_workspaces_dir(&global_root)
+            .join("ws_survivor")
+            .join("ORB-1")
+            .is_dir(),
+        "the live shared-root checkout's bundles must survive"
+    );
+    assert!(!partition_is_bound(&global_root, "ws_shared_deleted").expect("read binding"));
+    assert!(partition_is_bound(&global_root, "ws_survivor").expect("read survivor binding"));
+}
+
+/// [ORB-12223] Repo-local layout: dropping the catalog entry after a deleted
+/// checkout must not hide the already-bound stale partition.
+#[test]
+fn catalog_remove_keeps_a_deleted_repo_local_partition_stale_and_reclaimable() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let global_root = temp.path().join("global");
+    let deleted_root = temp.path().join("deleted");
+    fs::create_dir_all(deleted_root.join(".orbit")).expect("create deleted checkout");
+
+    write_registered_workspace(&global_root, "ws_deleted", "deleted");
+    write_registered_checkout(&global_root, "ws_deleted", &deleted_root);
+    bind_task_partition(&global_root, "ws_deleted", "deleted", &deleted_root);
+    write_task_bundle(&global_root, "ws_deleted", "ORB-3");
+    fs::remove_dir_all(&deleted_root).expect("delete checkout");
+
+    let results = runtime.doctor_workspace().expect("doctor before remove");
+    let row = status_of(&results, "orphan-task-stores");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Warning, "{row:?}");
+
+    let registry_path = workspace_registry::registry_path_for(&global_root);
+    let mut registry =
+        workspace_registry::load_registry_from(&registry_path).expect("load catalog");
+    let checkout = registry
+        .checkouts
+        .iter()
+        .find(|checkout| checkout.workspace_id == "ws_deleted")
+        .cloned()
+        .expect("catalog checkout");
+    retain_task_store_on_catalog_remove(&global_root, "ws_deleted", "deleted", Some(&checkout))
+        .expect("retain leftover");
+    workspace_registry::remove_workspace(&mut registry, "ws_deleted").expect("drop catalog");
+    workspace_registry::save_registry_to(&registry, &registry_path).expect("save catalog");
+
+    let results = runtime.doctor_workspace().expect("doctor after remove");
+    let row = status_of(&results, "orphan-task-stores");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Warning, "{row:?}");
+    assert!(row.message.contains("ws_deleted"), "{}", row.message);
+    assert!(
+        row.message.contains("missing checkout directories"),
+        "{}",
+        row.message
+    );
+
+    let removed = runtime
+        .remove_orphan_task_stores()
+        .expect("remove stale repo-local partition after catalog drop");
+    assert_eq!(removed.populated_partitions, 1, "{removed:?}");
+    assert_eq!(removed.task_bundles, 1, "{removed:?}");
+    assert!(
+        !task_workspaces_dir(&global_root)
+            .join("ws_deleted")
+            .exists()
+    );
+    assert!(!partition_is_bound(&global_root, "ws_deleted").expect("read binding"));
 }
 
 /// A catalog checkout that cannot be stat-ed is not evidence of deletion. Its

--- a/crates/orbit-cmd/src/tests/task_store.rs
+++ b/crates/orbit-cmd/src/tests/task_store.rs
@@ -4,14 +4,18 @@
 use std::fs;
 use std::path::Path;
 
+use chrono::Utc;
+use orbit_registry::workspace_registry;
 use orbit_store::maintenance::task_registry::{
     BindWorkspaceParams, RegisterWorkspaceParams, TaskRegistryStore, task_registry_path,
     task_workspaces_dir,
 };
+use orbit_types::workspace::{Workspace, WorkspaceCheckout, WorkspaceStatus};
 
 use crate::task_store::{
     bound_partition_id, inspect_task_store_partitions, partition_is_bound,
-    remove_checkout_task_stores, remove_unclaimed_task_stores, task_store_partition_path,
+    remove_checkout_task_stores, remove_unclaimed_task_stores, retain_task_store_on_catalog_remove,
+    task_store_partition_path,
 };
 
 fn bind(global_root: &Path, workspace_id: &str, slug: &str, repo_root: &Path) {
@@ -249,6 +253,150 @@ fn registered_checkoutless_workspace_claims_its_partition() {
         partition_is_bound(&global_root, "ws_mirror").expect("read bindings"),
         "the logical workspace registration must survive"
     );
+}
+
+fn write_catalog_workspace(global_root: &Path, workspace_id: &str, name: &str) {
+    let registry_path = workspace_registry::registry_path_for(global_root);
+    let mut registry =
+        workspace_registry::load_registry_from(&registry_path).expect("load catalog");
+    let now = Utc::now();
+    workspace_registry::register_workspace(
+        &mut registry,
+        Workspace {
+            id: workspace_id.to_string(),
+            name: name.to_string(),
+            owner_machine_id: None,
+            git_remote: None,
+            ship_mode: None,
+            base_branch: "main".to_string(),
+            status: WorkspaceStatus::Active,
+            created_at: now,
+            updated_at: now,
+        },
+    )
+    .expect("register catalog workspace");
+    workspace_registry::save_registry_to(&registry, &registry_path).expect("save catalog");
+}
+
+fn write_catalog_shared_root_checkout(global_root: &Path, workspace_id: &str, repo_root: &Path) {
+    let registry_path = workspace_registry::registry_path_for(global_root);
+    let mut registry =
+        workspace_registry::load_registry_from(&registry_path).expect("load catalog");
+    workspace_registry::register_checkout(
+        &mut registry,
+        WorkspaceCheckout::owner(
+            workspace_id.to_string(),
+            repo_root.to_path_buf(),
+            global_root.to_path_buf(),
+        ),
+    )
+    .expect("register shared-root catalog checkout");
+    workspace_registry::save_registry_to(&registry, &registry_path).expect("save catalog");
+}
+
+fn drop_catalog_workspace(global_root: &Path, workspace_id: &str) {
+    let registry_path = workspace_registry::registry_path_for(global_root);
+    let mut registry =
+        workspace_registry::load_registry_from(&registry_path).expect("load catalog");
+    workspace_registry::remove_workspace(&mut registry, workspace_id).expect("drop catalog");
+    workspace_registry::save_registry_to(&registry, &registry_path).expect("save catalog");
+}
+
+/// [ORB-12223] Dropping the catalog without copying checkout evidence lets a
+/// path-free task-registry binding re-claim the leftover. Retaining evidence
+/// first keeps it stale so the repair can reclaim it, even when a survivor
+/// already occupies the shared `orbit_dir`.
+#[test]
+fn retaining_checkout_evidence_keeps_a_shared_root_leftover_stale() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let survivor = temp.path().join("survivor");
+    let deleted = temp.path().join("deleted");
+    fs::create_dir_all(&global_root).expect("create global root");
+    fs::create_dir_all(&survivor).expect("create survivor checkout");
+    fs::create_dir_all(&deleted).expect("create deleted checkout");
+
+    bind_at(
+        &global_root,
+        "ws_survivor",
+        "survivor",
+        &survivor,
+        &global_root,
+    );
+    write_task_bundle(&global_root, "ws_survivor", "ORB-1");
+
+    register_logical_workspace(&global_root, "ws_deleted", "deleted");
+    write_catalog_workspace(&global_root, "ws_deleted", "deleted");
+    write_catalog_shared_root_checkout(&global_root, "ws_deleted", &deleted);
+    write_task_bundle(&global_root, "ws_deleted", "ORB-2");
+    fs::remove_dir_all(&deleted).expect("delete checkout");
+
+    let partitions = inspect_task_store_partitions(&global_root)
+        .expect("inspect before catalog drop")
+        .expect("partitions directory exists");
+    assert_eq!(
+        partitions
+            .stale
+            .iter()
+            .map(|partition| partition.path.clone())
+            .collect::<Vec<_>>(),
+        vec![task_store_partition_path(&global_root, "ws_deleted")]
+    );
+
+    let checkout = WorkspaceCheckout::owner(
+        "ws_deleted".to_string(),
+        deleted.clone(),
+        global_root.clone(),
+    );
+    let leftover =
+        retain_task_store_on_catalog_remove(&global_root, "ws_deleted", "deleted", Some(&checkout))
+            .expect("retain leftover");
+    assert_eq!(leftover.expect("leftover partition").task_bundles, 1);
+    drop_catalog_workspace(&global_root, "ws_deleted");
+
+    let partitions = inspect_task_store_partitions(&global_root)
+        .expect("inspect after catalog drop")
+        .expect("partitions directory exists");
+    assert_eq!(
+        partitions
+            .stale
+            .iter()
+            .map(|partition| partition.path.clone())
+            .collect::<Vec<_>>(),
+        vec![task_store_partition_path(&global_root, "ws_deleted")],
+        "catalog removal must not re-claim the leftover: {partitions:?}"
+    );
+    assert!(partitions.unowned.is_empty(), "{partitions:?}");
+
+    let removed = remove_unclaimed_task_stores(&global_root).expect("run the repair");
+    assert_eq!(removed.task_bundles_removed(), 1, "{removed:?}");
+    assert!(
+        !task_workspaces_dir(&global_root)
+            .join("ws_deleted")
+            .exists()
+    );
+    assert!(
+        task_workspaces_dir(&global_root)
+            .join("ws_survivor")
+            .join("ORB-1")
+            .is_dir()
+    );
+    assert!(partition_is_bound(&global_root, "ws_survivor").expect("read survivor binding"));
+}
+
+fn bind_at(global_root: &Path, workspace_id: &str, slug: &str, repo_root: &Path, orbit_dir: &Path) {
+    let tasks =
+        TaskRegistryStore::open(&task_registry_path(global_root)).expect("open task registry");
+    tasks
+        .bind_workspace(BindWorkspaceParams {
+            workspace_id: Some(workspace_id.to_string()),
+            slug: slug.to_string(),
+            repo_root: repo_root.to_path_buf(),
+            workspace_path: repo_root.to_path_buf(),
+            orbit_dir: orbit_dir.to_path_buf(),
+            repo_fingerprint: None,
+        })
+        .expect("bind task-registry workspace");
 }
 
 /// Residue with no task bundles carries nothing `orbit task reindex` could

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -4,8 +4,8 @@ summary: Check Orbit workspace, database, dashboard, log-sink, job-run, and rout
 tags: [operations, health, doctor, dashboard, routines]
 paths: ["crates/orbit-cmd/src/doctor.rs", "crates/orbit-core/src/application/job/run/reconcile.rs"]
 related_features: [orbit-core, activity-job, routines]
-related_artifacts: [ORB-10005, ORB-10070, ORB-10473, ORB-10501, ORB-10558, ORB-10986, ORB-11791, ORB-12109]
-last_validated: 2026-09-11
+related_artifacts: [ORB-10005, ORB-10070, ORB-10473, ORB-10501, ORB-10558, ORB-10986, ORB-11791, ORB-12109, ORB-12223]
+last_validated: 2026-09-12
 ---
 
 # Check Orbit Health
@@ -145,20 +145,29 @@ readable becomes a confirmed-stale binding, which the repair can then remove.
 
 For a partition whose binding is confirmed stale, the missing `repo_root` is the evidence that the
 checkout is gone. The confirmed repair removes that partition, including its task bundles, and
-retires the stale registry rows — as it does for every empty unclaimed partition. If the deleted
-checkout is still listed in the workspace catalog, first deregister it with its name, `ws_*` id, or
-recorded absolute checkout path:
+retires the stale registry rows — as it does for every empty unclaimed partition.
+
+**Recovery ordering for a deleted checkout.** Doctor can already classify the partition as stale
+while the workspace is still in the catalog (the catalog checkout's `repo_root` is the evidence).
+You may then either run the repair immediately, or first deregister the dead workspace:
 
 ```sh
 ORBIT_OPERATOR=1 orbit workspace remove <workspace-name-or-id-or-absolute-checkout-path>
 ```
 
-That command changes only the catalog; it does not delete `.orbit` or task bundles. The subsequent
-doctor repair removes the now-confirmed stale task-store partition:
+`workspace remove` changes only the catalog; it does not delete `.orbit` or task bundles. It
+**retains** the task-registry workspace binding and copies the catalog checkout into that
+registry so the leftover partition stays stale rather than flipping back to a claimed imported
+archive. A populated leftover is reported with its path, bundle count, and the reclaim command
+below. After removal, `orbit doctor` still warns on that partition; it must not report `ok`.
 
 ```sh
 orbit doctor --fix-orphan-task-stores --confirm
 ```
+
+Either order works: repair while the catalog still lists the checkout, or `workspace remove`
+then the same repair. Skipping the repair after `workspace remove` leaves the bundles on disk
+and unreachable through workspace selectors.
 
 Do not use that repair for an unknown or unreachable populated partition; reindex or restore it
 first. One residual limitation: a volume unmounted from a mountpoint that is itself still present


### PR DESCRIPTION
## Task

[ORB-12223](https://orbit-cli.com/tasks/ORB-12223) — [qa-sweep] `orbit workspace remove` re-hides the orphan task partition ORB-12170 just made visible: doctor flips back to `ok`, the confirmed repair reclaims nothing, and the task bundles are stranded

### Description

## Summary

ORB-12170 (`15246cd9a`) made `doctor`'s `orphan-task-stores` row correctly flag
a deleted checkout's task partition in the shared external-root layout, and
ORB-12169 (`e949ba6a4`) made `ORBIT_OPERATOR=1 orbit workspace remove <id>`
deregister that workspace. Running them in the order the doctor remediation and
the health-check runbook imply undoes the first fix: after `workspace remove`,
the same partition flips back to **claimed / ok**, the confirmed repair reclaims
nothing, and its task bundles become unreachable through every selector with no
diagnostic pointing at them.

`workspace remove` drops the catalog workspace and checkout rows, but leaves the
task-registry workspace binding — which is what `partition_claims`
(`crates/orbit-cmd/src/task_store.rs`) treats as the claim. So removing the
catalog entry removes the *evidence of staleness* while preserving the *claim*.

## Reproduction (orbit 0.21.0 built from `79aad9db4`, Linux 6.8)

Scratch Orbit root and checkouts under `/tmp`; the real `~/.orbit` is untouched.

```sh
orbit --root /tmp/qa/root init --non-interactive --host-name qa --task-prefix QA
cd /tmp/qa/scratchrepo && orbit --root /tmp/qa/root workspace init     # ws_scratchrepo
cd /tmp/qa/repo2      && orbit --root /tmp/qa/root workspace init      # ws_repo2
# ... create 3 tasks in ws_repo2 ...

rm -rf /tmp/qa/repo2                        # checkout deleted without teardown

cd /tmp/qa/scratchrepo && orbit --root /tmp/qa/root doctor
# orphan-task-stores  warning  1 stale task-store partition(s) point at missing
#   checkout directories: ws_repo2 (/tmp/qa/root/tasks/workspaces/ws_repo2,
#   3 task bundle(s))
#   Action: Run `orbit doctor --fix-orphan-task-stores --confirm`. Populated
#   stale partitions are deleted along with their task bundles.
#                                            <- ORB-12170 working as intended

ORBIT_OPERATOR=1 orbit --root /tmp/qa/root workspace remove ws_repo2
# workspace 'repo2' removed from registry     <- no mention of the 3 bundles

orbit --root /tmp/qa/root doctor
# orphan-task-stores  ok  2 task-store partition(s) scanned, all claimed by a
#                         workspace binding   <- regressed to "claimed"

orbit --root /tmp/qa/root doctor --fix-orphan-task-stores --confirm
# Removed 0 empty orphaned task-store partition(s) and 0 populated
# partition(s) (0 task bundle(s)).

ls /tmp/qa/root/tasks/workspaces/ws_repo2/
# QA-00058  QA-00059  QA-00069  (+ .bundle.lock files)  -- still on disk
```

The bundles are unreachable through every surface:

```sh
orbit --root /tmp/qa/root task list --workspace repo2
#   error: invalid input: unknown workspace selector 'repo2'; ...
orbit --root /tmp/qa/root task list --workspace ws_repo2
#   error: invalid input: unknown workspace selector 'ws_repo2'; ...
orbit --root /tmp/qa/root task show QA-00058
#   error: workspace error: task QA-00058 is owned by workspace 'repo2'
#   (ws_repo2), which has no readable local checkout on this machine; restore
#   or re-register that checkout
orbit --root /tmp/qa/root search "tool cross valid"
#   no results matching the query
```

`task show` still resolves the owning workspace *name*, confirming the
task-registry binding survived the catalog removal — that surviving row is what
`doctor` counts as the claim.

## Impact

Production impact: data is silently stranded on the operator's own recovery
path. The remediation `doctor` prints for a deleted checkout is
`--fix-orphan-task-stores --confirm`; an operator who instead reaches for
`workspace remove` first — the command ORB-12169 added for exactly this state,
and the natural reading of "deregister the dead workspace" — permanently loses
the only diagnostic that would have found those bundles. `doctor` then reports a
clean bill of health while the partition stays on disk forever. No warning is
emitted at removal time.

Not a duplicate of ORB-12170 (shared-root partitions claimed forever because
`workspace init` wrote no checkout binding; fixed and verified working here
before the removal) or ORB-12169 (`workspace remove` refusing a deleted
checkout; fixed and verified working here). This is the interaction of the two
fixes.

Not a duplicate of ORB-12216 either: that task covers the "unknown workspace
selector" wording for a registered-but-`invalid` workspace. Here the workspace
is genuinely gone from the catalog, so the selector message is correct; the
defect is the invisible, unreclaimable partition it leaves behind.

## Suggested direction

Decide who owns the task partition when a workspace is deregistered, and make
`workspace remove` state its decision. Either drop the task-registry workspace
binding with the catalog rows so the partition becomes genuinely orphaned and
the existing confirmed repair can reclaim it, or keep the binding and have
`workspace remove` report the partition path and bundle count it is leaving
behind plus the command that reclaims it. Whichever is chosen, `doctor` must not
report `ok` for a populated partition whose workspace no longer exists in the
catalog, and `docs/runbooks/health-checks.md` must describe the removal ordering
it assumes.

### Acceptance Criteria

- After a workspace is deregistered with `orbit workspace remove`, `orbit doctor` never reports its populated task-store partition as `ok`/claimed.
- A populated partition left behind by `workspace remove` is either reclaimable by `orbit doctor --fix-orphan-task-stores --confirm` or reported by `workspace remove` itself with its path, bundle count, and the command that reclaims it.
- The disposition of the task-registry workspace binding on removal is explicit and consistent with whichever option is chosen.
- Regression tests cover the full ordering in the shared external-root layout: deleted checkout -> doctor warns -> workspace remove -> doctor still reports the partition -> repair reclaims it, without regressing the repo-local layout or ORB-12170's detection.
- `docs/runbooks/health-checks.md` describes the recovery ordering it assumes for a deleted checkout.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `workspace remove` now copies the catalog checkout into the task registry before dropping catalog rows (`retain_task_store_on_catalog_remove` in `crates/orbit-cmd/src/task_store.rs`). The task-registry workspace binding is retained as checkout evidence so `partition_claims` can still classify a leftover partition. Shared-root `orbit_dir` collisions store that evidence under the per-checkout `repo_root` instead of stealing a survivor's binding.
- Populated leftovers are reported with path, bundle count, binding disposition, and `orbit doctor --fix-orphan-task-stores --confirm`.
- `docs/runbooks/health-checks.md` documents recovery ordering: deleted checkout → doctor warns (catalog still listed is enough) → optional `workspace remove` (does not hide the partition) → doctor still reports stale → confirmed repair reclaims.
Assessment: The chosen policy is retain-the-binding rather than unbind, because dropping the binding would make a populated leftover `unowned` and `--fix-orphan-task-stores` refuses those [ORB-12131]. Tests cover the shared-root path-free production shape (including a survivor occupying the shared `orbit_dir`) and the repo-local layout.

Criteria:
1. After `workspace remove`, doctor never reports the populated leftover as ok/claimed — passed. Shared-root and repo-local tests assert Warning + "missing checkout directories" after catalog drop; CLI test does the same through `WorkspaceRemoveArgs`.
2. Populated leftover is reclaimable by `--fix-orphan-task-stores --confirm` and reported by `workspace remove` with path, bundle count, and the reclaim command — passed. Repair counts and leftover println observed in the CLI test.
3. Task-registry binding disposition is explicit and consistent — passed. Binding is retained as checkout evidence; remove states that in stdout; runbook states it.
4. Regression tests cover deleted checkout → doctor warns → workspace remove → doctor still reports → repair reclaims, without regressing repo-local or ORB-12170 — passed. New tests plus existing `deleted_shared_root_catalog_checkout_partition_is_reported_and_removed` and `deleted_catalog_checkout_partition_is_reported_and_removed`.
5. `docs/runbooks/health-checks.md` describes the recovery ordering — passed.

Validation:
- `cargo test -p orbit-cmd --lib tests::doctor` — passed (38 tests, including the two new catalog-remove tests and ORB-12170 coverage)
- `cargo test -p orbit-cmd --lib tests::task_store` — passed (11 tests, including `retaining_checkout_evidence_keeps_a_shared_root_leftover_stale`)
- `cargo test -p orbit-cli --bin orbit shared_root_remove_keeps_a_deleted_checkout_partition_reclaimable` — passed (prints leftover path, 2 bundles, reclaim command; doctor stays Warning; repair reclaims)
- `cargo test -p orbit-cli --bin orbit remove_accepts_the_recorded_path_of_a_deleted_checkout` — passed
- `cargo clippy -p orbit-cmd -p orbit-cli --all-targets -- -D warnings` — passed
- `make ci-fast` — passed
- `make ci-lint` — passed
- `git diff --check` — passed

Remaining risks: `workspace remove` of a checkoutless imported archive (no catalog checkout) still leaves a path-free task-registry claim; that is not the deleted-checkout path this task covers. A leftover whose checkout is still present is classified live via the retained checkout binding rather than stale.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12223-6aa4a7c8`
- Behind base: 0
- Ahead of base: 1