### PR TITLE
task-pilot: stop returning `unassessed` complexity when selectors and rationale are already established

### DIFF
--- a/.orbit/resources/activities/task_pilot.yaml
+++ b/.orbit/resources/activities/task_pilot.yaml
@@ -236,19 +236,27 @@ spec:
        dependency bump with direct validation can be low; a caller migration
        is often medium; a trust-boundary or cross-subsystem redesign can be
        hard. These are policy examples, not proof of live-model classification
-       accuracy. If evidence cannot support a rating, return `unassessed`, name
-       concrete evidence gaps, and propose the smallest bounded investigation
-       through selectors and validation approach. Missing validation authority
-       belongs in `utility_warnings` as a readiness blocker. Complexity,
+       accuracy.
+       Whenever the pilot has produced selectors and a rationale, return an
+       assessed complexity (`low`, `medium`, or `hard`) with an appropriate
+       `confidence` level (`high`, `medium`, or `low`) expressing uncertainty.
+       Reserve `unassessed` strictly for tasks where the pilot cannot identify
+       the bounded repair at all, proposing the smallest bounded investigation
+       through selectors and validation approach.
+       Define `evidence_gaps` strictly as rating-changing unknowns only
+       (such as unknown fixture semantics, unresolved architecture choices, or
+       missing failure signatures that could change which complexity rating applies).
+       When `confidence` is `high`, `evidence_gaps` must be empty; when `confidence`
+       is `medium` or `low`, list those rating-changing unknowns in `evidence_gaps`.
+       Explicitly exclude 'validation not executed in this read-only assessment'
+       style entries: this lane is a read-only preflight and never builds, tests,
+       or runs validation commands (`proc.spawn` is CLI-only, so an MCP-transport
+       session does not advertise it at all). The structural absence of test
+       execution is never an evidence gap and must not be listed in `evidence_gaps`,
+       nor used to return `unassessed`. Name the checks that would establish the repair
+       in `validation_approach` / `reassessment_triggers`, and report missing validation
+       authority or readiness blockers in `utility_warnings`. Complexity,
        urgency, and readiness are separate decisions.
-       This lane is a read-only preflight and never builds, tests, or runs a
-       validation command; `proc.spawn` is CLI-only, so an MCP-transport
-       session does not advertise it at all. That absence of `proc.spawn` is
-       structural to the pilot lane and is not by itself an evidence gap: do
-       not return `unassessed` merely because you could not execute a build or
-       a test here. Name the check that would establish the repair in
-       `validation_approach` instead, and reserve `unassessed` for evidence
-       the pilot could have read at `source_revision` but did not find.
     7. Report recommendations only; do not apply them:
        `recommended_crew`, `recommended_complexity`, real `blocked_by` task IDs,
        `duplicate_of`, `already_landed`, `release_action_required`,
@@ -310,9 +318,13 @@ spec:
     },"error":null}
 
     Copy `partition_index` and `task_ids` exactly from the input and return one
-    task assessment per input ID. If evidence is insufficient to assign a
-    complexity, return the task as `unassessed` with actionable evidence gaps;
-    never omit it or invent certainty.
+    task assessment per input ID. Whenever you have produced selectors and a
+    rationale, return an assessed complexity (`low|medium|hard`) with an
+    appropriate `confidence` level (`high|medium|low`). Reserve `unassessed`
+    strictly for tasks where the bounded repair cannot be identified at all.
+    Define `evidence_gaps` as rating-changing unknowns only, leaving it empty
+    for `high` confidence, and never populate it with unexecuted validation
+    checks or read-only lane limitations.
   tools:
     - orbit.task.show
     - orbit.task.list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Highlights
+
+- **Task-pilot assessment precision**: task-pilot instructions define evidence gaps as rating-changing unknowns rather than unexecuted validation, and validate_recommendations allows assessed complexity with evidence gaps when confidence is low or medium. ([ORB-12232])
+
 ## 0.21.0
 
 ### Breaking Changes

--- a/crates/orbit-core/assets/activities/task_pilot.yaml
+++ b/crates/orbit-core/assets/activities/task_pilot.yaml
@@ -236,19 +236,27 @@ spec:
        dependency bump with direct validation can be low; a caller migration
        is often medium; a trust-boundary or cross-subsystem redesign can be
        hard. These are policy examples, not proof of live-model classification
