### PR TITLE
[code-review] The documented pre-review gate misses checked-in goldens: three of this window's merges were CI-failure repairs for help/description snapshot drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,9 @@ Project instructions for agents working on Orbit (loaded as both `AGENTS.md` and
 
 ## Build / Lint
 
-`make ci-fast` (fmt-check + guardrail scripts; no compile) and `make ci-lint` (the same workspace-wide, all-target clippy pass as CI, with warnings denied) must both pass before a task moves to `review`. Each task therefore pays for one workspace clippy compile; cold runs can take several minutes, while warm runs reuse Cargo's incremental cache. The full `make ci` is the canonical merge gate via [`.github/workflows/ci.yml`](.github/workflows/ci.yml) on every PR — don't run it per task locally.
+`make ci-fast` (fmt-check + guardrail scripts; no compile), `make ci-lint` (the same workspace-wide, all-target clippy pass as CI, with warnings denied), and `make goldens` (orbit-cli help/description snapshot tests; compiles `orbit-cli` only) must all pass before a task moves to `review`. Each task therefore pays for one workspace clippy compile plus a focused `orbit-cli` golden compile; cold runs can take several minutes, while warm runs reuse Cargo's incremental cache. `make ci-fast` does not compile. The full `make ci` is the canonical merge gate via [`.github/workflows/ci.yml`](.github/workflows/ci.yml) on every PR — don't run it per task locally.
+
+`make goldens` covers the checked-in CLI long-help text files under `crates/orbit-cli/src/command/tests/`, `crates/orbit-cli/tests/output_goldens/` (including `tool_list.json`), and `crates/orbit-cli/tests/snapshots/mcp_tools_list.json`. A Clap `///` help edit or MCP parameter-description change that leaves those files stale fails this gate locally. To regenerate after an intentional surface change, run `make goldens UPDATE=1`, which sets `ORBIT_UPDATE_HELP_GOLDENS=1`, `ORBIT_UPDATE_OUTPUT_GOLDENS=1`, and `ORBIT_MCP_UPDATE_SNAPSHOT=1` — the same variables the failing tests print. Review the diff before handing off.
 
 ## Mutable Fixture Operations
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build release run check test fmt fmt-check clippy clean install uninstall dev watch audit tree ci ci-fast ci-lint stability release-check docs-index cleanup-branches build-budget-test build-budget-bench compiler-cache-status compiler-cache-setup compiler-cache-bench cross-revision-check-test
+.PHONY: help build release run check test fmt fmt-check clippy clean install uninstall dev watch audit tree ci ci-fast ci-lint goldens stability release-check docs-index cleanup-branches build-budget-test build-budget-bench compiler-cache-status compiler-cache-setup compiler-cache-bench cross-revision-check-test
 
 # ------------------------------------------------------------
 # Config
@@ -31,6 +31,11 @@ else
 	INSTALL_TARGET_DIR := target/debug
 endif
 
+GOLDENS_FLAGS :=
+ifeq ($(UPDATE),1)
+	GOLDENS_FLAGS := --update
+endif
+
 # ------------------------------------------------------------
 # Help
 # ------------------------------------------------------------
@@ -51,6 +56,7 @@ help:
 	@echo "  make ci           Full CI pass (clippy + tests + doc + guardrails; also runs on PRs)"
 	@echo "  make ci-fast      Pre-handoff gate for agents (fast guardrail mode; skips full workspace compile/test/doc steps)"
 	@echo "  make ci-lint      Pre-handoff clippy gate for agents (compiles all workspace targets)"
+	@echo "  make goldens      Pre-handoff golden gate (orbit-cli help/description snapshots; UPDATE=1 regenerates)"
 	@echo "  make docs-index   Regenerate docs/INDEX.md"
 	@echo "  make stability    Verify per-crate stability tier markers"
 	@echo "  make release-check  Verify Cargo/npm/release version lockstep (see docs/runbooks/release.md)"
@@ -154,6 +160,11 @@ ci-fast:
 # the default workspace clippy pass in scripts/ci-guardrails.sh.
 ci-lint:
 	$(BUILD_BUDGET) -- $(CARGO) clippy $(WORKSPACE) --all-targets -- -D warnings
