### PR TITLE
docs(design): cite ORB-12236/ORB-12237 for the clock consolidation split

### DIFF
--- a/docs/design/auto-tasks/3_vision.md
+++ b/docs/design/auto-tasks/3_vision.md
@@ -11,7 +11,7 @@ summary: Forward-looking directions for the auto-task primitive — cross-worksp
 tags: [auto-tasks]
 paths: ["crates/orbit-core/src/application/auto_tasks/**"]
 related_features: [auto-tasks, routines]
-related_artifacts: [ORB-10149, ORB-11315, ORB-12233]
+related_artifacts: [ORB-10149, ORB-11315, ORB-12237]
 ---
 
 # Auto-tasks — Vision

--- a/docs/design/auto-tasks/4_decisions.md
+++ b/docs/design/auto-tasks/4_decisions.md
@@ -11,7 +11,7 @@ summary: Decision log for the auto-task primitive, including its move from a rou
 tags: [auto-tasks]
 paths: ["crates/orbit-core/src/application/auto_tasks/**"]
 related_features: [auto-tasks, routines]
-related_artifacts: [ORB-12233]
+related_artifacts: [ORB-12237]
 ---
 
 # Auto-tasks — Decisions
@@ -99,7 +99,7 @@ All run budgets in Orbit config, auto-task definitions, job/activity assets, wor
 
 ## Auto-task definitions are evaluated by the host tick, not fired by a routine
 
-**Recorded:** 2026-09-12 · [ORB-12233]
+**Recorded:** 2026-09-12 · [ORB-12237]
 **Code anchors:** `crates/orbit-core/src/application/auto_tasks/scheduler.rs::run_auto_task_scheduler_at`, `crates/orbit-core/src/application/routines/sweep.rs`
 
 ### Context
@@ -119,7 +119,7 @@ The scheduler pass was already a stateless, cursor-driven due evaluator — the 
 
 ## Task References
 
-- [ORB-12233] — moves auto-task evaluation into the host clock tick and retires the scheduler routine/job/activity.
+- [ORB-12237] — moves auto-task evaluation into the host clock tick and retires the scheduler routine/job/activity.
 - [ORB-10149] — Shipped the auto-task primitive (record, scheduler, CRUD, assets).
 - [ORB-10148] — Added the QA definition and no-diff workflow exemption.
 - [ORB-10472] — Isolated auto-task definition refresh from the registered

--- a/docs/design/routines/3_vision.md
+++ b/docs/design/routines/3_vision.md
@@ -11,7 +11,7 @@ summary: Target contract for the clock consolidation (one host tick for routines
 tags: [routines, scheduler]
 paths: ["crates/orbit-core/src/application/routines/**", "crates/orbit-cmd/src/registry_routines.rs", "crates/orbit-cmd/src/registry_runtime.rs", "crates/orbit-registry/src/**"]
 related_features: [routines, auto-tasks, activity-job, host-registry, task-migration]
-related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ORB-11315, ORB-12233]
+related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ORB-11315, ORB-12236, ORB-12237]
 ---
 
 # Routines — Vision
@@ -24,7 +24,7 @@ task, implementation, and validation evidence, not by drifting in.
 
 ## 0. Graduating: clock consolidation
 
