### PR TITLE
[ci-failure-sweep] Fix red CI: CI / Coverage (informational) / Collect workspace coverage

### DIFF
--- a/crates/orbit-cli/src/command/tests/friction_help/add.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/add.txt
@@ -6,7 +6,7 @@ Options:
       --body <BODY>                Markdown body describing what happened and why it caused friction
       --root <ROOT>                Override the Orbit root directory (highest precedence)
       --title <TITLE>              One-line record handle, max 120 chars; derived when omitted
-      --workspace <SELECTOR>       Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+      --workspace <SELECTOR>       Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory. Only active workspaces may be bound; commands fail if the workspace status is not active
       --tag <TAGS>                 Friction taxonomy tag; repeat or comma-separate for multiple tags
       --during-task <DURING_TASK>  Optional task ID being worked on when friction occurred
       --model <MODEL>              Agent family to attribute the record to (`codex`, `claude`, `gemini`, or `grok`)

--- a/crates/orbit-cli/src/command/tests/friction_help/list.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/list.txt
@@ -6,7 +6,7 @@ Options:
       --model <MODEL>         Optional model filter
       --root <ROOT>           Override the Orbit root directory (highest precedence)
       --status <STATUS>       Optional status filter: open, triaged, or resolved
-      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory. Only active workspaces may be bound; commands fail if the workspace status is not active
       --tag <TAG>             Optional tag filter
       --month <MONTH>         Optional YYYY-MM month filter for reported records
       --q <Q>                 Optional case-insensitive query over id, model, tags, status, task, and body

--- a/crates/orbit-cli/src/command/tests/friction_help/resolve.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/resolve.txt
@@ -8,5 +8,5 @@ Arguments:
 Options:
       --json                  Output as JSON
       --root <ROOT>           Override the Orbit root directory (highest precedence)
-      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory. Only active workspaces may be bound; commands fail if the workspace status is not active
   -h, --help                  Print help

--- a/crates/orbit-cli/src/command/tests/friction_help/root.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/root.txt
@@ -13,5 +13,5 @@ Commands:
 
 Options:
       --root <ROOT>           Override the Orbit root directory (highest precedence)
-      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory. Only active workspaces may be bound; commands fail if the workspace status is not active
   -h, --help                  Print help

--- a/crates/orbit-cli/src/command/tests/friction_help/show.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/show.txt
@@ -8,5 +8,5 @@ Arguments:
 Options:
       --json                  Output as JSON
       --root <ROOT>           Override the Orbit root directory (highest precedence)
-      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory. Only active workspaces may be bound; commands fail if the workspace status is not active
   -h, --help                  Print help

--- a/crates/orbit-cli/src/command/tests/friction_help/stats.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/stats.txt
@@ -5,5 +5,5 @@ Usage: orbit friction stats [OPTIONS]
 Options:
       --json                  Output as JSON
       --root <ROOT>           Override the Orbit root directory (highest precedence)
-      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory. Only active workspaces may be bound; commands fail if the workspace status is not active
   -h, --help                  Print help

--- a/crates/orbit-cli/src/command/tests/friction_help/tags.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/tags.txt
@@ -5,5 +5,5 @@ Usage: orbit friction tags [OPTIONS]
 Options:
       --json                  Output as JSON
       --root <ROOT>           Override the Orbit root directory (highest precedence)
-      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory. Only active workspaces may be bound; commands fail if the workspace status is not active
   -h, --help                  Print help

--- a/crates/orbit-cli/src/command/tests/friction_help/update.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/update.txt
@@ -9,7 +9,7 @@ Options:
       --root <ROOT>           Override the Orbit root directory (highest precedence)
       --status <STATUS>       Optional status: open, triaged, or resolved
       --tag <TAGS>            Optional replacement taxonomy tag; repeat or comma-separate for multiple tags
-      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory. Only active workspaces may be bound; commands fail if the workspace status is not active
       --body <BODY>           Optional replacement markdown body
       --title <TITLE>         Optional replacement title, max 120 chars; empty restores derivation
       --json                  Output as JSON


### PR DESCRIPTION
## Task

