### PR TITLE
[ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### DIFF
--- a/crates/orbit-cli/src/command/tests/operation_mode_help/enable.txt
+++ b/crates/orbit-cli/src/command/tests/operation_mode_help/enable.txt
@@ -10,7 +10,7 @@ Options:
       --for <WINDOW>
           Admission window from now, e.g. `30m`, `2h` (at most 24h)
       --workspace <SELECTOR>
-          Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+          Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory. Only active workspaces may be bound; commands fail if the workspace status is not active
       --right <RIGHTS>
           Right to grant: prepare, promote, or complete; repeat or comma-separate
       --preset <PRESET>

--- a/crates/orbit-cli/src/command/tests/operation_mode_help/explain.txt
+++ b/crates/orbit-cli/src/command/tests/operation_mode_help/explain.txt
@@ -10,7 +10,7 @@ Options:
       --completion <COMPLETION>
           Run-layer completion preference: review or done (an explicit done past the delivery cap is refused)
       --workspace <SELECTOR>
-          Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+          Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory. Only active workspaces may be bound; commands fail if the workspace status is not active
       --leaf-ceiling <LEAF_CEILING>
           Run-layer ceiling on concurrently live leaf runs
       --recovery-episodes <RECOVERY_EPISODES>

--- a/crates/orbit-cli/src/command/tests/operation_mode_help/list.txt
+++ b/crates/orbit-cli/src/command/tests/operation_mode_help/list.txt
@@ -6,5 +6,5 @@ Options:
       --limit <LIMIT>         Maximum number of grants to return (default 20)
       --root <ROOT>           Override the Orbit root directory (highest precedence)
       --json                  Output as JSON
-      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory. Only active workspaces may be bound; commands fail if the workspace status is not active
   -h, --help                  Print help

--- a/crates/orbit-cli/src/command/tests/operation_mode_help/revoke.txt
+++ b/crates/orbit-cli/src/command/tests/operation_mode_help/revoke.txt
@@ -6,7 +6,7 @@ Options:
       --id <ID>                    Grant ID; defaults to the workspace's active grant
       --root <ROOT>                Override the Orbit root directory (highest precedence)
       --reason <REASON>            Reason recorded with the revocation
-      --workspace <SELECTOR>       Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+      --workspace <SELECTOR>       Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory. Only active workspaces may be bound; commands fail if the workspace status is not active
       --if-revision <IF_REVISION>  Apply only if the grant is still at this revision
       --claim-token <CLAIM_TOKEN>  Token for this workspace's exclusive claim, when another operator holds one
       --json                       Output as JSON

--- a/crates/orbit-cli/src/command/tests/operation_mode_help/root.txt
+++ b/crates/orbit-cli/src/command/tests/operation_mode_help/root.txt
@@ -12,7 +12,7 @@ Commands:
 
 Options:
       --root <ROOT>           Override the Orbit root directory (highest precedence)
-      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory. Only active workspaces may be bound; commands fail if the workspace status is not active
   -h, --help                  Print help
 
 Preferences live under `[operation]` in config.toml and authorize nothing by

--- a/crates/orbit-cli/src/command/tests/operation_mode_help/show.txt
+++ b/crates/orbit-cli/src/command/tests/operation_mode_help/show.txt
@@ -8,5 +8,5 @@ Arguments:
 Options:
       --json                  Output as JSON
       --root <ROOT>           Override the Orbit root directory (highest precedence)
-      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory. Only active workspaces may be bound; commands fail if the workspace status is not active
   -h, --help                  Print help

--- a/crates/orbit-cli/src/command/tests/operation_mode_help/stop.txt
+++ b/crates/orbit-cli/src/command/tests/operation_mode_help/stop.txt
@@ -6,7 +6,7 @@ Options:
       --id <ID>                    Grant ID; defaults to the workspace's active grant
       --root <ROOT>                Override the Orbit root directory (highest precedence)
       --reason <REASON>            Reason recorded with the stop
-      --workspace <SELECTOR>       Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+      --workspace <SELECTOR>       Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory. Only active workspaces may be bound; commands fail if the workspace status is not active
       --if-revision <IF_REVISION>  Apply only if the grant is still at this revision
       --claim-token <CLAIM_TOKEN>  Token for this workspace's exclusive claim, when another operator holds one
       --json                       Output as JSON

--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -805,7 +805,7 @@
         "required": false
       },
       {
-        "description": "Optional task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:`, `dir:`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically.",
+        "description": "Optional task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:`, `dir:`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically. Existence checks verify the filesystem anchor only; a `symbol:` name and kind are not looked up.",
         "name": "context_files",
         "param_type": "string_list",
         "required": false
@@ -1277,7 +1277,7 @@
         "required": false
       },
       {
-        "description": "Task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically.",
+        "description": "Task context selectors as a comma-separated string or array of strings. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files referenced only for context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`. Legacy raw paths are accepted and upgraded automatically. Existence checks verify the filesystem anchor only; a `symbol:` name and kind are not looked up.",
         "name": "context_files",
         "param_type": "string_list",
         "required": false
@@ -1289,7 +1289,7 @@
         "required": false
       },
       {
-        "description": "Legacy alias for `context_files`. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files that are only relevant background context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`.",
+        "description": "Legacy alias for `context_files`. Add entries ONLY for existing files, directories, or symbols expected to be modified or deleted by the task. Do not add background-reading entries or files that are only relevant background context. Prefer canonical selectors: `file:path`, `dir:path`, or `symbol:path#name:kind`. Existence checks verify the filesystem anchor only; a `symbol:` name and kind are not looked up.",
         "name": "context",
         "param_type": "string",
         "required": false

--- a/crates/orbit-cmd/src/tests/workspace_catalog.rs
+++ b/crates/orbit-cmd/src/tests/workspace_catalog.rs
@@ -28,7 +28,7 @@ fn checkout(workspace_id: &str, root: &Path, name: &str) -> WorkspaceCheckout {
     WorkspaceCheckout::owner(workspace_id.to_string(), repo, orbit_dir)
 }
 
-/// A two-workspace registry plus one entry the registry marked invalid.
+/// A two-workspace registry plus one entry whose missing checkout is invalid.
 fn seeded_catalog() -> (tempfile::TempDir, RegistryWorkspaceCatalog) {
     let root = tempfile::tempdir().expect("root");
     let global = root.path().join("global");
@@ -37,10 +37,12 @@ fn seeded_catalog() -> (tempfile::TempDir, RegistryWorkspaceCatalog) {
     let alpha = workspace("ws_alpha", "alpha", WorkspaceStatus::Active);
     let beta = workspace("ws_beta", "beta", WorkspaceStatus::Active);
     let invalid = workspace("ws_invalid", "invalid-ws", WorkspaceStatus::Invalid);
+    let invalid_repo = root.path().join("invalid-ws");
+    let invalid_orbit_dir = invalid_repo.join(".orbit");
     let checkouts = vec![
         checkout(&alpha.id, root.path(), "alpha"),
         checkout(&beta.id, root.path(), "beta"),
-        checkout(&invalid.id, root.path(), "invalid-ws"),
+        WorkspaceCheckout::owner(invalid.id.clone(), invalid_repo, invalid_orbit_dir),
     ];
     save_registry_to(
         &WorkspaceRegistry {


### PR DESCRIPTION
## Task

[ORB-12231](https://orbit-cli.com/tasks/ORB-12231) — [ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `CI`
- Failing job: `Check / Clippy / Test`
- Failing step: `Run CI guardrails`
- Commit the runner actually checked out: `4a9613c01a16fca044366b5d9af6074d81110553`
- Normalized error signature (the dedupe identity, not a quote): `fail [ <n>.<n>s] ( <n>/<n>) orbit-cmd tests::workspace_catalog::a_non_active_workspace_is_not_selectable_by_name`
- Repository: `constellation-works/orbit`
- Release branch as GitHub reports it: `agent-main`
- Evidence collected at: 2026-09-12T01:31:03.658831038+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/constellation-works/orbit/actions/runs/34663681719 run `34663681719` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `4a9613c01a16fca044366b5d9af6074d81110553`
  - current head of that ref: `fdf062661c7192498f3c8f4aadbee7ca39942f46`
  - commit actually checked out: `4a9613c01a16fca044366b5d9af6074d81110553`
  - checkout evidence: `* branch            4a9613c01a16fca044366b5d9af6074d81110553 -> FETCH_HEAD`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/usr/bin/git checkout --progress --force 4a9613c01a16fca044366b5d9af6074d81110553`
  - failed job `Check / Clippy / Test` (id `103471180758`): https://github.com/constellation-works/orbit/actions/runs/34663681719/job/103471180758
  - failing step(s): `Run CI guardrails`

## Failed-step log excerpt

_Failure regions from a completely scanned command; the full command was not retained. 1431647 of 1452781 source bytes omitted, including 225570 assertion payload bytes. All 26 recognized failure anchors and bounded context are retained (64 KiB selection limit)._

```
2026-09-12T01:06:45.9296039Z ##[group]Run ./scripts/ci-guardrails.sh
[... 89760 command bytes omitted ...]
2026-09-12T01:10:23.8716887Z [31;1m        FAIL[0m [   0.013s] ( 389/5534) [35;1morbit-cmd[0m [36mtests::workspace_catalog[0m[36m::[0m[34;1ma_non_active_workspace_is_not_selectable_by_name[0m
2026-09-12T01:10:23.8723889Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T01:10:23.8724333Z 
2026-09-12T01:10:23.8724748Z     running 1 test
2026-09-12T01:10:23.8725467Z     test tests::workspace_catalog::a_non_active_workspace_is_not_selectable_by_name ... FAILED
2026-09-12T01:10:23.8726094Z 
2026-09-12T01:10:23.8726237Z     failures:
2026-09-12T01:10:23.8726442Z 
2026-09-12T01:10:23.8726587Z     failures:
2026-09-12T01:10:23.8727149Z         tests::workspace_catalog::a_non_active_workspace_is_not_selectable_by_name
2026-09-12T01:10:23.8727703Z 
2026-09-12T01:10:23.8728172Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 154 filtered out; finished in 0.00s
2026-09-12T01:10:23.8729030Z     [0m
2026-09-12T01:10:23.8729482Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T01:10:23.8729820Z 
2026-09-12T01:10:23.8731019Z     [0m[31;1mthread 'tests::workspace_catalog::a_non_active_workspace_is_not_selectable_by_name' (7161) panicked at crates/orbit-cmd/src/tests/workspace_catalog.rs:125:5:[0m
2026-09-12T01:10:23.8733782Z     [31;1massertion failed: catalog.resolve_scope(&WorkspaceScope::Selectors(vec!["invalid-ws".to_string()])).is_err()[0m
2026-09-12T01:10:23.8735659Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T01:10:23.8736289Z 
2026-09-12T01:10:23.8793405Z [32;1m        PASS[0m [   0.046s] ( 390/5534) [35;1morbit-cmd[0m [36mtests::task_store[0m[36m::[0m[34;1mremoving_a_checkout_leaves_a_catalog_named_partition_another_checkout_binds[0m
2026-09-12T01:10:23.8853741Z [32;1m        PASS[0m [   0.013s] ( 391/5534) [35;1morbit-cmd[0m [36mtests::workspace_catalog[0m[36m::[0m[34;1mall_registered_scope_covers_active_workspaces_only[0m
2026-09-12T01:10:23.8934398Z [32;1m        PASS[0m [   0.014s] ( 392/5534) [35;1morbit-cmd[0m [36mtests::workspace_catalog[0m[36m::[0m[34;1man_unknown_selector_fails_closed_by_name[0m
2026-09-12T01:10:23.8973123Z [32;1m        PASS[0m [   0.011s] ( 393/5534) [35;1morbit-cmd[0m [36mtests::workspace_catalog[0m[36m::[0m[34;1mcurrent_scope_never_asks_the_catalog_for_a_checkout[0m
2026-09-12T01:10:23.9037946Z [32;1m        PASS[0m [   0.008s] ( 394/5534) [35;1morbit-cmd[0m [36mupdate::tests::channel[0m[36m::[0m[34;1ma_cross_compiled_build_tree_is_still_a_local_build[0m
2026-09-12T01:10:23.9058843Z [32;1m        PASS[0m [   0.014s] ( 395/5534) [35;1morbit-cmd[0m [36mtests::workspace_catalog[0m[36m::[0m[34;1mrepeated_selectors_for_one_workspace_are_opened_once[0m
2026-09-12T01:10:23.9158948Z [32;1m        PASS[0m [   0.011s] ( 396/5534) [35;1morbit-cmd[0m [36mupdate::tests::channel[0m[36m::[0m[34;1man_explicit_managed_directory_outranks_the_shape_of_the_path[0m
2026-09-12T01:10:23.9182878Z [32;1m        PASS[0m [   0.012s] ( 397/5534) [35;1morbit-cmd[0m [36mupdate::tests::channel[0m[36m::[0m[34;1mdetect_with_homebrew_ownership_never_probes_a_non_homebrew_channel[0m
2026-09-12T01:10:23.9263480Z [32;1m        PASS[0m [   0.009s] ( 398/5534) [35;1morbit-cmd[0m [36mupdate::tests::channel[0m[36m::[0m[34;1mdetect_with_homebrew_ownership_resolves_the_legacy_migration[0m
[... 390636 command bytes omitted ...]
2026-09-12T01:11:12.7135070Z [31;1m        FAIL[0m [   0.435s] (2195/5534) [35;1morbit-cli::mcp_roundtrip[0m [34;1mmcp_serve_tools_list_matches_production_snapshot[0m
2026-09-12T01:11:12.7136351Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T01:11:12.7139401Z 
2026-09-12T01:11:12.7139583Z     running 1 test
2026-09-12T01:11:12.7140158Z     test mcp_serve_tools_list_matches_production_snapshot ... FAILED
2026-09-12T01:11:12.7140700Z 
2026-09-12T01:11:12.7140857Z     failures:
2026-09-12T01:11:12.7141076Z 
2026-09-12T01:11:12.7141221Z     failures:
2026-09-12T01:11:12.7141899Z         mcp_serve_tools_list_matches_production_snapshot
2026-09-12T01:11:12.7142327Z 
2026-09-12T01:11:12.7142825Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 53 filtered out; finished in 0.43s
2026-09-12T01:11:12.7143795Z     [0m
2026-09-12T01:11:12.7144283Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T01:11:12.7144648Z 
2026-09-12T01:11:12.7145617Z     [0m[31;1mthread 'mcp_serve_tools_list_matches_production_snapshot' (30716) panicked at crates/orbit-cli/tests/mcp_roundtrip.rs:493:5:[0m
2026-09-12T01:11:12.7148920Z     [31;1massertion `left == right` failed: tools/list drifted from tests/snapshots/mcp_tools_list.json. MCP tool schema changes are BREAKING (see RELEASING.md). If the change is intentional, regenerate the snapshot with `ORBIT_MCP_UPDATE_SNAPSHOT=1 cargo test -p orbit-cli --test mcp_roundtrip` and call the release breaking.[0m
2026-09-12T01:11:12.7527429Z       left: Array [Object {"description": String("Submit an asynchronous agent invocation for exploration or debugging and return its run ID. The agent runs on the host outside Orbit's filesystem sandbox, as the same OS user as Orbit, so it can reach anything that user can; it is admitted per invocation and requires operator capability. Remote callers also require an explicit destination-owned, workspace-scoped `agent_invoke` grant; its default mode requires a key-bound  [... 52783 assertion payload bytes omitted ...]
2026-09-12T01:11:12.8127635Z      right: Array [Object {"description": String("Submit an asynchronous agent invocation for exploration or debugging and return its run ID. The agent runs on the host outside Orbit's filesystem sandbox, as the same OS user as Orbit, so it can reach anything that user can; it is admitted per invocation and requires operator capability. Remote callers also require an explicit destination-owned, workspace-scoped `agent_invoke` grant; its default mode requires a key-bound  [... 52492 assertion payload bytes omitted ...]
2026-09-12T01:11:12.8406451Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T01:11:12.8407102Z 
2026-09-12T01:11:12.8408743Z [32;1m        PASS[0m [   0.056s] (2196/5534) [35;1morbit-store[0m [36mdriver::sqlite::audit_event_store::tests::audit_actor[0m[36m::[0m[34;1mactor_projection_is_written_on_insert_without_touching_role[0m
2026-09-12T01:11:12.8411720Z [32;1m        PASS[0m [   0.056s] (2197/5534) [35;1morbit-store[0m [36mdriver::sqlite::audit_event_store::tests::audit_actor[0m[36m::[0m[34;1mderived_event_actor_matches_the_persisted_projection[0m
2026-09-12T01:11:12.8610975Z [32;1m        PASS[0m [   0.051s] (2198/5534) [35;1morbit-store[0m [36mdriver::sqlite::audit_event_store::tests::audit_actor[0m[36m::[0m[34;1mevents_outside_the_window_are_excluded[0m
2026-09-12T01:11:12.9033111Z [32;1m        PASS[0m [   0.042s] (2199/5534) [35;1morbit-store[0m [36mdriver::sqlite::audit_event_store::tests::audit_actor[0m[36m::[0m[34;1mone_agent_recorded_at_three_granularities_aggregates_as_one_actor[0m
2026-09-12T01:11:12.9456348Z [32;1m        PASS[0m [   0.042s] (2200/5534) [35;1morbit-store[0m [36mdriver::sqlite::audit_event_store::tests::audit_actor[0m[36m::[0m[34;1msynthetic_and_human_actors_are_separable_by_kind[0m
2026-09-12T01:11:12.9879984Z [32;1m        PASS[0m [   0.042s] (2201/5534) [35;1morbit-store[0m [36mdriver::sqlite::audit_event_store::tests::audit_event_store[0m[36m::[0m[34;1maudit_event_aggregates_by_role_splits_subcommand_surface[0m
2026-09-12T01:11:13.0398631Z [32;1m        PASS[0m [   0.052s] (2202/5534) [35;1morbit-store[0m [36mdriver::sqlite::audit_event_store::tests::audit_event_store[0m[36m::[0m[34;1maudit_event_aggregates_by_tool_splits_failures_by_surface[0m
[... 262391 command bytes omitted ...]
2026-09-12T01:13:18.5490959Z [31;1m        FAIL[0m [   1.027s] (3432/5534) [35;1morbit-cli::output_goldens[0m [34;1mplain_and_json_forms_match_their_goldens[0m
2026-09-12T01:13:18.5492424Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T01:13:18.5492782Z 
2026-09-12T01:13:18.5492984Z     running 1 test
2026-09-12T01:13:18.5493762Z     test plain_and_json_forms_match_their_goldens ... FAILED
2026-09-12T01:13:18.5494260Z 
2026-09-12T01:13:18.5494398Z     failures:
2026-09-12T01:13:18.5494593Z 
2026-09-12T01:13:18.5494721Z     failures:
2026-09-12T01:13:18.5495099Z         plain_and_json_forms_match_their_goldens
2026-09-12T01:13:18.5495382Z 
2026-09-12T01:13:18.5495692Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 7 filtered out; finished in 1.02s
2026-09-12T01:13:18.5496247Z     [0m
2026-09-12T01:13:18.5496540Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T01:13:18.5496756Z 
2026-09-12T01:13:18.5497494Z     [0m[31;1mthread 'plain_and_json_forms_match_their_goldens' (100427) panicked at crates/orbit-cli/tests/output_goldens.rs:321:5:[0m
2026-09-12T01:13:18.5499668Z     [31;1massertion `left == right` failed: /home/runner/work/orbit/orbit/crates/orbit-cli/tests/output_goldens/tool_list.json drifted from its golden. If the new rendering is correct, regenerate with `ORBIT_UPDATE_OUTPUT_GOLDENS=1 cargo test -p orbit-cli --test output_goldens` and review the diff before committing.[0m
2026-09-12T01:13:18.5696243Z       left: "[\n  {\n    \"active\": true,\n    \"builtin\": true,\n    \"description\": \"Preflight the GitHub CLI surface: whether a GitHub CLI is present on this execution lane (`available`) and whether it holds usable credentials there (`authenticated`). Neither absence nor a missing credential is an error — both are reported so a caller can record a capability-unavailable outcome instead of mistaking it for a clean result.\",\n    \"enabled\": true,\n    \"name\":  [... 59140 assertion payload bytes omitted ...]
2026-09-12T01:13:18.6114965Z      right: "[\n  {\n    \"active\": true,\n    \"builtin\": true,\n    \"description\": \"Preflight the GitHub CLI surface: whether a GitHub CLI is present on this execution lane (`available`) and whether it holds usable credentials there (`authenticated`). Neither absence nor a missing credential is an error — both are reported so a caller can record a capability-unavailable outcome instead of mistaking it for a clean result.\",\n    \"enabled\": true,\n    \"name\":  [... 58849 assertion payload bytes omitted ...]
2026-09-12T01:13:18.6320464Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T01:13:18.6320802Z 
2026-09-12T01:13:19.8081694Z [32;1m        PASS[0m [   1.259s] (3433/5534) [35;1morbit-cli::output_goldens[0m [34;1mtask_show_relations_and_artifacts_match_golden[0m
2026-09-12T01:13:20.9306816Z [32;1m        PASS[0m [   1.122s] (3434/5534) [35;1morbit-cli::output_goldens[0m [34;1mtool_run_honors_format_ndjson_and_dry_run_json[0m
2026-09-12T01:13:21.5098094Z [32;1m        PASS[0m [   0.579s] (3435/5534) [35;1morbit-cli::proc_spawn_managed[0m [34;1mmanaged_cli_proc_spawn_applies_registered_workspace_policy[0m
2026-09-12T01:13:23.5418950Z [32;1m        PASS[0m [   2.032s] (3436/5534) [35;1morbit-cli::routine_root[0m [34;1mroutine_commands_honor_orbit_root_and_mutate_only_the_selected_root[0m
2026-09-12T01:13:24.7452302Z [32;1m        PASS[0m [   1.203s] (3437/5534) [35;1morbit-cli::routine_root[0m [34;1mroutine_list_honors_explicit_root_over_uninitialized_home_and_environment[0m
2026-09-12T01:13:25.3611618Z [32;1m        PASS[0m [   0.616s] (3438/5534) [35;1morbit-cli::semantic_companion[0m [34;1mcli_task_mutation_does_not_launch_background_companion[0m
2026-09-12T01:13:25.8737708Z [32;1m        PASS[0m [   0.513s] (3439/5534) [35;1morbit-cli::semantic_companion[0m [34;1mdirect_search_semantic_command_surfaces_companion_stderr[0m
[... 90664 command bytes omitted ...]
2026-09-12T01:16:25.4623058Z [31;1m        FAIL[0m [   0.012s] (3871/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests::friction[0m[36m::[0m[34;1mfriction_help_matches_the_shipped_surface[0m
2026-09-12T01:16:25.4623984Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T01:16:25.4624339Z 
2026-09-12T01:16:25.4624488Z     running 1 test
2026-09-12T01:16:25.4625075Z     test command::tests::friction::friction_help_matches_the_shipped_surface ... FAILED
2026-09-12T01:16:25.4625529Z 
2026-09-12T01:16:25.4625656Z     failures:
2026-09-12T01:16:25.4625848Z 
2026-09-12T01:16:25.4625997Z     failures:
2026-09-12T01:16:25.4626545Z         command::tests::friction::friction_help_matches_the_shipped_surface
2026-09-12T01:16:25.4627095Z 
2026-09-12T01:16:25.4628083Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 539 filtered out; finished in 0.00s
2026-09-12T01:16:25.4628953Z     [0m
2026-09-12T01:16:25.4629394Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T01:16:25.4629793Z 
2026-09-12T01:16:25.4631201Z     [0m[31;1mthread 'command::tests::friction::friction_help_matches_the_shipped_surface' (105748) panicked at crates/orbit-cli/src/command/tests/friction.rs:71:9:[0m
2026-09-12T01:16:25.4633140Z     [31;1massertion `left == right` failed: `orbit friction --help` drifted from the shipped surface[0m
2026-09-12T01:16:25.4638316Z       left: "Report, list, and triage friction records\n\nUsage: orbit friction [OPTIONS] <COMMAND>\n\nCommands:\n  add      Append a friction report\n  list     List friction records\n  show     Show a single friction record\n  stats    Compute friction rates\n  tags     List configured friction taxonomy tags\n  update   Update triage metadata for a friction record\n  resolve  Mark a friction record as resolved\n\nOptions:\n      --root <ROOT>           Override the Orbit root  [... 349 assertion payload bytes omitted ...]
2026-09-12T01:16:25.4647138Z      right: "Report, list, and triage friction records\n\nUsage: orbit friction [OPTIONS] <COMMAND>\n\nCommands:\n  add      Append a friction report\n  list     List friction records\n  show     Show a single friction record\n  stats    Compute friction rates\n  tags     List configured friction taxonomy tags\n  update   Update triage metadata for a friction record\n  resolve  Mark a friction record as resolved\n\nOptions:\n      --root <ROOT>           Override the Orbit root  [... 259 assertion payload bytes omitted ...]
2026-09-12T01:16:25.4652126Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T01:16:25.4664561Z 
2026-09-12T01:16:25.4747424Z [32;1m        PASS[0m [   0.012s] (3872/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests::friction[0m[36m::[0m[34;1minteger_filters_parse_as_numbers_not_strings[0m
2026-09-12T01:16:25.4956788Z [32;1m        PASS[0m [   0.021s] (3873/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests::friction[0m[36m::[0m[34;1mjson_flag_is_captured_for_every_verb[0m
2026-09-12T01:16:25.5070058Z [32;1m        PASS[0m [   0.011s] (3874/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests::friction[0m[36m::[0m[34;1mlist_projects_every_declared_filter[0m
2026-09-12T01:16:25.5206237Z [32;1m        PASS[0m [   0.014s] (3875/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests::friction[0m[36m::[0m[34;1mparameterless_verbs_send_an_empty_object[0m
2026-09-12T01:16:25.5319570Z [32;1m        PASS[0m [   0.011s] (3876/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests::friction[0m[36m::[0m[34;1mrepeated_tag_flags_accumulate_into_the_plural_wire_field[0m
2026-09-12T01:16:25.5495637Z [32;1m        PASS[0m [   0.017s] (3877/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests::friction[0m[36m::[0m[34;1mrequired_arguments_are_still_enforced[0m
2026-09-12T01:16:25.5608362Z [32;1m        PASS[0m [   0.011s] (3878/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests::friction[0m[36m::[0m[34;1munknown_friction_subcommands_are_rejected[0m
[... 6239 command bytes omitted ...]
2026-09-12T01:16:27.5286848Z [31;1m        FAIL[0m [   0.012s] (3908/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests::operation_mode[0m[36m::[0m[34;1moperation_help_matches_the_shipped_surface[0m
2026-09-12T01:16:27.5287822Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T01:16:27.5288036Z 
2026-09-12T01:16:27.5288124Z     running 1 test
2026-09-12T01:16:27.5288516Z     test command::tests::operation_mode::operation_help_matches_the_shipped_surface ... FAILED
2026-09-12T01:16:27.5288874Z 
2026-09-12T01:16:27.5289025Z     failures:
2026-09-12T01:16:27.5289259Z 
2026-09-12T01:16:27.5289399Z     failures:
2026-09-12T01:16:27.5289903Z         command::tests::operation_mode::operation_help_matches_the_shipped_surface
2026-09-12T01:16:27.5290233Z 
2026-09-12T01:16:27.5290514Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 539 filtered out; finished in 0.00s
2026-09-12T01:16:27.5291010Z     [0m
2026-09-12T01:16:27.5292970Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T01:16:27.5293324Z 
2026-09-12T01:16:27.5294335Z     [0m[31;1mthread 'command::tests::operation_mode::operation_help_matches_the_shipped_surface' (105822) panicked at crates/orbit-cli/src/command/tests/operation_mode.rs:59:9:[0m
2026-09-12T01:16:27.5295628Z     [31;1massertion `left == right` failed: help for ["orbit", "operation"] moved[0m
2026-09-12T01:16:27.5304087Z       left: "Explain, enable, stop, and revoke scoped operation-mode automation\n\nUsage: orbit operation [OPTIONS] <COMMAND>\n\nCommands:\n  explain  Explain the effective operation policy and authority\n  enable   Enable a scoped, bounded operation-mode grant\n  list     List recent operation-mode grants\n  show     Show one operation-mode grant\n  stop     Stop new admissions under a grant (admitted work keeps its bounds)\n  revoke   Hard-revoke a grant (admitted work loses  [... 894 assertion payload bytes omitted ...]
2026-09-12T01:16:27.5316532Z      right: "Explain, enable, stop, and revoke scoped operation-mode automation\n\nUsage: orbit operation [OPTIONS] <COMMAND>\n\nCommands:\n  explain  Explain the effective operation policy and authority\n  enable   Enable a scoped, bounded operation-mode grant\n  list     List recent operation-mode grants\n  show     Show one operation-mode grant\n  stop     Stop new admissions under a grant (admitted work keeps its bounds)\n  revoke   Hard-revoke a grant (admitted work loses  [... 804 assertion payload bytes omitted ...]
2026-09-12T01:16:27.5321215Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T01:16:27.5321873Z 
2026-09-12T01:16:27.5458252Z [32;1m        PASS[0m [   0.017s] (3909/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests::operation_mode[0m[36m::[0m[34;1mrun_auto_grant_conflicts_with_blanket_completion[0m
2026-09-12T01:16:27.5612026Z [32;1m        PASS[0m [   0.015s] (3910/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests::operation_mode[0m[36m::[0m[34;1mstop_and_revoke_carry_the_compare_and_set_revision[0m
2026-09-12T01:16:27.6312969Z [32;1m        PASS[0m [   0.070s] (3911/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests[0m[36m::[0m[34;1mrecursive_cli_help_uses_only_placeholder_artifact_ids[0m
2026-09-12T01:16:27.6427441Z [32;1m        PASS[0m [   0.011s] (3912/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests::search[0m[36m::[0m[34;1mglobal_workspace_and_search_workspaces_are_distinct[0m
2026-09-12T01:16:27.6542500Z [32;1m        PASS[0m [   0.011s] (3913/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests::search[0m[36m::[0m[34;1mpost_subcommand_workspace_binds_global_routing_not_search_scope[0m
2026-09-12T01:16:27.6654706Z [32;1m        PASS[0m [   0.011s] (3914/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests::search[0m[36m::[0m[34;1msearch_all_workspaces_parses_without_selectors[0m
2026-09-12T01:16:27.6757497Z [32;1m        PASS[0m [   0.010s] (3915/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests::search[0m[36m::[0m[34;1msearch_command_debug_assert_accepts_the_resolved_grammar[0m
[... 366387 command bytes omitted ...]
2026-09-12T01:23:29.9183843Z [31;1m     Summary[0m [ 798.506s] [1m5534[0m tests run: [1m5529[0m [32;1mpassed[0m ([1m1[0m [33;1mslow[0m), [1m5[0m [31;1mfailed[0m, [1m20[0m [33;1mskipped[0m
2026-09-12T01:23:29.9185187Z [31;1m        FAIL[0m [   0.013s] ( 389/5534) [35;1morbit-cmd[0m [36mtests::workspace_catalog[0m[36m::[0m[34;1ma_non_active_workspace_is_not_selectable_by_name[0m
2026-09-12T01:23:29.9186247Z [31;1m        FAIL[0m [   0.435s] (2195/5534) [35;1morbit-cli::mcp_roundtrip[0m [34;1mmcp_serve_tools_list_matches_production_snapshot[0m
2026-09-12T01:23:29.9187209Z [31;1m        FAIL[0m [   1.027s] (3432/5534) [35;1morbit-cli::output_goldens[0m [34;1mplain_and_json_forms_match_their_goldens[0m
2026-09-12T01:23:29.9188479Z [31;1m        FAIL[0m [   0.012s] (3871/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests::friction[0m[36m::[0m[34;1mfriction_help_matches_the_shipped_surface[0m
2026-09-12T01:23:29.9189791Z [31;1m        FAIL[0m [   0.012s] (3908/5534) [35;1morbit-cli::bin/orbit[0m [36mcommand::tests::operation_mode[0m[36m::[0m[34;1moperation_help_matches_the_shipped_surface[0m
2026-09-12T01:23:29.9213236Z [31;1merror[0m: test run failed
2026-09-12T01:23:29.9247421Z ##[error]Process completed with exit code 100.

```

_The collection display was truncated. Selected evidence is used for diagnosis; its retention limits are independent of that display._

_The run-scoped failed-step log came back empty, so this excerpt is the evidence from job `Check / Clippy / Test` (id `103471180758`), read from the job log API._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `CI` run https://github.com/constellation-works/orbit/actions/runs/34663380472 — superseded_by_newer_workflow_run: newer relevant run 34663681719 at 2026-09-12T01:04:10Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34607325655 — superseded_by_newer_workflow_run: newer relevant run 34663080877 at 2026-09-12T00:52:56Z is completed with conclusion success
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34592194455 — superseded_by_newer_workflow_run: newer relevant run 34663080877 at 2026-09-12T00:52:56Z is completed with conclusion success
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34590847020 — superseded_by_newer_workflow_run: newer relevant run 34663080877 at 2026-09-12T00:52:56Z is completed with conclusion success
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34590666628 — superseded_by_newer_workflow_run: newer relevant run 34663080877 at 2026-09-12T00:52:56Z is completed with conclusion success
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34590661824 — ref_no_longer_exists: branch 'orbit/ORB-12181-6aa3d9c6' has no head on origin: its pull request was merged or the branch was deleted, so this run describes code that is either already landed — where the landing branch's own runs are the current evidence — or abandoned

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 2,
  "current_failures_discovered": 3,
  "current_failures_investigated": 2,
  "current_failures_investigation_attempted": 6,
  "inconclusive": 0,
  "investigation_cursor": 496993,
  "job_log_reads": 3,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_job_log_reads": 6,
  "max_pull_requests": 10,
  "max_retired_ref_probes": 20,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely",
    "2 of 8 current or mixed-state runs were listed but not investigated (max_investigated_runs=6); their run URLs are still present, and the rotating slot reaches a different overflow candidate on the next sweep"
  ],
  "pull_requests_scanned": 0,
  "refs_scanned": 1,
  "retired_refs": [
    "orbit/ORB-12181-6aa3d9c6",
    "orbit/ORB-12182-6aa3d9c7",
    "orbit/ORB-12185-6aa3df4e",
    "orbit/ORB-12215-6aa4a19c",
    "orbit/ORB-12216-6aa4a19c"
  ],
  "runs_listed": 100,
  "unverified_refs": []
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `CI` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Fixed the workspace-catalog regression test fixture so the Invalid workspace has a missing recorded checkout; selector validation can no longer reactivate the fixture before the assertion.
- Updated the task-tool output golden for the current context-selector description.
- Updated all seven operation-mode help fixtures to include the current active-workspace binding restriction. The MCP snapshot and friction help fixtures were verified passing and left unchanged.

Assessment: The CI failures were repository-owned fixture/expectation drift, not infrastructure. Production selector validation remains fail-closed for non-active workspaces and was not weakened.

Acceptance criteria:
1. Passed — the scoped fixture and consumer-visible goldens/help surfaces match current behavior; no workflow, assertion, or lint rule was disabled or weakened.
2. Passed — each recorded failing test was reproduced before edits, and the final exact/narrow commands all passed:
   - cargo test -p orbit-cmd tests::workspace_catalog::a_non_active_workspace_is_not_selectable_by_name
   - cargo test -p orbit-cli --test mcp_roundtrip mcp_serve_tools_list_matches_production_snapshot
   - cargo test -p orbit-cli --test output_goldens plain_and_json_forms_match_their_goldens
   - cargo test -p orbit-cli --bin orbit command::tests::friction::friction_help_matches_the_shipped_surface
   - cargo test -p orbit-cli --bin orbit command::tests::operation_mode::operation_help_matches_the_shipped_surface
3. Passed — make ci-fast and make ci-lint both passed. ci-fast reported one environment capability skip for the non-privileged bubblewrap mount-namespace check.
4. Repository ownership confirmed — the failing workspace test was caused by its fixture creating an existing checkout for an Invalid workspace, while current validation intentionally reactivates Invalid entries whose checkout exists. No same-commit GitHub retry was available in this execution lane.

Validation:
- Failed with bounded environment limitation: ./scripts/ci-guardrails.sh. Its workspace clippy, 5,554/5,554 tests, doctests, documentation, and all preceding guardrails passed; the final cargo-deny step failed because the shared Cargo advisory database is read-only and its lock could not be acquired. This is not a repository failure.
- Passed: make ci-fast.
- Passed: make ci-lint.
- Passed: git diff --check.
- Passed: GIT_OPTIONAL_LOCKS=0 git status --short; only the nine intended scoped fixture/golden files are modified.
- Not run: full make ci, because repository guidance says it is the canonical PR merge gate and not a per-task local check; the exact guardrail script was run instead.

Remaining risk: cargo-deny could not validate advisories/licenses locally until a writable advisory database is supplied; CI's own dependency gate remains authoritative for that environment.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12231-6aa4b3cd`
- Behind base: 0
- Ahead of base: 1