+
+# Focused pre-review golden gate: CLI long-help text, output_goldens, and the
+# MCP tools/list snapshot. Compiles orbit-cli tests only. UPDATE=1 regenerates.
+goldens:
+	$(BUILD_BUDGET) -- ./scripts/check-goldens.sh $(GOLDENS_FLAGS)
 
 # Verify every workspace crate declares its stability tier
 stability:

--- a/crates/orbit-cli/src/command/tests/friction.rs
+++ b/crates/orbit-cli/src/command/tests/friction.rs
@@ -1,10 +1,10 @@
 //! The friction CLI is derived from the operation registry [ORB-10358]; these
 //! tests are the proof it stayed argv- and output-compatible.
 //!
-//! `friction_help/*.txt` were captured from the binary built at the commit
-//! before the migration. They are the shipped `--help` contract: if a change
-//! here makes them fail, the CLI surface moved and that is a consumer-visible
-//! break, not a test to re-bless.
+//! `friction_help/*.txt` freeze the shipped `--help` contract. Drift is a
+//! consumer-visible CLI surface change. If the new help is intentional,
+//! regenerate with `ORBIT_UPDATE_HELP_GOLDENS=1` (or `make goldens UPDATE=1`)
+//! and review the diff.
 
 use clap::Parser;
 use orbit_common::governance::friction::FrictionVerb;
@@ -20,60 +20,53 @@ fn invocation(args: &[&str]) -> super::super::friction::FrictionInvocation {
     }
 }
 