[ORB-12230](https://orbit-cli.com/tasks/ORB-12230) — [ci-failure-sweep] Fix red CI: CI / Coverage (informational) / Collect workspace coverage

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `CI`
- Failing job: `Coverage (informational)`
- Failing step: `Collect workspace coverage`
- Commit the runner actually checked out: `4a9613c01a16fca044366b5d9af6074d81110553`
- Normalized error signature (the dedupe identity, not a quote): `test command::tests::friction::friction_help_matches_the_shipped_surface ... failed`
- Repository: `constellation-works/orbit`
- Release branch as GitHub reports it: `agent-main`
- Evidence collected at: 2026-09-12T01:31:03.658831038+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/constellation-works/orbit/actions/runs/34663681719 run `34663681719` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `4a9613c01a16fca044366b5d9af6074d81110553`
  - current head of that ref: `fdf062661c7192498f3c8f4aadbee7ca39942f46`
  - commit actually checked out: `4a9613c01a16fca044366b5d9af6074d81110553`
  - checkout evidence: `* branch            4a9613c01a16fca044366b5d9af6074d81110553 -> FETCH_HEAD`
  - checkout evidence: `4a9613c01a16fca044366b5d9af6074d81110553`
  - checkout evidence: `##[group]Checking out the ref`
  - failed job `Coverage (informational)` (id `103471180590`): https://github.com/constellation-works/orbit/actions/runs/34663681719/job/103471180590
  - failing step(s): `Collect workspace coverage`

## Failed-step log excerpt

```
[...]
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.5009089Z test command::tests::doctor::orphan_task_store_removal_message_reports_zero_of_both_kinds ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.6223789Z test command::tests::doctor::failing_workspace_renders_diagnostics_and_exits_nonzero ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.6523835Z test command::tests::friction::audit_metadata_is_derived_from_the_registry ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.6583800Z test command::tests::doctor::fix_orphan_task_stores_without_confirm_fails_with_bundle_loss_message ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.6585203Z test command::tests::friction::blank_optional_values_are_dropped_and_required_values_pass_through ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.6617056Z test command::tests::friction::cli_parses_friction_list ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.6666662Z test command::tests::friction::cli_parses_friction_update ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.6697644Z test command::tests::friction::friction_help_matches_the_shipped_surface ... FAILED
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.6736976Z test command::tests::friction::integer_filters_parse_as_numbers_not_strings ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.6922427Z test command::tests::friction::each_verb_routes_to_its_registry_tool_name ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.6943739Z test command::tests::friction::json_flag_is_captured_for_every_verb ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.6993601Z test command::tests::friction::list_projects_every_declared_filter ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.7043181Z test command::tests::friction::parameterless_verbs_send_an_empty_object ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.7053827Z test command::tests::friction::repeated_tag_flags_accumulate_into_the_plural_wire_field ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.7143609Z test command::tests::friction::unknown_friction_subcommands_are_rejected ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.7183934Z test command::tests::friction::required_arguments_are_still_enforced ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.7237587Z test command::tests::gc::gc_help_exposes_positional_worktree_class ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.7238804Z test command::tests::gc::gc_preserves_yes_as_confirmation_alias ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.7319110Z test command::tests::gc::gc_worktrees_defaults_to_dry_run_and_accepts_scopes ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T01:07:44.7323266Z test command::tests::init::empty_host_name_fails_closed ... ok
```

_The collection display was truncated. Selected evidence is used for diagnosis; its retention limits are independent of that display._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `CI` run https://github.com/constellation-works/orbit/actions/runs/34663380472 — superseded_by_newer_workflow_run: newer relevant run 34663681719 at 2026-09-12T01:04:10Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34607325655 — superseded_by_newer_workflow_run: newer relevant run 34663080877 at 2026-09-12T00:52:56Z is completed with conclusion success
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34592194455 — superseded_by_newer_workflow_run: newer relevant run 34663080877 at 2026-09-12T00:52:56Z is completed with conclusion success
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34590847020 — superseded_by_newer_workflow_run: newer relevant run 34663080877 at 2026-09-12T00:52:56Z is completed with conclusion success
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34590666628 — superseded_by_newer_workflow_run: newer relevant run 34663080877 at 2026-09-12T00:52:56Z is completed with conclusion success
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34590661824 — ref_no_longer_exists: branch 'orbit/ORB-12181-6aa3d9c6' has no head on origin: its pull request was merged or the branch was deleted, so this run describes code that is either already landed — where the landing branch's own runs are the current evidence — or abandoned

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 2,
  "current_failures_discovered": 3,
  "current_failures_investigated": 2,
  "current_failures_investigation_attempted": 6,
  "inconclusive": 0,
  "investigation_cursor": 496993,
  "job_log_reads": 3,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_job_log_reads": 6,
  "max_pull_requests": 10,
  "max_retired_ref_probes": 20,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely",
    "2 of 8 current or mixed-state runs were listed but not investigated (max_investigated_runs=6); their run URLs are still present, and the rotating slot reaches a different overflow candidate on the next sweep"
  ],
  "pull_requests_scanned": 0,
  "refs_scanned": 1,
  "retired_refs": [
    "orbit/ORB-12181-6aa3d9c6",
    "orbit/ORB-12182-6aa3d9c7",
    "orbit/ORB-12185-6aa3df4e",
    "orbit/ORB-12215-6aa4a19c",
    "orbit/ORB-12216-6aa4a19c"
  ],
  "runs_listed": 100,
  "unverified_refs": []
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `CI` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated the eight existing friction CLI help golden files under crates/orbit-cli/src/command/tests/friction_help/ with the current --workspace description, including the active-workspace restriction.
- Root cause was repository-owned golden drift: the shipped Clap help had gained this wording while all friction help fixtures still contained the prior text. The assertion and CI workflow remain enabled and unchanged.

Acceptance criteria:
- Criterion 1: satisfied; only the affected golden fixtures changed, with no weakened assertion, lint, workflow, or non-blocking configuration.
- Criterion 2: the exact runner test, cargo test -p orbit-cli command::tests::friction::friction_help_matches_the_shipped_surface -- --exact --nocapture, was reproduced as failing before the fixture refresh and passed afterward with 1 test passed.
- Criterion 3: satisfied; make ci-fast and make ci-lint both completed successfully with exit code 0.
- Criterion 4: repository-owned cause confirmed by the local failing assertion showing generated help versus stale expected fixture; this was not treated as an infrastructure non-reproduction.

Validation:
- cargo test -p orbit-cli command::tests::friction::friction_help_matches_the_shipped_surface -- --exact --nocapture: passed after fix.
- make ci-fast: passed; the guardrail suite reported one environment-bounded skip for compiler-cache namespace creation because this worker lacks unprivileged mount-namespace permission.
- make ci-lint: passed with workspace clippy and warnings denied.
- git diff --check: passed.
- GIT_OPTIONAL_LOCKS=0 git status --short: expected eight modified scoped fixture files and no untracked files.

Assessment: Minimal, consistent fixture refresh matching the generated CLI surface. No remaining task-scoped risk identified.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12230-6aa4ae79`
- Behind base: 0
- Ahead of base: 1