### PR TITLE
`orbit run ship-sweep --dry-run` reports `ready backlog: 0` for a workspace whose `run readiness` lists eligible tasks

### DIFF
--- a/crates/orbit-cli/src/command/run/sweep.rs
+++ b/crates/orbit-cli/src/command/run/sweep.rs
@@ -42,11 +42,11 @@ pub struct ShipSweepCommand {
     pub json: bool,
 }
 
-struct SweepReport {
+pub(crate) struct SweepReport {
     workspace_id: String,
     workspace_name: String,
     action: &'static str,
-    reason: Option<String>,
+    skip_reason: Option<String>,
     ready_backlog: usize,
     /// Resolved ship mode for this workspace (`pr` / `local`). Set for the
     /// dispatch paths (`would_dispatch` / `dispatched`) so the operator can
@@ -57,12 +57,12 @@ struct SweepReport {
 }
 
 impl SweepReport {
-    fn skipped(ws: &Workspace, reason: &str, ready_backlog: usize) -> Self {
+    pub(crate) fn skipped(ws: &Workspace, reason: &str, ready_backlog: usize) -> Self {
         Self {
             workspace_id: ws.id.clone(),
             workspace_name: ws.name.clone(),
             action: "skipped",
-            reason: Some(reason.to_string()),
+            skip_reason: Some(reason.to_string()),
             ready_backlog,
             mode: None,
             run_id: None,
@@ -70,12 +70,12 @@ impl SweepReport {
         }
     }
 
-    fn to_json(&self) -> Value {
+    pub(crate) fn to_json(&self) -> Value {
         json!({
             "workspace_id": self.workspace_id,
             "workspace_name": self.workspace_name,
             "action": self.action,
-            "reason": self.reason,
+            "skip_reason": self.skip_reason,
             "ready_backlog": self.ready_backlog,
             "mode": self.mode,
             "run_id": self.run_id,
@@ -83,7 +83,7 @@ impl SweepReport {
         })
     }
 
-    fn to_line(&self) -> String {
+    pub(crate) fn to_line(&self) -> String {
         let mut line = format!(
             "{}: {} (ready backlog: {})",
             self.workspace_name, self.action, self.ready_backlog
@@ -91,7 +91,7 @@ impl SweepReport {
         if let Some(mode) = self.mode {
             line.push_str(&format!(" [{mode}]"));
         }
-        if let Some(reason) = &self.reason {
+        if let Some(reason) = &self.skip_reason {
             line.push_str(&format!(" — {reason}"));
         }
         if let Some(run_id) = &self.run_id {
@@ -178,7 +178,7 @@ fn sweep_workspace(
             workspace_id: ws.id.clone(),
             workspace_name: ws.name.clone(),
             action: "error",
-            reason: Some(error.to_string()),
+            skip_reason: Some(error.to_string()),
             ready_backlog: 0,
             mode: None,
             run_id: None,
@@ -187,7 +187,7 @@ fn sweep_workspace(
     })
 }
 
-fn sweep_active_workspace(
+pub(crate) fn sweep_active_workspace(
     global_root: &Path,
     ws: &Workspace,
     checkout: &WorkspaceCheckout,
@@ -195,9 +195,6 @@ fn sweep_active_workspace(
     dry_run: bool,
 ) -> Result<SweepReport, OrbitError> {
     let runtime = RegisteredRuntimeFactory::open_registered_checkout(global_root, ws, checkout)?;
-    if !runtime.workflow_auto_ship() {
-        return Ok(SweepReport::skipped(ws, "auto_ship_disabled", 0));
-    }
 
     let tasks = runtime.list_tasks()?;
     let status_by_id = runtime.task_status_index()?;
@@ -209,6 +206,14 @@ fn sweep_active_workspace(
                 && task_dependencies_ready_with_index(task, &status_by_id, &reference_index)
         })
         .count();
+
+    if !runtime.workflow_auto_ship() {
+        return Ok(SweepReport::skipped(
+            ws,
+            "auto_ship_disabled",
+            ready_backlog,
+        ));
+    }
     if ready_backlog == 0 {
         return Ok(SweepReport::skipped(ws, "no_ready_backlog", 0));
     }
@@ -231,7 +236,7 @@ fn sweep_active_workspace(
             workspace_id: ws.id.clone(),
             workspace_name: ws.name.clone(),
             action: "would_dispatch",
-            reason: None,
+            skip_reason: None,
             ready_backlog,
             mode: Some(mode.as_input_value()),
             run_id: None,
@@ -268,7 +273,7 @@ fn sweep_active_workspace(
         workspace_id: ws.id.clone(),
         workspace_name: ws.name.clone(),
         action: "dispatched",
-        reason: None,
+        skip_reason: None,
         ready_backlog,
         mode: Some(mode.as_input_value()),
         run_id: Some(invoke.run_id),

--- a/crates/orbit-cli/src/command/run/tests/mod.rs
+++ b/crates/orbit-cli/src/command/run/tests/mod.rs
@@ -4,6 +4,7 @@ mod format;
 mod job;
 mod ship;
 mod support;
+mod sweep;
 
 // Content moved from inline #[cfg(test)] mod tests in run/mod.rs per ORB-00221.
 

--- a/crates/orbit-cli/src/command/run/tests/sweep.rs
+++ b/crates/orbit-cli/src/command/run/tests/sweep.rs
@@ -1,0 +1,108 @@
+use chrono::Utc;
+use orbit_core::application::task::TaskAddParams;
+use orbit_core::runtime::WorkspaceRuntimeBinding;
+use orbit_core::{OrbitRuntime, ShipMode as CoreShipMode, TaskStatus};
+use orbit_types::workspace::{Workspace, WorkspaceCheckout, WorkspaceStatus};
+use serde_json::json;
+use tempfile::tempdir;
+
+use super::super::sweep::{SweepReport, sweep_active_workspace};
+
+#[test]
+fn disabled_auto_ship_reports_non_empty_ready_backlog_in_text_and_json() {
+    let fixture = tempdir().expect("fixture tempdir");
+    let global_root = fixture.path().join("global");
+    let repo_root = fixture.path().join("repo");
+    let orbit_dir = repo_root.join(".orbit");
+    std::fs::create_dir_all(&global_root).expect("global root");
+    std::fs::create_dir_all(&orbit_dir).expect("workspace root");
+    std::fs::write(
+        orbit_dir.join("config.toml"),
+        "[workflow]\nauto_ship = false\n",
+    )
+    .expect("write workspace config");
+    std::fs::write(
+        orbit_dir.join("config.yaml"),
+        "schema_version: 1\nworkspace_id: ws_sweep_test\n",
+    )
+    .expect("write workspace identity");
+
+    let binding = WorkspaceRuntimeBinding {
+        logical_workspace_id: "ws_sweep_test".to_string(),
+        task_partition_id: "ws_sweep_test".to_string(),
+        owner_machine_id: None,
+        repo_root: repo_root.clone(),
+        ship_mode: CoreShipMode::Pr,
+        base_branch: Some("agent-main".to_string()),
+    };
+    let runtime = OrbitRuntime::from_roots_with_binding(&global_root, &orbit_dir, binding)
+        .expect("build fixture runtime");
+    for title in ["first ready task", "second ready task"] {
+        runtime
+            .add_task(TaskAddParams {
+                title: title.to_string(),
+                description: "ready backlog fixture".to_string(),
+                plan: "fixture plan".to_string(),
+                status: Some(TaskStatus::Backlog),
+                ..TaskAddParams::default()
+            })
+            .expect("add ready backlog task");
+    }
+
+    let workspace = Workspace {
+        id: "ws_sweep_test".to_string(),
+        name: "sweep-test".to_string(),
+        owner_machine_id: None,
+        git_remote: None,
+        ship_mode: Some("pr".to_string()),
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    let checkout = WorkspaceCheckout::owner(workspace.id.clone(), repo_root, orbit_dir);
+
+    let report =
+        sweep_active_workspace(&global_root, &workspace, &checkout, CoreShipMode::Pr, true)
+            .expect("run disabled ship sweep");
+    let json = report.to_json();
+
+    assert_eq!(json["action"], "skipped");
+    assert_eq!(json["ready_backlog"], 2);
+    assert_eq!(json["skip_reason"], "auto_ship_disabled");
+    assert_eq!(json.get("reason"), None);
+    assert_eq!(
+        report.to_line(),
+        "sweep-test: skipped (ready backlog: 2) — auto_ship_disabled"
+    );
+}
+
+#[test]
+fn skipped_report_keeps_ready_backlog_separate_from_skip_reason() {
+    let workspace = Workspace {
+        id: "ws_sweep_test".to_string(),
+        name: "sweep-test".to_string(),
+        owner_machine_id: None,
+        git_remote: None,
+        ship_mode: None,
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    let report = SweepReport::skipped(&workspace, "auto_ship_disabled", 2);
+
+    assert_eq!(
+        report.to_json(),
+        json!({
+            "workspace_id": "ws_sweep_test",
+            "workspace_name": "sweep-test",
+            "action": "skipped",
+            "skip_reason": "auto_ship_disabled",
+            "ready_backlog": 2,
+            "mode": null,
+            "run_id": null,
+            "run_state": null,
+        })
+    );
+}


### PR DESCRIPTION
## Task

[ORB-12256](https://orbit-cli.com/tasks/ORB-12256) — `orbit run ship-sweep --dry-run` reports `ready backlog: 0` for a workspace whose `run readiness` lists eligible tasks

### Description

0.21.0, ws_nebula with two ready backlog tasks (DANI-10327 feature, DANI-10331 chore):

    orbit run readiness
    → Active leaf runs: 0/5; free slots: 5.  DANI-10327: eligible (ready)  DANI-10331: eligible (ready)
    orbit run ship-sweep --dry-run
    → nebula: skipped (ready backlog: 0) — auto_ship_disabled

`auto_ship_disabled` is the right skip reason, but `ready backlog: 0` is false and hides the fact that enabling `workflow.auto_ship` would dispatch two tasks. It looks like the readiness count is short-circuited when auto-ship is off. An operator using `--dry-run` to decide whether to enable auto-ship gets no signal.

## What to change

Compute the ready count independently of the skip decision (reuse the `readiness` snapshot logic), print it truthfully, and keep the reason. In JSON, emit both `ready_backlog` and `skip_reason`. Add a test with auto-ship disabled and a non-empty ready backlog.

### Acceptance Criteria

- `ship-sweep --dry-run` prints the true ready-backlog count even when the workspace is skipped for `auto_ship_disabled`
- JSON output carries `ready_backlog` and `skip_reason` separately
- Test covers disabled auto-ship with a non-empty ready backlog

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Moved task listing, status indexing, and dependency-ready backlog counting before the auto_ship gate, so disabled workspaces report their true ready backlog.
- Renamed the report field to skip_reason and emit skip_reason separately from ready_backlog in JSON; human-readable output continues to include both values.
- Added registered-workspace regression coverage with auto_ship=false and two ready backlog tasks, including text and exact JSON assertions.
Assessment: The fix is small and keeps the existing readiness-counting semantics while ensuring the skip decision cannot hide the backlog signal.

Criteria:
- True ready-backlog count for auto_ship_disabled: met; the regression reports ready_backlog=2 and text "ready backlog: 2".
- Separate JSON ready_backlog and skip_reason fields: met; JSON contains both and no legacy reason key.
- Disabled auto-ship with non-empty ready backlog test: met; the new test uses two persisted backlog fixtures and invokes the active sweep path.

Validation:
- PASS: cargo fmt --all -- --check.
- PASS: cargo test -p orbit-cli --bin orbit command::run::tests::sweep (2 tests).
- PASS: cargo test -p orbit-cli --bin orbit command::run::tests (80 tests).
- PASS: make ci-fast. Its compiler-cache namespace subcheck was skipped because Bubblewrap could not create a mount namespace in this environment; the guardrail completed successfully.
- PASS: make ci-lint (workspace clippy with warnings denied).
- PASS: git diff --check.
- PASS: GIT_OPTIONAL_LOCKS=0 git status --short; only the intended sweep implementation, test registration, and new test file are changed/untracked.
- NOT RUN: make ci, per workspace guidance that it is the canonical merge gate and should not be run per task.
- Initial command `cargo test -p orbit-cli --lib` failed because orbit-cli has no library target; the valid binary-target test command passed.

Remaining risks/deviations: Full CI was intentionally deferred to the merge gate; no other known deviations.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12256-6aa4c607`
- Behind base: 0
- Ahead of base: 1