### PR TITLE
[friction-curation] Flag an over-attached task-pilot context proposal instead of applying it silently

### DIFF
--- a/.orbit/resources/activities/task_pilot.yaml
+++ b/.orbit/resources/activities/task_pilot.yaml
@@ -181,6 +181,15 @@ spec:
        `workspace_path` at `source_revision` when that field is set; omit
        read-for-context files and working-tree-only or later-commit paths.
        Preserve the exact current list as `context_files_before`.
+       Derive the modification targets from evidence, never by sweeping a
+       directory or a crate. For a removal or a rename, the targets are the
+       files that actually reference the symbol — enumerate them
+       (`rg -l '<symbol>'` at `source_revision`) and propose those — not every
+       module in the crate that owns it. Deterministic apply attaches an
+       over-attachment finding when a proposal exceeds the selector budget for
+       its recommended complexity, and still applies the list: a genuinely
+       wide repair stays proposable, while a swept one is visible to the
+       orchestrator.
     4. If the task genuinely requires no repository diff, return an empty
        `context_files_after`, disposition `verified_no_diff`, and concrete
        `evidence`. For host-operational work use `host_operational` with
@@ -232,6 +241,14 @@ spec:
        through selectors and validation approach. Missing validation authority
        belongs in `utility_warnings` as a readiness blocker. Complexity,
        urgency, and readiness are separate decisions.
+       This lane is a read-only preflight and never builds, tests, or runs a
+       validation command; `proc.spawn` is CLI-only, so an MCP-transport
+       session does not advertise it at all. That absence of `proc.spawn` is
+       structural to the pilot lane and is not by itself an evidence gap: do
+       not return `unassessed` merely because you could not execute a build or
+       a test here. Name the check that would establish the repair in
+       `validation_approach` instead, and reserve `unassessed` for evidence
+       the pilot could have read at `source_revision` but did not find.
     7. Report recommendations only; do not apply them:
        `recommended_crew`, `recommended_complexity`, real `blocked_by` task IDs,
        `duplicate_of`, `already_landed`, `release_action_required`,

--- a/crates/orbit-core/assets/activities/task_pilot.yaml
+++ b/crates/orbit-core/assets/activities/task_pilot.yaml
@@ -181,6 +181,15 @@ spec:
        `workspace_path` at `source_revision` when that field is set; omit
        read-for-context files and working-tree-only or later-commit paths.
        Preserve the exact current list as `context_files_before`.
+       Derive the modification targets from evidence, never by sweeping a
+       directory or a crate. For a removal or a rename, the targets are the
+       files that actually reference the symbol — enumerate them
+       (`rg -l '<symbol>'` at `source_revision`) and propose those — not every
+       module in the crate that owns it. Deterministic apply attaches an
+       over-attachment finding when a proposal exceeds the selector budget for
+       its recommended complexity, and still applies the list: a genuinely
+       wide repair stays proposable, while a swept one is visible to the
+       orchestrator.
     4. If the task genuinely requires no repository diff, return an empty
        `context_files_after`, disposition `verified_no_diff`, and concrete
        `evidence`. For host-operational work use `host_operational` with
@@ -232,6 +241,14 @@ spec:
        through selectors and validation approach. Missing validation authority
        belongs in `utility_warnings` as a readiness blocker. Complexity,
        urgency, and readiness are separate decisions.
