### PR TITLE
[friction-curation] Name the task-store partition id distinctly from the workspace-registry id

### DIFF
--- a/crates/orbit-cli/src/audit_middleware.rs
+++ b/crates/orbit-cli/src/audit_middleware.rs
@@ -126,7 +126,7 @@ impl Drop for AuditGuard<'_> {
             workspace_id: self
                 .runtime
                 .workspace_runtime_binding()
-                .map(|binding| binding.workspace_id.clone()),
+                .map(|binding| binding.task_partition_id.clone()),
             caller_machine_id: None,
             caller_host_id: None,
             process_machine_id: None,

--- a/crates/orbit-cli/src/command/task/publication.rs
+++ b/crates/orbit-cli/src/command/task/publication.rs
@@ -395,7 +395,7 @@ fn selected_workspace_id(runtime: &OrbitRuntime) -> Result<String, orbit_core::O
 fn selected_task_workspace_id(runtime: &OrbitRuntime) -> Result<String, orbit_core::OrbitError> {
     runtime
         .workspace_runtime_binding()
-        .map(|binding| binding.workspace_id.clone())
+        .map(|binding| binding.task_partition_id.clone())
         .map_or_else(|| runtime.workspace_id(), Ok)
 }
 

--- a/crates/orbit-cli/src/command/workspace/publication.rs
+++ b/crates/orbit-cli/src/command/workspace/publication.rs
@@ -185,7 +185,7 @@ fn selected_workspace_id(runtime: &OrbitRuntime) -> Result<String, orbit_core::O
 fn selected_task_workspace_id(runtime: &OrbitRuntime) -> Result<String, orbit_core::OrbitError> {
     runtime
         .workspace_runtime_binding()
-        .map(|binding| binding.workspace_id.clone())
+        .map(|binding| binding.task_partition_id.clone())
         .map_or_else(|| runtime.workspace_id(), Ok)
 }
 

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -4586,7 +4586,7 @@ fn readonly_state_mount_keeps_cli_and_mcp_reads_observational() {
 
     // `TaskUpdateParams` has no workspace selector, so `--root canonical_root`
     // is the only routing this mutation gets: it always lands in the unbound
-    // canonical partition (`UNBOUND_DATA_DIR_WORKSPACE_ID`), not the checkout's
+    // canonical partition (`UNBOUND_DATA_DIR_PARTITION_ID`), not the checkout's
     // bound workspace. The denial below must therefore name that partition.
     let mutation = readonly_orbit_command(
         &worktree,
@@ -5160,7 +5160,7 @@ fn assert_readonly_mutation_failed(
 
 /// Both CLI and MCP mutations above route through `--root canonical_root`
 /// with no workspace selector, so the denial must name the unbound canonical
-/// partition (`UNBOUND_DATA_DIR_WORKSPACE_ID` in `orbit-core`'s runtime
+/// partition (`UNBOUND_DATA_DIR_PARTITION_ID` in `orbit-core`'s runtime
 /// builder) that write actually targeted, not a stale pre-layout-v3 lock path.
 #[cfg(target_os = "linux")]
 fn assert_readonly_diagnostic(label: &str, canonical_root: &Path, diagnostic: &str) {

--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -588,7 +588,7 @@ fn describe_partitions(partitions: &[task_store::UnclaimedPartition]) -> String 
         .map(|partition| {
             format!(
                 "{} ({}, {} task bundle(s))",
-                task_store::partition_id(&partition.path).unwrap_or("<unnamed>"),
+                task_store::partition_id_of(&partition.path).unwrap_or("<unnamed>"),
                 partition.path.display(),
                 partition.task_bundles
             )

--- a/crates/orbit-cmd/src/task_owner.rs
+++ b/crates/orbit-cmd/src/task_owner.rs
@@ -92,13 +92,13 @@ pub fn resolve_task_owner(
     let binding = tasks
         .find_task_binding(task_id)?
         .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, task_id.to_string()))?;
-    let partition = binding.workspace_id;
+    let partition = binding.partition_id;
 
     let registry = workspace_registry::load_registry_from(&workspace_registry::registry_path_for(
         global_root,
     ))?;
     let owner = workspace_registry::local_workspaces(&registry).find(|(workspace, checkout)| {
-        checkout_identity(&checkout.orbit_dir).is_some_and(|identity| identity == partition)
+        checkout_partition_id(&checkout.orbit_dir).is_some_and(|id| id == partition)
             || (checkout.orbit_dir == global_root && workspace.id == partition)
     });
     let Some((workspace, checkout)) = owner else {
@@ -143,11 +143,12 @@ pub fn bound_workspace_identity(runtime: &OrbitRuntime) -> Option<WorkspaceIdent
         .map(WorkspaceIdentity::of)
 }
 
-/// Checkout identity recorded in `<orbit_dir>/config.yaml`, which is the key
-/// the task registry partitions by (L-0098: it may differ from the logical
-/// registry ID). A checkout that has been deleted or never initialized has
-/// none, and is simply not a candidate owner.
-fn checkout_identity(orbit_dir: &Path) -> Option<String> {
+/// Task-store partition id recorded in `<orbit_dir>/config.yaml`, which is the
+/// key the task registry partitions by (L-0098: it is a different namespace
+/// from the workspace-registry id and may differ from it). A checkout that has
+/// been deleted or never initialized has none, and is simply not a candidate
+/// owner.
+fn checkout_partition_id(orbit_dir: &Path) -> Option<String> {
     read_workspace_config_optional(orbit_dir)
         .ok()
         .flatten()

--- a/crates/orbit-cmd/src/task_store.rs
+++ b/crates/orbit-cmd/src/task_store.rs
@@ -2,26 +2,34 @@
 //! and `doctor`'s orphan-partition check/fix [ORB-12109].
 //!
 //! `orbit-store` owns the per-workspace bundle layout
-//! (`<global_root>/tasks/workspaces/<workspace_id>/`) but knows nothing
+//! (`<global_root>/tasks/workspaces/<partition_id>/`) but knows nothing
 //! about the workspace registry; this module is the composition seam that
 //! lets a caller resolve or remove one workspace's partition without
 //! reaching around `orbit-store` from `orbit-cli`.
 //!
-//! The partition directory name is a *task-registry* workspace id
+//! A partition directory is named for a *task-store partition id*
 //! (`workspace_bindings.workspace_id` in `<global_root>/tasks/index.sqlite`),
-//! which is minted as `<slug>-<hash>` whenever a checkout binds without an
-//! explicit id. `orbit workspace init` may instead bind the catalog's `ws_*`
-//! id directly. The task registry and the workspace catalog therefore both
-//! contribute claims, using checkout evidence to distinguish live, stale, and
-//! unreachable state [ORB-12119]. `workspace remove` drops catalog rows only;
-//! it retains the task-registry binding and copies catalog checkout evidence
-//! so a leftover partition stays classifiable [ORB-12223].
+//! which the task registry mints as `<slug>-<hash>` whenever a checkout binds
+//! without an explicit id. That is a different namespace from the
+//! *workspace-registry id* (`Workspace.id` in `<global_root>/workspaces.json`,
+//! minted as `ws_<slug>`), which this module always spells
+//! `catalog_workspace_id`: a legacy `<slug>-<hash>` partition and the
+//! synthetic `ws_unbound-data-dir` partition have no catalog row at all, and
+//! only a workspace whose `orbit workspace init` bound the catalog id as its
+//! partition id spells the two the same. Reading a partition id as a catalog
+//! id is what made 18 of 22 live partitions look orphaned [ORB-12109].
+//!
+//! The task registry and the workspace catalog therefore both contribute
+//! claims, using checkout evidence to distinguish live, stale, and unreachable
+//! state [ORB-12119]. `workspace remove` drops catalog rows only; it retains
+//! the task-registry binding and copies catalog checkout evidence so a
+//! leftover partition stays classifiable [ORB-12223].
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use orbit_common::OrbitError;
-use orbit_core::runtime::UNBOUND_DATA_DIR_WORKSPACE_ID;
+use orbit_core::runtime::UNBOUND_DATA_DIR_PARTITION_ID;
 use orbit_registry::workspace_registry;
 pub use orbit_store::maintenance::task_registry::task_workspaces_dir;
 use orbit_store::maintenance::task_registry::{
@@ -31,9 +39,9 @@ use orbit_types::task::is_valid_orb_task_id;
 use orbit_types::workspace::WorkspaceCheckout;
 
 /// Path to one workspace's task-store partition under
-/// `<global_root>/tasks/workspaces/<workspace_id>/`.
-pub fn task_store_partition_path(global_root: &Path, workspace_id: &str) -> PathBuf {
-    task_workspaces_dir(global_root).join(workspace_id)
+/// `<global_root>/tasks/workspaces/<partition_id>/`.
+pub fn task_store_partition_path(global_root: &Path, partition_id: &str) -> PathBuf {
+    task_workspaces_dir(global_root).join(partition_id)
 }
 
 /// One partition directory that no registry claims, with the amount of task
@@ -102,7 +110,7 @@ pub fn inspect_task_store_partitions(
     let mut unowned = Vec::new();
     let mut unreachable = Vec::new();
     for path in partitions {
-        let Some(id) = partition_id(&path).map(str::to_owned) else {
+        let Some(id) = partition_id_of(&path).map(str::to_owned) else {
             continue;
         };
         if claims.claimed.contains(&id) {
@@ -187,18 +195,18 @@ pub fn remove_unclaimed_task_stores(global_root: &Path) -> Result<RemovedTaskSto
 
     let mut removed = RemovedTaskStores::default();
     for partition in partitions.stale {
-        let Some(workspace_id) = partition_id(&partition.path) else {
+        let Some(partition_id) = partition_id_of(&partition.path) else {
             continue;
         };
-        if remove_partition(&tasks, global_root, workspace_id)? {
+        if remove_partition(&tasks, global_root, partition_id)? {
             removed.stale.push(partition);
         }
     }
     for partition in partitions.removable {
-        let Some(workspace_id) = partition_id(&partition.path) else {
+        let Some(partition_id) = partition_id_of(&partition.path) else {
             continue;
         };
-        if remove_partition(&tasks, global_root, workspace_id)? {
+        if remove_partition(&tasks, global_root, partition_id)? {
             removed.empty.push(partition.path);
         }
     }
@@ -223,7 +231,7 @@ pub fn remove_checkout_task_stores(
     let mut targets: Vec<String> = Vec::new();
 
     if let Some(bound) = tasks.find_checkout_by_orbit_dir(orbit_dir)? {
-        targets.push(bound.workspace_id);
+        targets.push(bound.partition_id);
     }
     if let Some(catalog_id) = catalog_workspace_id
         && !targets.iter().any(|id| id == catalog_id)
@@ -233,9 +241,9 @@ pub fn remove_checkout_task_stores(
     }
 
     let mut removed = Vec::new();
-    for workspace_id in targets {
-        if remove_partition(&tasks, global_root, &workspace_id)? {
-            removed.push(task_store_partition_path(global_root, &workspace_id));
+    for partition_id in targets {
+        if remove_partition(&tasks, global_root, &partition_id)? {
+            removed.push(task_store_partition_path(global_root, &partition_id));
         }
     }
     Ok(removed)
@@ -250,14 +258,14 @@ pub fn bound_partition_id(
 ) -> Result<Option<String>, OrbitError> {
     Ok(open_task_registry(global_root)?
         .find_checkout_by_orbit_dir(orbit_dir)?
-        .map(|binding| binding.workspace_id))
+        .map(|binding| binding.partition_id))
 }
 
-/// Whether the task registry still binds `workspace_id` as a partition.
-pub fn partition_is_bound(global_root: &Path, workspace_id: &str) -> Result<bool, OrbitError> {
+/// Whether the task registry still binds `partition_id` as a partition.
+pub fn partition_is_bound(global_root: &Path, partition_id: &str) -> Result<bool, OrbitError> {
     Ok(open_task_registry(global_root)?
-        .workspace_ids()?
-        .contains(workspace_id))
+        .partition_ids()?
+        .contains(partition_id))
 }
 
 /// Copy a catalog checkout into the task registry before `workspace remove`
@@ -275,23 +283,27 @@ pub fn partition_is_bound(global_root: &Path, workspace_id: &str) -> Result<bool
 /// shared external root), evidence is stored under the per-checkout
 /// `repo_root` instead of stealing that binding. `checkout_evidence` reads
 /// `repo_root`.
+///
+/// Only a workspace that bound its catalog id as its partition id has a
+/// leftover to retain here; a checkout on a legacy `<slug>-<hash>` partition
+/// has none under this name and this call does nothing.
 pub fn retain_task_store_on_catalog_remove(
     global_root: &Path,
-    workspace_id: &str,
+    catalog_workspace_id: &str,
     slug: &str,
     catalog_checkout: Option<&WorkspaceCheckout>,
 ) -> Result<Option<UnclaimedPartition>, OrbitError> {
-    let leftover = leftover_task_partition(global_root, workspace_id);
+    let leftover = leftover_task_partition(global_root, catalog_workspace_id);
     if leftover.is_some()
         && let Some(checkout) = catalog_checkout
     {
-        ensure_checkout_evidence(global_root, workspace_id, slug, checkout)?;
+        ensure_checkout_evidence(global_root, catalog_workspace_id, slug, checkout)?;
     }
     Ok(leftover)
 }
 
-fn leftover_task_partition(global_root: &Path, workspace_id: &str) -> Option<UnclaimedPartition> {
-    let path = task_store_partition_path(global_root, workspace_id);
+fn leftover_task_partition(global_root: &Path, partition_id: &str) -> Option<UnclaimedPartition> {
+    let path = task_store_partition_path(global_root, partition_id);
     if !path.is_dir() {
         return None;
     }
@@ -303,21 +315,21 @@ fn leftover_task_partition(global_root: &Path, workspace_id: &str) -> Option<Unc
 
 fn ensure_checkout_evidence(
     global_root: &Path,
-    workspace_id: &str,
+    partition_id: &str,
     slug: &str,
     checkout: &WorkspaceCheckout,
 ) -> Result<(), OrbitError> {
     let tasks = open_task_registry(global_root)?;
-    if tasks.find_workspace_checkout(workspace_id)?.is_some() {
+    if tasks.find_workspace_checkout(partition_id)?.is_some() {
         return Ok(());
     }
 
     let orbit_dir = match tasks.find_checkout_by_orbit_dir(&checkout.orbit_dir)? {
-        Some(existing) if existing.workspace_id != workspace_id => checkout.repo_root.clone(),
+        Some(existing) if existing.partition_id != partition_id => checkout.repo_root.clone(),
         _ => checkout.orbit_dir.clone(),
     };
     tasks.bind_workspace(BindWorkspaceParams {
-        workspace_id: Some(workspace_id.to_string()),
+        partition_id: Some(partition_id.to_string()),
         slug: slug.to_string(),
         repo_root: checkout.repo_root.clone(),
         workspace_path: checkout.repo_root.clone(),
@@ -328,6 +340,9 @@ fn ensure_checkout_evidence(
 }
 
 /// Who claims each partition on this host, and why the rest do not.
+///
+/// Every set is keyed by *partition id*. A catalog workspace contributes a
+/// claim only where its id is also a partition id — never the other way round.
 struct PartitionClaims {
     /// Registered task workspaces, live workspace catalog ids, and the
     /// synthetic partition every `--root <data-dir>` write lands in.
@@ -352,30 +367,30 @@ fn partition_claims(global_root: &Path) -> Result<PartitionClaims, OrbitError> {
         gone: BTreeSet::new(),
         unreachable: BTreeMap::new(),
     };
-    for workspace_id in tasks.workspace_ids()? {
-        let Some(checkout) = tasks.find_workspace_checkout(&workspace_id)? else {
+    for partition_id in tasks.partition_ids()? {
+        let Some(checkout) = tasks.find_workspace_checkout(&partition_id)? else {
             // Imported task archives register their source workspace without a
             // machine-local checkout. That logical registration still owns its
             // partition on this host.
-            claims.claimed.insert(workspace_id);
+            claims.claimed.insert(partition_id);
             continue;
         };
-        claims.checkout_bound.insert(workspace_id.clone());
+        claims.checkout_bound.insert(partition_id.clone());
         match checkout_evidence(&checkout.repo_root) {
             CheckoutEvidence::Present => {
-                claims.claimed.insert(workspace_id);
+                claims.claimed.insert(partition_id);
             }
             CheckoutEvidence::Gone => {
-                claims.gone.insert(workspace_id);
+                claims.gone.insert(partition_id);
             }
             CheckoutEvidence::Unreachable(reason) => {
-                claims.unreachable.insert(workspace_id, reason);
+                claims.unreachable.insert(partition_id, reason);
             }
         }
     }
     claims
         .claimed
-        .insert(UNBOUND_DATA_DIR_WORKSPACE_ID.to_string());
+        .insert(UNBOUND_DATA_DIR_PARTITION_ID.to_string());
 
     let registry_path = workspace_registry::registry_path_for(global_root);
     if registry_path.exists() {
@@ -402,34 +417,40 @@ fn partition_claims(global_root: &Path) -> Result<PartitionClaims, OrbitError> {
 }
 
 /// Add a catalog checkout's claim when the task registry has only a path-free
-/// logical registration for the same partition id.
+/// logical registration for the partition of the same name.
+///
+/// `catalog_workspace_id` comes from the workspace registry, so it claims a
+/// partition only when `workspace init` named that partition after it. It is
+/// never evidence about any other partition.
 fn record_catalog_checkout_evidence(
     claims: &mut PartitionClaims,
-    workspace_id: &str,
+    catalog_workspace_id: &str,
     checkout: &WorkspaceCheckout,
 ) {
     // A task-registry checkout binding has a more specific identity than the
     // catalog fallback. This matters when legacy or reindexed state names the
     // same partition with different path metadata.
-    if claims.checkout_bound.contains(workspace_id) {
+    if claims.checkout_bound.contains(catalog_workspace_id) {
         return;
     }
 
     match checkout_evidence(&checkout.repo_root) {
         CheckoutEvidence::Present => {
-            claims.claimed.insert(workspace_id.to_string());
-            claims.gone.remove(workspace_id);
-            claims.unreachable.remove(workspace_id);
+            claims.claimed.insert(catalog_workspace_id.to_string());
+            claims.gone.remove(catalog_workspace_id);
+            claims.unreachable.remove(catalog_workspace_id);
         }
         CheckoutEvidence::Gone => {
-            claims.claimed.remove(workspace_id);
-            claims.gone.insert(workspace_id.to_string());
-            claims.unreachable.remove(workspace_id);
+            claims.claimed.remove(catalog_workspace_id);
+            claims.gone.insert(catalog_workspace_id.to_string());
+            claims.unreachable.remove(catalog_workspace_id);
         }
         CheckoutEvidence::Unreachable(reason) => {
-            claims.claimed.remove(workspace_id);
-            claims.gone.remove(workspace_id);
-            claims.unreachable.insert(workspace_id.to_string(), reason);
+            claims.claimed.remove(catalog_workspace_id);
+            claims.gone.remove(catalog_workspace_id);
+            claims
+                .unreachable
+                .insert(catalog_workspace_id.to_string(), reason);
         }
     }
 }
@@ -541,8 +562,8 @@ fn task_store_partitions(global_root: &Path) -> Result<Option<Vec<PathBuf>>, Orb
     ))
 }
 
-/// Workspace id a partition directory is named for.
-pub fn partition_id(partition: &Path) -> Option<&str> {
+/// Task-store partition id a partition directory is named for.
+pub fn partition_id_of(partition: &Path) -> Option<&str> {
     partition.file_name().and_then(|name| name.to_str())
 }
 
@@ -563,17 +584,17 @@ fn count_task_bundles(partition: &Path) -> usize {
         .count()
 }
 
-/// Whether `workspace_id`'s partition holds *another* checkout's task state,
+/// Whether `partition_id`'s partition holds *another* checkout's task state,
 /// and so is not this checkout's to delete. The registry normalizes the paths
 /// it stores, so the comparison canonicalizes too.
 fn bound_to_another_checkout(
     tasks: &TaskRegistryStore,
-    workspace_id: &str,
+    partition_id: &str,
     orbit_dir: &Path,
 ) -> Result<bool, OrbitError> {
-    let binding = match tasks.find_workspace_checkout(workspace_id) {
+    let binding = match tasks.find_workspace_checkout(partition_id) {
         Ok(binding) => binding,
-        // Not a well-formed workspace id, so no binding can name it.
+        // Not a well-formed partition id, so no binding can name it.
         Err(OrbitError::InvalidInput(_)) => return Ok(false),
         Err(error) => return Err(error),
     };
@@ -589,17 +610,17 @@ fn bound_to_another_checkout(
 fn remove_partition(
     tasks: &TaskRegistryStore,
     global_root: &Path,
-    workspace_id: &str,
+    partition_id: &str,
 ) -> Result<bool, OrbitError> {
-    // A directory name that is not a well-formed workspace id can hold no
+    // A directory name that is not a well-formed partition id can hold no
     // bindings; its directory is still this function's to remove.
-    if let Err(error) = tasks.unbind_workspace(workspace_id)
+    if let Err(error) = tasks.unbind_workspace(partition_id)
         && !matches!(error, OrbitError::InvalidInput(_))
     {
         return Err(error);
     }
 
-    let path = task_store_partition_path(global_root, workspace_id);
+    let path = task_store_partition_path(global_root, partition_id);
     if !path.is_dir() {
         return Ok(false);
     }

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -123,7 +123,7 @@ fn bind_task_partition_at(
         TaskRegistryStore::open(&task_registry_path(global_root)).expect("open task registry");
     tasks
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some(workspace_id.to_string()),
+            partition_id: Some(workspace_id.to_string()),
             slug: slug.to_string(),
             repo_root: repo_root.to_path_buf(),
             workspace_path: repo_root.to_path_buf(),
@@ -138,7 +138,7 @@ fn register_task_workspace(global_root: &Path, workspace_id: &str, slug: &str) {
         TaskRegistryStore::open(&task_registry_path(global_root)).expect("open task registry");
     tasks
         .register_workspace(RegisterWorkspaceParams {
-            workspace_id: workspace_id.to_string(),
+            partition_id: workspace_id.to_string(),
             slug: slug.to_string(),
             repo_fingerprint: None,
         })

--- a/crates/orbit-cmd/src/tests/registry_routines.rs
+++ b/crates/orbit-cmd/src/tests/registry_routines.rs
@@ -129,6 +129,6 @@ fn workspace_discovery_builds_bound_runtimes() {
         .1
         .workspace_runtime_binding()
         .expect("binding");
-    assert_eq!(binding.workspace_id, "ws_runtime");
+    assert_eq!(binding.task_partition_id, "ws_runtime");
     assert_eq!(binding.ship_mode.as_input_value(), "pr");
 }

--- a/crates/orbit-cmd/src/tests/registry_runtime.rs
+++ b/crates/orbit-cmd/src/tests/registry_runtime.rs
@@ -51,7 +51,7 @@ fn binding_preserves_logical_and_runtime_ids_and_ship_mode() {
     let resolved = resolved_workspace_binding(&workspace, &checkout).expect("resolved binding");
     assert_eq!(resolved.logical_workspace_id, "logical-abc123");
     assert_eq!(resolved.runtime.logical_workspace_id, "logical-abc123");
-    assert_eq!(resolved.runtime.workspace_id, "ws_runtime_config");
+    assert_eq!(resolved.runtime.task_partition_id, "ws_runtime_config");
     assert_eq!(
         resolved.runtime.owner_machine_id.as_deref(),
         Some("hm_owner")
@@ -93,7 +93,7 @@ fn registered_checkout_opens_a_bound_runtime() {
     let binding = runtime
         .workspace_runtime_binding()
         .expect("runtime binding");
-    assert_eq!(binding.workspace_id, "ws_runtime");
+    assert_eq!(binding.task_partition_id, "ws_runtime");
     assert_eq!(binding.repo_root, repo);
     assert_eq!(binding.ship_mode.as_input_value(), "local");
     assert_eq!(
@@ -160,7 +160,7 @@ fn explicit_shared_root_selects_checkout_by_cwd_and_does_not_fall_back() {
     assert_eq!(
         workspace_runtime_binding(&selected.workspace, &selected.checkout)
             .expect("runtime binding")
-            .workspace_id,
+            .task_partition_id,
         "ws_shared_runtime"
     );
 

--- a/crates/orbit-cmd/src/tests/task_store.rs
+++ b/crates/orbit-cmd/src/tests/task_store.rs
@@ -23,7 +23,7 @@ fn bind(global_root: &Path, workspace_id: &str, slug: &str, repo_root: &Path) {
         TaskRegistryStore::open(&task_registry_path(global_root)).expect("open task registry");
     tasks
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some(workspace_id.to_string()),
+            partition_id: Some(workspace_id.to_string()),
             slug: slug.to_string(),
             repo_root: repo_root.to_path_buf(),
             workspace_path: repo_root.to_path_buf(),
@@ -38,7 +38,7 @@ fn register_logical_workspace(global_root: &Path, workspace_id: &str, slug: &str
         TaskRegistryStore::open(&task_registry_path(global_root)).expect("open task registry");
     tasks
         .register_workspace(RegisterWorkspaceParams {
-            workspace_id: workspace_id.to_string(),
+            partition_id: workspace_id.to_string(),
             slug: slug.to_string(),
             repo_fingerprint: None,
         })
@@ -278,7 +278,12 @@ fn write_catalog_workspace(global_root: &Path, workspace_id: &str, name: &str) {
     workspace_registry::save_registry_to(&registry, &registry_path).expect("save catalog");
 }
 
-fn write_catalog_shared_root_checkout(global_root: &Path, workspace_id: &str, repo_root: &Path) {
+fn write_catalog_checkout(
+    global_root: &Path,
+    workspace_id: &str,
+    repo_root: &Path,
+    orbit_dir: &Path,
+) {
     let registry_path = workspace_registry::registry_path_for(global_root);
     let mut registry =
         workspace_registry::load_registry_from(&registry_path).expect("load catalog");
@@ -287,11 +292,17 @@ fn write_catalog_shared_root_checkout(global_root: &Path, workspace_id: &str, re
         WorkspaceCheckout::owner(
             workspace_id.to_string(),
             repo_root.to_path_buf(),
-            global_root.to_path_buf(),
+            orbit_dir.to_path_buf(),
         ),
     )
-    .expect("register shared-root catalog checkout");
+    .expect("register catalog checkout");
     workspace_registry::save_registry_to(&registry, &registry_path).expect("save catalog");
+}
+
+/// A checkout whose orbit dir is the shared external root the catalog records
+/// for every workspace on it.
+fn write_catalog_shared_root_checkout(global_root: &Path, workspace_id: &str, repo_root: &Path) {
+    write_catalog_checkout(global_root, workspace_id, repo_root, global_root);
 }
 
 fn drop_catalog_workspace(global_root: &Path, workspace_id: &str) {
@@ -389,7 +400,7 @@ fn bind_at(global_root: &Path, workspace_id: &str, slug: &str, repo_root: &Path,
         TaskRegistryStore::open(&task_registry_path(global_root)).expect("open task registry");
     tasks
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some(workspace_id.to_string()),
+            partition_id: Some(workspace_id.to_string()),
             slug: slug.to_string(),
             repo_root: repo_root.to_path_buf(),
             workspace_path: repo_root.to_path_buf(),
@@ -397,6 +408,61 @@ fn bind_at(global_root: &Path, workspace_id: &str, slug: &str, repo_root: &Path,
             repo_fingerprint: None,
         })
         .expect("bind task-registry workspace");
+}
+
+/// [ORB-12109] The task-store partition id and the workspace-registry id are
+/// two namespaces. A checkout the catalog knows as `ws_repo` keeps its task
+/// state in the legacy `repo-a1b2c3` partition the task registry minted for
+/// it, and no partition is ever named for the catalog id. Resolving ownership
+/// through the catalog therefore reports a live partition as orphaned — the
+/// defect that made the repair capable of deleting a whole host's tasks.
+#[test]
+fn a_live_checkout_keeps_its_legacy_partition_despite_a_ws_catalog_id() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let repo_root = temp.path().join("repo");
+    let orbit_dir = repo_root.join(".orbit");
+    fs::create_dir_all(&global_root).expect("create global root");
+    fs::create_dir_all(&orbit_dir).expect("create checkout");
+
+    bind(&global_root, "repo-a1b2c3", "repo", &repo_root);
+    write_task_bundle(&global_root, "repo-a1b2c3", "ORB-1");
+    write_catalog_workspace(&global_root, "ws_repo", "repo");
+    write_catalog_checkout(&global_root, "ws_repo", &repo_root, &orbit_dir);
+
+    assert_eq!(
+        bound_partition_id(&global_root, &orbit_dir).expect("resolve bound partition"),
+        Some("repo-a1b2c3".to_string()),
+        "the checkout's task state lives under the minted partition id, not its catalog id"
+    );
+    assert!(
+        !task_store_partition_path(&global_root, "ws_repo").exists(),
+        "no partition is named for the catalog id"
+    );
+
+    let partitions = inspect_task_store_partitions(&global_root)
+        .expect("inspect partitions")
+        .expect("partitions directory exists");
+    assert_eq!(partitions.scanned, 1);
+    assert!(
+        partitions.unowned.is_empty(),
+        "a partition claimed by the task registry must not be read as unowned \
+         because the workspace catalog spells its workspace id differently: {partitions:?}"
+    );
+    assert!(partitions.removable.is_empty(), "{partitions:?}");
+    assert!(partitions.stale.is_empty(), "{partitions:?}");
+    assert!(partitions.unreachable.is_empty(), "{partitions:?}");
+
+    let removed = remove_unclaimed_task_stores(&global_root).expect("run the repair");
+    assert!(removed.is_empty(), "the repair removed {removed:?}");
+    assert!(
+        task_workspaces_dir(&global_root)
+            .join("repo-a1b2c3")
+            .join("ORB-1")
+            .is_dir(),
+        "the live checkout's task bundle must survive the repair"
+    );
+    assert!(partition_is_bound(&global_root, "repo-a1b2c3").expect("read bindings"));
 }
 
 /// Residue with no task bundles carries nothing `orbit task reindex` could

--- a/crates/orbit-core/src/adapter/engine_host/tests/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/tests/runtime_host.rs
@@ -1288,7 +1288,7 @@ fn orbit_workspace_selector_reports_the_logical_catalog_id() {
         &orbit_dir,
         WorkspaceRuntimeBinding {
             logical_workspace_id: "ws_orbit".to_string(),
-            workspace_id: "daniel-e9c542".to_string(),
+            task_partition_id: "daniel-e9c542".to_string(),
             owner_machine_id: None,
             repo_root: repo,
             ship_mode: ShipMode::Local,

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dispatch.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dispatch.rs
@@ -347,7 +347,7 @@ fn workspace_ship_input_prefers_the_registry_neutral_runtime_binding() {
         &workspace,
         WorkspaceRuntimeBinding {
             logical_workspace_id: "ws_bound".to_string(),
-            workspace_id: "ws_bound".to_string(),
+            task_partition_id: "ws_bound".to_string(),
             owner_machine_id: None,
             repo_root: repo,
             ship_mode: ShipMode::Pr,

--- a/crates/orbit-core/src/adapter/tool_host/hub_registry.rs
+++ b/crates/orbit-core/src/adapter/tool_host/hub_registry.rs
@@ -18,14 +18,18 @@ pub struct HubCoordinationExecutor;
 impl HubCoordinationExecutor {
     /// Registers the path-free task-registry partition for a logical workspace.
     /// Workspace initialization calls this once; identical repeats are safe.
+    ///
+    /// `workspace init` deliberately names the partition after the workspace
+    /// registry id it just minted, which is why a freshly initialized
+    /// workspace spells both ids `ws_<slug>`; older checkouts do not.
     pub fn register_workspace(
         global_root: &Path,
-        workspace_id: impl Into<String>,
+        partition_id: impl Into<String>,
         slug: impl Into<String>,
     ) -> Result<(), OrbitError> {
         let registry = TaskRegistryStore::open(&task_registry_path(global_root))?;
         registry.register_workspace(RegisterWorkspaceParams {
-            workspace_id: workspace_id.into(),
+            partition_id: partition_id.into(),
             slug: slug.into(),
             repo_fingerprint: None,
         })?;
@@ -37,7 +41,7 @@ impl HubCoordinationExecutor {
     /// leave split-brain state after workspace init.
     pub fn bind_checkout(
         global_root: &Path,
-        workspace_id: impl Into<String>,
+        partition_id: impl Into<String>,
         slug: impl Into<String>,
         repo_root: &Path,
         orbit_dir: &Path,
@@ -45,7 +49,7 @@ impl HubCoordinationExecutor {
     ) -> Result<(), OrbitError> {
         let registry = TaskRegistryStore::open(&task_registry_path(global_root))?;
         let params = BindWorkspaceParams {
-            workspace_id: Some(workspace_id.into()),
+            partition_id: Some(partition_id.into()),
             slug: slug.into(),
             repo_root: repo_root.to_path_buf(),
             workspace_path: repo_root.to_path_buf(),

--- a/crates/orbit-core/src/application/job/tests/exec/ci_sweep.rs
+++ b/crates/orbit-core/src/application/job/tests/exec/ci_sweep.rs
@@ -270,8 +270,8 @@ fn bound_runtime(
         &repo.join(".orbit"),
         crate::WorkspaceRuntimeBinding {
             logical_workspace_id: workspace_id.clone(),
+            task_partition_id: workspace_id,
             owner_machine_id: None,
-            workspace_id,
             repo_root: repo.clone(),
             ship_mode: orbit_types::workflow::ShipMode::Pr,
             base_branch: branch.map(ToOwned::to_owned),

--- a/crates/orbit-core/src/application/task/tests/paths.rs
+++ b/crates/orbit-core/src/application/task/tests/paths.rs
@@ -205,7 +205,7 @@ fn explicit_root_runtime() -> (tempfile::TempDir, OrbitRuntime) {
     TaskRegistryStore::open(&task_registry_path(&data_dir))
         .expect("open task registry")
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some("ws_repo".to_string()),
+            partition_id: Some("ws_repo".to_string()),
             slug: "repo".to_string(),
             repo_root: repo,
             workspace_path: root.path().join("repo"),

--- a/crates/orbit-core/src/bootstrap/task_migration.rs
+++ b/crates/orbit-core/src/bootstrap/task_migration.rs
@@ -79,7 +79,7 @@ impl OrbitRuntime {
             .unwrap_or("workspace")
             .to_string();
         registry.bind_workspace(BindWorkspaceParams {
-            workspace_id: Some(workspace_id.to_string()),
+            partition_id: Some(workspace_id.to_string()),
             slug,
             repo_root: binding.repo_root.clone(),
             workspace_path: binding.repo_root.clone(),

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -40,7 +40,7 @@ use crate::skill_catalog::SkillCatalog;
 /// maintenance that decides whether a task-store partition is orphaned must
 /// recognize it rather than delete the tasks every `--root` write lands in
 /// [ORB-12119].
-pub const UNBOUND_DATA_DIR_WORKSPACE_ID: &str = "ws_unbound-data-dir";
+pub const UNBOUND_DATA_DIR_PARTITION_ID: &str = "ws_unbound-data-dir";
 
 /// Runtime builder. Global root provides activities, jobs, executors, policies,
 /// config, global skills, and SQLite. Shared root provides existing workspace
@@ -86,7 +86,7 @@ pub(crate) fn build_context_from_roots(
             .as_ref()
             .map(|config| config.workspace_id.clone())
     }
-    .unwrap_or_else(|| UNBOUND_DATA_DIR_WORKSPACE_ID.to_string());
+    .unwrap_or_else(|| UNBOUND_DATA_DIR_PARTITION_ID.to_string());
     let import_report = if configured.is_none() {
         orbit_store::workflow::legacy_state::ImportReport::skipped()
     } else {
@@ -227,6 +227,16 @@ pub(crate) fn build_context_from_roots(
     ))
 }
 
+/// Resolve the task-store partition this runtime reads and writes task
+/// bundles in.
+///
+/// The partition id is the task registry's own namespace
+/// (`workspace_bindings.workspace_id`, the directory name under
+/// `tasks/workspaces/`), not the workspace-registry `ws_*` id: a checkout
+/// bound before `workspace init` supplied an id keeps a minted
+/// `<slug>-<hash>` partition, and an unselected `--root` data directory lands
+/// in [`UNBOUND_DATA_DIR_PARTITION_ID`]. Only
+/// `binding.logical_workspace_id` names a workspace-registry row.
 fn build_v2_task_backends(
     global_root: &Path,
     paths: &WorkspacePaths,
@@ -249,20 +259,20 @@ fn build_v2_task_backends(
             binding.logical_workspace_id.clone(),
         ));
     }
-    let workspace_id_hint = runtime_binding.map(|binding| binding.workspace_id.as_str());
+    let partition_id_hint = runtime_binding.map(|binding| binding.task_partition_id.as_str());
     // An explicit `--root` data directory is not a checkout. Binding
     // `parent(data-dir)` as `repo_root` mints a synthetic workspace (e.g.
     // `tmp-XXXXXX` for `/tmp`) that later `workspace init --force` cannot
     // reclaim. Skip that mint unless a selected checkout supplied a hint.
-    if workspace_id_hint.is_none() && is_explicit_data_dir(global_root, &paths.orbit_dir) {
-        let workspace_id = config
+    if partition_id_hint.is_none() && is_explicit_data_dir(global_root, &paths.orbit_dir) {
+        let partition_id = config
             .as_ref()
             .map(|config| config.workspace_id.clone())
-            .unwrap_or_else(|| UNBOUND_DATA_DIR_WORKSPACE_ID.to_string());
-        return Ok(coordination_task_backends(registry, workspace_id));
+            .unwrap_or_else(|| UNBOUND_DATA_DIR_PARTITION_ID.to_string());
+        return Ok(coordination_task_backends(registry, partition_id));
     }
-    let configured_id = config.as_ref().map(|config| config.workspace_id.as_str());
-    if let (Some(hint), Some(configured)) = (workspace_id_hint, configured_id)
+    let configured_partition_id = config.as_ref().map(|config| config.workspace_id.as_str());
+    if let (Some(hint), Some(configured)) = (partition_id_hint, configured_partition_id)
         && configured != hint
     {
         return Err(OrbitError::WorkspaceError(format!(
@@ -274,26 +284,26 @@ fn build_v2_task_backends(
     // row instead of asking `bind_workspace` for the drifted id, which fails
     // closed and takes every command in the checkout down (ORB-10985). The
     // config write below reconciles the checkout identity back onto it.
-    let workspace_id = match registry.find_checkout_by_orbit_dir(&paths.orbit_dir)? {
+    let partition_id = match registry.find_checkout_by_orbit_dir(&paths.orbit_dir)? {
         Some(bound) => {
-            if configured_id.is_some_and(|configured| configured != bound.workspace_id) {
+            if configured_partition_id.is_some_and(|configured| configured != bound.partition_id) {
                 tracing::warn!(
                     target: "orbit.core.bootstrap",
                     orbit_dir = %paths.orbit_dir.display(),
-                    bound_workspace_id = %bound.workspace_id,
-                    configured_workspace_id = configured_id,
-                    "checkout identity diverged from its task-registry binding; adopting the bound workspace"
+                    bound_partition_id = %bound.partition_id,
+                    configured_partition_id = configured_partition_id,
+                    "checkout identity diverged from its task-registry binding; adopting the bound partition"
                 );
             }
-            Some(bound.workspace_id)
+            Some(bound.partition_id)
         }
-        None => match configured_id.or(workspace_id_hint) {
+        None => match configured_partition_id.or(partition_id_hint) {
             Some(id) => Some(id.to_string()),
-            None => rebind_candidate_workspace_id(&registry, paths)?,
+            None => rebind_candidate_partition_id(&registry, paths)?,
         },
     };
     let binding = registry.bind_workspace(BindWorkspaceParams {
-        workspace_id,
+        partition_id,
         slug: workspace_slug(&paths.repo_root),
         repo_root: paths.repo_root.clone(),
         workspace_path: paths.repo_root.clone(),
@@ -302,12 +312,12 @@ fn build_v2_task_backends(
     })?;
     if config
         .as_ref()
-        .is_none_or(|config| config.workspace_id != binding.workspace_id)
+        .is_none_or(|config| config.workspace_id != binding.partition_id)
         && let Err(error) = write_workspace_config(
             &paths.orbit_dir,
             &WorkspaceConfig {
                 schema_version: 1,
-                workspace_id: binding.workspace_id.clone(),
+                workspace_id: binding.partition_id.clone(),
             },
         )
     {
@@ -325,7 +335,7 @@ fn build_v2_task_backends(
         }
     }
 
-    Ok(workspace_task_backends(registry, binding.workspace_id))
+    Ok(workspace_task_backends(registry, binding.partition_id))
 }
 
 /// Recreate the selected checkout's task-registry binding after its index was
@@ -345,7 +355,7 @@ fn ensure_explicit_root_task_binding(
     }
 
     registry.bind_workspace(BindWorkspaceParams {
-        workspace_id: Some(binding.logical_workspace_id.clone()),
+        partition_id: Some(binding.logical_workspace_id.clone()),
         slug: workspace_slug(&binding.repo_root),
         repo_root: binding.repo_root.clone(),
         workspace_path: binding.repo_root.clone(),
@@ -355,7 +365,7 @@ fn ensure_explicit_root_task_binding(
     Ok(())
 }
 
-fn rebind_candidate_workspace_id(
+fn rebind_candidate_partition_id(
     registry: &TaskRegistryStore,
     paths: &WorkspacePaths,
 ) -> Result<Option<String>, OrbitError> {
@@ -363,7 +373,7 @@ fn rebind_candidate_workspace_id(
         registry.find_rebind_candidates(&paths.repo_root, &paths.repo_root, &paths.orbit_dir)?;
     match candidates.as_slice() {
         [] => Ok(None),
-        [candidate] => Ok(Some(candidate.workspace_id.clone())),
+        [candidate] => Ok(Some(candidate.partition_id.clone())),
         _ => Err(OrbitError::WorkspaceError(format!(
             "workspace config is missing and multiple task artifact bindings match '{}'; restore .orbit/config.yaml or choose a workspace binding",
             paths.orbit_dir.display()

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -68,7 +68,7 @@ pub use resolve::{
 pub use resolve::{is_global_orbit_root, resolve_global_root, try_resolve_initialized_roots};
 // `pub` for host task-store maintenance in `orbit-cmd`, which must recognize
 // the one partition id no registry claims [ORB-12119].
-pub use builder::UNBOUND_DATA_DIR_WORKSPACE_ID;
+pub use builder::UNBOUND_DATA_DIR_PARTITION_ID;
 pub use run_input::managed_workspace_selector_from_env;
 pub(crate) use task::{failed_run_error_context, is_workflow_failure_state};
 
@@ -132,9 +132,13 @@ pub struct WorkspaceRuntimeBinding {
     /// Logical catalog ID (`ws_*`). Nested managed CLI/MCP calls use this
     /// selector instead of rediscovering ownership from a linked-worktree cwd.
     pub logical_workspace_id: String,
-    /// Checkout identity from `.orbit/config.yaml`, which the task registry
-    /// partitions by (L-0098: it may differ from `logical_workspace_id`).
-    pub workspace_id: String,
+    /// Task-store partition id: the checkout identity from
+    /// `.orbit/config.yaml` that the task registry partitions task bundles by
+    /// (`workspace_bindings.workspace_id`). A different namespace from
+    /// `logical_workspace_id` above, which the workspace registry mints, and
+    /// the two genuinely differ for any checkout bound before `workspace init`
+    /// supplied an id (L-0098).
+    pub task_partition_id: String,
     /// Registered owner of the logical workspace. Automation resolves the
     /// default owner of a delivery definition from it, so an unambiguously
     /// owned workspace needs no redundant per-definition configuration.
@@ -153,7 +157,7 @@ pub fn workspace_runtime_binding(
 ) -> Result<WorkspaceRuntimeBinding, OrbitError> {
     Ok(WorkspaceRuntimeBinding {
         logical_workspace_id: workspace.id.clone(),
-        workspace_id: workspace_id_for_orbit_dir(&checkout.orbit_dir)?,
+        task_partition_id: workspace_id_for_orbit_dir(&checkout.orbit_dir)?,
         owner_machine_id: workspace.owner_machine_id.clone(),
         repo_root: checkout.repo_root.clone(),
         ship_mode: resolved_ship_mode(workspace),
@@ -204,7 +208,7 @@ impl OrbitRuntime {
         // those were already initialized by workspace init.
         let binding = WorkspaceRuntimeBinding {
             logical_workspace_id: "ws_memory".to_string(),
-            workspace_id: "ws_memory".to_string(),
+            task_partition_id: "ws_memory".to_string(),
             owner_machine_id: None,
             repo_root: data_root.to_path_buf(),
             ship_mode: ShipMode::Local,

--- a/crates/orbit-core/src/runtime/tests/builder.rs
+++ b/crates/orbit-core/src/runtime/tests/builder.rs
@@ -66,7 +66,7 @@ fn registry_neutral_binding_controls_workspace_id_repo_root_and_ship_mode() {
 
     let binding = WorkspaceRuntimeBinding {
         logical_workspace_id: "ws_bound".to_string(),
-        workspace_id: "ws_bound".to_string(),
+        task_partition_id: "ws_bound".to_string(),
         owner_machine_id: None,
         repo_root: custom_repo_root.clone(),
         ship_mode: ShipMode::Pr,
@@ -102,7 +102,7 @@ fn registry_neutral_binding_rejects_a_conflicting_workspace_config() {
         &workspace_root,
         WorkspaceRuntimeBinding {
             logical_workspace_id: "ws_other".to_string(),
-            workspace_id: "ws_other".to_string(),
+            task_partition_id: "ws_other".to_string(),
             owner_machine_id: None,
             repo_root: root.path().join("repo"),
             ship_mode: ShipMode::Local,
@@ -340,7 +340,7 @@ fn explicit_data_dir_runtime_recovers_the_stored_checkout_repo_root() {
         TaskRegistryStore::open(&task_registry_path(&data_dir)).expect("open task registry");
     let bound = registry
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some("ws_repo".to_string()),
+            partition_id: Some("ws_repo".to_string()),
             slug: "repo".to_string(),
             repo_root: repo_root.clone(),
             workspace_path: repo_root.clone(),

--- a/crates/orbit-store/src/compose/tests/factory.rs
+++ b/crates/orbit-store/src/compose/tests/factory.rs
@@ -50,7 +50,7 @@ fn workspace_task_backends_exposes_create_get_and_list_trait_surface() {
     std::fs::create_dir_all(&orbit_dir).expect("create orbit dir");
     let binding = registry
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some("orbit-test-123456".to_string()),
+            partition_id: Some("orbit-test-123456".to_string()),
             slug: "Orbit Test".to_string(),
             repo_root: repo_dir.clone(),
             workspace_path: repo_dir.clone(),
@@ -58,7 +58,7 @@ fn workspace_task_backends_exposes_create_get_and_list_trait_surface() {
             repo_fingerprint: None,
         })
         .expect("bind workspace");
-    let backends = workspace_task_backends(registry, binding.workspace_id);
+    let backends = workspace_task_backends(registry, binding.partition_id);
 
     let created = backends
         .task
@@ -115,7 +115,7 @@ fn coordination_backends_create_and_schedule_across_checkoutless_workspaces() {
     ] {
         registry
             .register_workspace(RegisterWorkspaceParams {
-                workspace_id: workspace_id.to_string(),
+                partition_id: workspace_id.to_string(),
                 slug: slug.to_string(),
                 repo_fingerprint: None,
             })

--- a/crates/orbit-store/src/contracts/task_registry.rs
+++ b/crates/orbit-store/src/contracts/task_registry.rs
@@ -6,7 +6,10 @@ use orbit_types::task::{TaskPriority, TaskStatus};
 
 #[derive(Debug, Clone)]
 pub struct BindWorkspaceParams {
-    pub workspace_id: Option<String>,
+    /// Task-store partition id to bind the checkout to, or `None` to mint one.
+    /// A distinct namespace from the workspace-registry id, even when a caller
+    /// passes a `ws_*` id in; see `task_workspaces_dir`.
+    pub partition_id: Option<String>,
     pub slug: String,
     pub repo_root: PathBuf,
     pub workspace_path: PathBuf,
@@ -17,14 +20,18 @@ pub struct BindWorkspaceParams {
 /// Path-free coordination record for a logical workspace.
 #[derive(Debug, Clone)]
 pub struct RegisterWorkspaceParams {
-    pub workspace_id: String,
+    /// Task-store partition the imported workspace's bundles live in.
+    pub partition_id: String,
     pub slug: String,
     pub repo_fingerprint: Option<String>,
 }
 
+/// Logical task-registry row for one task-store partition.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkspaceBinding {
-    pub workspace_id: String,
+    /// Names the partition directory under `tasks/workspaces/`, not a
+    /// workspace-registry row.
+    pub partition_id: String,
     pub slug: String,
     pub repo_fingerprint: Option<String>,
     pub created_at: DateTime<Utc>,
@@ -34,7 +41,8 @@ pub struct WorkspaceBinding {
 /// Machine-local checkout attached to a logical workspace, when one exists.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkspaceCheckoutBinding {
-    pub workspace_id: String,
+    /// Partition this checkout's task bundles live in.
+    pub partition_id: String,
     pub repo_root: PathBuf,
     pub workspace_path: PathBuf,
     pub orbit_dir: PathBuf,
@@ -45,7 +53,7 @@ pub struct WorkspaceCheckoutBinding {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TaskBundleBinding {
     pub task_id: String,
-    pub workspace_id: String,
+    pub partition_id: String,
     pub canonical_path: PathBuf,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -72,7 +80,7 @@ pub struct TaskIndexFilter {
 /// never reported here.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DanglingRelationTarget {
-    pub workspace_id: String,
+    pub partition_id: String,
     pub source_task_id: String,
     pub relation_type: String,
     pub target_task_id: String,

--- a/crates/orbit-store/src/driver/file/workspace_binding.rs
+++ b/crates/orbit-store/src/driver/file/workspace_binding.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use orbit_common::OrbitError;
 use serde::{Deserialize, Serialize};
 
-use crate::fs::path_safety::validate_workspace_id;
+use crate::fs::path_safety::validate_partition_id;
 use crate::fs::yaml::{parse_yaml_with, write_yaml_atomic_with};
 
 use crate::contracts::WorkspaceConfig;
@@ -84,7 +84,7 @@ pub fn write_workspace_config(
     orbit_dir: &Path,
     config: &WorkspaceConfig,
 ) -> Result<(), OrbitError> {
-    let workspace_id = validate_workspace_id(&config.workspace_id)?;
+    let workspace_id = validate_partition_id(&config.workspace_id)?;
     if config.schema_version != CONFIG_SCHEMA_VERSION {
         return Err(OrbitError::InvalidInput(format!(
             "unsupported workspace config schema_version {}",
@@ -110,6 +110,6 @@ fn validate_workspace_config_doc(doc: WorkspaceConfigDoc) -> Result<WorkspaceCon
     }
     Ok(WorkspaceConfig {
         schema_version: doc.schema_version,
-        workspace_id: validate_workspace_id(&doc.workspace_id)?,
+        workspace_id: validate_partition_id(&doc.workspace_id)?,
     })
 }

--- a/crates/orbit-store/src/driver/sqlite/task_registry/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/mod.rs
@@ -1,7 +1,7 @@
 //! SQLite task-registry storage split into focused schema, query, config, and store modules.
 //!
 //! `types` contains the public task-registry data structs.
-//! `workspace_id` derives, validates, and allocates workspace identifiers.
+//! `partition_id` derives, validates, and allocates task-store partition ids.
 //! `schema` owns SQLite schema setup, migrations, and registry user-version guards.
 //! `queries` contains internal SQL helpers and row-to-type mapping.
 //! `util` contains shared path, time, relation, and WAL helpers used by the registry.
@@ -10,11 +10,11 @@
 
 use std::path::{Path, PathBuf};
 
+mod partition_id;
 mod queries;
 mod schema;
 mod store;
 mod util;
-mod workspace_id;
 
 // Reader compatibility floor, not a counter for additive setup. Action keys
 // preserve the v5 task/allocator format and can be ignored by older readers.
@@ -27,9 +27,34 @@ pub fn task_registry_path(global_root: &Path) -> PathBuf {
 }
 
 /// Root directory of the per-workspace task bundle partitions
-/// (`<global_root>/tasks/workspaces/<workspace_id>/`), mirroring the
+/// (`<global_root>/tasks/workspaces/<partition_id>/`), mirroring the
 /// `workspaces_dir` the store itself derives from [`task_registry_path`]'s
 /// parent in `store.rs`.
+///
+/// # Two id spaces, one spelling
+///
+/// Each subdirectory is named for a **task-store partition id**: the
+/// `workspace_bindings.workspace_id` column of
+/// `<global_root>/tasks/index.sqlite`, minted by
+/// [`TaskRegistryStore::bind_workspace`] whenever a checkout binds without an
+/// explicit id. The **workspace-registry id** is a different namespace with a
+/// different owner: `Workspace.id` in `<global_root>/workspaces.json`, minted
+/// as `ws_<slug>` by `orbit workspace init`, which then passes that `ws_*` id
+/// back in as the partition id — so for a workspace created that way the two
+/// ids read identically and look like one value.
+///
+/// They are not. These partition ids have no workspace-registry row at all:
+///
+/// - legacy `<slug>-<hash>` ids (for example `orbit-5c61b3`), minted here for
+///   every checkout that bound before `workspace init` supplied an id;
+/// - `ws_unbound-data-dir`, the synthetic partition every `--root <data-dir>`
+///   write lands in.
+///
+/// Code that reads both registries must therefore resolve a partition's owner
+/// through this registry. Comparing these directory names against the
+/// workspace registry made 18 of 22 live partitions look orphaned and turned
+/// the doctor repair into a command that would have deleted the host's whole
+/// task store [ORB-12109 / ORB-12119].
 pub fn task_workspaces_dir(global_root: &Path) -> PathBuf {
     global_root.join("tasks").join("workspaces")
 }

--- a/crates/orbit-store/src/driver/sqlite/task_registry/partition_id.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/partition_id.rs
@@ -5,9 +5,14 @@ use rusqlite::Connection;
 
 use super::queries::{workspace_by_id, workspace_checkout_by_id};
 use crate::fs::path_safety::normalize_path;
-pub(super) use crate::fs::path_safety::validate_workspace_id;
+pub(super) use crate::fs::path_safety::validate_partition_id;
 
-/// Allocate an unused logical workspace id for `slug` + `path`.
+/// Allocate an unused task-store partition id for `slug` + `path`.
+///
+/// The minted `<slug>-<hash>` form is this registry's own namespace: nothing
+/// in the workspace registry (`<global_root>/workspaces.json`) names it, and a
+/// caller that already has a `ws_*` workspace id passes it in instead of
+/// allocating here.
 ///
 /// A candidate counts as taken when *either* registry table already claims it:
 /// the logical `workspace_bindings` row or the machine-local
@@ -15,13 +20,13 @@ pub(super) use crate::fs::path_safety::validate_workspace_id;
 /// allocator hand back an id whose checkout row already existed, which then
 /// failed the caller's checkout-collision check instead of retrying with the
 /// next attempt (ORB-10507).
-pub(super) fn next_workspace_id_candidate(
+pub(super) fn next_partition_id_candidate(
     conn: &Connection,
     slug: &str,
     path: &Path,
 ) -> Result<String, OrbitError> {
     for attempt in 0..1000 {
-        let candidate = workspace_id_candidate(slug, path, attempt);
+        let candidate = partition_id_candidate(slug, path, attempt);
         if workspace_by_id(conn, &candidate)?.is_none()
             && workspace_checkout_by_id(conn, &candidate)?.is_none()
         {
@@ -29,11 +34,11 @@ pub(super) fn next_workspace_id_candidate(
         }
     }
     Err(OrbitError::Store(format!(
-        "could not allocate workspace id for slug '{slug}'"
+        "could not allocate a task-store partition id for slug '{slug}'"
     )))
 }
 
-pub(super) fn workspace_id_candidate(slug: &str, path: &Path, attempt: u32) -> String {
+pub(super) fn partition_id_candidate(slug: &str, path: &Path, attempt: u32) -> String {
     let input = format!("{}:{}:{attempt}", slug, normalize_path(path).display());
     let hash = blake3::hash(input.as_bytes()).to_hex();
     format!("{slug}-{}", &hash[..6])

--- a/crates/orbit-store/src/driver/sqlite/task_registry/queries.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/queries.rs
@@ -49,12 +49,12 @@ pub(super) fn workspace_checkout_by_paths(
 
 pub(super) fn workspace_by_id(
     conn: &Connection,
-    workspace_id: &str,
+    partition_id: &str,
 ) -> Result<Option<WorkspaceBinding>, OrbitError> {
     conn.query_row(
         "SELECT workspace_id, slug, repo_fingerprint, created_at, updated_at
          FROM workspace_bindings WHERE workspace_id = ?1",
-        [workspace_id],
+        [partition_id],
         decode_workspace_binding,
     )
     .optional()
@@ -63,12 +63,12 @@ pub(super) fn workspace_by_id(
 
 pub(super) fn workspace_checkout_by_id(
     conn: &Connection,
-    workspace_id: &str,
+    partition_id: &str,
 ) -> Result<Option<WorkspaceCheckoutBinding>, OrbitError> {
     conn.query_row(
         "SELECT workspace_id, repo_root, workspace_path, orbit_dir, created_at, updated_at
          FROM workspace_checkout_bindings WHERE workspace_id = ?1",
-        [workspace_id],
+        [partition_id],
         decode_workspace_checkout_binding,
     )
     .optional()
@@ -91,7 +91,7 @@ pub(super) fn task_bundle_by_id(
 
 pub(super) fn task_ids_for_workspace(
     conn: &Connection,
-    workspace_id: &str,
+    partition_id: &str,
 ) -> Result<BTreeSet<String>, OrbitError> {
     let mut stmt = conn
         .prepare(
@@ -101,7 +101,7 @@ pub(super) fn task_ids_for_workspace(
         )
         .map_err(|e| OrbitError::Store(e.to_string()))?;
     let rows = stmt
-        .query_map([workspace_id], |row| row.get::<_, String>(0))
+        .query_map([partition_id], |row| row.get::<_, String>(0))
         .map_err(|e| OrbitError::Store(e.to_string()))?;
     rows.collect::<Result<BTreeSet<_>, _>>()
         .map_err(|e| OrbitError::Store(e.to_string()))
@@ -109,7 +109,7 @@ pub(super) fn task_ids_for_workspace(
 
 pub(super) fn write_task_index_rows(
     tx: &rusqlite::Transaction<'_>,
-    workspace_id: &str,
+    partition_id: &str,
     envelope: &TaskEnvelopeV2,
 ) -> Result<(), OrbitError> {
     tx.execute(
@@ -127,7 +127,7 @@ pub(super) fn write_task_index_rows(
             complexity = excluded.complexity",
         params![
             &envelope.id,
-            workspace_id,
+            partition_id,
             envelope.status.to_string(),
             envelope.priority.to_string(),
             envelope.job_run_id.as_deref(),
@@ -143,7 +143,7 @@ pub(super) fn write_task_index_rows(
         tx.execute(
             "INSERT OR IGNORE INTO task_bundle_tags(task_id, workspace_id, tag)
              VALUES (?1, ?2, ?3)",
-            params![&envelope.id, workspace_id, &tag],
+            params![&envelope.id, partition_id, &tag],
         )
         .map_err(|e| OrbitError::Store(e.to_string()))?;
     }
@@ -155,7 +155,7 @@ pub(super) fn write_task_index_rows(
             ) VALUES (?1, ?2, ?3, ?4)",
             params![
                 &envelope.id,
-                workspace_id,
+                partition_id,
                 relation_type_name(relation.relation_type),
                 &relation.target
             ],
@@ -184,7 +184,7 @@ pub(super) fn decode_workspace_binding(
     row: &rusqlite::Row<'_>,
 ) -> rusqlite::Result<WorkspaceBinding> {
     Ok(WorkspaceBinding {
-        workspace_id: row.get(0)?,
+        partition_id: row.get(0)?,
         slug: row.get(1)?,
         repo_fingerprint: row.get(2)?,
         created_at: parse_timestamp(&row.get::<_, String>(3)?)?,
@@ -196,7 +196,7 @@ pub(super) fn decode_workspace_checkout_binding(
     row: &rusqlite::Row<'_>,
 ) -> rusqlite::Result<WorkspaceCheckoutBinding> {
     Ok(WorkspaceCheckoutBinding {
-        workspace_id: row.get(0)?,
+        partition_id: row.get(0)?,
         repo_root: PathBuf::from(row.get::<_, String>(1)?),
         workspace_path: PathBuf::from(row.get::<_, String>(2)?),
         orbit_dir: PathBuf::from(row.get::<_, String>(3)?),
@@ -210,7 +210,7 @@ pub(super) fn decode_task_bundle_binding(
 ) -> rusqlite::Result<TaskBundleBinding> {
     Ok(TaskBundleBinding {
         task_id: row.get(0)?,
-        workspace_id: row.get(1)?,
+        partition_id: row.get(1)?,
         canonical_path: PathBuf::from(row.get::<_, String>(2)?),
         created_at: parse_timestamp(&row.get::<_, String>(3)?)?,
         updated_at: parse_timestamp(&row.get::<_, String>(4)?)?,

--- a/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
@@ -11,6 +11,7 @@ use orbit_types::task::{
 };
 use rusqlite::{Connection, TransactionBehavior, params, params_from_iter};
 
+use super::partition_id::{next_partition_id_candidate, sanitize_slug, validate_partition_id};
 use super::queries::{
     decode_task_bundle_binding, decode_workspace_checkout_binding, task_bundle_by_id,
     task_ids_for_workspace, workspace_by_id, workspace_by_orbit_dir, workspace_checkout_by_id,
@@ -21,7 +22,6 @@ use super::schema::{
     registry_user_version,
 };
 use super::util::{now_string, parse_relation_type_name, path_to_string, relation_type_name};
-use super::workspace_id::{next_workspace_id_candidate, sanitize_slug, validate_workspace_id};
 use crate::contracts::{
     AllocatorSeedOutcome, BindWorkspaceParams, DanglingRelationTarget, RegisterWorkspaceParams,
     TaskBundleBinding, TaskCompletionByComplexity, TaskIndexFilter, WorkspaceBinding,
@@ -89,6 +89,18 @@ impl TaskRegistryStore {
         })
     }
 
+    /// Bind one checkout to its task-store partition, minting the partition id
+    /// when the caller supplies none.
+    ///
+    /// The id this returns names the directory under
+    /// [`task_workspaces_dir`](super::task_workspaces_dir) that holds the
+    /// checkout's task bundles, and is stored in
+    /// `workspace_bindings.workspace_id`. It is *not* a workspace-registry id:
+    /// a caller that passes `params.partition_id` decides which namespace the
+    /// partition is named in, and a caller that passes `None` gets a minted
+    /// `<slug>-<hash>` id that no workspace registry knows. See
+    /// [`task_workspaces_dir`](super::task_workspaces_dir) for the two id
+    /// spaces in full.
     pub fn bind_workspace(
         &self,
         params: BindWorkspaceParams,
@@ -97,10 +109,10 @@ impl TaskRegistryStore {
         let workspace_path = normalize_path(&params.workspace_path);
         let orbit_dir = normalize_path(&params.orbit_dir);
         let slug = sanitize_slug(&params.slug);
-        let requested_workspace_id = params
-            .workspace_id
+        let requested_partition_id = params
+            .partition_id
             .as_deref()
-            .map(validate_workspace_id)
+            .map(validate_partition_id)
             .transpose()?;
 
         // Runtime construction asks for the same binding on every command.
@@ -113,13 +125,13 @@ impl TaskRegistryStore {
                 .lock()
                 .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
             if let Some(existing) = workspace_by_orbit_dir(&conn, &orbit_dir)? {
-                if let Some(requested) = &requested_workspace_id
-                    && requested != &existing.workspace_id
+                if let Some(requested) = &requested_partition_id
+                    && requested != &existing.partition_id
                 {
                     return Err(OrbitError::InvalidInput(format!(
                         "orbit dir '{}' is already bound to workspace '{}', not '{}'",
                         orbit_dir.display(),
-                        existing.workspace_id,
+                        existing.partition_id,
                         requested
                     )));
                 }
@@ -136,13 +148,13 @@ impl TaskRegistryStore {
             .map_err(|e| OrbitError::Store(e.to_string()))?;
 
         if let Some(existing) = workspace_by_orbit_dir(&tx, &orbit_dir)? {
-            if let Some(requested) = &requested_workspace_id
-                && requested != &existing.workspace_id
+            if let Some(requested) = &requested_partition_id
+                && requested != &existing.partition_id
             {
                 return Err(OrbitError::InvalidInput(format!(
                     "orbit dir '{}' is already bound to workspace '{}', not '{}'",
                     orbit_dir.display(),
-                    existing.workspace_id,
+                    existing.partition_id,
                     requested
                 )));
             }
@@ -150,19 +162,19 @@ impl TaskRegistryStore {
             return Ok(existing);
         }
 
-        let workspace_id = match requested_workspace_id {
+        let partition_id = match requested_partition_id {
             Some(id) => id,
             // A checkout is identified by its repo root and workspace path, not
             // by the orbit dir the caller happens to be running with. Reusing
             // the id already bound to those paths keeps a repeat bind from
             // minting a second logical workspace for the same checkout.
             None => match workspace_checkout_by_paths(&tx, &repo_root, &workspace_path)? {
-                Some(existing) => existing.workspace_id,
-                None => next_workspace_id_candidate(&tx, &slug, &workspace_path)?,
+                Some(existing) => existing.partition_id,
+                None => next_partition_id_candidate(&tx, &slug, &workspace_path)?,
             },
         };
         let now = now_string();
-        if let Some(existing) = workspace_checkout_by_id(&tx, &workspace_id)? {
+        if let Some(existing) = workspace_checkout_by_id(&tx, &partition_id)? {
             // The logical workspace already has a checkout, and it is bound to
             // a different orbit dir (a matching one returned above). When the
             // checkout paths are unchanged this is the same checkout whose
@@ -174,7 +186,7 @@ impl TaskRegistryStore {
                 || normalize_path(&existing.workspace_path) != workspace_path
             {
                 return Err(OrbitError::Store(format!(
-                    "workspace id '{workspace_id}' already has a local checkout at '{}'",
+                    "workspace id '{partition_id}' already has a local checkout at '{}'",
                     existing.orbit_dir.display()
                 )));
             }
@@ -182,22 +194,22 @@ impl TaskRegistryStore {
                 "UPDATE workspace_checkout_bindings
                  SET orbit_dir = ?2, updated_at = ?3
                  WHERE workspace_id = ?1",
-                params![workspace_id, path_to_string(&orbit_dir), now],
+                params![partition_id, path_to_string(&orbit_dir), now],
             )
             .map_err(|e| OrbitError::Store(e.to_string()))?;
-            let binding = workspace_checkout_by_id(&tx, &workspace_id)?.ok_or_else(|| {
+            let binding = workspace_checkout_by_id(&tx, &partition_id)?.ok_or_else(|| {
                 OrbitError::Store("failed to read rebound workspace checkout binding".into())
             })?;
             tx.commit().map_err(|e| OrbitError::Store(e.to_string()))?;
             return Ok(binding);
         }
 
-        if workspace_by_id(&tx, &workspace_id)?.is_none() {
+        if workspace_by_id(&tx, &partition_id)?.is_none() {
             tx.execute(
                 "INSERT INTO workspace_bindings (
                     workspace_id, slug, repo_fingerprint, created_at, updated_at
                 ) VALUES (?1, ?2, ?3, ?4, ?4)",
-                params![workspace_id, slug, params.repo_fingerprint, now],
+                params![partition_id, slug, params.repo_fingerprint, now],
             )
             .map_err(|e| OrbitError::Store(e.to_string()))?;
         }
@@ -206,7 +218,7 @@ impl TaskRegistryStore {
                 workspace_id, repo_root, workspace_path, orbit_dir, created_at, updated_at
             ) VALUES (?1, ?2, ?3, ?4, ?5, ?5)",
             params![
-                workspace_id,
+                partition_id,
                 path_to_string(&repo_root),
                 path_to_string(&workspace_path),
                 path_to_string(&orbit_dir),
@@ -215,14 +227,14 @@ impl TaskRegistryStore {
         )
         .map_err(|e| OrbitError::Store(e.to_string()))?;
 
-        let binding = workspace_checkout_by_id(&tx, &workspace_id)?.ok_or_else(|| {
+        let binding = workspace_checkout_by_id(&tx, &partition_id)?.ok_or_else(|| {
             OrbitError::Store("failed to read inserted workspace checkout binding".into())
         })?;
         tx.commit().map_err(|e| OrbitError::Store(e.to_string()))?;
         Ok(binding)
     }
 
-    /// Move `orbit_dir` onto `params.workspace_id`, replacing any checkout
+    /// Move `orbit_dir` onto `params.partition_id`, replacing any checkout
     /// currently bound to that directory.
     ///
     /// `bind_workspace` fails closed when the orbit dir already belongs to a
@@ -238,8 +250,8 @@ impl TaskRegistryStore {
         let workspace_path = normalize_path(&params.workspace_path);
         let orbit_dir = normalize_path(&params.orbit_dir);
         let slug = sanitize_slug(&params.slug);
-        let workspace_id =
-            validate_workspace_id(params.workspace_id.as_deref().ok_or_else(|| {
+        let partition_id =
+            validate_partition_id(params.partition_id.as_deref().ok_or_else(|| {
                 OrbitError::InvalidInput("rebind_checkout requires an explicit workspace id".into())
             })?)?;
 
@@ -252,18 +264,18 @@ impl TaskRegistryStore {
             .map_err(|e| OrbitError::Store(e.to_string()))?;
         let now = now_string();
 
-        if workspace_by_id(&tx, &workspace_id)?.is_none() {
+        if workspace_by_id(&tx, &partition_id)?.is_none() {
             tx.execute(
                 "INSERT INTO workspace_bindings (
                     workspace_id, slug, repo_fingerprint, created_at, updated_at
                 ) VALUES (?1, ?2, ?3, ?4, ?4)",
-                params![workspace_id, slug, params.repo_fingerprint, now],
+                params![partition_id, slug, params.repo_fingerprint, now],
             )
             .map_err(|e| OrbitError::Store(e.to_string()))?;
         }
 
         if let Some(existing) = workspace_by_orbit_dir(&tx, &orbit_dir)?
-            && existing.workspace_id != workspace_id
+            && existing.partition_id != partition_id
         {
             tx.execute(
                 "DELETE FROM workspace_checkout_bindings WHERE orbit_dir = ?1",
@@ -272,13 +284,13 @@ impl TaskRegistryStore {
             .map_err(|e| OrbitError::Store(e.to_string()))?;
         }
 
-        if workspace_checkout_by_id(&tx, &workspace_id)?.is_some() {
+        if workspace_checkout_by_id(&tx, &partition_id)?.is_some() {
             tx.execute(
                 "UPDATE workspace_checkout_bindings
                  SET repo_root = ?2, workspace_path = ?3, orbit_dir = ?4, updated_at = ?5
                  WHERE workspace_id = ?1",
                 params![
-                    workspace_id,
+                    partition_id,
                     path_to_string(&repo_root),
                     path_to_string(&workspace_path),
                     path_to_string(&orbit_dir),
@@ -292,7 +304,7 @@ impl TaskRegistryStore {
                     workspace_id, repo_root, workspace_path, orbit_dir, created_at, updated_at
                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?5)",
                 params![
-                    workspace_id,
+                    partition_id,
                     path_to_string(&repo_root),
                     path_to_string(&workspace_path),
                     path_to_string(&orbit_dir),
@@ -302,7 +314,7 @@ impl TaskRegistryStore {
             .map_err(|e| OrbitError::Store(e.to_string()))?;
         }
 
-        let binding = workspace_checkout_by_id(&tx, &workspace_id)?.ok_or_else(|| {
+        let binding = workspace_checkout_by_id(&tx, &partition_id)?.ok_or_else(|| {
             OrbitError::Store("failed to read rebound workspace checkout binding".into())
         })?;
         tx.commit().map_err(|e| OrbitError::Store(e.to_string()))?;
@@ -315,7 +327,7 @@ impl TaskRegistryStore {
         &self,
         params: RegisterWorkspaceParams,
     ) -> Result<WorkspaceBinding, OrbitError> {
-        let workspace_id = validate_workspace_id(&params.workspace_id)?;
+        let partition_id = validate_partition_id(&params.partition_id)?;
         let slug = sanitize_slug(&params.slug);
         let mut conn = self
             .conn
@@ -324,10 +336,10 @@ impl TaskRegistryStore {
         let tx = conn
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .map_err(|e| OrbitError::Store(e.to_string()))?;
-        if let Some(existing) = workspace_by_id(&tx, &workspace_id)? {
+        if let Some(existing) = workspace_by_id(&tx, &partition_id)? {
             if existing.slug != slug || existing.repo_fingerprint != params.repo_fingerprint {
                 return Err(OrbitError::InvalidInput(format!(
-                    "logical workspace '{workspace_id}' is already registered with different metadata"
+                    "logical workspace '{partition_id}' is already registered with different metadata"
                 )));
             }
             tx.commit().map_err(|e| OrbitError::Store(e.to_string()))?;
@@ -339,10 +351,10 @@ impl TaskRegistryStore {
             "INSERT INTO workspace_bindings(
                 workspace_id, slug, repo_fingerprint, created_at, updated_at
              ) VALUES (?1, ?2, ?3, ?4, ?4)",
-            params![workspace_id, slug, params.repo_fingerprint, now],
+            params![partition_id, slug, params.repo_fingerprint, now],
         )
         .map_err(|e| OrbitError::Store(e.to_string()))?;
-        let binding = workspace_by_id(&tx, &workspace_id)?.ok_or_else(|| {
+        let binding = workspace_by_id(&tx, &partition_id)?.ok_or_else(|| {
             OrbitError::Store("failed to read inserted logical workspace binding".into())
         })?;
         tx.commit().map_err(|e| OrbitError::Store(e.to_string()))?;
@@ -358,10 +370,10 @@ impl TaskRegistryStore {
     /// never an implicit source move.
     pub fn record_workspace_repo_fingerprint(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
         repo_fingerprint: &str,
     ) -> Result<WorkspaceBinding, OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         if repo_fingerprint.trim() != repo_fingerprint || repo_fingerprint.is_empty() {
             return Err(OrbitError::InvalidInput(
                 "workspace repository fingerprint must be non-empty and trimmed".to_string(),
@@ -374,13 +386,13 @@ impl TaskRegistryStore {
         let tx = conn
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .map_err(|error| OrbitError::Store(error.to_string()))?;
-        let existing = workspace_by_id(&tx, &workspace_id)?
-            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, workspace_id.clone()))?;
+        let existing = workspace_by_id(&tx, &partition_id)?
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, partition_id.clone()))?;
         match existing.repo_fingerprint.as_deref() {
             Some(current) if current == repo_fingerprint => {}
             Some(_) => {
                 return Err(OrbitError::InvalidInput(format!(
-                    "workspace '{workspace_id}' is registered with a different source-repository fingerprint"
+                    "workspace '{partition_id}' is registered with a different source-repository fingerprint"
                 )));
             }
             None => {
@@ -388,12 +400,12 @@ impl TaskRegistryStore {
                     "UPDATE workspace_bindings
                      SET repo_fingerprint = ?2, updated_at = ?3
                      WHERE workspace_id = ?1",
-                    params![workspace_id, repo_fingerprint, now_string()],
+                    params![partition_id, repo_fingerprint, now_string()],
                 )
                 .map_err(|error| OrbitError::Store(error.to_string()))?;
             }
         }
-        let binding = workspace_by_id(&tx, &workspace_id)?.ok_or_else(|| {
+        let binding = workspace_by_id(&tx, &partition_id)?.ok_or_else(|| {
             OrbitError::Store("failed to read fingerprinted workspace binding".to_string())
         })?;
         tx.commit()
@@ -406,8 +418,8 @@ impl TaskRegistryStore {
     /// Allocation commits independently from bundle registration. A crash between
     /// allocation and registration can leave numeric holes; those holes are expected
     /// and are not reused.
-    pub fn allocate_task_id(&self, workspace_id: &str) -> Result<String, OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+    pub fn allocate_task_id(&self, partition_id: &str) -> Result<String, OrbitError> {
+        let partition_id = validate_partition_id(partition_id)?;
         let mut conn = self
             .conn
             .lock()
@@ -416,8 +428,8 @@ impl TaskRegistryStore {
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .map_err(|e| OrbitError::Store(e.to_string()))?;
 
-        if workspace_by_id(&tx, &workspace_id)?.is_none() {
-            return Err(OrbitError::not_found(NotFoundKind::Workspace, workspace_id));
+        if workspace_by_id(&tx, &partition_id)?.is_none() {
+            return Err(OrbitError::not_found(NotFoundKind::Workspace, partition_id));
         }
 
         let (next, task_prefix): (i64, String) = tx
@@ -536,28 +548,28 @@ impl TaskRegistryStore {
 
     pub fn canonical_task_bundle_path(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
         task_id: &str,
     ) -> Result<PathBuf, OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         validate_orb_task_id(task_id)?;
-        Ok(self.workspaces_dir.join(workspace_id).join(task_id))
+        Ok(self.workspaces_dir.join(partition_id).join(task_id))
     }
 
     pub fn register_task_bundle(
         &self,
         task_id: &str,
-        workspace_id: &str,
+        partition_id: &str,
         canonical_path: &Path,
     ) -> Result<TaskBundleBinding, OrbitError> {
         validate_orb_task_id(task_id)?;
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         let canonical_path = normalize_path(canonical_path);
         let expected_path =
-            normalize_path(&self.canonical_task_bundle_path(&workspace_id, task_id)?);
+            normalize_path(&self.canonical_task_bundle_path(&partition_id, task_id)?);
         if canonical_path != expected_path {
             return Err(OrbitError::InvalidInput(format!(
-                "canonical path for task '{task_id}' in workspace '{workspace_id}' must be '{}', got '{}'",
+                "canonical path for task '{task_id}' in workspace '{partition_id}' must be '{}', got '{}'",
                 expected_path.display(),
                 canonical_path.display()
             )));
@@ -571,8 +583,8 @@ impl TaskRegistryStore {
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .map_err(|e| OrbitError::Store(e.to_string()))?;
 
-        if workspace_by_id(&tx, &workspace_id)?.is_none() {
-            return Err(OrbitError::not_found(NotFoundKind::Workspace, workspace_id));
+        if workspace_by_id(&tx, &partition_id)?.is_none() {
+            return Err(OrbitError::not_found(NotFoundKind::Workspace, partition_id));
         }
 
         let now = now_string();
@@ -584,7 +596,7 @@ impl TaskRegistryStore {
                 workspace_id = excluded.workspace_id,
                 canonical_path = excluded.canonical_path,
                 updated_at = excluded.updated_at",
-            params![task_id, workspace_id, path_to_string(&canonical_path), now],
+            params![task_id, partition_id, path_to_string(&canonical_path), now],
         )
         .map_err(|e| OrbitError::Store(e.to_string()))?;
 
@@ -598,10 +610,10 @@ impl TaskRegistryStore {
     pub fn unregister_task_bundle(
         &self,
         task_id: &str,
-        workspace_id: &str,
+        partition_id: &str,
     ) -> Result<bool, OrbitError> {
         validate_orb_task_id(task_id)?;
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         let mut conn = self
             .conn
             .lock()
@@ -613,7 +625,7 @@ impl TaskRegistryStore {
         let Some(binding) = task_bundle_by_id(&tx, task_id)? else {
             return Ok(false);
         };
-        if binding.workspace_id != workspace_id {
+        if binding.partition_id != partition_id {
             return Ok(false);
         }
 
@@ -634,7 +646,7 @@ impl TaskRegistryStore {
             .execute(
                 "DELETE FROM task_bundle_bindings
                  WHERE task_id = ?1 AND workspace_id = ?2",
-                params![task_id, workspace_id],
+                params![task_id, partition_id],
             )
             .map_err(|e| OrbitError::Store(e.to_string()))?;
         tx.commit().map_err(|e| OrbitError::Store(e.to_string()))?;
@@ -643,9 +655,9 @@ impl TaskRegistryStore {
 
     pub fn tasks_for_workspace(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
     ) -> Result<Vec<TaskBundleBinding>, OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         let conn = self
             .conn
             .lock()
@@ -659,7 +671,7 @@ impl TaskRegistryStore {
             )
             .map_err(|e| OrbitError::Store(e.to_string()))?;
         let rows = stmt
-            .query_map([workspace_id], decode_task_bundle_binding)
+            .query_map([partition_id], decode_task_bundle_binding)
             .map_err(|e| OrbitError::Store(e.to_string()))?;
         rows.collect::<Result<Vec<_>, _>>()
             .map_err(|e| OrbitError::Store(e.to_string()))
@@ -667,10 +679,10 @@ impl TaskRegistryStore {
 
     pub fn replace_task_index(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
         envelope: &TaskEnvelopeV2,
     ) -> Result<(), OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         envelope.validate()?;
 
         let mut conn = self
@@ -683,16 +695,16 @@ impl TaskRegistryStore {
 
         let binding = task_bundle_by_id(&tx, &envelope.id)?
             .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, envelope.id.clone()))?;
-        if binding.workspace_id != workspace_id {
+        if binding.partition_id != partition_id {
             return Err(OrbitError::InvalidInput(format!(
                 "task '{}' is registered to workspace '{}', not '{}'",
-                envelope.id, binding.workspace_id, workspace_id
+                envelope.id, binding.partition_id, partition_id
             )));
         }
 
         validate_relations_in_registry(
             &tx,
-            &workspace_id,
+            &partition_id,
             &envelope.id,
             &envelope.relations,
             std::slice::from_ref(&envelope.id),
@@ -710,16 +722,16 @@ impl TaskRegistryStore {
         )
         .map_err(|e| OrbitError::Store(e.to_string()))?;
 
-        write_task_index_rows(&tx, &workspace_id, envelope)?;
+        write_task_index_rows(&tx, &partition_id, envelope)?;
         tx.commit().map_err(|e| OrbitError::Store(e.to_string()))
     }
 
     pub fn replace_workspace_task_indexes(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
         envelopes: &[TaskEnvelopeV2],
     ) -> Result<(), OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         for envelope in envelopes {
             envelope.validate()?;
         }
@@ -732,7 +744,7 @@ impl TaskRegistryStore {
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .map_err(|e| OrbitError::Store(e.to_string()))?;
 
-        let registered = task_ids_for_workspace(&tx, &workspace_id)?;
+        let registered = task_ids_for_workspace(&tx, &partition_id)?;
         let requested = envelopes
             .iter()
             .map(|envelope| envelope.id.clone())
@@ -740,7 +752,7 @@ impl TaskRegistryStore {
         if registered != requested {
             return Err(OrbitError::Store(format!(
                 "task index rebuild for workspace '{}' expected registered ids {:?}, got {:?}",
-                workspace_id, registered, requested
+                partition_id, registered, requested
             )));
         }
 
@@ -755,7 +767,7 @@ impl TaskRegistryStore {
         for envelope in envelopes {
             validate_relations_in_registry(
                 &tx,
-                &workspace_id,
+                &partition_id,
                 &envelope.id,
                 &envelope.relations,
                 &replacement_sources,
@@ -765,31 +777,31 @@ impl TaskRegistryStore {
 
         tx.execute(
             "DELETE FROM task_bundle_tags WHERE workspace_id = ?1",
-            [&workspace_id],
+            [&partition_id],
         )
         .map_err(|e| OrbitError::Store(e.to_string()))?;
         tx.execute(
             "DELETE FROM task_bundle_relations WHERE workspace_id = ?1",
-            [&workspace_id],
+            [&partition_id],
         )
         .map_err(|e| OrbitError::Store(e.to_string()))?;
         tx.execute(
             "DELETE FROM task_bundle_index WHERE workspace_id = ?1",
-            [&workspace_id],
+            [&partition_id],
         )
         .map_err(|e| OrbitError::Store(e.to_string()))?;
 
         for envelope in envelopes {
-            write_task_index_rows(&tx, &workspace_id, envelope)?;
+            write_task_index_rows(&tx, &partition_id, envelope)?;
         }
         tx.commit().map_err(|e| OrbitError::Store(e.to_string()))
     }
 
     pub fn indexed_task_versions_for_workspace(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
     ) -> Result<BTreeMap<String, String>, OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         let conn = self
             .conn
             .lock()
@@ -802,7 +814,7 @@ impl TaskRegistryStore {
             )
             .map_err(|e| OrbitError::Store(e.to_string()))?;
         let rows = stmt
-            .query_map([workspace_id], |row| {
+            .query_map([partition_id], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
             })
             .map_err(|e| OrbitError::Store(e.to_string()))?;
@@ -812,9 +824,9 @@ impl TaskRegistryStore {
 
     pub fn indexed_task_count_for_workspace(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
     ) -> Result<usize, OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         let conn = self
             .conn
             .lock()
@@ -822,7 +834,7 @@ impl TaskRegistryStore {
         let count: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM task_bundle_index WHERE workspace_id = ?1",
-                [workspace_id],
+                [partition_id],
                 |row| row.get(0),
             )
             .map_err(|e| OrbitError::Store(e.to_string()))?;
@@ -862,9 +874,9 @@ impl TaskRegistryStore {
     /// was added by migration and has not been written yet (`NULL`).
     pub fn workspace_index_has_null_complexity(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
     ) -> Result<bool, OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         let conn = self
             .conn
             .lock()
@@ -875,7 +887,7 @@ impl TaskRegistryStore {
                     SELECT 1 FROM task_bundle_index
                     WHERE workspace_id = ?1 AND complexity IS NULL
                  )",
-                [workspace_id],
+                [partition_id],
                 |row| row.get(0),
             )
             .map_err(|e| OrbitError::Store(e.to_string()))?;
@@ -887,9 +899,9 @@ impl TaskRegistryStore {
     /// [`complexity_bucket`].
     pub fn completion_by_complexity(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
     ) -> Result<Vec<TaskCompletionByComplexity>, OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         let conn = self
             .conn
             .lock()
@@ -903,7 +915,7 @@ impl TaskRegistryStore {
             )
             .map_err(|e| OrbitError::Store(e.to_string()))?;
         let rows = stmt
-            .query_map([&workspace_id], |row| {
+            .query_map([&partition_id], |row| {
                 Ok((
                     row.get::<_, Option<String>>(0)?,
                     row.get::<_, String>(1)?,
@@ -946,9 +958,9 @@ impl TaskRegistryStore {
     /// task reports `unset` here too.
     pub fn complexity_by_task_id(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
     ) -> Result<BTreeMap<String, String>, OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         let conn = self
             .conn
             .lock()
@@ -961,7 +973,7 @@ impl TaskRegistryStore {
             )
             .map_err(|e| OrbitError::Store(e.to_string()))?;
         let rows = stmt
-            .query_map([workspace_id], |row| {
+            .query_map([partition_id], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
             })
             .map_err(|e| OrbitError::Store(e.to_string()))?;
@@ -977,11 +989,11 @@ impl TaskRegistryStore {
     /// registry without mutating allocator, bundle, or index state.
     pub fn validate_task_relations(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
         source_task_id: &str,
         relations: &[TaskRelation],
     ) -> Result<(), OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         validate_orb_task_id(source_task_id)?;
         let conn = self
             .conn
@@ -989,7 +1001,7 @@ impl TaskRegistryStore {
             .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
         validate_relations_in_registry(
             &conn,
-            &workspace_id,
+            &partition_id,
             source_task_id,
             relations,
             &[source_task_id.to_string()],
@@ -1002,22 +1014,22 @@ impl TaskRegistryStore {
     /// cannot consume an ID or write a partial bundle.
     pub fn validate_new_task_relation_targets(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
         relations: &[TaskRelation],
     ) -> Result<(), OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         let conn = self
             .conn
             .lock()
             .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
-        validate_relation_targets_exist(&conn, &workspace_id, None, relations)
+        validate_relation_targets_exist(&conn, &partition_id, None, relations)
     }
 
     /// Audit the coordination registry for relation edges whose target is a
     /// valid `ORB-` task id with no registered task bundle — the "grandfathered"
     /// relations that make [`validate_relation_targets_exist`] reject an index
     /// rebuild (ORB-10305). Scans indexed relation rows across the whole
-    /// registry, or a single workspace when `workspace_id` is set, so these
+    /// registry, or a single workspace when `partition_id` is set, so these
     /// targets can be surfaced (and cleaned) proactively instead of only when a
     /// rebuild trips over them.
     ///
@@ -1026,9 +1038,9 @@ impl TaskRegistryStore {
     /// edges legitimately allow to dangle are excluded.
     pub fn dangling_relation_targets(
         &self,
-        workspace_id: Option<&str>,
+        partition_id: Option<&str>,
     ) -> Result<Vec<DanglingRelationTarget>, OrbitError> {
-        let workspace_id = workspace_id.map(validate_workspace_id).transpose()?;
+        let partition_id = partition_id.map(validate_partition_id).transpose()?;
         let conn = self
             .conn
             .lock()
@@ -1041,9 +1053,9 @@ impl TaskRegistryStore {
              WHERE b.task_id IS NULL",
         );
         let mut values: Vec<String> = Vec::new();
-        if let Some(workspace_id) = &workspace_id {
+        if let Some(partition_id) = &partition_id {
             sql.push_str(" AND r.workspace_id = ?1");
-            values.push(workspace_id.clone());
+            values.push(partition_id.clone());
         }
         sql.push_str(
             " ORDER BY r.workspace_id, r.source_task_id, r.relation_type, r.target_task_id",
@@ -1066,7 +1078,7 @@ impl TaskRegistryStore {
         let mut dangling = Vec::new();
         let known_prefixes = known_task_prefixes(&conn)?;
         for row in rows {
-            let (workspace_id, source_task_id, relation_type, target_task_id) =
+            let (partition_id, source_task_id, relation_type, target_task_id) =
                 row.map_err(|e| OrbitError::Store(e.to_string()))?;
             // Non-task artifact targets and foreign-prefix task references are
             // both allowed to remain unresolved here. Only a locally known
@@ -1081,7 +1093,7 @@ impl TaskRegistryStore {
                 continue;
             }
             dangling.push(DanglingRelationTarget {
-                workspace_id,
+                partition_id,
                 source_task_id,
                 relation_type,
                 target_task_id,
@@ -1092,13 +1104,13 @@ impl TaskRegistryStore {
 
     pub fn indexed_task_ids_filtered(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
         filter: &TaskIndexFilter,
     ) -> Result<Vec<String>, OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         let required_tags = normalize_task_tags(filter.tags.clone());
         let mut sql = String::from("SELECT task_id FROM task_bundle_index WHERE workspace_id = ?");
-        let mut values = vec![workspace_id.clone()];
+        let mut values = vec![partition_id.clone()];
         if let Some(status) = filter.status {
             sql.push_str(" AND status = ?");
             values.push(status.to_string());
@@ -1143,7 +1155,7 @@ impl TaskRegistryStore {
             .map_err(|e| OrbitError::Store(e.to_string()))?;
         for tag in required_tags {
             let rows = tag_stmt
-                .query_map(params![&workspace_id, &tag], |row| row.get::<_, String>(0))
+                .query_map(params![&partition_id, &tag], |row| row.get::<_, String>(0))
                 .map_err(|e| OrbitError::Store(e.to_string()))?;
             let set = rows
                 .collect::<Result<BTreeSet<_>, _>>()
@@ -1157,11 +1169,11 @@ impl TaskRegistryStore {
 
     pub fn indexed_relation_targets(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
         source_task_id: &str,
         relation_type: TaskRelationType,
     ) -> Result<Vec<String>, OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         validate_orb_task_id(source_task_id)?;
         let conn = self
             .conn
@@ -1177,7 +1189,7 @@ impl TaskRegistryStore {
         let rows = stmt
             .query_map(
                 params![
-                    workspace_id,
+                    partition_id,
                     source_task_id,
                     relation_type_name(relation_type)
                 ],
@@ -1190,11 +1202,11 @@ impl TaskRegistryStore {
 
     pub fn indexed_relation_sources(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
         target_task_id: &str,
         relation_type: TaskRelationType,
     ) -> Result<Vec<String>, OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         validate_orb_task_id(target_task_id)?;
         let conn = self
             .conn
@@ -1210,7 +1222,7 @@ impl TaskRegistryStore {
         let rows = stmt
             .query_map(
                 params![
-                    workspace_id,
+                    partition_id,
                     target_task_id,
                     relation_type_name(relation_type)
                 ],
@@ -1263,14 +1275,14 @@ impl TaskRegistryStore {
         &self.workspaces_dir
     }
 
-    /// Every logical workspace id the registry binds.
+    /// Every task-store partition id the registry binds.
     ///
     /// This is the id space the on-disk partitions under
     /// `<global>/tasks/workspaces/` are named after, so a caller deciding
     /// whether a partition directory is still claimed asks here rather than
     /// inferring an owner from the workspace catalog, whose `ws_*` ids are a
     /// different namespace [ORB-12119].
-    pub fn workspace_ids(&self) -> Result<BTreeSet<String>, OrbitError> {
+    pub fn partition_ids(&self) -> Result<BTreeSet<String>, OrbitError> {
         let conn = self
             .conn
             .lock()
@@ -1294,8 +1306,8 @@ impl TaskRegistryStore {
     /// dependent rows are deleted explicitly rather than left to
     /// `ON DELETE CASCADE`, which a connection without `foreign_keys=ON` would
     /// silently skip.
-    pub fn unbind_workspace(&self, workspace_id: &str) -> Result<bool, OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+    pub fn unbind_workspace(&self, partition_id: &str) -> Result<bool, OrbitError> {
+        let partition_id = validate_partition_id(partition_id)?;
         let mut conn = self
             .conn
             .lock()
@@ -1318,13 +1330,13 @@ impl TaskRegistryStore {
             "DELETE FROM task_bundle_bindings WHERE workspace_id = ?1",
             "DELETE FROM workspace_checkout_bindings WHERE workspace_id = ?1",
         ] {
-            tx.execute(statement, [&workspace_id])
+            tx.execute(statement, [&partition_id])
                 .map_err(|e| OrbitError::Store(e.to_string()))?;
         }
         let deleted = tx
             .execute(
                 "DELETE FROM workspace_bindings WHERE workspace_id = ?1",
-                [&workspace_id],
+                [&partition_id],
             )
             .map_err(|e| OrbitError::Store(e.to_string()))?;
 
@@ -1337,28 +1349,28 @@ impl TaskRegistryStore {
     /// SQLite connection directly.
     pub fn find_workspace_binding(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
     ) -> Result<Option<WorkspaceBinding>, OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         let conn = self
             .conn
             .lock()
             .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
-        workspace_by_id(&conn, &workspace_id)
+        workspace_by_id(&conn, &partition_id)
     }
 
     /// Look up the machine-local checkout for a logical workspace, if this
     /// machine has one.
     pub fn find_workspace_checkout(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
     ) -> Result<Option<WorkspaceCheckoutBinding>, OrbitError> {
-        let workspace_id = validate_workspace_id(workspace_id)?;
+        let partition_id = validate_partition_id(partition_id)?;
         let conn = self
             .conn
             .lock()
             .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
-        workspace_checkout_by_id(&conn, &workspace_id)
+        workspace_checkout_by_id(&conn, &partition_id)
     }
 
     /// Look up the checkout bound to an orbit dir, if one is bound.
@@ -1381,11 +1393,11 @@ impl TaskRegistryStore {
     /// Resolve a checkout before a task operation touches checkout-local files.
     pub fn require_workspace_checkout(
         &self,
-        workspace_id: &str,
+        partition_id: &str,
     ) -> Result<WorkspaceCheckoutBinding, OrbitError> {
-        self.find_workspace_checkout(workspace_id)?.ok_or_else(|| {
+        self.find_workspace_checkout(partition_id)?.ok_or_else(|| {
             OrbitError::InvalidInput(format!(
-                "workspace '{workspace_id}' has no local checkout binding; link or initialize a checkout before running this file operation"
+                "workspace '{partition_id}' has no local checkout binding; link or initialize a checkout before running this file operation"
             ))
         })
     }

--- a/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
@@ -42,7 +42,7 @@ fn bind(store: &TaskRegistryStore, root: &Path) -> WorkspaceCheckoutBinding {
     fs::create_dir_all(&orbit_dir).expect("create orbit dir");
     store
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some("orbit-test-123456".into()),
+            partition_id: Some("orbit-test-123456".into()),
             slug: "Orbit Test".into(),
             repo_root: root.to_path_buf(),
             workspace_path: root.to_path_buf(),
@@ -58,7 +58,7 @@ fn create_canonical_bundle(
     task_id: &str,
 ) -> PathBuf {
     let bundle_dir = store
-        .canonical_task_bundle_path(&workspace.workspace_id, task_id)
+        .canonical_task_bundle_path(&workspace.partition_id, task_id)
         .expect("canonical bundle path");
     fs::create_dir_all(&bundle_dir).expect("create bundle");
     bundle_dir
@@ -124,11 +124,11 @@ fn allocator_returns_monotonic_orb_ids() {
     let workspace = bind(&store, temp.path());
 
     assert_eq!(
-        store.allocate_task_id(&workspace.workspace_id).expect("id"),
+        store.allocate_task_id(&workspace.partition_id).expect("id"),
         "ORB-00000"
     );
     assert_eq!(
-        store.allocate_task_id(&workspace.workspace_id).expect("id"),
+        store.allocate_task_id(&workspace.partition_id).expect("id"),
         "ORB-00001"
     );
 }
@@ -144,11 +144,11 @@ fn allocator_uses_host_prefix_and_expands_past_five_digits() {
     let workspace = bind(&store, temp.path());
 
     assert_eq!(
-        store.allocate_task_id(&workspace.workspace_id).expect("id"),
+        store.allocate_task_id(&workspace.partition_id).expect("id"),
         "DE-99999"
     );
     assert_eq!(
-        store.allocate_task_id(&workspace.workspace_id).expect("id"),
+        store.allocate_task_id(&workspace.partition_id).expect("id"),
         "DE-100000"
     );
 }
@@ -545,7 +545,7 @@ fn allocator_is_global_across_workspaces() {
     fs::create_dir_all(second_root.join(".orbit")).expect("create second orbit dir");
     let second = store
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some("second-abcdef".into()),
+            partition_id: Some("second-abcdef".into()),
             slug: "Second".into(),
             repo_root: second_root.clone(),
             workspace_path: second_root.clone(),
@@ -556,13 +556,13 @@ fn allocator_is_global_across_workspaces() {
 
     assert_eq!(
         store
-            .allocate_task_id(&first.workspace_id)
+            .allocate_task_id(&first.partition_id)
             .expect("first id"),
         "ORB-00000"
     );
     assert_eq!(
         store
-            .allocate_task_id(&second.workspace_id)
+            .allocate_task_id(&second.partition_id)
             .expect("second id"),
         "ORB-00001"
     );
@@ -574,14 +574,14 @@ fn checkoutless_workspaces_coordinate_cross_workspace_relations_without_paths() 
     let store = store(&temp);
     let first = store
         .register_workspace(RegisterWorkspaceParams {
-            workspace_id: "logical-first-aaaaaa".into(),
+            partition_id: "logical-first-aaaaaa".into(),
             slug: "Logical First".into(),
             repo_fingerprint: Some("first-fingerprint".into()),
         })
         .expect("register first logical workspace");
     let second = store
         .register_workspace(RegisterWorkspaceParams {
-            workspace_id: "logical-second-bbbbbb".into(),
+            partition_id: "logical-second-bbbbbb".into(),
             slug: "Logical Second".into(),
             repo_fingerprint: None,
         })
@@ -589,22 +589,22 @@ fn checkoutless_workspaces_coordinate_cross_workspace_relations_without_paths() 
 
     assert!(
         store
-            .find_workspace_checkout(&first.workspace_id)
+            .find_workspace_checkout(&first.partition_id)
             .expect("find first checkout")
             .is_none()
     );
     assert!(
         store
-            .find_workspace_checkout(&second.workspace_id)
+            .find_workspace_checkout(&second.partition_id)
             .expect("find second checkout")
             .is_none()
     );
 
     let target_id = store
-        .allocate_task_id(&second.workspace_id)
+        .allocate_task_id(&second.partition_id)
         .expect("allocate target");
     let source_id = store
-        .allocate_task_id(&first.workspace_id)
+        .allocate_task_id(&first.partition_id)
         .expect("allocate source");
     assert_eq!(
         (target_id.as_str(), source_id.as_str()),
@@ -612,8 +612,8 @@ fn checkoutless_workspaces_coordinate_cross_workspace_relations_without_paths() 
     );
 
     for (workspace_id, task_id) in [
-        (second.workspace_id.as_str(), target_id.as_str()),
-        (first.workspace_id.as_str(), source_id.as_str()),
+        (second.partition_id.as_str(), target_id.as_str()),
+        (first.partition_id.as_str(), source_id.as_str()),
     ] {
         let path = store
             .canonical_task_bundle_path(workspace_id, task_id)
@@ -625,13 +625,13 @@ fn checkoutless_workspaces_coordinate_cross_workspace_relations_without_paths() 
     }
     store
         .replace_task_index(
-            &second.workspace_id,
+            &second.partition_id,
             &envelope(&target_id, TaskStatus::Done, Vec::new(), Vec::new()),
         )
         .expect("index completed target");
     store
         .replace_task_index(
-            &first.workspace_id,
+            &first.partition_id,
             &envelope(
                 &source_id,
                 TaskStatus::Backlog,
@@ -659,19 +659,19 @@ fn checkoutless_workspaces_coordinate_cross_workspace_relations_without_paths() 
     );
     assert_eq!(
         store
-            .indexed_relation_targets(&first.workspace_id, &source_id, TaskRelationType::BlockedBy,)
+            .indexed_relation_targets(&first.partition_id, &source_id, TaskRelationType::BlockedBy,)
             .expect("cross-workspace dependency"),
         vec![target_id.clone()]
     );
     assert_eq!(
         store
-            .indexed_task_count_for_workspace(&first.workspace_id)
+            .indexed_task_count_for_workspace(&first.partition_id)
             .expect("first count"),
         1
     );
     assert_eq!(
         store
-            .indexed_task_count_for_workspace(&second.workspace_id)
+            .indexed_task_count_for_workspace(&second.partition_id)
             .expect("second count"),
         1
     );
@@ -680,7 +680,7 @@ fn checkoutless_workspaces_coordinate_cross_workspace_relations_without_paths() 
     let missing_target = "ORB-09999";
     let error = store
         .validate_new_task_relation_targets(
-            &first.workspace_id,
+            &first.partition_id,
             &[TaskRelation {
                 relation_type: TaskRelationType::BlockedBy,
                 target: missing_target.into(),
@@ -688,7 +688,7 @@ fn checkoutless_workspaces_coordinate_cross_workspace_relations_without_paths() 
         )
         .expect_err("missing global target");
     assert!(error.to_string().contains(missing_target));
-    assert!(error.to_string().contains(&first.workspace_id));
+    assert!(error.to_string().contains(&first.partition_id));
     assert_eq!(
         store.allocator_next_number().expect("allocator after"),
         before_allocator,
@@ -697,7 +697,7 @@ fn checkoutless_workspaces_coordinate_cross_workspace_relations_without_paths() 
 
     let error = store
         .replace_task_index(
-            &first.workspace_id,
+            &first.partition_id,
             &envelope(
                 &source_id,
                 TaskStatus::Review,
@@ -710,7 +710,7 @@ fn checkoutless_workspaces_coordinate_cross_workspace_relations_without_paths() 
         )
         .expect_err("missing relation target");
     assert!(error.to_string().contains(missing_target));
-    assert!(error.to_string().contains(&first.workspace_id));
+    assert!(error.to_string().contains(&first.partition_id));
     assert_eq!(
         store
             .global_task_status_index()
@@ -721,7 +721,7 @@ fn checkoutless_workspaces_coordinate_cross_workspace_relations_without_paths() 
     );
     assert_eq!(
         store
-            .indexed_relation_targets(&first.workspace_id, &source_id, TaskRelationType::BlockedBy,)
+            .indexed_relation_targets(&first.partition_id, &source_id, TaskRelationType::BlockedBy,)
             .expect("relation after rejected update"),
         vec![target_id]
     );
@@ -729,7 +729,7 @@ fn checkoutless_workspaces_coordinate_cross_workspace_relations_without_paths() 
     let foreign_target = "DK-00042";
     store
         .validate_new_task_relation_targets(
-            &first.workspace_id,
+            &first.partition_id,
             &[TaskRelation {
                 relation_type: TaskRelationType::BlockedBy,
                 target: foreign_target.into(),
@@ -738,7 +738,7 @@ fn checkoutless_workspaces_coordinate_cross_workspace_relations_without_paths() 
         .expect("foreign-prefix target cannot be verified locally");
     store
         .replace_task_index(
-            &first.workspace_id,
+            &first.partition_id,
             &envelope(
                 &source_id,
                 TaskStatus::Review,
@@ -758,13 +758,13 @@ fn checkoutless_workspaces_coordinate_cross_workspace_relations_without_paths() 
         .expect("index foreign-prefix relations");
     assert_eq!(
         store
-            .indexed_relation_targets(&first.workspace_id, &source_id, TaskRelationType::RelatedTo)
+            .indexed_relation_targets(&first.partition_id, &source_id, TaskRelationType::RelatedTo)
             .expect("foreign relation target"),
         vec![foreign_target.to_string()]
     );
     assert!(
         store
-            .dangling_relation_targets(Some(&first.workspace_id))
+            .dangling_relation_targets(Some(&first.partition_id))
             .expect("audit foreign target")
             .is_empty(),
         "allowed foreign references are not locally dangling"
@@ -779,23 +779,23 @@ fn dangling_relation_targets_reports_only_grandfathered_orb_targets() {
 
     // A resolvable target and the source both exist in the registry.
     let target_id = store
-        .allocate_task_id(&workspace.workspace_id)
+        .allocate_task_id(&workspace.partition_id)
         .expect("allocate target");
     let source_id = store
-        .allocate_task_id(&workspace.workspace_id)
+        .allocate_task_id(&workspace.partition_id)
         .expect("allocate source");
     for task_id in [target_id.as_str(), source_id.as_str()] {
         let path = store
-            .canonical_task_bundle_path(&workspace.workspace_id, task_id)
+            .canonical_task_bundle_path(&workspace.partition_id, task_id)
             .expect("canonical bundle path");
         fs::create_dir_all(&path).expect("create canonical bundle");
         store
-            .register_task_bundle(task_id, &workspace.workspace_id, &path)
+            .register_task_bundle(task_id, &workspace.partition_id, &path)
             .expect("register bundle");
     }
     store
         .replace_task_index(
-            &workspace.workspace_id,
+            &workspace.partition_id,
             &envelope(&target_id, TaskStatus::Done, Vec::new(), Vec::new()),
         )
         .expect("index target");
@@ -803,7 +803,7 @@ fn dangling_relation_targets_reports_only_grandfathered_orb_targets() {
     // target; the audit must flag neither.
     store
         .replace_task_index(
-            &workspace.workspace_id,
+            &workspace.partition_id,
             &envelope(
                 &source_id,
                 TaskStatus::Backlog,
@@ -842,7 +842,7 @@ fn dangling_relation_targets_reports_only_grandfathered_orb_targets() {
             ) VALUES (?1, ?2, ?3, ?4)",
             params![
                 source_id,
-                workspace.workspace_id,
+                workspace.partition_id,
                 "related_to",
                 missing_target
             ],
@@ -861,10 +861,10 @@ fn dangling_relation_targets_reports_only_grandfathered_orb_targets() {
     assert_eq!(dangling[0].source_task_id, source_id);
     assert_eq!(dangling[0].target_task_id, missing_target);
     assert_eq!(dangling[0].relation_type, "related_to");
-    assert_eq!(dangling[0].workspace_id, workspace.workspace_id);
+    assert_eq!(dangling[0].partition_id, workspace.partition_id);
     assert_eq!(
         store
-            .dangling_relation_targets(Some(&workspace.workspace_id))
+            .dangling_relation_targets(Some(&workspace.partition_id))
             .expect("scoped audit")
             .len(),
         1
@@ -877,7 +877,7 @@ fn dangling_relation_targets_reports_only_grandfathered_orb_targets() {
     fs::create_dir_all(&orbit_two).expect("create second orbit dir");
     let workspace_two = store
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some("orbit-two-654321".into()),
+            partition_id: Some("orbit-two-654321".into()),
             slug: "Orbit Two".into(),
             repo_root: repo_two.clone(),
             workspace_path: repo_two.clone(),
@@ -886,18 +886,18 @@ fn dangling_relation_targets_reports_only_grandfathered_orb_targets() {
         })
         .expect("bind second workspace");
     let source_two = store
-        .allocate_task_id(&workspace_two.workspace_id)
+        .allocate_task_id(&workspace_two.partition_id)
         .expect("allocate second source");
     let path_two = store
-        .canonical_task_bundle_path(&workspace_two.workspace_id, &source_two)
+        .canonical_task_bundle_path(&workspace_two.partition_id, &source_two)
         .expect("second canonical path");
     fs::create_dir_all(&path_two).expect("create second bundle");
     store
-        .register_task_bundle(&source_two, &workspace_two.workspace_id, &path_two)
+        .register_task_bundle(&source_two, &workspace_two.partition_id, &path_two)
         .expect("register second source");
     store
         .replace_task_index(
-            &workspace_two.workspace_id,
+            &workspace_two.partition_id,
             &envelope(&source_two, TaskStatus::Backlog, Vec::new(), Vec::new()),
         )
         .expect("index second source");
@@ -909,7 +909,7 @@ fn dangling_relation_targets_reports_only_grandfathered_orb_targets() {
             ) VALUES (?1, ?2, ?3, ?4)",
             params![
                 source_two,
-                workspace_two.workspace_id,
+                workspace_two.partition_id,
                 "blocked_by",
                 "ORB-08888"
             ],
@@ -927,14 +927,14 @@ fn dangling_relation_targets_reports_only_grandfathered_orb_targets() {
     );
     assert_eq!(
         store
-            .dangling_relation_targets(Some(&workspace_two.workspace_id))
+            .dangling_relation_targets(Some(&workspace_two.partition_id))
             .expect("scoped to second")
             .len(),
         1
     );
     assert_eq!(
         store
-            .dangling_relation_targets(Some(&workspace.workspace_id))
+            .dangling_relation_targets(Some(&workspace.partition_id))
             .expect("scoped to first")
             .len(),
         1
@@ -958,7 +958,7 @@ fn allocator_reports_exhaustion() {
     }
 
     assert!(matches!(
-        store.allocate_task_id(&workspace.workspace_id),
+        store.allocate_task_id(&workspace.partition_id),
         Err(OrbitError::Store(message)) if message.contains("exhausted")
     ));
 }
@@ -970,7 +970,7 @@ fn bind_workspace_is_idempotent_for_orbit_dir() {
     let first = bind(&store, temp.path());
     let second = store
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some(first.workspace_id.clone()),
+            partition_id: Some(first.partition_id.clone()),
             slug: "Changed".into(),
             repo_root: temp.path().join("."),
             workspace_path: temp.path().join("."),
@@ -979,8 +979,8 @@ fn bind_workspace_is_idempotent_for_orbit_dir() {
         })
         .expect("idempotent bind");
 
-    assert_eq!(first.workspace_id, second.workspace_id);
-    assert_eq!(first.workspace_id, second.workspace_id);
+    assert_eq!(first.partition_id, second.partition_id);
+    assert_eq!(first.partition_id, second.partition_id);
 }
 
 #[test]
@@ -990,7 +990,7 @@ fn publication_fingerprint_is_adopted_once_and_then_fails_closed() {
     let workspace = bind(&store, temp.path());
     assert_eq!(
         store
-            .find_workspace_binding(&workspace.workspace_id)
+            .find_workspace_binding(&workspace.partition_id)
             .expect("find workspace")
             .expect("workspace")
             .repo_fingerprint,
@@ -998,18 +998,18 @@ fn publication_fingerprint_is_adopted_once_and_then_fails_closed() {
     );
 
     let recorded = store
-        .record_workspace_repo_fingerprint(&workspace.workspace_id, "ssh://source.test/orbit.git")
+        .record_workspace_repo_fingerprint(&workspace.partition_id, "ssh://source.test/orbit.git")
         .expect("record fingerprint");
     assert_eq!(
         recorded.repo_fingerprint.as_deref(),
         Some("ssh://source.test/orbit.git")
     );
     store
-        .record_workspace_repo_fingerprint(&workspace.workspace_id, "ssh://source.test/orbit.git")
+        .record_workspace_repo_fingerprint(&workspace.partition_id, "ssh://source.test/orbit.git")
         .expect("idempotent recording");
 
     let error = store
-        .record_workspace_repo_fingerprint(&workspace.workspace_id, "ssh://source.test/other.git")
+        .record_workspace_repo_fingerprint(&workspace.partition_id, "ssh://source.test/other.git")
         .expect_err("mismatch must fail");
     assert!(error.to_string().contains("different source-repository"));
 }
@@ -1027,7 +1027,7 @@ fn bind_workspace_rebinds_same_checkout_under_a_new_orbit_dir() {
     fs::create_dir_all(&ephemeral_orbit_dir).expect("create ephemeral orbit dir");
     let second = store
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some(first.workspace_id.clone()),
+            partition_id: Some(first.partition_id.clone()),
             slug: "Orbit Test".into(),
             repo_root: temp.path().to_path_buf(),
             workspace_path: temp.path().to_path_buf(),
@@ -1036,11 +1036,11 @@ fn bind_workspace_rebinds_same_checkout_under_a_new_orbit_dir() {
         })
         .expect("rebind under a new orbit dir");
 
-    assert_eq!(second.workspace_id, first.workspace_id);
+    assert_eq!(second.partition_id, first.partition_id);
     assert_eq!(second.orbit_dir, normalize_path(&ephemeral_orbit_dir));
     assert_eq!(
         store
-            .find_workspace_checkout(&first.workspace_id)
+            .find_workspace_checkout(&first.partition_id)
             .expect("find checkout")
             .expect("checkout exists")
             .orbit_dir,
@@ -1057,7 +1057,7 @@ fn bind_workspace_reuses_derived_id_for_same_paths_under_a_new_orbit_dir() {
     let first_orbit_dir = repo_root.join(".orbit");
     fs::create_dir_all(&first_orbit_dir).expect("create orbit dir");
     let derive = |orbit_dir: PathBuf| BindWorkspaceParams {
-        workspace_id: None,
+        partition_id: None,
         slug: "Orbit Test".into(),
         repo_root: repo_root.clone(),
         workspace_path: repo_root.clone(),
@@ -1075,7 +1075,7 @@ fn bind_workspace_reuses_derived_id_for_same_paths_under_a_new_orbit_dir() {
         .expect("derive second binding");
 
     assert_eq!(
-        second.workspace_id, first.workspace_id,
+        second.partition_id, first.partition_id,
         "the same checkout paths resolve back to one logical workspace"
     );
     assert_eq!(second.orbit_dir, normalize_path(&ephemeral_orbit_dir));
@@ -1091,7 +1091,7 @@ fn bind_workspace_rejects_reusing_an_id_for_a_different_checkout() {
     let other_orbit_dir = other_root.join(".orbit");
     fs::create_dir_all(&other_orbit_dir).expect("create other orbit dir");
     let result = store.bind_workspace(BindWorkspaceParams {
-        workspace_id: Some(first.workspace_id.clone()),
+        partition_id: Some(first.partition_id.clone()),
         slug: "Orbit Test".into(),
         repo_root: other_root.clone(),
         workspace_path: other_root,
@@ -1112,7 +1112,7 @@ fn bind_workspace_rejects_explicit_workspace_id_conflict() {
     bind(&store, temp.path());
 
     let result = store.bind_workspace(BindWorkspaceParams {
-        workspace_id: Some("other-abcdef".into()),
+        partition_id: Some("other-abcdef".into()),
         slug: "Changed".into(),
         repo_root: temp.path().join("."),
         workspace_path: temp.path().join("."),
@@ -1132,7 +1132,7 @@ fn rebind_checkout_moves_orbit_dir_onto_the_requested_workspace() {
     fs::create_dir_all(&data_dir).expect("create data dir");
     let synthetic = store
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some("tmp-5b7149".into()),
+            partition_id: Some("tmp-5b7149".into()),
             slug: "tmp".into(),
             repo_root: parent.clone(),
             workspace_path: parent,
@@ -1145,7 +1145,7 @@ fn rebind_checkout_moves_orbit_dir_onto_the_requested_workspace() {
     fs::create_dir_all(&repo_root).expect("create repo");
     let rebound = store
         .rebind_checkout(BindWorkspaceParams {
-            workspace_id: Some("ws_qa".into()),
+            partition_id: Some("ws_qa".into()),
             slug: "qa".into(),
             repo_root: repo_root.clone(),
             workspace_path: repo_root.clone(),
@@ -1154,12 +1154,12 @@ fn rebind_checkout_moves_orbit_dir_onto_the_requested_workspace() {
         })
         .expect("rebind orbit dir");
 
-    assert_eq!(rebound.workspace_id, "ws_qa");
+    assert_eq!(rebound.partition_id, "ws_qa");
     assert_eq!(rebound.repo_root, normalize_path(&repo_root));
     assert_eq!(rebound.orbit_dir, normalize_path(&data_dir));
     assert!(
         store
-            .find_workspace_checkout(&synthetic.workspace_id)
+            .find_workspace_checkout(&synthetic.partition_id)
             .expect("lookup synthetic")
             .is_none(),
         "the synthetic checkout row must not keep the data dir"
@@ -1168,7 +1168,7 @@ fn rebind_checkout_moves_orbit_dir_onto_the_requested_workspace() {
         .find_rebind_candidates(&repo_root, &repo_root, &data_dir)
         .expect("lookup rebound orbit dir");
     assert_eq!(by_orbit.len(), 1);
-    assert_eq!(by_orbit[0].workspace_id, "ws_qa");
+    assert_eq!(by_orbit[0].partition_id, "ws_qa");
 }
 
 #[test]
@@ -1247,7 +1247,7 @@ fn persistence_consumers_share_workspace_id_grammar() {
         );
         let store = store(&temp);
         let registry_result = store.register_workspace(RegisterWorkspaceParams {
-            workspace_id: raw.into(),
+            partition_id: raw.into(),
             slug: "Workspace".into(),
             repo_fingerprint: None,
         });
@@ -1262,7 +1262,7 @@ fn persistence_consumers_share_workspace_id_grammar() {
                     expected
                 );
                 assert_eq!(
-                    registry_result.expect("registry accepts id").workspace_id,
+                    registry_result.expect("registry accepts id").partition_id,
                     expected
                 );
             }
@@ -1404,7 +1404,7 @@ fn rebind_candidates_match_normalized_paths() {
         .expect("candidates");
 
     assert_eq!(candidates.len(), 1);
-    assert_eq!(candidates[0].workspace_id, workspace.workspace_id);
+    assert_eq!(candidates[0].partition_id, workspace.partition_id);
 }
 
 #[test]
@@ -1416,7 +1416,7 @@ fn register_task_bundle_rejects_non_canonical_path() {
     fs::create_dir_all(&wrong_path).expect("create wrong bundle");
 
     assert!(matches!(
-        store.register_task_bundle("ORB-00000", &workspace.workspace_id, &wrong_path),
+        store.register_task_bundle("ORB-00000", &workspace.partition_id, &wrong_path),
         Err(OrbitError::InvalidInput(_))
     ));
 }
@@ -1430,13 +1430,13 @@ fn generated_task_index_filters_by_status_priority_and_tags() {
     for task_id in ["ORB-00000", "ORB-00001"] {
         let bundle_dir = create_canonical_bundle(&store, &workspace, task_id);
         store
-            .register_task_bundle(task_id, &workspace.workspace_id, &bundle_dir)
+            .register_task_bundle(task_id, &workspace.partition_id, &bundle_dir)
             .expect("register bundle");
     }
 
     store
         .replace_task_index(
-            &workspace.workspace_id,
+            &workspace.partition_id,
             &envelope(
                 "ORB-00000",
                 TaskStatus::Backlog,
@@ -1447,7 +1447,7 @@ fn generated_task_index_filters_by_status_priority_and_tags() {
         .expect("index first task");
     store
         .replace_task_index(
-            &workspace.workspace_id,
+            &workspace.partition_id,
             &envelope(
                 "ORB-00001",
                 TaskStatus::Review,
@@ -1459,14 +1459,14 @@ fn generated_task_index_filters_by_status_priority_and_tags() {
 
     assert_eq!(
         store
-            .indexed_task_count_for_workspace(&workspace.workspace_id)
+            .indexed_task_count_for_workspace(&workspace.partition_id)
             .expect("index count"),
         2
     );
     assert_eq!(
         store
             .indexed_task_ids_filtered(
-                &workspace.workspace_id,
+                &workspace.partition_id,
                 &TaskIndexFilter {
                     status: Some(TaskStatus::Review),
                     priority: Some(TaskPriority::High),
@@ -1480,7 +1480,7 @@ fn generated_task_index_filters_by_status_priority_and_tags() {
     assert_eq!(
         store
             .indexed_task_ids_filtered(
-                &workspace.workspace_id,
+                &workspace.partition_id,
                 &TaskIndexFilter {
                     status: None,
                     priority: None,
@@ -1501,13 +1501,13 @@ fn generated_relation_index_supports_forward_and_inverse_lookup() {
     for task_id in ["ORB-00000", "ORB-00001", "ORB-00002"] {
         let bundle_dir = create_canonical_bundle(&store, &workspace, task_id);
         store
-            .register_task_bundle(task_id, &workspace.workspace_id, &bundle_dir)
+            .register_task_bundle(task_id, &workspace.partition_id, &bundle_dir)
             .expect("register bundle");
     }
 
     store
         .replace_task_index(
-            &workspace.workspace_id,
+            &workspace.partition_id,
             &envelope(
                 "ORB-00000",
                 TaskStatus::Backlog,
@@ -1529,7 +1529,7 @@ fn generated_relation_index_supports_forward_and_inverse_lookup() {
     assert_eq!(
         store
             .indexed_relation_targets(
-                &workspace.workspace_id,
+                &workspace.partition_id,
                 "ORB-00000",
                 TaskRelationType::BlockedBy,
             )
@@ -1539,7 +1539,7 @@ fn generated_relation_index_supports_forward_and_inverse_lookup() {
     assert_eq!(
         store
             .indexed_relation_sources(
-                &workspace.workspace_id,
+                &workspace.partition_id,
                 "ORB-00001",
                 TaskRelationType::BlockedBy,
             )
@@ -1556,12 +1556,12 @@ fn unregister_task_bundle_removes_binding_indexes_and_relation_edges() {
     for task_id in ["ORB-00000", "ORB-00001"] {
         let bundle_dir = create_canonical_bundle(&store, &workspace, task_id);
         store
-            .register_task_bundle(task_id, &workspace.workspace_id, &bundle_dir)
+            .register_task_bundle(task_id, &workspace.partition_id, &bundle_dir)
             .expect("register bundle");
     }
     store
         .replace_task_index(
-            &workspace.workspace_id,
+            &workspace.partition_id,
             &envelope(
                 "ORB-00000",
                 TaskStatus::Backlog,
@@ -1576,12 +1576,12 @@ fn unregister_task_bundle_removes_binding_indexes_and_relation_edges() {
 
     assert!(
         store
-            .unregister_task_bundle("ORB-00000", &workspace.workspace_id)
+            .unregister_task_bundle("ORB-00000", &workspace.partition_id)
             .expect("unregister")
     );
     assert_eq!(
         store
-            .tasks_for_workspace(&workspace.workspace_id)
+            .tasks_for_workspace(&workspace.partition_id)
             .expect("tasks")
             .into_iter()
             .map(|binding| binding.task_id)
@@ -1590,14 +1590,14 @@ fn unregister_task_bundle_removes_binding_indexes_and_relation_edges() {
     );
     assert_eq!(
         store
-            .indexed_task_count_for_workspace(&workspace.workspace_id)
+            .indexed_task_count_for_workspace(&workspace.partition_id)
             .expect("index count"),
         0
     );
     assert_eq!(
         store
             .indexed_relation_sources(
-                &workspace.workspace_id,
+                &workspace.partition_id,
                 "ORB-00001",
                 TaskRelationType::BlockedBy,
             )
@@ -1617,7 +1617,7 @@ fn unregister_task_bundle_preserves_sibling_workspace_indexes() {
         fs::create_dir_all(&orbit_dir).expect("create orbit dir");
         store
             .bind_workspace(BindWorkspaceParams {
-                workspace_id: Some(workspace_id.into()),
+                partition_id: Some(workspace_id.into()),
                 slug: workspace_id.into(),
                 repo_root: root.to_path_buf(),
                 workspace_path: root.to_path_buf(),
@@ -1632,12 +1632,12 @@ fn unregister_task_bundle_preserves_sibling_workspace_indexes() {
     for task_id in ["ORB-1", "ORB-2"] {
         let bundle_dir = create_canonical_bundle(&store, &workspace_b, task_id);
         store
-            .register_task_bundle(task_id, &workspace_b.workspace_id, &bundle_dir)
+            .register_task_bundle(task_id, &workspace_b.partition_id, &bundle_dir)
             .expect("register bundle");
     }
     store
         .replace_task_index(
-            &workspace_b.workspace_id,
+            &workspace_b.partition_id,
             &envelope(
                 "ORB-1",
                 TaskStatus::Backlog,
@@ -1648,7 +1648,7 @@ fn unregister_task_bundle_preserves_sibling_workspace_indexes() {
         .expect("index tagged task");
     store
         .replace_task_index(
-            &workspace_b.workspace_id,
+            &workspace_b.partition_id,
             &envelope(
                 "ORB-2",
                 TaskStatus::Backlog,
@@ -1662,11 +1662,11 @@ fn unregister_task_bundle_preserves_sibling_workspace_indexes() {
         .expect("index inbound relation");
 
     let versions_before = store
-        .indexed_task_versions_for_workspace(&workspace_b.workspace_id)
+        .indexed_task_versions_for_workspace(&workspace_b.partition_id)
         .expect("versions before unregister");
     let tagged_before = store
         .indexed_task_ids_filtered(
-            &workspace_b.workspace_id,
+            &workspace_b.partition_id,
             &TaskIndexFilter {
                 status: None,
                 priority: None,
@@ -1677,7 +1677,7 @@ fn unregister_task_bundle_preserves_sibling_workspace_indexes() {
         .expect("tagged tasks before unregister");
     let relation_sources_before = store
         .indexed_relation_sources(
-            &workspace_b.workspace_id,
+            &workspace_b.partition_id,
             "ORB-1",
             TaskRelationType::BlockedBy,
         )
@@ -1685,19 +1685,19 @@ fn unregister_task_bundle_preserves_sibling_workspace_indexes() {
 
     assert!(
         !store
-            .unregister_task_bundle("ORB-1", &workspace_a.workspace_id)
+            .unregister_task_bundle("ORB-1", &workspace_a.partition_id)
             .expect("unregister sibling task")
     );
     assert_eq!(
         store
-            .indexed_task_versions_for_workspace(&workspace_b.workspace_id)
+            .indexed_task_versions_for_workspace(&workspace_b.partition_id)
             .expect("versions after unregister"),
         versions_before
     );
     assert_eq!(
         store
             .indexed_task_ids_filtered(
-                &workspace_b.workspace_id,
+                &workspace_b.partition_id,
                 &TaskIndexFilter {
                     status: None,
                     priority: None,
@@ -1711,7 +1711,7 @@ fn unregister_task_bundle_preserves_sibling_workspace_indexes() {
     assert_eq!(
         store
             .indexed_relation_sources(
-                &workspace_b.workspace_id,
+                &workspace_b.partition_id,
                 "ORB-1",
                 TaskRelationType::BlockedBy,
             )
@@ -1729,25 +1729,25 @@ fn completion_by_complexity_keeps_unset_as_its_own_bucket() {
     for task_id in ["ORB-00000", "ORB-00001", "ORB-00002", "ORB-00003"] {
         let bundle_dir = create_canonical_bundle(&store, &workspace, task_id);
         store
-            .register_task_bundle(task_id, &workspace.workspace_id, &bundle_dir)
+            .register_task_bundle(task_id, &workspace.partition_id, &bundle_dir)
             .expect("register bundle");
     }
 
     let mut hard_done = envelope("ORB-00000", TaskStatus::Done, Vec::new(), Vec::new());
     hard_done.complexity = Some(TaskComplexity::Hard);
     store
-        .replace_task_index(&workspace.workspace_id, &hard_done)
+        .replace_task_index(&workspace.partition_id, &hard_done)
         .expect("index hard");
 
     let mut medium_rejected = envelope("ORB-00001", TaskStatus::Rejected, Vec::new(), Vec::new());
     medium_rejected.complexity = Some(TaskComplexity::Medium);
     store
-        .replace_task_index(&workspace.workspace_id, &medium_rejected)
+        .replace_task_index(&workspace.partition_id, &medium_rejected)
         .expect("index medium");
 
     store
         .replace_task_index(
-            &workspace.workspace_id,
+            &workspace.partition_id,
             &envelope("ORB-00002", TaskStatus::Archived, Vec::new(), Vec::new()),
         )
         .expect("index unset");
@@ -1757,11 +1757,11 @@ fn completion_by_complexity_keeps_unset_as_its_own_bucket() {
     let mut unassessed_backlog = envelope("ORB-00003", TaskStatus::Backlog, Vec::new(), Vec::new());
     unassessed_backlog.complexity = Some(TaskComplexity::Unassessed);
     store
-        .replace_task_index(&workspace.workspace_id, &unassessed_backlog)
+        .replace_task_index(&workspace.partition_id, &unassessed_backlog)
         .expect("index unassessed");
 
     let rows = store
-        .completion_by_complexity(&workspace.workspace_id)
+        .completion_by_complexity(&workspace.partition_id)
         .expect("aggregate");
     assert_eq!(
         rows.iter()
@@ -1783,7 +1783,7 @@ fn completion_by_complexity_keeps_unset_as_its_own_bucket() {
     assert_eq!(hard.by_status.get("done").copied(), Some(1));
 
     let map = store
-        .complexity_by_task_id(&workspace.workspace_id)
+        .complexity_by_task_id(&workspace.partition_id)
         .expect("map");
     assert_eq!(map.get("ORB-00000").map(String::as_str), Some("hard"));
     assert_eq!(map.get("ORB-00002").map(String::as_str), Some(UNSET_BUCKET));
@@ -1826,7 +1826,7 @@ fn seeded_allocator_hands_out_seeded_id() {
     let workspace = bind(&store, temp.path());
     store.seed_allocator_start(10_000).expect("seed");
     let id = store
-        .allocate_task_id(&workspace.workspace_id)
+        .allocate_task_id(&workspace.partition_id)
         .expect("allocate");
     assert_eq!(id, "ORB-10000");
 }
@@ -1849,14 +1849,14 @@ fn workspace_ids_lists_every_bound_partition() {
     let workspace = bind(&store, temp.path());
     store
         .register_workspace(RegisterWorkspaceParams {
-            workspace_id: "ws_remote".into(),
+            partition_id: "ws_remote".into(),
             slug: "remote".into(),
             repo_fingerprint: None,
         })
         .expect("register logical workspace");
 
-    let ids = store.workspace_ids().expect("list workspace ids");
-    assert!(ids.contains(&workspace.workspace_id));
+    let ids = store.partition_ids().expect("list workspace ids");
+    assert!(ids.contains(&workspace.partition_id));
     assert!(ids.contains("ws_remote"));
 }
 
@@ -1870,11 +1870,11 @@ fn unbind_workspace_retires_the_checkout_and_its_task_bundles() {
     let workspace = bind(&store, temp.path());
     let bundle_dir = create_canonical_bundle(&store, &workspace, "ORB-00000");
     store
-        .register_task_bundle("ORB-00000", &workspace.workspace_id, &bundle_dir)
+        .register_task_bundle("ORB-00000", &workspace.partition_id, &bundle_dir)
         .expect("register bundle");
     store
         .replace_task_index(
-            &workspace.workspace_id,
+            &workspace.partition_id,
             &envelope(
                 "ORB-00000",
                 TaskStatus::Backlog,
@@ -1886,13 +1886,13 @@ fn unbind_workspace_retires_the_checkout_and_its_task_bundles() {
 
     assert!(
         store
-            .unbind_workspace(&workspace.workspace_id)
+            .unbind_workspace(&workspace.partition_id)
             .expect("unbind workspace")
     );
 
     assert!(
         store
-            .find_workspace_binding(&workspace.workspace_id)
+            .find_workspace_binding(&workspace.partition_id)
             .expect("read workspace binding")
             .is_none()
     );
@@ -1911,7 +1911,7 @@ fn unbind_workspace_retires_the_checkout_and_its_task_bundles() {
     );
     assert!(
         !store
-            .unbind_workspace(&workspace.workspace_id)
+            .unbind_workspace(&workspace.partition_id)
             .expect("second unbind is a no-op"),
         "unbinding an unknown workspace reports that nothing was retired"
     );
@@ -1930,7 +1930,7 @@ fn unbind_workspace_retires_relations_pointing_into_it() {
     fs::create_dir_all(&other_orbit_dir).expect("create other orbit dir");
     let other = store
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some("other-654321".into()),
+            partition_id: Some("other-654321".into()),
             slug: "Other".into(),
             repo_root: other_root.clone(),
             workspace_path: other_root,
@@ -1940,8 +1940,8 @@ fn unbind_workspace_retires_relations_pointing_into_it() {
         .expect("bind other workspace");
 
     for (workspace_id, task_id) in [
-        (&retired.workspace_id, "ORB-00000"),
-        (&other.workspace_id, "ORB-00001"),
+        (&retired.partition_id, "ORB-00000"),
+        (&other.partition_id, "ORB-00001"),
     ] {
         let bundle_dir = store
             .canonical_task_bundle_path(workspace_id, task_id)
@@ -1953,7 +1953,7 @@ fn unbind_workspace_retires_relations_pointing_into_it() {
     }
     store
         .replace_task_index(
-            &other.workspace_id,
+            &other.partition_id,
             &envelope(
                 "ORB-00001",
                 TaskStatus::Backlog,
@@ -1967,7 +1967,7 @@ fn unbind_workspace_retires_relations_pointing_into_it() {
         .expect("index the pointing task");
 
     store
-        .unbind_workspace(&retired.workspace_id)
+        .unbind_workspace(&retired.partition_id)
         .expect("unbind workspace");
 
     let conn = store.conn.lock().expect("lock registry");

--- a/crates/orbit-store/src/fs/path_safety.rs
+++ b/crates/orbit-store/src/fs/path_safety.rs
@@ -12,8 +12,10 @@ pub(crate) fn validate_path_stem(stem: &str, kind: &str) -> Result<(), OrbitErro
     )))
 }
 
-/// Validate persisted logical and legacy workspace identifiers.
-pub(crate) fn validate_workspace_id(raw: &str) -> Result<String, OrbitError> {
+/// Validate a persisted task-store partition id: the canonical `ws_<name>`
+/// form a workspace registration supplies, or the legacy `<slug>-<hash>` form
+/// the task registry mints for an unregistered checkout.
+pub(crate) fn validate_partition_id(raw: &str) -> Result<String, OrbitError> {
     let trimmed = raw.trim();
     let logical = trimmed.strip_prefix("ws_").is_some_and(|name| {
         !name.is_empty()

--- a/crates/orbit-store/src/repository/task/tests/test_support.rs
+++ b/crates/orbit-store/src/repository/task/tests/test_support.rs
@@ -75,7 +75,7 @@ pub(crate) fn bundle_store(temp: &TempDir) -> TaskBundleStoreV2 {
     fs::create_dir_all(&orbit_dir).expect("create orbit dir");
     let binding = registry
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some("orbit-test-123456".to_string()),
+            partition_id: Some("orbit-test-123456".to_string()),
             slug: "Orbit Test".to_string(),
             repo_root: temp.path().join("repo"),
             workspace_path: temp.path().join("repo"),
@@ -83,7 +83,7 @@ pub(crate) fn bundle_store(temp: &TempDir) -> TaskBundleStoreV2 {
             repo_fingerprint: None,
         })
         .expect("bind workspace");
-    TaskBundleStoreV2::new(registry, binding.workspace_id)
+    TaskBundleStoreV2::new(registry, binding.partition_id)
 }
 
 pub(crate) fn task_lock_path(bundle_dir: &Path) -> PathBuf {

--- a/crates/orbit-store/src/repository/task/v2/tests/listing_bench.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/listing_bench.rs
@@ -63,7 +63,7 @@ pub(super) fn seed(global: &Path, workspace: &str, count: usize) -> TaskV2Store 
     let registry = TaskRegistryStore::open(&task_registry_path(global)).unwrap();
     registry
         .register_workspace(RegisterWorkspaceParams {
-            workspace_id: workspace.to_string(),
+            partition_id: workspace.to_string(),
             slug: workspace.to_string(),
             repo_fingerprint: None,
         })
@@ -79,7 +79,7 @@ pub(super) fn seed(global: &Path, workspace: &str, count: usize) -> TaskV2Store 
     fs::write(orbit_dir.join("config.toml"), "").unwrap();
     registry
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some(workspace.to_string()),
+            partition_id: Some(workspace.to_string()),
             slug: workspace.to_string(),
             repo_root: repo.clone(),
             workspace_path: repo,

--- a/crates/orbit-store/src/repository/task/v2/tests/mod.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/mod.rs
@@ -22,7 +22,7 @@ pub(super) fn store(temp: &TempDir) -> TaskV2Store {
     std::fs::create_dir_all(&orbit_dir).expect("create orbit dir");
     let binding = registry
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some("orbit-test-123456".to_string()),
+            partition_id: Some("orbit-test-123456".to_string()),
             slug: "Orbit Test".to_string(),
             repo_root: repo_dir.clone(),
             workspace_path: repo_dir.clone(),
@@ -30,7 +30,7 @@ pub(super) fn store(temp: &TempDir) -> TaskV2Store {
             repo_fingerprint: None,
         })
         .expect("bind workspace");
-    TaskV2Store::new(registry, binding.workspace_id)
+    TaskV2Store::new(registry, binding.partition_id)
 }
 
 pub(super) fn create_params(title: &str, status: TaskStatus) -> TaskCreateParams {

--- a/crates/orbit-store/src/workflow/task/mod.rs
+++ b/crates/orbit-store/src/workflow/task/mod.rs
@@ -242,7 +242,7 @@ pub fn export_tasks(
                 "workspace '{workspace_id}' is not registered in the coordination registry"
             ))
         })?;
-    let workspace_id = binding.workspace_id.clone();
+    let workspace_id = binding.partition_id.clone();
 
     let registered: BTreeSet<String> = registry
         .tasks_for_workspace(&workspace_id)?
@@ -405,7 +405,7 @@ pub fn import_tasks(
                 }
             }
             Some(existing) => {
-                let identical = existing.workspace_id == target.workspace_id
+                let identical = existing.partition_id == target.workspace_id
                     && read_bundle_at(&existing.canonical_path)
                         .ok()
                         .is_some_and(|current| current == staged.bundle);
@@ -634,10 +634,10 @@ fn owner_wins_verdict(
     // Replacing in place keeps the mirror where the registry already binds it;
     // moving a task between workspaces is a reconciliation this rule cannot
     // decide from the id.
-    if existing.workspace_id != target_workspace_id {
+    if existing.partition_id != target_workspace_id {
         return Err(OrbitError::InvalidInput(format!(
             "task id '{source_id}' is registered to workspace '{}' locally but this archive lands in '{target_workspace_id}'; resolve the workspace before syncing",
-            existing.workspace_id
+            existing.partition_id
         )));
     }
     Ok(MirrorVerdict::Replace(existing.canonical_path.clone()))
@@ -732,14 +732,14 @@ fn resolve_target(
             ))
         })?;
         return Ok(ImportTarget {
-            workspace_id: binding.workspace_id,
+            workspace_id: binding.partition_id,
             register: None,
         });
     }
 
     if let Some(binding) = registry.find_workspace_binding(&manifest.source_workspace_id)? {
         return Ok(ImportTarget {
-            workspace_id: binding.workspace_id,
+            workspace_id: binding.partition_id,
             register: None,
         });
     }
@@ -748,7 +748,7 @@ fn resolve_target(
     // only its logical coordination identity. A later checkout link may add a
     // checkout binding; migration must never fabricate checkout paths.
     let params = RegisterWorkspaceParams {
-        workspace_id: manifest.source_workspace_id.clone(),
+        partition_id: manifest.source_workspace_id.clone(),
         slug: manifest.source_workspace_slug.clone(),
         repo_fingerprint: None,
     };
@@ -844,12 +844,12 @@ impl<'a> WriteGuard<'a> {
             let _ = self.registry.unbind_workspace(&workspace_id);
         }
         for id in self.registered_ids.drain(..) {
-            // workspace_id is not needed to look up the (global) binding, but the
-            // API takes it; recover it from the binding.
+            // The partition id is not needed to look up the (global) binding,
+            // but the API takes it; recover it from the binding.
             if let Ok(Some(binding)) = self.registry.find_task_binding(&id) {
                 let _ = self
                     .registry
-                    .unregister_task_bundle(&id, &binding.workspace_id);
+                    .unregister_task_bundle(&id, &binding.partition_id);
             }
         }
         for dir in self.written_dirs.drain(..) {

--- a/crates/orbit-store/src/workflow/task/publication.rs
+++ b/crates/orbit-store/src/workflow/task/publication.rs
@@ -330,10 +330,10 @@ pub(crate) fn build_publication_snapshot_from_task_workspace(
                 "task workspace '{task_workspace_id}' is not registered in the coordination registry"
             ))
         })?;
-    if binding.workspace_id != task_workspace_id {
+    if binding.partition_id != task_workspace_id {
         return Err(OrbitError::InvalidInput(format!(
             "task workspace selector '{task_workspace_id}' resolved to unexpected workspace '{}'",
-            binding.workspace_id
+            binding.partition_id
         )));
     }
 

--- a/crates/orbit-store/src/workflow/task/publish.rs
+++ b/crates/orbit-store/src/workflow/task/publish.rs
@@ -278,10 +278,10 @@ fn assert_registered_workspace(
                 request.task_workspace_id
             ))
         })?;
-    if binding.workspace_id != request.task_workspace_id {
+    if binding.partition_id != request.task_workspace_id {
         return Err(publish_error(format!(
             "task workspace selector '{}' resolved to unexpected workspace '{}'",
-            request.task_workspace_id, binding.workspace_id
+            request.task_workspace_id, binding.partition_id
         )));
     }
     match binding.repo_fingerprint.as_deref() {

--- a/crates/orbit-store/src/workflow/task/reindex.rs
+++ b/crates/orbit-store/src/workflow/task/reindex.rs
@@ -37,7 +37,7 @@ pub fn reindex_workspace(
                 "workspace '{workspace_id}' is not registered in the coordination registry"
             ))
         })?;
-    let workspace_id = binding.workspace_id.clone();
+    let workspace_id = binding.partition_id.clone();
 
     let workspace_dir = registry.workspaces_dir().join(&workspace_id);
     let mut candidates = on_disk_task_ids(&workspace_dir)?;

--- a/crates/orbit-store/src/workflow/task/restore.rs
+++ b/crates/orbit-store/src/workflow/task/restore.rs
@@ -125,7 +125,7 @@ fn restore_publication_inner(
                 missing.push(published);
             }
             Some(binding) => {
-                let identical = binding.workspace_id == task_workspace_id
+                let identical = binding.partition_id == task_workspace_id
                     && read_bundle_at(&binding.canonical_path)
                         .is_ok_and(|bundle| bundle == published.bundle);
                 if request.mode != PublicationRestoreMode::AllowIdenticalRetry || !identical {
@@ -213,7 +213,7 @@ fn assert_destination_pairing(
                 request.task_workspace_id
             ))
         })?;
-    if binding.workspace_id != request.task_workspace_id {
+    if binding.partition_id != request.task_workspace_id {
         return Err(restore_error(
             "task workspace selector resolved to another workspace",
         ));

--- a/crates/orbit-store/src/workflow/task/tests/mod.rs
+++ b/crates/orbit-store/src/workflow/task/tests/mod.rs
@@ -210,7 +210,7 @@ fn bind(registry: &TaskRegistryStore, global: &Path, ws_id: &str) -> WorkspaceCh
     fs::create_dir_all(&orbit_dir).expect("create orbit dir");
     registry
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some(ws_id.to_string()),
+            partition_id: Some(ws_id.to_string()),
             slug: "sample".to_string(),
             repo_root: orbit_dir.parent().unwrap().to_path_buf(),
             workspace_path: orbit_dir.parent().unwrap().to_path_buf(),
@@ -224,7 +224,7 @@ fn bundle_store(
     registry: &TaskRegistryStore,
     binding: &WorkspaceCheckoutBinding,
 ) -> TaskBundleStoreV2 {
-    TaskBundleStoreV2::new(registry.clone(), binding.workspace_id.clone())
+    TaskBundleStoreV2::new(registry.clone(), binding.partition_id.clone())
 }
 
 fn make_bundle(id: &str, title: &str, relations: Vec<TaskRelation>) -> TaskBundleV2 {

--- a/crates/orbit-store/src/workflow/task/tests/publish.rs
+++ b/crates/orbit-store/src/workflow/task/tests/publish.rs
@@ -79,7 +79,7 @@ fn owned_workspace(
     let repo_root = orbit_dir.parent().unwrap().to_path_buf();
     registry
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some(workspace_id.to_string()),
+            partition_id: Some(workspace_id.to_string()),
             slug: "sample".to_string(),
             repo_root: repo_root.clone(),
             workspace_path: repo_root,

--- a/crates/orbit-store/src/workflow/task/tests/restore.rs
+++ b/crates/orbit-store/src/workflow/task/tests/restore.rs
@@ -53,7 +53,7 @@ fn bind_restore(
     fs::create_dir_all(&orbit_dir).unwrap();
     registry
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some(workspace_id.to_string()),
+            partition_id: Some(workspace_id.to_string()),
             slug: "restore".to_string(),
             repo_root: orbit_dir.parent().unwrap().to_path_buf(),
             workspace_path: orbit_dir.parent().unwrap().to_path_buf(),

--- a/crates/orbit-web/src/api/tests/task_response_bench.rs
+++ b/crates/orbit-web/src/api/tests/task_response_bench.rs
@@ -52,8 +52,8 @@ async fn task_response_benchmark() {
                 repo_root: repo_root.clone(),
                 active: true,
                 binding: Some(WorkspaceRuntimeBinding {
-                    workspace_id: id.clone(),
-                    logical_workspace_id: id,
+                    logical_workspace_id: id.clone(),
+                    task_partition_id: id,
                     owner_machine_id: None,
                     repo_root,
                     ship_mode: ShipMode::Local,

--- a/crates/orbit-web/src/api/tests/workspaces.rs
+++ b/crates/orbit-web/src/api/tests/workspaces.rs
@@ -65,7 +65,7 @@ pub(super) fn workspace_entry(
 ) -> WsEntry {
     let binding = active.then(|| WorkspaceRuntimeBinding {
         logical_workspace_id: format!("ws_{id}"),
-        workspace_id: format!("ws_{id}"),
+        task_partition_id: format!("ws_{id}"),
         owner_machine_id: None,
         repo_root: repo_root.clone(),
         ship_mode: ShipMode::Local,
@@ -1014,7 +1014,7 @@ async fn refresh_rebinds_workspace_to_new_checkout() {
         before
             .workspace_runtime_binding()
             .expect("dashboard runtime binding")
-            .workspace_id,
+            .task_partition_id,
         "ws_alpha"
     );
 
@@ -1037,7 +1037,7 @@ async fn refresh_rebinds_workspace_to_new_checkout() {
         after
             .workspace_runtime_binding()
             .expect("dashboard runtime binding")
-            .workspace_id,
+            .task_partition_id,
         "ws_alpha_v2",
         "logical registry id may differ from the runtime's configured id"
     );

--- a/crates/orbit-web/src/state.rs
+++ b/crates/orbit-web/src/state.rs
@@ -439,7 +439,7 @@ impl DashboardState {
             orbit_dir: PathBuf::new(),
             binding: Some(WorkspaceRuntimeBinding {
                 logical_workspace_id: SINGLE_WORKSPACE_ID.to_string(),
-                workspace_id: SINGLE_WORKSPACE_ID.to_string(),
+                task_partition_id: SINGLE_WORKSPACE_ID.to_string(),
                 owner_machine_id: None,
                 repo_root: PathBuf::new(),
                 ship_mode: ShipMode::Local,
@@ -453,7 +453,7 @@ impl DashboardState {
             CachedRuntime {
                 binding: WorkspaceRuntimeBinding {
                     logical_workspace_id: SINGLE_WORKSPACE_ID.to_string(),
-                    workspace_id: SINGLE_WORKSPACE_ID.to_string(),
+                    task_partition_id: SINGLE_WORKSPACE_ID.to_string(),
                     owner_machine_id: None,
                     repo_root: PathBuf::new(),
                     ship_mode: ShipMode::Local,

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -101,10 +101,13 @@ individual flag; neither command upgrades the binary or pulls a remote repositor
 `.orbit/` and the global task-store partition its task state is bound to, retiring that
 partition's rows in `~/.orbit/tasks/index.sqlite` in the same step.
 
-A partition directory is normally named for a **task-registry** workspace id
+A partition directory is named for a **task-store partition id**
 (`workspace_bindings.workspace_id` in `~/.orbit/tasks/index.sqlite`), minted as `<slug>-<hash>`
-for a checkout that binds without an explicit id. `orbit workspace init` may instead use its
-catalog `ws_*` id directly. A task-registry checkout claim is live while its recorded `repo_root`
+for a checkout that binds without an explicit id. That is a different namespace from the
+workspace-registry id in `~/.orbit/workspaces.json`: `orbit workspace init` passes its catalog
+`ws_*` id in as the partition id, so those workspaces spell both the same, while a legacy
+`<slug>-<hash>` partition and the synthetic `ws_unbound-data-dir` partition have no catalog row at
+all. Partition ownership is therefore always resolved through the task registry. A task-registry checkout claim is live while its recorded `repo_root`
 is present on disk; a catalog checkout supplies the same per-checkout evidence when `workspace init`
 has only a path-free task-registry registration. The shared external Orbit root (`--root
 <data-dir>`) is not used as checkout evidence because several checkouts may share it. A missing


### PR DESCRIPTION
## Task

[ORB-12226](https://orbit-cli.com/tasks/ORB-12226) — [friction-curation] Name the task-store partition id distinctly from the workspace-registry id

### Description

## Problem

Orbit carries two different workspace identifier namespaces, both spelled `workspace_id` and both typed `&str`/`String`:

- **Workspace registry** (`~/.orbit/workspaces.json`): `Workspace.id` / `checkout.workspace_id`, minted by `orbit workspace init` as `ws_<slug>` (for example `ws_orbit`).
- **Task registry** (`<global_root>/tasks/index.sqlite`, `workspace_bindings.workspace_id`): the task-store *partition* id, minted by `TaskRegistryStore::bind_workspace` (`crates/orbit-store/src/driver/sqlite/task_registry/store.rs:92`) as `<slug>-<hash>` for older checkouts and adopted from the existing orbit-dir row on identity drift (`crates/orbit-core/src/runtime/builder.rs:274-296`). It is the directory name under `task_workspaces_dir` (`crates/orbit-store/src/driver/sqlite/task_registry/mod.rs:33`).

On this host the live Orbit partition is `orbit-5c61b3` while the registered workspace is `ws_orbit`, and newer workspaces use `ws_*` in *both* registries — so a reader who checks only a recent workspace concludes the two namespaces are one. Nothing in the type system or the names separates them.

## Why It Matters

This has already caused a critical defect. The ORB-12109 delivery (commit `48773f492`) compared partition directory names against `workspace_registry::find_workspace_by_id`, which made 18 of 22 live partitions look orphaned and turned `orbit doctor --fix-orphan-task-stores` into a command that would delete the host's entire task store. It was repaired under ORB-12119 / ORB-12131 / ORB-12143, but the naming that invited it is unchanged, and establishing the split still costs a reviewer roughly 25 minutes of dumping `workspace_bindings` against `workspaces.json` (F2026-09-126).

## Constraints / Notes

- Keep the persisted column name `workspace_bindings.workspace_id` and every on-disk layout unchanged: this is a source-level naming and documentation change, not a migration.
- Valid partition ids include the legacy `<slug>-<hash>` form and `ws_unbound-data-dir`, neither of which has a workspace-registry row. Say so where the relationship is documented.
- A full newtype is welcome only where it stays contained (the task-registry API and the code that reads both registries). Do not spread a new wrapper type across unrelated call sites to satisfy the rename; a distinct parameter/field name plus documentation at the minting and resolution sites is the required outcome.

### Acceptance Criteria

- At the sites that mint or resolve the task-store partition id (`TaskRegistryStore::bind_workspace`, `task_workspaces_dir`, and the runtime binding adoption in `crates/orbit-core/src/runtime/builder.rs`), the identifier is named distinctly from the workspace-registry id so the two cannot be read as the same value.
- A doc comment at the partition-directory resolution point states both namespaces, which registry mints each, and that legacy `<slug>-<hash>` and `ws_unbound-data-dir` partition ids have no workspace-registry row.
- `crates/orbit-cmd/src/task_store.rs` — the code that compares partitions against the workspace registry — uses the distinct name, and a test exercises a partition id that is not a `ws_*` id so a future comparison against the wrong namespace fails loudly.
- No persisted schema, column name, or on-disk directory name changes; existing task-registry tests pass unchanged except for renamed identifiers.
- `make ci-fast` and `make ci-lint` pass, and `cargo test -p orbit-store --lib` plus `cargo test -p orbit-cmd` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Outcome

Named the task-store partition id distinctly from the workspace-registry id across the minting,
resolution, and comparison sites, documented the two namespaces where the partition directory is
resolved, and added a regression test that fails loudly if ownership is ever resolved through the
wrong registry. No persisted schema, column, or on-disk directory name changed: every SQL statement
still reads and writes `workspace_bindings.workspace_id`, `.orbit/config.yaml` still carries
`workspace_id`, and partition directories keep their names.

## Criteria

1. **Distinct names at the mint/resolve sites — met.**
   - `TaskRegistryStore::bind_workspace` (crates/orbit-store/src/driver/sqlite/task_registry/store.rs)
     and every other registry method now take/bind `partition_id`;
     `BindWorkspaceParams`/`RegisterWorkspaceParams`/`WorkspaceBinding`/`WorkspaceCheckoutBinding`/
     `TaskBundleBinding`/`DanglingRelationTarget` expose `partition_id`
     (crates/orbit-store/src/contracts/task_registry.rs); `TaskRegistryStore::workspace_ids()` is now
     `partition_ids()`; `driver/sqlite/task_registry/workspace_id.rs` is renamed to `partition_id.rs`
     with `next_partition_id_candidate` / `partition_id_candidate`; `path_safety::validate_workspace_id`
     is `validate_partition_id`.
   - `task_workspaces_dir` (task_registry/mod.rs) documents the partition namespace.
   - Runtime adoption in crates/orbit-core/src/runtime/builder.rs uses `partition_id`,
     `partition_id_hint`, `configured_partition_id`, `rebind_candidate_partition_id`, and
     `UNBOUND_DATA_DIR_PARTITION_ID`; `WorkspaceRuntimeBinding.workspace_id` is now
     `task_partition_id`, sitting next to `logical_workspace_id` so the pair can no longer be read as
     one value.
2. **Doc at the partition-directory resolution point — met.** `task_workspaces_dir` carries a
   "Two id spaces, one spelling" section naming both namespaces, which registry mints each
   (`bind_workspace` vs `orbit workspace init`), why `workspace init` workspaces spell them the same,
   and that legacy `<slug>-<hash>` and `ws_unbound-data-dir` partitions have no workspace-registry
   row. Supporting docs at `bind_workspace`, `partition_ids`, `next_partition_id_candidate`,
   `build_v2_task_backends`, the contract fields, and the `task_store.rs` module header.
3. **orbit-cmd/src/task_store.rs — met.** Partition-denoting params/locals are `partition_id`;
   workspace-registry values are always `catalog_workspace_id`; the path-name helper is
   `partition_id_of`. New test
   `tests::task_store::a_live_checkout_keeps_its_legacy_partition_despite_a_ws_catalog_id` binds a
   live checkout to the legacy partition `repo-a1b2c3` while the catalog knows it as `ws_repo`, and
   asserts nothing is removable/stale/unowned/unreachable and the repair removes nothing. Verified it
   fails loudly: with `partition_claims` mutated to drop the task-registry claim (simulating a catalog
   comparison), the test panics with "a partition claimed by the task registry must not be read as
   unowned...". The mutation was reverted; the test passes on the delivered code.
4. **No persisted change — met.** SQL column names, `config.yaml` keys and on-disk partition names
   are untouched (`grep` for renamed identifiers inside SQL literals is empty). The 240-line diff in
   `task_registry/tests/mod.rs` is identifier renames only (diff filtered for non-id changes is
   empty).

## Validation

- `make ci-fast` — passed (exit 0).
- `make ci-lint` — passed (exit 0).
- `cargo test -p orbit-store --lib` — passed: 525 passed, 0 failed, 7 ignored.
- `cargo test -p orbit-core --lib` — passed: 1420 passed, 0 failed (extra evidence for the builder
  rename).
- `cargo doc -p orbit-store --no-deps` — no warnings (intra-doc links resolve).
- `cargo test -p orbit-cmd` — 157 passed, 1 failed: `tests::workspace_catalog::
  a_non_active_workspace_is_not_selectable_by_name`. **Pre-existing at HEAD 56d6c2c64, not caused by
  this task**: reproduced on a pristine `git archive HEAD` tree with the identical assertion failure.
  Root cause is `resolve_workspace_selector` calling `validate_workspaces`, which flips the fixture's
  `Invalid` workspace back to `Active` because the fixture creates its `repo_root` on disk. Filed as
  friction F2026-09-139. Every task_store and doctor test in that suite passes.
- `git diff --check` clean; `git status --short` accounted for below.

## Scope notes

Field renames on the task-registry contracts are compiler-enforced, so the diff touches 44 files;
everything outside the four `context_files` is a mechanical rename of the same fields at their read
sites (orbit-store workflow/tests, orbit-core, orbit-cli, orbit-web) with no behavior change. Files
appended to `context_files`: the renamed module `partition_id.rs` (new tracked path),
`contracts/task_registry.rs`, `task_registry/queries.rs`, `fs/path_safety.rs`,
`orbit-core/src/runtime/mod.rs`, `orbit-cmd/src/task_owner.rs`, `orbit-cmd/src/tests/task_store.rs`,
and `docs/runbooks/health-checks.md` (its "Reclaim orphaned task stores" section describes the same
namespace split and was aligned to the new vocabulary).

New untracked file created by the module rename:
`crates/orbit-store/src/driver/sqlite/task_registry/partition_id.rs` (the old `workspace_id.rs` shows
as a tracked deletion; `git mv` was unavailable because `.git` is read-only in this sandbox).

## Risk

No newtype was introduced, so the two namespaces are still both `String` — the separation is by name
and documentation, as the task required. User-facing error text was left unchanged except the
internal allocator message ("could not allocate a task-store partition id for slug ..."), which no
test asserts.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12226-6aa4ad0c`
- Behind base: 0
- Ahead of base: 1