-Decided 2026-09-12; implemented by [ORB-12233]. The reasoning is in
+Decided 2026-09-12; implemented by [ORB-12236] (hosts/role removal) then [ORB-12237] (tick, `orbit clock`, scheduler retirement). The reasoning is in
 [One host tick evaluates routines and auto-task definitions in-process](./4_decisions.md#one-host-tick-evaluates-routines-and-auto-task-definitions-in-process),
 [Definitions carry no host pin: every owner checkout is an independent schedule](./4_decisions.md#definitions-carry-no-host-pin-every-owner-checkout-is-an-independent-schedule),
 and [Registration is the automation opt-in; there is no routine-source role](./4_decisions.md#registration-is-the-automation-opt-in-there-is-no-routine-source-role).
@@ -219,8 +219,9 @@ External:
 
 ## Task References
 
-- [ORB-12233] — implements the clock consolidation (§0): one host tick for routines and
-  auto-tasks, `orbit clock`, no host pins, no source role.
+- [ORB-12236] — implements §0.3 eligibility: removes `hosts:` pins and `[routines] role`.
+- [ORB-12237] — implements §0.1, §0.2, §0.4, §0.5: `orbit clock`, the combined tick, scheduler
+  retirement, and the docs fold; depends on [ORB-12236].
 - [ORB-11315] — proposes shared state-driven triggers and durable coverage semantics.
 
 - [ORB-10001] — authored this design-doc folder (proposal; no implementation).

--- a/docs/design/routines/4_decisions.md
+++ b/docs/design/routines/4_decisions.md
@@ -11,7 +11,7 @@ summary: Decision log for the routines scheduler — OS clock, one host tick for
 tags: [routines, scheduler]
 paths: ["crates/orbit-core/src/application/routines/**", "crates/orbit-cmd/src/registry_routines.rs", "crates/orbit-cmd/src/registry_runtime.rs", "crates/orbit-registry/src/**"]
 related_features: [routines, auto-tasks, activity-job, host-registry, task-migration]
-related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ORB-10739, ORB-10986, ORB-11082, ORB-12233]
+related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ORB-10739, ORB-10986, ORB-11082, ORB-12236, ORB-12237]
 ---
 
 # Routines — Decisions
@@ -183,7 +183,7 @@ Store the supported whole-minute cadence in host-local `~/.orbit/clock.toml` and
 
 ## One host tick evaluates routines and auto-task definitions in-process
 
-**Recorded:** 2026-09-12 · [ORB-12233]
+**Recorded:** 2026-09-12 · [ORB-12237]
 **Code anchors:** `crates/orbit-core/src/application/routines/sweep.rs`, `crates/orbit-core/src/application/auto_tasks/scheduler.rs::run_auto_task_scheduler_at`, `crates/orbit-cli/src/command/clock/**`
 
 ### Context
@@ -206,7 +206,7 @@ The clock is host infrastructure shared by both evaluators, so its CLI moves to 
 
 ## Definitions carry no host pin: every owner checkout is an independent schedule
 
-**Recorded:** 2026-09-12 · [ORB-12233]
+**Recorded:** 2026-09-12 · [ORB-12236]
 
 ### Context
 
@@ -230,7 +230,7 @@ Migration: `hosts:` is accepted and ignored with a load warning for one release,
 
 ## Registration is the automation opt-in; there is no routine-source role
 
-**Recorded:** 2026-09-12 · [ORB-12233]
+**Recorded:** 2026-09-12 · [ORB-12236]
 **Code anchors:** `crates/orbit-config/src/{raw,resolved}.rs` (the `[routines] role` key, removed), `crates/orbit-core/src/application/routines/loader.rs`
 
 ### Context
@@ -249,7 +249,8 @@ Remove the `[routines]` config section. The tick evaluates definitions from ever
 
 ## Task References
 
-- [ORB-12233] — implements the clock consolidation recorded in the three 2026-09-12 entries.
+- [ORB-12236] — removes `hosts:` pins and `[routines] role = "source"` (the second and third 2026-09-12 entries).
+- [ORB-12237] — moves auto-task evaluation into the host tick, adds `orbit clock`, retires the scheduler routine/job/activity (the first 2026-09-12 entry); depends on [ORB-12236].
 - [ORB-10001] — authored this design-doc folder (proposal).
 - [ORB-10021] — implemented routines v1; allocated and accepted [The OS owns the clock: stateless orbit sweep under launchd/systemd, no resident daemon](#the-os-owns-the-clock-stateless-orbit-sweep-under-launchdsystemd-no-resident-daemon)..[Routine definitions are git-shared; scheduler state is host-local and never synced](#routine-definitions-are-git-shared-scheduler-state-is-host-local-and-never-synced).
 - [ORB-10129] — shipped the default triage routine; allocated and accepted [Default routines seed per-workspace at init with host and name resolved at seed time](#default-routines-seed-per-workspace-at-init-with-host-and-name-resolved-at-seed-time).


### PR DESCRIPTION
ORB-12233 was retired (no epic); the work is now two standalone tasks — **ORB-12236** (remove `hosts:` pins and `[routines] role`) and **ORB-12237** (`orbit clock`, combined tick, retire the auto-task scheduler trio; depends on 12236). This repoints the `Recorded` lines, Task References, `related_artifacts`, and the `3_vision.md §0` lead-in accordingly. No other content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)