+       This lane is a read-only preflight and never builds, tests, or runs a
+       validation command; `proc.spawn` is CLI-only, so an MCP-transport
+       session does not advertise it at all. That absence of `proc.spawn` is
+       structural to the pilot lane and is not by itself an evidence gap: do
+       not return `unassessed` merely because you could not execute a build or
+       a test here. Name the check that would establish the repair in
+       `validation_approach` instead, and reserve `unassessed` for evidence
+       the pilot could have read at `source_revision` but did not find.
     7. Report recommendations only; do not apply them:
        `recommended_crew`, `recommended_complexity`, real `blocked_by` task IDs,
        `duplicate_of`, `already_landed`, `release_action_required`,

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs
@@ -48,6 +48,46 @@ struct ValidatedTask {
 
 const STORAGE_APPLY_ATTEMPTS: usize = 3;
 
+/// Field carrying the deterministic over-attachment finding this boundary
+/// injects into an applied assessment [ORB-12228]. It sits beside
+/// [`VALIDATION_TOOL_WARNINGS`] so the orchestrator reads the agent's findings
+/// and the host's in the same assessment.
+const CONTEXT_ATTACHMENT_WARNINGS: &str = "context_attachment_warnings";
+
+/// Selector budget for a proposal at each recommended complexity.
+///
+/// Context selectors are both the executor's reading list and the task's lock
+/// reservations, so a proposal far larger than the assessed repair serializes
+/// unrelated work on the same files and hides the real modification targets.
+/// Each budget sits well above the largest honest attachment observed for its
+/// tier, which makes exceeding it a signal that the pilot swept a directory
+/// instead of deriving targets from references. `unassessed` shares the
+/// strictest budget: a pilot that could not size the repair has no evidence
+/// for reserving a wide surface either.
+fn context_selector_cap(complexity: TaskComplexity) -> usize {
+    match complexity {
+        TaskComplexity::Unassessed | TaskComplexity::Low => 10,
+        TaskComplexity::Medium => 20,
+        TaskComplexity::Hard => 40,
+    }
+}
+
+/// Report an over-budget proposal without refusing it. Genuinely large-surface
+/// work must stay applyable, so this returns a finding for the orchestrator to
+/// weigh rather than a validation error [ORB-12228].
+fn over_attachment_findings(complexity: TaskComplexity, after: &[String]) -> Vec<String> {
+    let cap = context_selector_cap(complexity);
+    if after.len() <= cap {
+        return Vec::new();
+    }
+    vec![format!(
+        "over-attached context: {} selectors proposed for {complexity} complexity, above the \
+         {cap}-selector budget for that tier; context selectors are lock reservations and the \
+         executor's reading list, so each one should be a file this task modifies",
+        after.len()
+    )]
+}
+
 pub(in super::super) fn apply(
     runtime: &OrbitRuntime,
     action: &str,
@@ -423,10 +463,12 @@ pub(in super::super) fn apply(
                     continue;
                 }
             };
-            // The pilot never sees the deterministic feasibility findings, so
-            // apply attaches them here: every downstream readiness and
-            // admission rule then reads one assessment that carries both the
-            // agent's findings and the lane's [ORB-11980].
+            // The pilot never sees the deterministic findings — the lane's
+            // validation-tool feasibility [ORB-11980] and this boundary's
+            // over-attachment budget [ORB-12228] — so apply attaches them
+            // here: every downstream readiness and admission rule then reads
+            // one assessment carrying both the agent's findings and the
+            // host's.
             let mut assessment = (*assessment).clone();
             if let Value::Object(fields) = &mut assessment {
                 fields.insert(
@@ -437,6 +479,10 @@ pub(in super::super) fn apply(
                 fields.insert(
                     "selector_normalizations".to_string(),
                     json!(selectors.normalizations),
+                );
+                fields.insert(
+                    CONTEXT_ATTACHMENT_WARNINGS.to_string(),
+                    json!(over_attachment_findings(complexity, &after)),
                 );
             }
 

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs
@@ -118,6 +118,19 @@ fn partition_result(partition_index: usize, task_ids: &[String], tasks: Vec<Valu
     })
 }
 
+/// Materialize `count` workspace files and return the canonical `file:`
+/// selectors naming them, so an over-attachment fixture proposes selectors
+/// that all resolve.
+fn workspace_selectors(repo_root: &std::path::Path, count: usize) -> Vec<String> {
+    (0..count)
+        .map(|index| {
+            let relative = format!("src/module_{index:02}.rs");
+            write_workspace_file(repo_root, &relative);
+            format!("file:{relative}")
+        })
+        .collect()
+}
+
 #[test]
 fn automatic_readiness_requires_selectors_and_no_deferring_finding() {
     let mut assessment = json!({
@@ -1181,4 +1194,128 @@ fn out_of_workspace_selector_is_rejected_before_mutation() {
             .contains("inside workspace")
     );
     assert!(runtime.get_task(&task.id).unwrap().context_files.is_empty());
+}
+
+/// [ORB-12228] Reproduces F2026-09-137: the pilot swept every module in a
+/// crate instead of deriving targets from the references to the symbol, and
+/// apply accepted the oversized list silently. Apply must keep applying it —
+/// a genuinely wide repair has to stay proposable — while attaching a finding
+/// that names the proposed count and the budget it exceeded.
+#[test]
+fn over_attached_proposal_is_reported_and_still_applied() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    let selectors = workspace_selectors(&repo_root, 12);
+    let task = seed_task(&runtime, "swept-crate", TaskStatus::Backlog, &[], &[]);
+    let task_ids = vec![task.id.clone()];
+    let prepared_snapshot = prepared(&runtime, &repo_root, &task_ids);
+    let mut assessment = selector_assessment_with_complexity(
+        &task,
+        selectors.iter().map(String::as_str).collect(),
+        "unassessed",
+    );
+    assessment["evidence_gaps"] = json!(["the caller set for the removed symbol is unverified"]);
+    let result = partition_result(0, &task_ids, vec![assessment]);
+
+    let output = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": prepared_snapshot,
+            "results": [result],
+            "workspace_path": repo_root,
+        }),
+    )
+    .expect("an over-attached proposal is reported, not refused");
+
+    assert_eq!(output["status"], "succeeded");
+    assert_eq!(output["tasks"][0]["context_files_after"], json!(selectors));
+    assert_eq!(
+        runtime
+            .get_task(&task.id)
+            .expect("task after apply")
+            .context_files,
+        selectors
+    );
+    let findings = output["tasks"][0]["context_attachment_warnings"]
+        .as_array()
+        .expect("context_attachment_warnings array");
+    assert_eq!(findings.len(), 1);
+    let finding = findings[0].as_str().expect("finding string");
+    assert!(
+        finding.contains("12 selectors") && finding.contains("10-selector budget"),
+        "finding must name the proposed count and the cap: {finding}"
+    );
+    assert!(
+        finding.contains("unassessed"),
+        "finding must name the tier whose budget was exceeded: {finding}"
+    );
+}
+
+/// [ORB-12228] The budget is per recommended complexity, and staying inside it
+/// attaches nothing: the same twelve selectors are ordinary for a `medium`
+/// repair, and a proposal exactly at the strictest budget is still inside it.
+#[test]
+fn proposal_within_its_complexity_budget_attaches_no_finding() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    let selectors = workspace_selectors(&repo_root, 12);
+    let medium = seed_task(&runtime, "wide-medium", TaskStatus::Backlog, &[], &[]);
+    let unassessed = seed_task(&runtime, "at-budget", TaskStatus::Backlog, &[], &[]);
+    let task_ids = vec![medium.id.clone(), unassessed.id.clone()];
+    let prepared_snapshot = prepared(&runtime, &repo_root, &task_ids);
+    let mut at_budget = selector_assessment_with_complexity(
+        &unassessed,
+        selectors[..10].iter().map(String::as_str).collect(),
+        "unassessed",
+    );
+    at_budget["evidence_gaps"] = json!(["the reproduction for the failure is not yet known"]);
+    let result = partition_result(
+        0,
+        &task_ids,
+        vec![
+            selector_assessment_with_complexity(
+                &medium,
+                selectors.iter().map(String::as_str).collect(),
+                "medium",
+            ),
+            at_budget,
+        ],
+    );
+
+    let output = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": prepared_snapshot,
+            "results": [result],
+            "workspace_path": repo_root,
+        }),
+    )
+    .expect("apply proposals inside their budgets");
+
+    assert_eq!(output["status"], "succeeded");
+    let applied = |task_id: &str| -> Value {
+        output["tasks"]
+            .as_array()
+            .expect("applied assessments")
+            .iter()
+            .find(|assessment| assessment["task_id"] == task_id)
+            .expect("assessment for task")
+            .clone()
+    };
+    for task_id in [&medium.id, &unassessed.id] {
+        assert_eq!(
+            applied(task_id)["context_attachment_warnings"],
+            json!([]),
+            "task {task_id} must carry no over-attachment finding"
+        );
+    }
+    assert_eq!(
+        applied(&medium.id)["context_files_after"],
+        json!(selectors),
+        "the wider medium proposal still applies in full"
+    );
+    assert_eq!(
+        applied(&unassessed.id)["context_files_after"],
+        json!(selectors[..10])
+    );
 }