-       accuracy. If evidence cannot support a rating, return `unassessed`, name
-       concrete evidence gaps, and propose the smallest bounded investigation
-       through selectors and validation approach. Missing validation authority
-       belongs in `utility_warnings` as a readiness blocker. Complexity,
+       accuracy.
+       Whenever the pilot has produced selectors and a rationale, return an
+       assessed complexity (`low`, `medium`, or `hard`) with an appropriate
+       `confidence` level (`high`, `medium`, or `low`) expressing uncertainty.
+       Reserve `unassessed` strictly for tasks where the pilot cannot identify
+       the bounded repair at all, proposing the smallest bounded investigation
+       through selectors and validation approach.
+       Define `evidence_gaps` strictly as rating-changing unknowns only
+       (such as unknown fixture semantics, unresolved architecture choices, or
+       missing failure signatures that could change which complexity rating applies).
+       When `confidence` is `high`, `evidence_gaps` must be empty; when `confidence`
+       is `medium` or `low`, list those rating-changing unknowns in `evidence_gaps`.
+       Explicitly exclude 'validation not executed in this read-only assessment'
+       style entries: this lane is a read-only preflight and never builds, tests,
+       or runs validation commands (`proc.spawn` is CLI-only, so an MCP-transport
+       session does not advertise it at all). The structural absence of test
+       execution is never an evidence gap and must not be listed in `evidence_gaps`,
+       nor used to return `unassessed`. Name the checks that would establish the repair
+       in `validation_approach` / `reassessment_triggers`, and report missing validation
+       authority or readiness blockers in `utility_warnings`. Complexity,
        urgency, and readiness are separate decisions.
-       This lane is a read-only preflight and never builds, tests, or runs a
-       validation command; `proc.spawn` is CLI-only, so an MCP-transport
-       session does not advertise it at all. That absence of `proc.spawn` is
-       structural to the pilot lane and is not by itself an evidence gap: do
-       not return `unassessed` merely because you could not execute a build or
-       a test here. Name the check that would establish the repair in
-       `validation_approach` instead, and reserve `unassessed` for evidence
-       the pilot could have read at `source_revision` but did not find.
     7. Report recommendations only; do not apply them:
        `recommended_crew`, `recommended_complexity`, real `blocked_by` task IDs,
        `duplicate_of`, `already_landed`, `release_action_required`,
@@ -310,9 +318,13 @@ spec:
     },"error":null}
 
     Copy `partition_index` and `task_ids` exactly from the input and return one
-    task assessment per input ID. If evidence is insufficient to assign a
-    complexity, return the task as `unassessed` with actionable evidence gaps;
-    never omit it or invent certainty.
+    task assessment per input ID. Whenever you have produced selectors and a
+    rationale, return an assessed complexity (`low|medium|hard`) with an
+    appropriate `confidence` level (`high|medium|low`). Reserve `unassessed`
+    strictly for tasks where the bounded repair cannot be identified at all.
+    Define `evidence_gaps` as rating-changing unknowns only, leaving it empty
+    for `high` confidence, and never populate it with unexecuted validation
+    checks or read-only lane limitations.
   tools:
     - orbit.task.show
     - orbit.task.list

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
@@ -673,10 +673,10 @@ fn validate_recommendations(
             format!("task {task_id} unassessed complexity requires actionable evidence_gaps"),
         ));
     }
-    if complexity.is_assessed() && !evidence_gaps.is_empty() {
+    if complexity.is_assessed() && !evidence_gaps.is_empty() && confidence == "high" {
         return Err(action_failed(
             action,
-            format!("task {task_id} must remain unassessed while evidence_gaps are present"),
+            format!("task {task_id} with high confidence must not have evidence_gaps"),
         ));
     }
     for field in [

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_assessment.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_assessment.rs
@@ -289,3 +289,57 @@ fn an_applied_assessment_is_durable_and_only_a_later_audited_pass_changes_it() {
         Some(TaskComplexity::Unassessed)
     );
 }
+
+#[test]
+fn assessed_complexity_with_evidence_gaps_persists_when_confidence_is_low() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "src/gap.rs");
+    let task = seed_task(&runtime, "assessed repair with rating-changing unknowns");
+    let prepared = prepare_task(&runtime, &repo_root, &task);
+    let mut result = assessment(&task, "file:src/gap.rs", "medium");
+    result["confidence"] = json!("low");
+    result["evidence_gaps"] =
+        json!(["Unresolved fixture semantics might change the repair to hard."]);
+
+    let output = apply_assessment(&runtime, &repo_root, prepared, &task, result);
+    assert_eq!(output["status"], "succeeded");
+    let updated = runtime.get_task(&task.id).expect("reload assessed task");
+    assert_eq!(updated.complexity, Some(TaskComplexity::Medium));
+}
+
+#[test]
+fn assessed_complexity_with_evidence_gaps_is_rejected_when_confidence_is_high() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "src/gap.rs");
+    let task = seed_task(&runtime, "high-confidence repair claiming gaps");
+    let prepared = prepare_task(&runtime, &repo_root, &task);
+    let mut result = assessment(&task, "file:src/gap.rs", "medium");
+    result["confidence"] = json!("high");
+    result["evidence_gaps"] = json!(["Contradictory gap under high confidence."]);
+
+    let output = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": prepared,
+            "results": [{
+                "partition_index": 0,
+                "task_ids": [task.id],
+                "tasks": [result],
+                "summary": "assessment fixture",
+            }],
+            "workspace_path": &repo_root,
+        }),
+    )
+    .expect("apply result");
+    assert_eq!(output["status"], "failed");
+    assert_eq!(output["repair_count"], 1);
+    let errors = &output["repair_partitions"][0]["validation_errors"];
+    assert!(
+        errors.as_array().unwrap().iter().any(|e| e
+            .as_str()
+            .unwrap()
+            .contains("with high confidence must not have evidence_gaps")),
+        "expected high-confidence evidence_gaps rejection, got: {errors:?}"
+    );
+}


