### PR TITLE
[code-review] ORB-12232 added an `## Unreleased` CHANGELOG bullet during task execution, which RELEASING.md forbids and no guardrail catches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Highlights
 
-- **Task-pilot assessment precision**: task-pilot instructions define evidence gaps as rating-changing unknowns rather than unexecuted validation, and validate_recommendations allows assessed complexity with evidence gaps when confidence is low or medium. ([ORB-12232])
 - **Dashboard inline task editors**: the expanded task detail edits complexity, description, tags, acceptance criteria, and context files in place, each saved as a single-field `PATCH /api/tasks/:id` with inline errors and an allow-missing-context escape. ([ORB-12235])
 
 ## 0.21.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -151,8 +151,7 @@ Task execution never touches `CHANGELOG.md` — no PR adds an `## Unreleased` bu
 
 `scripts/check-changelog-style.sh` still lints whatever lands under `## Unreleased`, so it's worth drafting bullets there first if that helps you iterate before moving them into the version section — but that section is scratch space at release time now, not a per-PR accumulation target. Released `## <X.Y.Z>` sections are frozen history and are never reflowed.
 
-<!-- Enforcement decision: We deliberately do not enforce the rule against task-time CHANGELOG.md modifications mechanically in CI guardrails or pre-commit hooks. Mechanical checks based on branch names or commit message patterns are brittle, break shallow checkouts, and interfere with release drafters using `## Unreleased` as scratch space during release preparation. Policy adherence is maintained via AGENTS.md / CLAUDE.md guidelines and PR review. -->
-_Enforcement decision_: We deliberately do not enforce the restriction against task-time `CHANGELOG.md` modifications mechanically (e.g., via commit-message heuristics or CI guardrails). A mechanical check would interfere with release drafters who legitimately edit `CHANGELOG.md` during release preparation or use `## Unreleased` as temporary scratch space, and branch- or commit-based checks are fragile in shallow CI checkouts. The rule is maintained through authoring guidance in `AGENTS.md` and review instead.
+**Not enforced mechanically**: no guardrail rejects a `CHANGELOG.md` edit from a non-release commit, and that is deliberate. Release drafting itself edits the file, and the commit- or branch-shaped heuristics that would tell the two apart are unreliable in shallow CI checkouts. The rule lives in [`AGENTS.md`](AGENTS.md) ("CHANGELOG entries") and in review instead; `scripts/check-changelog-style.sh` keeps linting bullet shape either way.
 
 ### 3. Confirm breaking changes with the human
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -151,6 +151,9 @@ Task execution never touches `CHANGELOG.md` — no PR adds an `## Unreleased` bu
 
 `scripts/check-changelog-style.sh` still lints whatever lands under `## Unreleased`, so it's worth drafting bullets there first if that helps you iterate before moving them into the version section — but that section is scratch space at release time now, not a per-PR accumulation target. Released `## <X.Y.Z>` sections are frozen history and are never reflowed.
 
+<!-- Enforcement decision: We deliberately do not enforce the rule against task-time CHANGELOG.md modifications mechanically in CI guardrails or pre-commit hooks. Mechanical checks based on branch names or commit message patterns are brittle, break shallow checkouts, and interfere with release drafters using `## Unreleased` as scratch space during release preparation. Policy adherence is maintained via AGENTS.md / CLAUDE.md guidelines and PR review. -->
+_Enforcement decision_: We deliberately do not enforce the restriction against task-time `CHANGELOG.md` modifications mechanically (e.g., via commit-message heuristics or CI guardrails). A mechanical check would interfere with release drafters who legitimately edit `CHANGELOG.md` during release preparation or use `## Unreleased` as temporary scratch space, and branch- or commit-based checks are fragile in shallow CI checkouts. The rule is maintained through authoring guidance in `AGENTS.md` and review instead.
+
 ### 3. Confirm breaking changes with the human
 
 Surface the breaking-change candidate list before drafting the final section. Show each candidate with its task ID, title, and the reason it was flagged. Let the human accept, downgrade, or add to the list. Do not classify autonomously.


### PR DESCRIPTION
## Task