### PR DESCRIPTION
## Task

[ORB-12228](https://orbit-cli.com/tasks/ORB-12228) — [friction-curation] Flag an over-attached task-pilot context proposal instead of applying it silently

### Description

## Problem

The task-pilot apply path accepts whatever selector list the pilot proposes, as long as every anchor resolves (`validate_after_selectors` in `crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs`). Nothing relates the *size* of the proposal to the work, so a wildly over-attached context is applied silently.

## Reproduction (F2026-09-137)

2026-09-11 14:17 UTC, pilot run `jrun-20260911-1417-t1` on ORB-12211 (remove the dead `workspace_path` selector-root plumbing left after ORB-12208). The applied context was **52 `file:` selectors** — essentially every source and test module under `crates/orbit-core/src/application/task/` plus adjacent crates — for a change whose real modification targets were the six non-test files that reference the symbol (`rg -l workspace_path` outside `tests/`). Complexity was left `unassessed` because the pilot lane has no `proc.spawn` to validate a build. The orchestrator trimmed the list by hand before promotion.

## Why It Matters

- Context selectors double as lock reservations: 52 file locks serialize every concurrent task touching that crate.
- A low-complexity task with a 50-file reading list misleads both the executor and the reviewer.
- The pilot lane's structural lack of `proc.spawn` is being reported as an evidence gap that blocks complexity assessment, which is what left this task `unassessed` while its context inflated.

## Constraints / Notes

- Report, do not refuse. Apply must keep applying the proposal; the finding belongs next to the existing deterministic findings the host attaches at apply time (`VALIDATION_TOOL_WARNINGS` / `context_files_after` in `apply.rs`), so downstream readiness and the orchestrator see it in the same assessment. Adding a new rejection here would block ordinary large-surface tasks.
- `crates/orbit-core/assets/activities/task_pilot.yaml` has a byte-identity mirror at `.orbit/resources/activities/task_pilot.yaml`, asserted through `include_str!` and checked by `scripts/sync-activity-assets.sh --check` in `make ci-fast`; change both.
- Keep the threshold and its rationale documented next to the code that applies it; a task whose real surface is genuinely large must still be applyable with the finding attached.

### Acceptance Criteria

- When a pilot assessment proposes more context selectors than the documented cap for its recommended complexity (with `unassessed` treated as the strictest tier), apply attaches a deterministic over-attachment finding to the assessment naming the proposed count and the cap, and still applies the selectors — demonstrated by a test that asserts both the finding and the applied `context_files_after`.
- A proposal within the cap attaches no such finding, demonstrated by a test.
- `crates/orbit-core/assets/activities/task_pilot.yaml` tells the pilot to derive modification targets for a removal or rename from the files that actually reference the symbol rather than sweeping every module in the crate, and states that the absence of `proc.spawn` in the pilot lane is structural and is not by itself an evidence gap that forces `unassessed` complexity.
- `.orbit/resources/activities/task_pilot.yaml` matches the canonical asset: `./scripts/sync-activity-assets.sh --check` exits 0.
- `make ci-fast` and `make ci-lint` pass, and `cargo test -p orbit-core --lib task_pilot` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Apply now attaches a deterministic over-attachment finding to a task-pilot assessment whose selector proposal exceeds the budget for its recommended complexity, and the pilot instruction tells the pilot to derive targets from references and stops treating the lane's lack of `proc.spawn` as an evidence gap.

## Change

- `crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs`
  - New `context_selector_cap(TaskComplexity)` documents the per-tier selector budget next to the code that applies it: `unassessed`/`low` = 10 (unassessed shares the strictest tier), `medium` = 20, `hard` = 40. Rationale is in the doc comment: selectors are both the executor's reading list and the task's lock reservations, so a proposal far larger than the assessed repair serializes unrelated work and hides the real modification targets. Budgets sit above the largest honest per-tier attachment observed in the live store (low p90 5, medium max 11, hard max 37), so exceeding one signals a swept directory rather than an ordinary wide surface.
  - New `over_attachment_findings` reports, never refuses: it returns one finding naming the proposed count, the complexity tier, and the budget. Apply injects it as `context_attachment_warnings` in the same block that already injects `validation_tool_warnings`, `context_files_after`, and `selector_normalizations`, so downstream readiness, the audit note, and the orchestrator read one assessment. The selectors still apply unchanged; no new rejection path was added, so a genuinely large-surface task remains applyable. `member_ready` was deliberately left untouched — gating readiness on the budget would block ordinary large-surface work from automatic promotion, which the task explicitly forbids.
  - Updated the neighboring comment so it names both deterministic findings (ORB-11980 feasibility and ORB-12228 budget) rather than only the first.
- `crates/orbit-core/assets/activities/task_pilot.yaml` (step 3): derive modification targets from evidence, never by sweeping a directory or crate; for a removal or rename the targets are the files that actually reference the symbol (`rg -l '<symbol>'` at `source_revision`), not every module in the owning crate. States that apply attaches an over-attachment finding above the budget and still applies the list.
- `crates/orbit-core/assets/activities/task_pilot.yaml` (step 6): the pilot lane is a read-only preflight that never builds or tests, and `proc.spawn` is CLI-only so an MCP-transport session does not advertise it; that absence is structural to the lane and is not by itself an evidence gap forcing `unassessed`. Directs the pilot to name the establishing check in `validation_approach` and to reserve `unassessed` for evidence it could have read at `source_revision` but did not find.
- `.orbit/resources/activities/task_pilot.yaml` regenerated with `./scripts/sync-activity-assets.sh`; byte-identical to the canonical asset.
- `crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs`: added `workspace_selectors` fixture helper (in the helper block at the top of the file) plus two tests.

## Acceptance criteria

1. Over-cap proposal is flagged and still applied — met. `over_attached_proposal_is_reported_and_still_applied` proposes 12 resolving `file:` selectors at `unassessed` complexity (strictest tier, cap 10) and asserts both sides: `context_attachment_warnings` holds exactly one finding containing "12 selectors", "10-selector budget" and "unassessed", *and* `context_files_after` plus the persisted `task.context_files` equal the full 12-selector list.
2. In-cap proposal attaches no finding — met. `proposal_within_its_complexity_budget_attaches_no_finding` applies two tasks in one partition: the same 12 selectors at `medium` (cap 20, tier-dependence) and exactly 10 selectors at `unassessed` (the strictest budget's boundary). Both assert `context_attachment_warnings == []` and the full applied list.
3. Pilot instruction updates — met; both paragraphs above are in the canonical asset.
4. Mirror identity — met; `./scripts/sync-activity-assets.sh --check` exits 0.
5. Gates — met; see validation below.

## Validation

- `./scripts/sync-activity-assets.sh --check` — passed (exit 0).
- `make ci-fast` — passed (exit 0).
- `make ci-lint` — passed (exit 0).
- `cargo test -p orbit-core --lib task_pilot` — passed: 59 passed, 0 failed, including both new tests.
- Fault detection: temporarily raised the strict-tier cap from 10 to 100 and re-ran `cargo test -p orbit-core --lib task_pilot::over_attached`; the new test failed as expected, then the edit was reverted and the suite re-run green. The test is a real regression detector, not a source-text check.
- `git diff --check` clean; `git status --short` shows only the four declared context files modified, no untracked paths.

## Risks / deviations

- The budgets are a policy judgment calibrated against the current task store's per-tier distribution, not a derived invariant. If typical attachment sizes shift, `context_selector_cap` is the single place to retune; its doc comment carries the rationale.
- The finding is advisory only. It does not affect `member_ready`, admission, or the applied selector list, by design (the task requires "report, do not refuse"); acting on it stays with the orchestrator or a human reviewer.
- The instruction changes are prose directed at a live model. The tests prove the deterministic apply-side behavior; they cannot prove that a pilot run will in fact stop sweeping crates or stop returning `unassessed` for a missing build. That effect is observable only in future pilot runs.
- `tests/task_pilot.rs` is now ~1320 lines, already past the 800-line design warning before this change. Splitting it is out of scope here.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12228-6aa4abdc`
- Behind base: 0
- Ahead of base: 1