### PR DESCRIPTION
## Task

[ORB-12232](https://orbit-cli.com/tasks/ORB-12232) — task-pilot: stop returning `unassessed` complexity when selectors and rationale are already established

### Description

## Problem
The `task_pilot` activity instruction (`crates/orbit-core/assets/activities/task_pilot.yaml`, step 6 and the closing paragraph) tells the pilot to return `recommended_complexity: unassessed` whenever "evidence cannot support a rating" and to list `evidence_gaps`. In practice the pilot treats the inherent limits of a read-only preflight — "tests were not executed in this read-only assessment", "`make ci-fast` has not been run for the proposed repair" — as evidence gaps, and so returns `unassessed` even when it has already produced concrete selectors, a rationale, and a validation approach. The apply step (`crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs`, `validate_recommendations`) then hard-couples the two: any non-empty `evidence_gaps` **forces** `unassessed` ("must remain unassessed while evidence_gaps are present"), so the task is persisted with `complexity_after: unassessed`.

Observed on the current host (2026-09-12, workspace `orbit`):
- **ORB-12231** — pilot applied 4 `context_files`, wrote a full rationale and validation approach, `confidence: low`, `recommended_complexity: unassessed`, evidence gaps = "targeted tests and documented pre-handoff gates have not been executed in this read-only assessment" (+2 similar). `complexity_before: unassessed → complexity_after: unassessed`.
- **ORB-12230** — pilot applied 1 selector with `confidence: high`, still `unassessed`; evidence gaps = "exact failing test was not executed during this read-only assessment", "`make ci-fast` has not been run".
- **ORB-12219** — `[auto-task]` no-diff task, `unassessed`, 0 selectors.

## Why It Matters
- These tasks never become dispatchable: `complexity` must be assessed for promotion/ship, and humans/agents cannot set it via `orbit.task.update` without also re-doing the pilot's work.
- `automatic_exclusion_reason` only excludes a task as `context_files_not_empty` when complexity is **assessed**, so an unassessed task with selectors is re-selected by every `task_pilot_pipeline` sweep — repeated pilot runs that change nothing.
- The pilot cannot ever run the tests it cites as a gap (it is read-only, `proc_allowed_programs: [git, rg]`), so the gap is unresolvable by design and the instruction is self-defeating.

## Constraints / Notes
- Primary fix is the **agent instruction** in `task_pilot.yaml`: define an evidence gap as something that changes *which* rating applies (unknown fixture semantics, unresolved architecture choice, missing failure signature), not the absence of executed validation. Execution of validation belongs in `validation_approach` / `reassessment_triggers`, and validation-readiness in `utility_warnings` (which the instruction already says). State explicitly that a read-only pilot must still rate `low|medium|hard` when selectors and rationale exist, using `confidence` to express uncertainty; `unassessed` is reserved for tasks where the pilot cannot identify the bounded repair at all.
- Revisit the apply-side validator coupling (`validate_recommendations`: `is_assessed() && !evidence_gaps.is_empty()` → error). Either relax it (allow assessed + non-empty gaps when confidence is `low`/`medium`), or keep it and make the instruction tell the pilot to move non-rating gaps out of `evidence_gaps`. Pick one and keep instruction and validator consistent; update `tests/task_pilot_assessment.rs` accordingly.
- Keep the embedded asset and the seeded copy in sync (`crates/orbit-core/assets/activities/task_pilot.yaml` is the source; `~/.orbit/resources` is re-seeded by `orbit init --non-interactive` on deploy). Note the workspace-local `.orbit/resources/jobs/task_pilot_pipeline.yaml` already drifts from the embedded job; don't widen that drift.
- Consider whether `[auto-task]` no-diff tasks (ORB-12219) should get a default rating from the auto-task definition instead of relying on the pilot.
- Rollback: revert the YAML instruction change; no schema or store migration involved.

### Acceptance Criteria

- `crates/orbit-core/assets/activities/task_pilot.yaml` step 6 (and the closing envelope paragraph) define `evidence_gaps` as rating-changing unknowns only, explicitly exclude 'validation not executed in this read-only assessment' style entries, and instruct the pilot to return an assessed `low|medium|hard` with a `confidence` level whenever it has produced selectors and a rationale.
- `validate_recommendations` in `crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs` and the instruction are consistent: either the `is_assessed() && !evidence_gaps.is_empty()` rejection is relaxed with a unit test in `v2_host/tests/task_pilot_assessment.rs` covering assessed+gaps+low-confidence, or a test asserts the existing rule and the instruction tells the pilot where non-rating gaps go instead.
- Re-running `orbit run ship`-independent task-pilot (`orbit tool run orbit.workflow.run ...` / the `task_pilot_pipeline` job) on ORB-12230 and ORB-12231 persists an assessed complexity (`complexity_after` in the `task_pilot_applied` history note is not `unassessed`).
- `cargo test -p orbit-core task_pilot` passes and `./scripts/ci-guardrails.sh` passes.
- CHANGELOG.md has an entry describing the instruction/validator change.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Acceptance Criteria Results

1. **task_pilot.yaml Instruction Refinement**:
   - `crates/orbit-core/assets/activities/task_pilot.yaml` (step 6 and closing envelope paragraph) updated to define `evidence_gaps` strictly as rating-changing unknowns only.
   - Explicitly excludes "validation not executed in this read-only assessment" style entries, noting that absence of test execution in read-only preflight is not an evidence gap.
   - Instructs pilot to return assessed complexity (`low|medium|hard`) with confidence level (`high|medium|low`) whenever selectors and rationale are produced.
   - Synchronized with `.orbit/resources/activities/task_pilot.yaml` via `./scripts/sync-activity-assets.sh` and verified with `--check`.

2. **Validator and Tests Alignment**:
   - In `crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs` (`validate_recommendations`), relaxed `is_assessed() && !evidence_gaps.is_empty()` to allow assessed complexity with evidence gaps when confidence is `low` or `medium`.
   - Rejects evidence gaps for assessed complexity only when confidence is `high` (`task {task_id} with high confidence must not have evidence_gaps`).
   - Added unit tests in `crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_assessment.rs`:
     - `assessed_complexity_with_evidence_gaps_persists_when_confidence_is_low` (verifies assessed complexity + gaps persists under low confidence).
     - `assessed_complexity_with_evidence_gaps_is_rejected_when_confidence_is_high` (verifies rejection when confidence is high).

3. **Re-running Task-Pilot on ORB-12230 and ORB-12231**:
   - Re-running `task_pilot_pipeline` via `orbit run job task_pilot_pipeline --input task_id=ORB-12230 --json` (run `jrun-20260912-0221-t1`) was denied at `prepare_task_pilot` with `git fetch lock: ~/workspace/constellation/codebases/orbit/.git/.orbit-git-fetch.lock is not writable: Read-only file system (os error 30)`.
   - Per Instruction §7, this is an expected Bubblewrap sandbox mount boundary (agent sandbox mounts `.git` read-only).
   - In-memory / tempdir integration tests in `v2_host/tests/task_pilot_assessment.rs` independently verify that assessed complexity persists correctly with confidence and evidence gaps.

4. **Validation and Guardrails**:
   - `cargo test -p orbit-core task_pilot`: All 61 tests pass.
   - `./scripts/ci-guardrails.sh --fast`: All format, lint, doc, security, and activity asset checks pass cleanly.
   - `cargo fmt --all -- --check`: Clean.
   - `./scripts/sync-activity-assets.sh --check`: Clean.
   - `./scripts/check-changelog-style.sh`: Clean.

5. **Changelog Entry**:
   - Added entry under `## Unreleased` -> `### Highlights` in `CHANGELOG.md` detailing the task_pilot instruction and recommendation validator relaxation.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12232-6aa4ae79`
- Behind base: 0
- Ahead of base: 1