### PR TITLE
[friction-curation] Count worktree status from untrimmed porcelain output

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/commit/git_ops.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/git_ops.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use orbit_common::OrbitError;
 use orbit_exec::{EnvironmentMode, NoSandbox, run_process};
 
-use super::super::git::{git_output, git_output_paths, git_request, git_success};
+use super::super::git::{git_output, git_output_paths, git_output_raw, git_request, git_success};
 use super::author::GitAuthor;
 
 pub(super) fn git_commit_with_identity(
@@ -137,8 +137,11 @@ pub(super) fn ensure_named_branch(workspace_path: &Path) -> Result<(), OrbitErro
     Ok(())
 }
 
+/// Uses [`git_output_raw`] rather than [`git_output`]: the latter trims the
+/// whole output, which would misalign the index/worktree columns of a
+/// single-line result by one byte (see `git_output`'s doc comment).
 pub(super) fn ensure_no_unmerged_changes(workspace_path: &Path) -> Result<(), OrbitError> {
-    let status = git_output(workspace_path, &["status", "--porcelain"])?;
+    let status = git_output_raw(workspace_path, &["status", "--porcelain"])?;
     for line in status.lines() {
         if line.len() < 2 {
             continue;

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
@@ -16,7 +16,7 @@ use crate::context::RuntimeHost;
 
 use super::super::input::{canonicalize_existing_dir, input_string_field, required_job_run_id};
 use super::failure::commit_head_matches_failure_handoff;
-use super::git::{git_output, git_success};
+use super::git::{git_output, git_output_raw, git_success};
 use super::handoff::reject_failed_delivery;
 use author::{append_co_author_trailers, commit_author_for_tasks, reviewer_author};
 use git_ops::{
@@ -496,8 +496,12 @@ struct WorktreeStatusCounts {
     untracked: usize,
 }
 
+/// Uses [`git_output_raw`] rather than [`git_output`]: the latter trims the
+/// whole output, which would eat the leading status column of a single-line
+/// result (` M path` -> `M path`) and misalign the index/worktree columns by
+/// one byte (see `git_output`'s doc comment).
 fn worktree_status_counts(workspace_path: &Path) -> Result<WorktreeStatusCounts, OrbitError> {
-    let status = git_output(
+    let status = git_output_raw(
         workspace_path,
         &["status", "--porcelain=v1", "--untracked-files=all"],
     )?;

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/mod.rs
@@ -10,3 +10,41 @@ mod message;
 mod scope;
 mod summary;
 pub(in crate::executor::automation::vcs::commit) mod test_support;
+
+use std::fs;
+
+use super::super::git::git_success;
+use super::worktree_status_counts;
+
+/// ORB-12225: with exactly one dirty entry, `git status --porcelain`'s single
+/// line is ` M README.md`. Reading it through `git_output` (rather than
+/// `git_output_raw`) trims the leading space, shifting the index/worktree
+/// columns by one byte and misclassifying the unstaged entry as staged.
+#[test]
+fn worktree_status_counts_single_unstaged_modification() {
+    let temp = test_support::initialized_git_repo();
+    let repo = temp.path();
+    fs::write(repo.join("README.md"), "changed\n").expect("modify tracked file");
+
+    let counts = worktree_status_counts(repo).expect("read worktree status");
+
+    assert_eq!(counts.staged, 0);
+    assert_eq!(counts.unstaged, 1);
+    assert_eq!(counts.untracked, 0);
+}
+
+#[test]
+fn worktree_status_counts_multi_entry_mix() {
+    let temp = test_support::initialized_git_repo();
+    let repo = temp.path();
+    fs::write(repo.join("README.md"), "changed\n").expect("modify tracked file");
+    fs::write(repo.join("staged.txt"), "staged\n").expect("write staged file");
+    git_success(repo, &["add", "staged.txt"]).expect("stage new file");
+    fs::write(repo.join("untracked.txt"), "untracked\n").expect("write untracked file");
+
+    let counts = worktree_status_counts(repo).expect("read worktree status");
+
+    assert_eq!(counts.staged, 1);
+    assert_eq!(counts.unstaged, 1);
+    assert_eq!(counts.untracked, 1);
+}

--- a/crates/orbit-engine/src/executor/automation/vcs/git.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/git.rs
@@ -279,6 +279,15 @@ pub(crate) fn git_output_paths(
         .collect())
 }
 
+/// Runs Git and trims the *entire* stdout string as one unit.
+///
+/// Safe for single-value output (`rev-parse`, `remote get-url`,
+/// `symbolic-ref`, and the like). Do not use this for `git status
+/// --porcelain` or any other fixed-width, column-oriented format: trimming
+/// the whole string eats the leading status column whenever the result is a
+/// single line (` M path` becomes `M path`), misaligning every column-offset
+/// read by one byte. Column-offset porcelain readers must use
+/// [`git_output_raw`] instead, which preserves each line's leading bytes.
 pub(crate) fn git_output(current_dir: &Path, args: &[&str]) -> Result<String, OrbitError> {
     Ok(git_output_raw(current_dir, args)?.trim().to_string())
 }

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/merge.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/merge.rs
@@ -8,8 +8,8 @@ use crate::executor::automation::input::{canonicalize_existing_dir, input_string
 
 use super::super::git::{
     BaseSyncMode, GitTimeoutBudget, GitTimeoutBudgetGuard, base_sync_mode_from_input,
-    git_command_success, git_failure_error, git_output, git_run, git_success, git_timeout_error,
-    resolve_worktree_start_point,
+    git_command_success, git_failure_error, git_output, git_output_raw, git_run, git_success,
+    git_timeout_error, resolve_worktree_start_point,
 };
 use super::super::handoff::rebase_in_progress;
 use super::resolve_shared_worktree_path;
@@ -261,8 +261,11 @@ fn parse_divergence_count(
     })
 }
 
+/// Uses [`git_output_raw`] rather than [`git_output`]: the latter trims the
+/// whole output, which would misalign the index/worktree columns of a
+/// single-line result by one byte (see `git_output`'s doc comment).
 pub(super) fn ensure_clean_checkout(path: &Path, label: &str) -> Result<(), OrbitError> {
-    let status = git_output(path, &["status", "--porcelain"])?;
+    let status = git_output_raw(path, &["status", "--porcelain"])?;
     if status.trim().is_empty() {
         return Ok(());
     }


### PR DESCRIPTION
## Task

[ORB-12225](https://orbit-cli.com/tasks/ORB-12225) — [friction-curation] Count worktree status from untrimmed porcelain output

### Description

## Problem

`git_output` (`crates/orbit-engine/src/executor/automation/vcs/git.rs:282-284`) trims the *whole* stdout string before returning it. For `git status --porcelain`, whose records are `XY<space>path`, that eats the leading status column whenever the result is a single line: ` M src/lib.rs\n` comes back as `M src/lib.rs`.

`worktree_status_counts` (`crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs:499-521`) reads that trimmed string and takes the first two characters of each line as the index and worktree state. With exactly one dirty entry whose index column is a space, the entry is counted as staged and never as unstaged — the two columns are shifted by one byte. With two or more entries the bug is invisible, because only the first line loses leading whitespace.

The same trap was already fixed once, in `dirty_worktree_paths` (`crates/orbit-engine/src/executor/automation/vcs/freshness.rs:328-343`, ORB-12032), which switched to `git_output_raw` and documents exactly this reason. `worktree_status_counts` is the remaining `git_output` + column-offset reader; the `-z` readers (`review_gate::uncommitted_paths`, `commit::summary::parse_status_entries`) already use `git_output_raw` and split on NUL, so they are unaffected.

## Why It Matters

`worktree_status_counts` feeds `empty_stage_error` (`commit/mod.rs:455-475`), the diagnostic a delivery run prints when there is nothing to commit: `Observed after 'git add --all': N staged, M unstaged, K untracked file(s)`. A misclassified single entry sends whoever reads that message toward the wrong explanation of why the commit step refused.

## Reproduction

In a repo with exactly one unstaged modification, `git status --porcelain` emits ` M src/lib.rs`. Through `git_output` the leading space is gone, so `index_state` is `M` (counted staged) and `worktree_state` is a space (not counted unstaged); the correct reading is zero staged and one unstaged.

## Constraints / Notes

- Do not change `git_output`'s own trimming contract: many callers read single-value output (`rev-parse`, `remote get-url`, `symbolic-ref`) and depend on it. Fix the porcelain reader and make the hazard explicit where `git_output` is defined, the way `freshness.rs` already does at its call site.
- Keep the counts' meaning unchanged for multi-entry output; this is an alignment fix, not a semantics change.

### Acceptance Criteria

- A unit test drives `worktree_status_counts` (or the `empty_stage_error` message it feeds) against a worktree whose `git status --porcelain` output is exactly one unstaged modification, and asserts 0 staged / 1 unstaged; the test fails against the current trimmed-read implementation.
- A multi-entry case (staged, unstaged, and untracked together) keeps its existing counts, demonstrated by a test.
- `git_output`'s doc comment names the whole-string trim and points column-offset porcelain readers at `git_output_raw`, and no remaining caller in `crates/orbit-engine/src/executor/automation/vcs/` parses fixed-width porcelain columns out of `git_output`.
- `make ci-fast` and `make ci-lint` pass, and `cargo test -p orbit-engine --lib` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed the porcelain column-shift hazard and eliminated every remaining fixed-width-column reader of `git_output` in `crates/orbit-engine/src/executor/automation/vcs/`.

Criterion 1 (single-entry test fails against old code): `worktree_status_counts_single_unstaged_modification` in `commit/tests/mod.rs` creates a repo with exactly one unstaged modification and asserts `staged==0, unstaged==1, untracked==0`. Verified directly: temporarily reverted `worktree_status_counts` to call `git_output` instead of `git_output_raw` and reran this test — it failed with `staged=1` (left) vs expected `0` (right), confirming it detects the original fault. Restored the fix afterward; `git diff` matches the intended change set.

Criterion 2 (multi-entry case unchanged): `worktree_status_counts_multi_entry_mix` covers one staged, one unstaged, one untracked file together and asserts `staged==1, unstaged==1, untracked==1` — the pre-existing counting semantics.

Criterion 3 (doc comment + no remaining column-offset callers): Added a doc comment to `git_output` in `git.rs` naming the whole-string trim hazard and pointing to `git_output_raw`. Grepped the whole `vcs/` directory for `--porcelain` usage and found two more column-offset readers beyond `worktree_status_counts` that had the identical latent hazard (harmless today only because merge-conflict codes like `UU`/`AA`/`DD` never start with a space, but structurally the same bug class): `commit/git_ops.rs::ensure_no_unmerged_changes` and `worktree/merge.rs::ensure_clean_checkout`, both indexing `bytes[0]`/`bytes[1]` of `git_output`'s result. Switched both to `git_output_raw` and documented why, matching `worktree_status_counts` and the existing `freshness.rs::dirty_worktree_paths` precedent (ORB-12032). Confirmed no other `--porcelain` caller in the directory does fixed-width parsing (`worktree/mod.rs` and `worktree/merge.rs`'s `worktree list --porcelain` readers use `strip_prefix` on whole key-value lines, not column offsets; `worktree/setup.rs`, `commit/already_landed.rs`, `worktree/gc.rs` only check emptiness). Appended `commit/git_ops.rs` and `worktree/merge.rs` to `context_files` via `orbit.task.update` with a comment explaining why, since they were needed to satisfy criterion 3 but weren't in the original scope.

Criterion 4 (validation commands):
- `cargo test -p orbit-engine --lib` — passed, 688 passed / 0 failed / 3 ignored.
- `make ci-fast` — passed (after one `rustfmt` import-order fix).
- `make ci-lint` — passed (workspace clippy, warnings denied, clean build).
- `git diff --check` — clean, no whitespace errors.
- `git status --short` — only the five intended tracked-file modifications; no untracked files, no stray build artifacts in the worktree.

No deviations or open risks. Left all changes uncommitted for the pipeline to commit/PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12225-6aa4aae4`
- Behind base: 0
- Ahead of base: 1