-/// Render `--help` for an argv prefix, exactly as the binary prints it.
-fn help_for(args: &[&str]) -> String {
-    let mut argv = args.to_vec();
-    argv.push("--help");
-    match Cli::try_parse_from(argv) {
-        Ok(_) => panic!("--help exits before parsing"),
-        Err(error) => error.to_string(),
-    }
-}
-
 #[test]
 fn friction_help_matches_the_shipped_surface() {
-    let cases: &[(&[&str], &str)] = &[
+    let cases: &[(&[&str], &str, &str)] = &[
         (
             &["orbit", "friction"],
+            "friction_help/root.txt",
             include_str!("friction_help/root.txt"),
         ),
         (
             &["orbit", "friction", "add"],
+            "friction_help/add.txt",
             include_str!("friction_help/add.txt"),
         ),
         (
             &["orbit", "friction", "list"],
+            "friction_help/list.txt",
             include_str!("friction_help/list.txt"),
         ),
         (
             &["orbit", "friction", "show"],
+            "friction_help/show.txt",
             include_str!("friction_help/show.txt"),
         ),
         (
             &["orbit", "friction", "stats"],
+            "friction_help/stats.txt",
             include_str!("friction_help/stats.txt"),
         ),
         (
             &["orbit", "friction", "tags"],
+            "friction_help/tags.txt",
             include_str!("friction_help/tags.txt"),
         ),
         (
             &["orbit", "friction", "update"],
+            "friction_help/update.txt",
             include_str!("friction_help/update.txt"),
         ),
         (
             &["orbit", "friction", "resolve"],
+            "friction_help/resolve.txt",
             include_str!("friction_help/resolve.txt"),
         ),
     ];
 
-    for (args, expected) in cases {
-        assert_eq!(
-            help_for(args),
-            *expected,
-            "`{} --help` drifted from the shipped surface",
-            args.join(" ")
-        );
+    for (args, relative, expected) in cases {
+        super::assert_help_matches_golden(args, relative, expected);
     }
 }
 

--- a/crates/orbit-cli/src/command/tests/mod.rs
+++ b/crates/orbit-cli/src/command/tests/mod.rs
@@ -26,6 +26,8 @@ use super::{
     web::WebSubcommand,
 };
 
+const UPDATE_HELP_GOLDENS_ENV: &str = "ORBIT_UPDATE_HELP_GOLDENS";
+
 fn assert_cli_rejects(args: &[&str], kind: ErrorKind, expected: &str) {
     let error = match Cli::try_parse_from(args.iter().copied()) {
         Ok(_) => panic!("form should be rejected"),
@@ -66,6 +68,38 @@ fn assert_help_tree_has_no_concrete_artifact_ids(command: &Command) {
     for subcommand in command.get_subcommands() {
         assert_help_tree_has_no_concrete_artifact_ids(subcommand);
     }
+}
+
+/// Render `--help` for an argv prefix, exactly as the binary prints it.
+fn help_for(args: &[&str]) -> String {
+    let mut argv = args.to_vec();
+    argv.push("--help");
+    match Cli::try_parse_from(argv) {
+        Ok(_) => panic!("--help exits before parsing"),
+        Err(error) => error.to_string(),
+    }
+}
+
+/// Compare rendered help against a checked-in golden, or overwrite it when
+/// `ORBIT_UPDATE_HELP_GOLDENS=1`.
+fn assert_help_matches_golden(args: &[&str], relative: &str, expected: &str) {
+    let actual = help_for(args);
+    if std::env::var(UPDATE_HELP_GOLDENS_ENV).as_deref() == Ok("1") {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/command/tests")
+            .join(relative);
+        std::fs::write(&path, &actual)
+            .unwrap_or_else(|err| panic!("write help golden {}: {err}", path.display()));
+        return;
+    }
+    assert_eq!(
+        actual,
+        expected,
+        "`{} --help` drifted from {relative}. If the new help is intentional, regenerate with \
+         `{UPDATE_HELP_GOLDENS_ENV}=1 cargo test -p orbit-cli --bin orbit help_matches_the_shipped_surface` \
+         or `make goldens UPDATE=1`, then review the diff.",
+        args.join(" ")
+    );
 }
 
 #[test]

--- a/crates/orbit-cli/src/command/tests/operation_mode.rs
+++ b/crates/orbit-cli/src/command/tests/operation_mode.rs
@@ -1,5 +1,7 @@
 //! The `orbit operation` CLI is derived from the operation-mode registry
 //! [ORB-11332]; these tests freeze its argv surface and input projection.
+//! Help goldens regenerate with `ORBIT_UPDATE_HELP_GOLDENS=1` or
+//! `make goldens UPDATE=1`.
 
 use clap::Parser;
 use orbit_common::governance::operation_mode::OperationModeVerb;
@@ -14,49 +16,47 @@ fn invocation(args: &[&str]) -> super::super::operation_mode::OperationModeInvoc
     }
 }
 
-fn help_for(args: &[&str]) -> String {
-    let mut argv = args.to_vec();
-    argv.push("--help");
-    match Cli::try_parse_from(argv) {
-        Ok(_) => panic!("--help exits before parsing"),
-        Err(error) => error.to_string(),
-    }
-}
-
 #[test]
 fn operation_help_matches_the_shipped_surface() {
-    let cases: &[(&[&str], &str)] = &[
+    let cases: &[(&[&str], &str, &str)] = &[
         (
             &["orbit", "operation"],
+            "operation_mode_help/root.txt",
             include_str!("operation_mode_help/root.txt"),
         ),
         (
             &["orbit", "operation", "explain"],
+            "operation_mode_help/explain.txt",
             include_str!("operation_mode_help/explain.txt"),
         ),
         (
             &["orbit", "operation", "enable"],
+            "operation_mode_help/enable.txt",
             include_str!("operation_mode_help/enable.txt"),
         ),
         (
             &["orbit", "operation", "list"],
+            "operation_mode_help/list.txt",
             include_str!("operation_mode_help/list.txt"),
         ),
         (
             &["orbit", "operation", "show"],
+            "operation_mode_help/show.txt",
             include_str!("operation_mode_help/show.txt"),
         ),
         (
             &["orbit", "operation", "stop"],
+            "operation_mode_help/stop.txt",
             include_str!("operation_mode_help/stop.txt"),
         ),
         (
             &["orbit", "operation", "revoke"],
+            "operation_mode_help/revoke.txt",
             include_str!("operation_mode_help/revoke.txt"),
         ),
     ];
-    for (args, expected) in cases {
-        assert_eq!(help_for(args), *expected, "help for {args:?} moved");
+    for (args, relative, expected) in cases {
+        super::assert_help_matches_golden(args, relative, expected);
     }
 }
 

--- a/docs/runbooks/build-budget.md
+++ b/docs/runbooks/build-budget.md
@@ -16,7 +16,7 @@ private Cargo target directory.
 ## Supported entry points
 
 The repository's heavy Make targets enter the budget automatically: `build`, `release`,
-`run`, `check`, `test`, `clippy`, `ci`, `ci-lint`, `install`, and `watch`. `make ci` holds
+`run`, `check`, `test`, `clippy`, `ci`, `ci-lint`, `goldens`, `install`, and `watch`. `make ci` holds
 one slot around the complete CI script; its nested Cargo commands inherit that admission
 instead of reacquiring a slot. `dev` is covered through its `build` prerequisite.
 

--- a/docs/runbooks/executor-onboarding.md
+++ b/docs/runbooks/executor-onboarding.md
@@ -130,9 +130,10 @@ cargo test -p orbit-engine --test v2_local_shell
 ./scripts/sync-plugin-skills.sh --check
 make ci-fast
 make ci-lint
+make goldens
 ```
 
-The first two commands are examples of target selection, not provider CLI flags. If no provider-specific test target exists yet, run the package's relevant test module and add the integration fixture before calling the lane supported. `make ci-fast` and `make ci-lint` are the repository handoff gates; do not substitute a live authenticated smoke for fixture coverage.
+The first two commands are examples of target selection, not provider CLI flags. If no provider-specific test target exists yet, run the package's relevant test module and add the integration fixture before calling the lane supported. `make ci-fast`, `make ci-lint`, and `make goldens` are the repository handoff gates; do not substitute a live authenticated smoke for fixture coverage.
 
 ## Package and hand off managed assets
 

--- a/scripts/check-goldens.sh
+++ b/scripts/check-goldens.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify (or, with --update, regenerate) checked-in orbit-cli help and
+# description goldens without running the workspace test suite.
+#
+# Covers:
+#   - CLI long-help text under crates/orbit-cli/src/command/tests/
+#   - crates/orbit-cli/tests/output_goldens/ (including tool_list.json)
+#   - crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+#
+# Regeneration env vars (also printed by the failing tests):
+#   ORBIT_UPDATE_HELP_GOLDENS=1
+#   ORBIT_UPDATE_OUTPUT_GOLDENS=1
+#   ORBIT_MCP_UPDATE_SNAPSHOT=1
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+update=false
+case "${1:-}" in
+  "") ;;
+  --update) update=true ;;
+  *)
+    echo "usage: check-goldens.sh [--update]" >&2
+    exit 2
+    ;;
+esac
+
+if [[ "$update" == true ]]; then
+  export ORBIT_UPDATE_HELP_GOLDENS=1
+  export ORBIT_UPDATE_OUTPUT_GOLDENS=1
+  export ORBIT_MCP_UPDATE_SNAPSHOT=1
+fi
+
+cargo="${CARGO:-cargo}"
+
+"$cargo" test -p orbit-cli --bin orbit help_matches_the_shipped_surface
+"$cargo" test -p orbit-cli --test output_goldens
+"$cargo" test -p orbit-cli --test mcp_roundtrip \
+  mcp_serve_tools_list_matches_production_snapshot -- --exact

--- a/scripts/test-ci-fast-guards.py
+++ b/scripts/test-ci-fast-guards.py
@@ -140,6 +140,56 @@ with open(os.environ["GUARD_TEST_LOG"], "a") as log:
         result = self.dependency_result("orbit-core", "orbit-exec", "dev")
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_goldens_runs_only_the_orbit_cli_snapshot_tests(self):
+        result = self.run_guard("check-goldens.sh")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = [json.loads(line) for line in self.log.read_text().splitlines()]
+        self.assertEqual(
+            calls,
+            [
+                ["test", "-p", "orbit-cli", "--bin", "orbit", "help_matches_the_shipped_surface"],
+                ["test", "-p", "orbit-cli", "--test", "output_goldens"],
+                [
+                    "test",
+                    "-p",
+                    "orbit-cli",
+                    "--test",
+                    "mcp_roundtrip",
+                    "mcp_serve_tools_list_matches_production_snapshot",
+                    "--",
+                    "--exact",
+                ],
+            ],
+        )
+
+    def test_goldens_update_sets_regeneration_env_vars(self):
+        self.write_executable(
+            self.bin / "cargo",
+            '''#!/usr/bin/env python3
+import json, os, sys
+with open(os.environ["GUARD_TEST_LOG"], "a") as log:
+    log.write(json.dumps({
+        "argv": sys.argv[1:],
+        "help": os.environ.get("ORBIT_UPDATE_HELP_GOLDENS"),
+        "output": os.environ.get("ORBIT_UPDATE_OUTPUT_GOLDENS"),
+        "mcp": os.environ.get("ORBIT_MCP_UPDATE_SNAPSHOT"),
+    }) + "\\n")
+''',
+        )
+        result = self.run_guard("check-goldens.sh", "--update")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = [json.loads(line) for line in self.log.read_text().splitlines()]
+        self.assertEqual(len(calls), 3)
+        for call in calls:
+            self.assertEqual(call["help"], "1")
+            self.assertEqual(call["output"], "1")
+            self.assertEqual(call["mcp"], "1")
+
+    def test_goldens_rejects_unknown_flags(self):
+        result = self.run_guard("check-goldens.sh", "--fast")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("usage: check-goldens.sh [--update]", result.stderr)
+
 
 class CargoDenyGuardrailTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Task

[ORB-12242](https://orbit-cli.com/tasks/ORB-12242) — [code-review] The documented pre-review gate misses checked-in goldens: three of this window's merges were CI-failure repairs for help/description snapshot drift

### Description

## Summary

`CLAUDE.md` / `AGENTS.md` (Build / Lint) name `make ci-fast` and `make ci-lint` as the two checks that "must both pass before a task moves to `review`", and explicitly say not to run the full `make ci` per task locally. Neither target runs `cargo test`:

- `Makefile:150-151` — `ci-fast` = `./scripts/ci-guardrails.sh --fast` (guardrail scripts, no compile).
- `Makefile:155-156` — `ci-lint` = `cargo clippy --all-targets -- -D warnings`.

So a task that edits a Clap `///` doc comment or an MCP `ToolParam` description passes both gates locally and reliably lands red CI, because the rendered text is also checked into goldens that only the test suite compares:

- `crates/orbit-cli/src/command/tests/**/*.txt` (rendered long help per subcommand)
- `crates/orbit-cli/tests/output_goldens/tool_list.json` (`crates/orbit-cli/tests/output_goldens.rs:317-325`)
- `crates/orbit-cli/tests/snapshots/mcp_tools_list.json` (`crates/orbit-cli/tests/mcp_roundtrip.rs:486-496`)

## Evidence from this window (`79aad9db4..adb260750`)

Three of seventeen merges are repairs for exactly this drift, from only two originating changes:

- `a559f8611` (ORB-12221, #1988) — ORB-12215 changed three MCP parameter descriptions without regenerating `mcp_tools_list.json`; `make test` was red at HEAD.
- `8b07d1329` (ORB-12230, #1997) — ORB-12216's one-sentence `--workspace` help addition left eight `friction_help/*.txt` goldens stale.
- `ea3a773ce` (ORB-12231, #2002) — the same `--workspace` sentence left seven more `operation_mode_help/*.txt` goldens plus `tool_list.json` stale, and needed a second sweep because the first repaired a different job's subset.

Each repair cost a full task, a PR, and a red-CI cycle for a change whose whole diff was one help string.

## Failure scenario

An agent edits `#[arg(long)]` help or a tool-parameter description, runs the two documented gates, both pass, the task moves to `review` and merges. CI then fails on `orbit-cli` snapshot tests, a ci-failure-sweep task is minted, and a second PR regenerates the goldens — while `agent-main` is red for everyone in between.

## Suggested resolution

Give the pre-review gate a way to see golden drift without paying for the full suite — for example a `make goldens` / guardrail step that runs just `cargo test -p orbit-cli --test output_goldens`, `--test mcp_roundtrip`, and the `command::tests` help-golden module, plus a line in the agent guide naming the regeneration environment variables the failure messages already print.

### Acceptance Criteria

- A documented, single command regenerates or verifies every checked-in help/description golden (CLI long-help text files, `output_goldens/tool_list.json`, `snapshots/mcp_tools_list.json`), and the agent guide points at it from the Build / Lint section.
- Changing one Clap help string or one MCP parameter description and running the documented pre-review gate surfaces the stale goldens locally instead of only in CI.
- The added check does not require the full workspace test suite, and `make ci-fast` keeps its no-compile contract or the guide states plainly which gate now compiles.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `make goldens` (budget-wrapped `scripts/check-goldens.sh`) as a third documented pre-review gate. It verifies CLI long-help goldens (`cargo test -p orbit-cli --bin orbit help_matches_the_shipped_surface`), `crates/orbit-cli/tests/output_goldens/` including `tool_list.json`, and `mcp_tools_list.json` via the filtered snapshot test `mcp_serve_tools_list_matches_production_snapshot -- --exact`.
- `make goldens UPDATE=1` sets `ORBIT_UPDATE_HELP_GOLDENS`, `ORBIT_UPDATE_OUTPUT_GOLDENS`, and `ORBIT_MCP_UPDATE_SNAPSHOT`. Help-golden modules now share that write path and print the same env vars on failure.
- `CLAUDE.md` Build / Lint now requires `make ci-fast`, `make ci-lint`, and `make goldens`. `make ci-fast` stays no-compile; the guide states that `make goldens` compiles `orbit-cli` tests only.
- Current docs aligned: `docs/runbooks/build-budget.md` (new compiling target) and `docs/runbooks/executor-onboarding.md` (handoff gate list). Mock coverage in `scripts/test-ci-fast-guards.py` locks the cargo argv.
- New file declared as `file:scripts/check-goldens.sh`.

Assessment: Focused gate matches the failure mode from this window (help-string / MCP description drift passing ci-fast+ci-lint). Filtering `mcp_roundtrip` to the snapshot test keeps the gate off the rest of that binary, including sandbox-hostile cases.

Strategic decisions:
- Third gate rather than folding goldens into `ci-fast`, preserving the no-compile contract.
- `--bin orbit` instead of `--lib` because `orbit-cli` is binary-only (`[[bin]] name = "orbit"`).
- Do not run the full `mcp_roundtrip` binary; compile it, execute only the snapshot test.

Criteria:
1. Single documented command regenerates or verifies every checked-in help/description golden, and the agent guide points at it from Build / Lint — met (`make goldens` / `make goldens UPDATE=1`; CLAUDE.md names the three env vars).
2. Changing one Clap help string or one MCP parameter description and running the documented pre-review gate surfaces stale goldens locally — met. Temporary `--workspace` help probe failed help goldens in ~3s; temporary `orbit.task.add` title-parameter description failed `output_goldens/tool_list.json` in ~14s. Both probes reverted.
3. Added check does not require the full workspace suite; `make ci-fast` keeps no-compile — met. Script unit tests assert the three cargo invocations; `make ci-fast` exit 0; `test_fast_does_not_enumerate_or_compile_tests` still passes.

Validation:
- `make goldens`: passed (exit 0) at the final tree after probe reverts. Help tests 2 passed; output_goldens 8 passed; mcp snapshot 1 passed / 53 filtered.
- Clap-drift probe: `make goldens` failed (exit 101) on both help-golden tests; reverted.
- MCP-description probe: `make goldens` failed (exit 101) on `plain_and_json_forms_match_their_goldens` / `tool_list.json`; reverted.
- `python3 scripts/test-ci-fast-guards.py`: passed (19 tests).
- `make ci-fast`: passed (exit 0). `test-compiler-cache-namespaces` reported skip because unprivileged user namespaces are unavailable to bwrap in this runner — sandbox denial, not a failure.
- `make ci-lint`: passed (exit 0, workspace clippy all-targets, warnings denied).
- `git diff --check`: passed.
- `make test` / full `make ci`: not run (workspace policy: not per-task).

Remaining risks:
- Website contributing pages still mention only `make ci-fast` (they already omitted `ci-lint` before this change).
- `make goldens` compiles `orbit-cli` plus its dependency tree for those three test targets, not every workspace crate.
- Help-golden UPDATE writes files via `include_str!` companions; a follow-up `make goldens` without UPDATE is still the verify path after regeneration.

Untracked new source: `scripts/check-goldens.sh` (declared `file:` selector). Changes left uncommitted.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12242-6aa4c2ec`
- Behind base: 0
- Ahead of base: 1