### PR TITLE
[friction-curation] Bound an interactive orbit init prompt when stdin is open but never answers

### DIFF
--- a/crates/orbit-cli/src/command/init/agent_prompt.rs
+++ b/crates/orbit-cli/src/command/init/agent_prompt.rs
@@ -1,11 +1,12 @@
 //! Interactive prompts that collect the default crew and, when more than one
 //! cheap-tier family is detected, the system crew during `orbit init`.
 
-use std::io::{self, BufRead, ErrorKind, Write};
+use std::io::{self, Write};
 
 use orbit_config::CrewSeed;
 
 use super::agent_detect::{DetectedAgents, default_model_for, default_provider};
+use super::prompt_stdin;
 
 pub trait Prompter {
     fn message(&mut self, text: &str) -> io::Result<()>;
@@ -25,20 +26,7 @@ impl Prompter for StdinPrompter {
     fn prompt(&mut self, prompt: &str) -> io::Result<String> {
         let stderr = io::stderr();
         let mut out = stderr.lock();
-        write!(out, "{prompt}")?;
-        out.flush()?;
-
-        let stdin = io::stdin();
-        let mut line = String::new();
-        let bytes_read = stdin.lock().read_line(&mut line)?;
-        if bytes_read == 0 {
-            return Err(io::Error::new(
-                ErrorKind::UnexpectedEof,
-                "stdin closed before an interactive prompt was answered; pass --task-prefix/--host-name or --non-interactive",
-            ));
-        }
-
-        Ok(line.trim().to_string())
+        prompt_stdin::read_trimmed_line(prompt, &mut out)
     }
 }
 

--- a/crates/orbit-cli/src/command/init/command.rs
+++ b/crates/orbit-cli/src/command/init/command.rs
@@ -6,10 +6,15 @@ use orbit_registry::{
     HostIdentityOutcome, HostIdentityState, NewHostIdentity, ensure_host_identity,
     inspect_host_identity, os_hostname, validate_new_task_prefix,
 };
-use std::io::{self, BufRead, Write};
+#[cfg(test)]
+use std::io::BufRead;
+use std::io::{self, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
 use super::collect_config_seed_for_init;
+use super::prompt_stdin;
+#[cfg(test)]
+use super::prompt_stdin::STDIN_CLOSED_BEFORE_PROMPT;
 use crate::command::{CommandOut, CommandOutput, Execute};
 
 #[derive(Args)]
@@ -249,24 +254,30 @@ fn prompt_host_name() -> Result<String, OrbitError> {
 const MAX_TASK_PREFIX_ATTEMPTS: usize = 4;
 
 fn prompt_task_prefix() -> Result<String, OrbitError> {
-    let stdin = io::stdin();
-    let mut reader = stdin.lock();
     let stderr = io::stderr();
     let mut output = stderr.lock();
-
-    prompt_task_prefix_from(&mut reader, &mut output)
+    collect_task_prefix(&mut output, |prompt, output| {
+        prompt_stdin::read_trimmed_line(prompt, output).map_err(prompt_io_to_orbit)
+    })
 }
 
+#[cfg(test)]
 pub(super) fn prompt_task_prefix_from(
     reader: &mut impl BufRead,
     output: &mut impl Write,
 ) -> Result<String, OrbitError> {
+    collect_task_prefix(output, |prompt, output| {
+        read_line_from(prompt, reader, output)
+    })
+}
+
+fn collect_task_prefix<W, F>(output: &mut W, mut read_answer: F) -> Result<String, OrbitError>
+where
+    W: Write,
+    F: FnMut(&str, &mut W) -> Result<String, OrbitError>,
+{
     for _ in 0..MAX_TASK_PREFIX_ATTEMPTS {
-        let answer = read_line_from(
-            "Task prefix (2-5 uppercase ASCII letters): ",
-            reader,
-            output,
-        )?;
+        let answer = read_answer("Task prefix (2-5 uppercase ASCII letters): ", output)?;
         match validate_new_task_prefix(&answer) {
             Ok(prefix) => return Ok(prefix),
             Err(error) => {
@@ -281,14 +292,21 @@ pub(super) fn prompt_task_prefix_from(
 }
 
 fn read_line(prompt: &str) -> Result<String, OrbitError> {
-    let stdin = io::stdin();
-    let mut reader = stdin.lock();
     let stderr = io::stderr();
     let mut output = stderr.lock();
-
-    read_line_from(prompt, &mut reader, &mut output)
+    prompt_stdin::read_trimmed_line(prompt, &mut output).map_err(prompt_io_to_orbit)
 }
 
+fn prompt_io_to_orbit(error: io::Error) -> OrbitError {
+    match error.kind() {
+        ErrorKind::UnexpectedEof | ErrorKind::TimedOut => {
+            OrbitError::InvalidInput(error.to_string())
+        }
+        _ => OrbitError::Io(error.to_string()),
+    }
+}
+
+#[cfg(test)]
 fn read_line_from(
     prompt: &str,
     reader: &mut impl BufRead,
@@ -306,8 +324,7 @@ fn read_line_from(
 
     if bytes_read == 0 {
         return Err(OrbitError::InvalidInput(
-            "stdin closed before an interactive prompt was answered; pass --task-prefix/--host-name or --non-interactive"
-                .to_string(),
+            STDIN_CLOSED_BEFORE_PROMPT.to_string(),
         ));
     }
 

--- a/crates/orbit-cli/src/command/init/mod.rs
+++ b/crates/orbit-cli/src/command/init/mod.rs
@@ -10,6 +10,7 @@
 pub mod agent_detect;
 pub mod agent_prompt;
 mod command;
+mod prompt_stdin;
 mod seed;
 
 pub use command::InitCommand;

--- a/crates/orbit-cli/src/command/init/prompt_stdin.rs
+++ b/crates/orbit-cli/src/command/init/prompt_stdin.rs
@@ -1,0 +1,181 @@
+//! Bounded reads from the process stdin for `orbit init` prompts.
+//!
+//! A human at a TTY may take as long as they need. A non-TTY stdin (pipe,
+//! socket, redirected file) is given a short window to deliver a line so an
+//! agent harness that leaves stdin open cannot hang forever holding the init
+//! lock. The bound is on waiting, not on descriptor kind alone: a pipe that
+//! already has answers still completes.
+//!
+//! The in-memory `BufRead` helpers in `command.rs` stay unbounded; this
+//! module is the real-stdin boundary only.
+
+use std::io::{self, ErrorKind, Write};
+use std::sync::{Mutex, MutexGuard};
+use std::time::Duration;
+
+use crate::output::sink;
+
+pub(super) const STDIN_CLOSED_BEFORE_PROMPT: &str = "stdin closed before an interactive prompt was answered; pass --task-prefix/--host-name or --non-interactive";
+
+pub(super) const STDIN_PROMPT_TIMEOUT: &str = "stdin did not answer an interactive prompt; pass --task-prefix/--host-name or --non-interactive";
+
+/// Ceiling for one non-TTY prompt. Piped answers are already in the kernel
+/// buffer, so a working pipe returns immediately; this only trips when the
+/// descriptor stays silent.
+pub(super) const NON_TTY_PROMPT_TIMEOUT: Duration = Duration::from_secs(2);
+
+struct StdinLeftover {
+    buf: Vec<u8>,
+}
+
+fn leftover() -> MutexGuard<'static, StdinLeftover> {
+    static STATE: Mutex<StdinLeftover> = Mutex::new(StdinLeftover { buf: Vec::new() });
+    STATE.lock().unwrap_or_else(|poison| poison.into_inner())
+}
+
+/// Write `prompt` to `output` and read one trimmed line from process stdin.
+pub(super) fn read_trimmed_line(prompt: &str, output: &mut impl Write) -> io::Result<String> {
+    write!(output, "{prompt}")?;
+    output.flush()?;
+
+    let timeout = if sink::stdin_is_terminal() {
+        None
+    } else {
+        Some(NON_TTY_PROMPT_TIMEOUT)
+    };
+    read_stdin_line(timeout)
+}
+
+fn read_stdin_line(timeout: Option<Duration>) -> io::Result<String> {
+    let mut leftover = leftover();
+    loop {
+        if let Some(line) = take_complete_line(&mut leftover.buf) {
+            return Ok(line);
+        }
+        if let Some(timeout) = timeout {
+            wait_for_stdin(timeout)?;
+        }
+        match fill_leftover(&mut leftover.buf)? {
+            Fill::More => {}
+            Fill::Eof => {
+                return Ok(take_trailing_line(&mut leftover.buf));
+            }
+        }
+    }
+}
+
+enum Fill {
+    More,
+    Eof,
+}
+
+fn fill_leftover(buf: &mut Vec<u8>) -> io::Result<Fill> {
+    let mut chunk = [0u8; 1024];
+    let n = read_stdin_bytes(&mut chunk)?;
+    if n == 0 {
+        if buf.is_empty() {
+            return Err(closed_stdin());
+        }
+        return Ok(Fill::Eof);
+    }
+    buf.extend_from_slice(&chunk[..n]);
+    Ok(Fill::More)
+}
+
+fn take_complete_line(buf: &mut Vec<u8>) -> Option<String> {
+    let idx = buf.iter().position(|&b| b == b'\n')?;
+    let mut line: Vec<u8> = buf.drain(..=idx).collect();
+    if line.last() == Some(&b'\n') {
+        line.pop();
+    }
+    if line.last() == Some(&b'\r') {
+        line.pop();
+    }
+    Some(utf8_line(line))
+}
+
+fn take_trailing_line(buf: &mut Vec<u8>) -> String {
+    utf8_line(std::mem::take(buf))
+}
+
+fn utf8_line(line: Vec<u8>) -> String {
+    String::from_utf8_lossy(&line).trim().to_string()
+}
+
+fn closed_stdin() -> io::Error {
+    io::Error::new(ErrorKind::UnexpectedEof, STDIN_CLOSED_BEFORE_PROMPT)
+}
+
+#[cfg(unix)]
+fn timed_out_stdin() -> io::Error {
+    io::Error::new(ErrorKind::TimedOut, STDIN_PROMPT_TIMEOUT)
+}
+
+fn wait_for_stdin(timeout: Duration) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsRawFd;
+        wait_for_fd(io::stdin().as_raw_fd(), timeout)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = timeout;
+        Ok(())
+    }
+}
+
+fn read_stdin_bytes(buf: &mut [u8]) -> io::Result<usize> {
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsRawFd;
+        read_fd(io::stdin().as_raw_fd(), buf)
+    }
+    #[cfg(not(unix))]
+    {
+        use std::io::Read;
+        io::stdin().read(buf)
+    }
+}
+
+#[cfg(unix)]
+pub(super) fn wait_for_fd(fd: std::os::fd::RawFd, timeout: Duration) -> io::Result<()> {
+    let timeout_ms = i32::try_from(timeout.as_millis()).unwrap_or(i32::MAX);
+    let mut fds = [libc::pollfd {
+        fd,
+        events: libc::POLLIN,
+        revents: 0,
+    }];
+    loop {
+        // SAFETY: `fds` is a one-element pollfd array we own for the call;
+        // `fd` is a live descriptor (process stdin or a test socket).
+        let rc = unsafe { libc::poll(fds.as_mut_ptr(), 1, timeout_ms) };
+        if rc < 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() == ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(err);
+        }
+        if rc == 0 {
+            return Err(timed_out_stdin());
+        }
+        return Ok(());
+    }
+}
+
+#[cfg(unix)]
+fn read_fd(fd: std::os::fd::RawFd, buf: &mut [u8]) -> io::Result<usize> {
+    loop {
+        // SAFETY: `fd` is a live descriptor; `buf` is a valid writable slice
+        // we own for `buf.len()` bytes.
+        let n = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
+        if n < 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() == ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(err);
+        }
+        return Ok(n as usize);
+    }
+}

--- a/crates/orbit-cli/src/command/init/tests/mod.rs
+++ b/crates/orbit-cli/src/command/init/tests/mod.rs
@@ -1,4 +1,5 @@
 mod agent_detect;
 mod agent_prompt;
 mod command;
+mod prompt_stdin;
 mod seed;

--- a/crates/orbit-cli/src/command/init/tests/prompt_stdin.rs
+++ b/crates/orbit-cli/src/command/init/tests/prompt_stdin.rs
@@ -1,0 +1,37 @@
+#![cfg(unix)]
+
+use std::io::{ErrorKind, Write};
+use std::os::fd::AsRawFd;
+use std::os::unix::net::UnixStream;
+use std::time::{Duration, Instant};
+
+use super::super::prompt_stdin::{STDIN_PROMPT_TIMEOUT, wait_for_fd};
+
+#[test]
+fn wait_for_fd_times_out_on_a_silent_open_socket() {
+    let (reader, _writer) = UnixStream::pair().expect("unix socket pair");
+    let start = Instant::now();
+    let error = wait_for_fd(reader.as_raw_fd(), Duration::from_millis(200))
+        .expect_err("silent socket times out");
+
+    assert_eq!(error.kind(), ErrorKind::TimedOut);
+    assert_eq!(error.to_string(), STDIN_PROMPT_TIMEOUT);
+    assert!(
+        error.to_string().contains("--task-prefix")
+            && error.to_string().contains("--host-name")
+            && error.to_string().contains("--non-interactive"),
+        "{error}"
+    );
+    assert!(
+        start.elapsed() < Duration::from_secs(2),
+        "timeout took {:?}",
+        start.elapsed()
+    );
+}
+
+#[test]
+fn wait_for_fd_returns_when_the_peer_writes() {
+    let (reader, mut writer) = UnixStream::pair().expect("unix socket pair");
+    writer.write_all(b"host\n").expect("write answer");
+    wait_for_fd(reader.as_raw_fd(), Duration::from_millis(200)).expect("data is ready");
+}

--- a/crates/orbit-cli/src/output/sink.rs
+++ b/crates/orbit-cli/src/output/sink.rs
@@ -230,6 +230,15 @@ impl OutputSink {
     }
 }
 
+/// Whether process stdin is a terminal.
+///
+/// Interactive prompts (`orbit init`) wait without a deadline when a human is
+/// at stdin, and apply a hang-breaker on a pipe or socket. This is independent
+/// of [`OutputSink::is_tty`], which describes stdout.
+pub fn stdin_is_terminal() -> bool {
+    std::io::stdin().is_terminal()
+}
+
 /// `COLUMNS` first, then what the terminal reported, then 0.
 ///
 /// A non-TTY sink is 0 regardless of either, so `COLUMNS=200 orbit … > file`

--- a/crates/orbit-cli/tests/init_interactive_stdin.rs
+++ b/crates/orbit-cli/tests/init_interactive_stdin.rs
@@ -1,0 +1,188 @@
+//! Binary coverage for interactive `orbit init` when stdin is a pipe or closed.
+//!
+//! The hang this guards is an *open* descriptor that never delivers data
+//! (F2026-09-114): closed stdin was already handled. These tests drive the
+//! real `orbit` binary so the bound sits at process stdin, not the in-memory
+//! `BufRead` seam.
+
+#![allow(missing_docs)]
+#![cfg(unix)]
+// Fixtures use expect/unwrap for concise failure diagnostics.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+
+use orbit_common::test_env;
+use tempfile::{TempDir, tempdir};
+
+const HANG_DEADLINE: Duration = Duration::from_secs(8);
+const SUCCESS_DEADLINE: Duration = Duration::from_secs(60);
+const CLOSED_STDIN_MESSAGE: &str = "stdin closed before an interactive prompt was answered; pass --task-prefix/--host-name or --non-interactive";
+
+struct IsolatedHome {
+    _temp: TempDir,
+    home: PathBuf,
+    work: PathBuf,
+    empty_path: PathBuf,
+}
+
+impl IsolatedHome {
+    fn new() -> Self {
+        let temp = tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let work = temp.path().join("work");
+        let empty_path = temp.path().join("empty-path");
+        fs::create_dir_all(&home).expect("create home");
+        fs::create_dir_all(&work).expect("create work");
+        fs::create_dir_all(&empty_path).expect("create empty PATH");
+        Self {
+            _temp: temp,
+            home,
+            work,
+            empty_path,
+        }
+    }
+}
+
+fn orbit_init(home: &Path, work: &Path, path: &Path) -> Command {
+    let mut command = Command::new(assert_cmd::cargo::cargo_bin!("orbit"));
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
+    command
+        .current_dir(work)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("PATH", path)
+        .env_remove("ORBIT_HOME")
+        .arg("init");
+    command
+}
+
+fn wait_with_deadline(child: &mut Child, deadline: Duration) -> Option<ExitStatus> {
+    let start = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait().expect("try_wait") {
+            return Some(status);
+        }
+        if start.elapsed() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn read_stdio(child: &mut Child) -> (String, String) {
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    if let Some(mut pipe) = child.stdout.take() {
+        let _ = pipe.read_to_string(&mut stdout);
+    }
+    if let Some(mut pipe) = child.stderr.take() {
+        let _ = pipe.read_to_string(&mut stderr);
+    }
+    (stdout, stderr)
+}
+
+fn combined_output(stdout: &str, stderr: &str) -> String {
+    format!("{stdout}{stderr}")
+}
+
+fn names_identity_flags(output: &str) -> bool {
+    output.contains("--task-prefix")
+        && output.contains("--host-name")
+        && output.contains("--non-interactive")
+}
+
+/// Fresh `orbit init` with no identity flags hits the crew prompt first
+/// (`StdinPrompter`), so a silent open pipe covers the agent-detection path
+/// through the same guarded read as host-name / task-prefix.
+#[test]
+fn silent_open_stdin_pipe_exits_instead_of_hanging() {
+    let fixture = IsolatedHome::new();
+    let mut child = orbit_init(&fixture.home, &fixture.work, &fixture.empty_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn orbit init");
+    let child_stdin = child.stdin.take().expect("piped stdin stays open");
+
+    let status = wait_with_deadline(&mut child, HANG_DEADLINE)
+        .unwrap_or_else(|| panic!("orbit init blocked on an open silent stdin until killed"));
+    drop(child_stdin);
+
+    let (stdout, stderr) = read_stdio(&mut child);
+    let output = combined_output(&stdout, &stderr);
+    assert!(
+        !status.success(),
+        "silent stdin must fail\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        names_identity_flags(&output),
+        "expected flags in the error, got stdout={stdout:?} stderr={stderr:?}"
+    );
+}
+
+#[test]
+fn closed_stdin_keeps_the_existing_message() {
+    let fixture = IsolatedHome::new();
+    let mut child = orbit_init(&fixture.home, &fixture.work, &fixture.empty_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn orbit init");
+
+    let status = wait_with_deadline(&mut child, HANG_DEADLINE)
+        .unwrap_or_else(|| panic!("orbit init < /dev/null blocked until killed"));
+    let (stdout, stderr) = read_stdio(&mut child);
+    let output = combined_output(&stdout, &stderr);
+    assert!(
+        !status.success(),
+        "closed stdin must fail\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        output.contains(CLOSED_STDIN_MESSAGE),
+        "expected {CLOSED_STDIN_MESSAGE:?}, got stdout={stdout:?} stderr={stderr:?}"
+    );
+}
+
+#[test]
+fn piped_host_name_and_task_prefix_still_complete_interactive_init() {
+    let fixture = IsolatedHome::new();
+    let mut child = orbit_init(&fixture.home, &fixture.work, &fixture.empty_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn orbit init");
+
+    {
+        let mut stdin = child.stdin.take().expect("piped stdin");
+        // Empty line accepts the recommended default crew; no system-crew
+        // prompt runs when PATH has no provider CLIs. Then identity.
+        stdin
+            .write_all(b"\npipe-host\nZZ\n")
+            .expect("write interactive answers");
+    }
+
+    let status = wait_with_deadline(&mut child, SUCCESS_DEADLINE)
+        .unwrap_or_else(|| panic!("orbit init with a delivering pipe did not finish"));
+    let (stdout, stderr) = read_stdio(&mut child);
+    assert!(
+        status.success(),
+        "piped answers must complete init\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let host = fs::read_to_string(fixture.home.join(".orbit").join("host.toml"))
+        .expect("host.toml after interactive init");
+    assert!(host.contains("host_id = \"pipe-host\""), "{host}");
+    assert!(host.contains("task_prefix = \"ZZ\""), "{host}");
+}


### PR DESCRIPTION
## Task

[ORB-12224](https://orbit-cli.com/tasks/ORB-12224) — [friction-curation] Bound an interactive orbit init prompt when stdin is open but never answers

### Description

## Problem

`orbit init` blocks forever when stdin is an open descriptor that never delivers data. `read_line_from` (`crates/orbit-cli/src/command/init/command.rs:293-313`) only guards the *closed* case: `read_line` returning `Ok(0)` produces the actionable `stdin closed before an interactive prompt was answered; pass --task-prefix/--host-name or --non-interactive`. An agent or tool harness does not close stdin — it hands the child an open socket — so the read never returns and the guard never fires.

## Reproduction (F2026-09-114, run jrun during ORB-12009)

`orbit init` without identity flags hung indefinitely with no output:

```
$ ps -eo pid,stat,wchan:20,args
382 Sl unix_stream_data_wai ~/.orbit/bin/orbit init
$ ls -l /proc/382/fd
0 -> socket:[7418596]   # open socket: not a tty, not a closed pipe
4 -> /tmp/.../.orbit/.host.toml.lock
```

The process held `.host.toml.lock` for the whole hang (pid-stamped, so it was reclaimed after the kill). The same shape applies to the agent-detection prompt in `crates/orbit-cli/src/command/init/agent_prompt.rs:33`.

The failure mode is a silent, output-free hang rather than an error, which is far harder to attribute than the guarded EOF case. The workspace's own QA auto-task already carries the workaround as folklore (`.orbit/auto_tasks/qa-sweep.yaml`: "Root `init` hangs on stdin without `--non-interactive`").

## Why It Matters

Every non-interactive caller that forgets a flag hangs instead of being told what to pass, holding an init lock while it does. The existing error message already names the exact repair; it just never gets emitted for the most common non-interactive caller shape.

## Constraints / Notes

- Preserve the existing closed-stdin behavior and its message verbatim.
- Do not turn a pipe that *does* deliver answers into a refusal: a piped host name and task prefix must still complete `orbit init` interactively. A bare `IsTerminal` refusal at the prompt boundary would break that case, so the bound has to be on waiting, not on the descriptor kind alone (for example a bounded wait around the real-stdin read, applied only when stdin is not a terminal).
- Keep the injectable `read_line_from` / `prompt_task_prefix_from` seam usable by the existing in-memory `BufRead` unit tests; the new bound belongs at the real-stdin boundary, not inside the shared helper.
- `--non-interactive`, `--host-name` and `--task-prefix` behavior is unchanged.

### Acceptance Criteria

- A test drives the real `orbit init` binary (no identity flags) with a stdin pipe the parent holds open and never writes to, and the command exits non-zero within a bounded time with an error naming --task-prefix/--host-name/--non-interactive, instead of blocking until killed.
- `orbit init < /dev/null` still fails with the existing message `stdin closed before an interactive prompt was answered; pass --task-prefix/--host-name or --non-interactive`.
- A regression test shows that a pipe that does deliver a host name and task prefix still completes `orbit init` interactively, so the change does not refuse a working non-interactive pipe.
- The agent-detection prompt path (`crates/orbit-cli/src/command/init/agent_prompt.rs`) is covered by the same bound, demonstrated by a test or by routing it through the same guarded read.
- `make ci-fast` and `make ci-lint` pass, and `cargo test -p orbit-cli --bin orbit command::init` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `crates/orbit-cli/src/command/init/prompt_stdin.rs`: real-stdin boundary for `orbit init` prompts. TTY stdin waits unbounded; non-TTY stdin `poll(2)`s for 2s then reads. Closed stdin keeps the verbatim message `stdin closed before an interactive prompt was answered; pass --task-prefix/--host-name or --non-interactive`. A silent open pipe/socket times out with a distinct error that still names those flags. A leftover buffer keeps multi-line piped answers across prompts.
- Wired `command.rs` host-name / task-prefix reads and `agent_prompt.rs` `StdinPrompter` through that reader. `read_line_from` / `prompt_task_prefix_from` stay the in-memory `BufRead` seam (cfg(test)).
- `output/sink.rs` now owns `stdin_is_terminal()` so the crate terminal-state guard still has a single IsTerminal site (stdout TTY vs stdin TTY are independent).
- Unit tests: `wait_for_fd` times out on a silent unix socket and returns when the peer writes. Existing Cursor tests unchanged.
- Binary tests in `crates/orbit-cli/tests/init_interactive_stdin.rs` (integration tests own `CARGO_BIN_EXE_*`): isolated child via `clear_inherited_authority` + disposable HOME/USERPROFILE + empty PATH.

Criteria:
1. Silent open `Stdio::piped()` (parent holds the writer, never writes): `orbit init` with no identity flags exits non-zero within 8s; stderr names `--task-prefix`/`--host-name`/`--non-interactive`. Passed (`silent_open_stdin_pipe_exits_instead_of_hanging`). Fresh root hits `StdinPrompter` first.
2. `stdin(Stdio::null())` still contains `stdin closed before an interactive prompt was answered; pass --task-prefix/--host-name or --non-interactive`. Passed (`closed_stdin_keeps_the_existing_message`).
3. Pipe delivering `\npipe-host\nZZ\n` (default crew + host + prefix) completes init and writes those identity values. Passed (`piped_host_name_and_task_prefix_still_complete_interactive_init`).
4. Agent-detection prompt uses the same guarded read (`StdinPrompter::prompt` → `read_trimmed_line`); the silent-pipe binary test exercises that path. Passed.
5. Lint/tests: passed as listed below.

Validation:
- `cargo test -p orbit-cli --bin orbit command::init --offline`: passed (23 tests).
- `cargo test -p orbit-cli --test init_interactive_stdin --offline`: passed (3 tests). Extra command because the real binary is an integration test.
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed. Uncommitted: 5 modified + 3 new files declared in context_files.

Strategic decisions: bound is on waiting (`poll`), not a bare `IsTerminal` refusal, so a delivering pipe still works. Stdin TTY is queried through `sink::stdin_is_terminal` rather than at the prompt site.

Deviations from original plan: binary tests live in crate-root `tests/init_interactive_stdin.rs`, not `src/command/init/tests/command.rs`, because `CARGO_BIN_EXE_orbit` is set for integration tests only. Unit coverage of the poll helper still runs under `command::init`.

Design weaknesses / risks:
- Severity: low. Mitigation: n/a for this task. The hang-breaker is unix `poll`; non-unix wait is currently a no-op. CI is Linux and macOS.
- `--non-interactive` / `--host-name` / `--task-prefix` never reach the reader and were not re-tested beyond existing unit coverage.

Friction: none filed. This implements F2026-09-114 (already `resolves`). The terminal-state guard was followed, not a new gotcha worth recording.

Assessment: scoped, tested at the real-binary boundary, existing closed-stdin and piped-answer paths preserved. Left uncommitted for the pipeline.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12224-6aa4aae3`
- Behind base: 0
- Ahead of base: 1