[ORB-12241](https://orbit-cli.com/tasks/ORB-12241) — [code-review] ORB-12232 added an `## Unreleased` CHANGELOG bullet during task execution, which RELEASING.md forbids and no guardrail catches

### Description

## Summary

Commit `e57f36a3f` (ORB-12232, PR #2001) added a new section to `CHANGELOG.md:3-7`:

```markdown
## Unreleased

### Highlights

- **Task-pilot assessment precision**: … ([ORB-12232])
```

Two current, authoritative documents forbid this:

- `RELEASING.md:146`: "Task execution never touches `CHANGELOG.md` — no PR adds an `## Unreleased` bullet. Instead, the release drafter compiles the new `## <X.Y.Z>` section directly from `git log v<prev>..HEAD` …" and `RELEASING.md:152`: that section "is scratch space at release time now, not a per-PR accumulation target".
- `CLAUDE.md` / `AGENTS.md` (CHANGELOG entries): "Do not modify `CHANGELOG.md` during task execution; it is compiled at release time from merged work."

`git log --oneline -- CHANGELOG.md` confirms the convention: every other entry back to v0.10.0 is a `chore: prepare v<X.Y.Z> release` commit. `e57f36a3f` is the only task commit in that history.

## Failure scenario

The next release drafter compiles `## 0.22.0` from `git log v0.21.0..HEAD`, which already includes ORB-12232. The stray `## Unreleased` section is not consumed by that process, so the same change is either duplicated (once under `0.22.0`, once under a permanent `Unreleased` heading above it) or silently shipped as an "unreleased" claim about work that is already released. Readers of the published changelog see a phantom pending entry.

Secondarily, the precedent invites every task PR to accumulate bullets, which is the per-PR merge-conflict pattern `RELEASING.md` retired.

## Why CI did not catch it

`scripts/check-changelog-style.sh` lints only bullet *length* under `## Unreleased` (`:11`, `:41`, `:76`); the bullet is ~36 words, under the 60-word limit, so `make ci-fast` passes. Nothing enforces the "task execution never touches CHANGELOG.md" rule.

## Suggested resolution

Remove the `## Unreleased` section added by `e57f36a3f` (leaving the ORB-12232 change itself alone; it will be picked up from the git log at release time), and consider extending `scripts/check-changelog-style.sh` — or a guardrail in `scripts/ci-guardrails.sh` — to fail when a non-release commit modifies `CHANGELOG.md`.

### Acceptance Criteria

- `CHANGELOG.md` no longer carries the `## Unreleased` Highlights bullet added by `e57f36a3f`, and the released `## 0.21.0` and earlier sections are untouched.
- The ORB-12232 change remains discoverable for the release drafter through its merged commit, with no code or behavior change made by this cleanup.
- Either a guardrail rejects a CHANGELOG.md edit from a non-release commit, or a comment in RELEASING.md records the decision not to enforce it mechanically.

## Execution Summary

<details>
<summary>Click to expand</summary>

### Acceptance Criteria Mapping
- Criterion 1: `CHANGELOG.md` no longer carries the `## Unreleased` Highlights bullet added by `e57f36a3f`, and the released `## 0.21.0` and earlier sections are untouched.
  - Result: Passed. Removed the ORB-12232 bullet from CHANGELOG.md. Compared diff against `v0.21.0` tag to verify all sections from `## 0.21.0` down are untouched byte-for-byte.
- Criterion 2: The ORB-12232 change remains discoverable for the release drafter through its merged commit, with no code or behavior change made by this cleanup.
  - Result: Passed. Verified commit `e57f36a3f` is present in `git log v0.21.0..HEAD` with full attribution. No code or behavior changes were made.
- Criterion 3: Either a guardrail rejects a CHANGELOG.md edit from a non-release commit, or a comment in RELEASING.md records the decision not to enforce it mechanically.
  - Result: Passed. Added comment and enforcement decision note in `RELEASING.md` explaining why the rule is not enforced mechanically (risk of false positives during release drafting where `## Unreleased` serves as scratch space, and shallow CI clone limitations).

### Validation Commands
- `./scripts/check-changelog-style.sh`: Passed (exit 0).
- `make ci-fast`: Passed (exit 0).
- `git diff --check`: Passed (exit 0).
- `git status --short`: Passed (only CHANGELOG.md and RELEASING.md modified).
- `git log v0.21.0..HEAD --grep="ORB-12232"`: Passed (exit 0, commit e57f36a3f discoverable).

### Remaining Risks or Deviations
None. The subsequent ORB-12235 bullet in `CHANGELOG.md` was preserved to keep the edit minimally scoped to ORB-12232 as specified in acceptance criteria.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12241-6aa4c2ec`
- Behind base: 0
- Ahead of base: 2