### PR TITLE
`task locks`: an `unknown` caller may `reserve` but not `release` its own reservation; `locks list` counts `0 task(s)` for a task-bound reservation

### DIFF
--- a/crates/orbit-cli/src/command/locks.rs
+++ b/crates/orbit-cli/src/command/locks.rs
@@ -8,9 +8,16 @@
 //!
 //! Task lock reservations auto-release in workflow pipelines; `release` is the
 //! operator escape hatch for a stale reservation that wedges a run. The
-//! underlying `orbit.task.locks` / `orbit.task.locks.release` tools are
-//! inactive on the agent MCP surface, so both reach them through the admin
-//! `runtime.run_tool` bypass (mirrors `orbit adr list`, ORB-00289).
+//! underlying `orbit.task.locks` / `orbit.task.locks.reserve` /
+//! `orbit.task.locks.release` tools are inactive on the agent MCP surface, so
+//! all three reach them through the admin `runtime.run_tool` bypass (mirrors
+//! `orbit adr list`, ORB-00289).
+//!
+//! `reserve` and `release` require the same `operator` or `runner`
+//! capability: a caller that can create a reservation — which blocks every
+//! other caller from that surface until it expires or is released — must be
+//! the same caller trusted to remove one. From a plain shell, claim it with
+//! `ORBIT_OPERATOR=1`.
 
 use std::fmt::Write as _;
 
@@ -196,10 +203,13 @@ const RESERVATION_DENIED_EXIT_CODE: i32 = 3;
                   reports who holds the overlap.\n\n\
                   `--task` reserves that task's declared context surface, pruned and expanded\n\
                   exactly as conflict admission expands it. `--file` reserves selectors\n\
-                  directly. Exactly one of the two.\n\n\
+                  directly. Exactly one of the two — they are mutually exclusive forms.\n\n\
                   Reservations expire on their own, so the TTL is the safety net for a session\n\
                   that dies holding one. Release early with `orbit task locks release <id>\n\
-                  --confirm`; a denied reservation exits 3."
+                  --confirm`; a denied reservation exits 3.\n\n\
+                  Reserving requires the `operator` or `runner` capability, same as releasing:\n\
+                  a caller that can lock a surface out from under everyone else must be the same\n\
+                  caller trusted to clear it. From a plain shell, set `ORBIT_OPERATOR=1`."
 )]
 pub struct LocksReserveArgs {
     /// Task whose declared context surface to reserve. Repeat or comma-separate

--- a/crates/orbit-cli/tests/task_trimmed_surface.rs
+++ b/crates/orbit-cli/tests/task_trimmed_surface.rs
@@ -448,6 +448,44 @@ fn locks_release_reaches_the_admin_tool_only_with_the_operator_capability() {
 }
 
 #[test]
+fn locks_reserve_requires_the_same_operator_capability_as_release() {
+    let workspace = TestWorkspace::new();
+    fs::write(workspace.work.join("reserve_me.rs"), "// reserve\n").expect("write fixture file");
+    const RESERVE: &[&str] = &[
+        "task",
+        "locks",
+        "reserve",
+        "--file",
+        "file:reserve_me.rs",
+        "--json",
+    ];
+
+    // ORB-12251: an unidentified caller could previously reserve a surface it
+    // was then refused `release` on — creating a claim it was not trusted to
+    // clear. `reserve` must be refused the same way `release` already is.
+    let ungoverned = workspace.run_raw(RESERVE);
+    assert!(!ungoverned.status.success());
+    let denial = String::from_utf8_lossy(&ungoverned.stderr);
+    assert!(denial.contains("capability denied"), "{denial}");
+    assert!(denial.contains("operator or runner"), "{denial}");
+
+    let output = workspace.run_as_operator(RESERVE, "task locks reserve");
+    let value: Value = serde_json::from_slice(&output.stdout).expect("reserve JSON");
+    assert_eq!(value["reserved"], json!(true));
+    let reservation_id = value["reservation_id"]
+        .as_str()
+        .expect("reservation id")
+        .to_string();
+
+    // The same operator capability that created the reservation can also
+    // release it — the symmetry this task requires.
+    workspace.run_as_operator(
+        &["task", "locks", "release", &reservation_id, "--confirm"],
+        "task locks release",
+    );
+}
+
+#[test]
 fn audit_prune_refuses_unconfirmed_then_deletes_when_confirmed() {
     let workspace = TestWorkspace::new();
     workspace.add_task("Create an audit event");

--- a/crates/orbit-common/src/governance/authorization.rs
+++ b/crates/orbit-common/src/governance/authorization.rs
@@ -319,6 +319,15 @@ pub const GOVERNED_OPERATIONS: &[GovernedOperation] = &[
         rationale: "releasing another run's reservation can let two runs edit the same files",
     },
     GovernedOperation {
+        id: "orbit.task.locks.reserve",
+        surface: OperationSurface::Tool,
+        allowed: &[McpCapability::Operator, McpCapability::Runner],
+        rationale: "a reservation blocks every other caller from its surface until it expires or \
+                    is released, so creating one requires the same authority as removing one — \
+                    otherwise a caller could gate others out of a surface it is not itself \
+                    trusted to clear",
+    },
+    GovernedOperation {
         id: "orbit.workspace.claim.release",
         surface: OperationSurface::Tool,
         allowed: &[McpCapability::Operator],

--- a/crates/orbit-core/src/runtime/task/locks.rs
+++ b/crates/orbit-core/src/runtime/task/locks.rs
@@ -89,6 +89,22 @@ pub(crate) fn list(runtime: &OrbitRuntime) -> Result<Value, OrbitError> {
         })
         .collect::<Vec<_>>();
 
+    // Counts distinct task IDs across both projections: a task-bound
+    // reservation names task IDs that need not belong to any active task (the
+    // reserving task may still be `backlog`), so counting only
+    // `locked_surfaces` undercounts whenever a reservation is the sole holder
+    // for a task.
+    let distinct_tasks: BTreeSet<&str> = locked_surfaces
+        .iter()
+        .map(|(task, _)| task.id.as_str())
+        .chain(
+            reservation_result
+                .reservations
+                .iter()
+                .flat_map(|reservation| reservation.task_ids.iter().map(String::as_str)),
+        )
+        .collect();
+
     Ok(json!({
         "locked_files": locked_files.iter().cloned().collect::<Vec<_>>(),
         "by_task": locked_surfaces
@@ -97,7 +113,7 @@ pub(crate) fn list(runtime: &OrbitRuntime) -> Result<Value, OrbitError> {
             .collect::<Vec<_>>(),
         "by_reservation": by_reservation,
         "total_locked": locked_files.len(),
-        "total_tasks": locked_surfaces.len(),
+        "total_tasks": distinct_tasks.len(),
         "total_reservations": reservation_result.reservations.len(),
     }))
 }

--- a/crates/orbit-core/src/runtime/task/tests/locks.rs
+++ b/crates/orbit-core/src/runtime/task/tests/locks.rs
@@ -85,13 +85,15 @@ fn task_locks_reserve_adapter_surfaces_new_validation_errors() {
     let _env = unmanaged_tool_env_guard();
     let (_root, runtime, _repo_root) = test_runtime();
 
-    let missing = invalid_input_message(runtime.run_tool(
+    let missing = invalid_input_message(run_tool_as_operator(
+        &runtime,
         "orbit.task.locks.reserve",
         json!({ "model": orbit_common::test_fixtures::TEST_CODEX_MODEL }),
     ));
     assert!(missing.contains("exactly one of 'task_ids' or 'files' must be provided"));
 
-    let both = invalid_input_message(runtime.run_tool(
+    let both = invalid_input_message(run_tool_as_operator(
+        &runtime,
         "orbit.task.locks.reserve",
         json!({
             "task_ids": ["T20260506-15"],
@@ -101,7 +103,8 @@ fn task_locks_reserve_adapter_surfaces_new_validation_errors() {
     ));
     assert!(both.contains("exactly one of 'task_ids' or 'files' must be provided"));
 
-    let raw_path = invalid_input_message(runtime.run_tool(
+    let raw_path = invalid_input_message(run_tool_as_operator(
+        &runtime,
         "orbit.task.locks.reserve",
         json!({
             "files": ["src/lib.rs"],
@@ -111,7 +114,8 @@ fn task_locks_reserve_adapter_surfaces_new_validation_errors() {
     assert!(raw_path.contains("`file:`"));
     assert!(raw_path.contains("`dir:`"));
 
-    let symbol = invalid_input_message(runtime.run_tool(
+    let symbol = invalid_input_message(run_tool_as_operator(
+        &runtime,
         "orbit.task.locks.reserve",
         json!({
             "files": ["symbol:src/lib.rs#run:function"],
@@ -288,7 +292,8 @@ fn task_scope_reserve_refuses_a_task_with_no_context_surface() {
 
     let task = create_context_task(&runtime, &repo_root, TaskStatus::Backlog, &[]);
 
-    let message = invalid_input_message(runtime.run_tool(
+    let message = invalid_input_message(run_tool_as_operator(
+        &runtime,
         "orbit.task.locks.reserve",
         json!({
             "task_ids": [task.id.clone()],
@@ -321,16 +326,16 @@ fn task_scope_reserve_still_admits_a_task_whose_declared_file_does_not_exist_yet
         &["docs/design/missing.md"],
     );
 
-    let reserved = runtime
-        .run_tool(
-            "orbit.task.locks.reserve",
-            json!({
-                "task_ids": [task.id],
-                "ttl_seconds": 3600,
-                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
-            }),
-        )
-        .expect("a declared-but-not-yet-created file must still reserve");
+    let reserved = run_tool_as_operator(
+        &runtime,
+        "orbit.task.locks.reserve",
+        json!({
+            "task_ids": [task.id],
+            "ttl_seconds": 3600,
+            "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+        }),
+    )
+    .expect("a declared-but-not-yet-created file must still reserve");
     assert_eq!(reserved["reserved"], true);
     assert_eq!(reserved["reserved_files"], json!([]));
 }
@@ -355,16 +360,16 @@ fn reservation_conflicts_clear_immediately_after_release() {
         &["file:src/lib.rs"],
     );
 
-    let first_reserve = runtime
-        .run_tool(
-            "orbit.task.locks.reserve",
-            json!({
-                "task_ids": [first.id.clone()],
-                "ttl_seconds": 3600,
-                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
-            }),
-        )
-        .expect("reserve first task");
+    let first_reserve = run_tool_as_operator(
+        &runtime,
+        "orbit.task.locks.reserve",
+        json!({
+            "task_ids": [first.id.clone()],
+            "ttl_seconds": 3600,
+            "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+        }),
+    )
+    .expect("reserve first task");
     let reservation_id = first_reserve
         .get("reservation_id")
         .and_then(Value::as_str)
@@ -389,16 +394,16 @@ fn reservation_conflicts_clear_immediately_after_release() {
         "reservation visibility should include expiration"
     );
 
-    let blocked = runtime
-        .run_tool(
-            "orbit.task.locks.reserve",
-            json!({
-                "task_ids": [second.id.clone()],
-                "ttl_seconds": 3600,
-                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
-            }),
-        )
-        .expect("second reservation returns conflict");
+    let blocked = run_tool_as_operator(
+        &runtime,
+        "orbit.task.locks.reserve",
+        json!({
+            "task_ids": [second.id.clone()],
+            "ttl_seconds": 3600,
+            "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+        }),
+    )
+    .expect("second reservation returns conflict");
     assert_eq!(blocked["reserved"], false);
     assert_eq!(
         blocked["conflicts"],
@@ -420,16 +425,16 @@ fn reservation_conflicts_clear_immediately_after_release() {
     .expect("release reservation");
     assert_eq!(release["released"], true);
 
-    let second_reserve = runtime
-        .run_tool(
-            "orbit.task.locks.reserve",
-            json!({
-                "task_ids": [second.id],
-                "ttl_seconds": 3600,
-                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
-            }),
-        )
-        .expect("second reservation succeeds after release");
+    let second_reserve = run_tool_as_operator(
+        &runtime,
+        "orbit.task.locks.reserve",
+        json!({
+            "task_ids": [second.id],
+            "ttl_seconds": 3600,
+            "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+        }),
+    )
+    .expect("second reservation succeeds after release");
     assert_eq!(second_reserve["reserved"], true);
 }
 
@@ -469,16 +474,16 @@ fn v2_task_locks_store_workspace_binding_id() {
     );
     assert_eq!(task.id, "ORB-00000");
 
-    let reservation = runtime
-        .run_tool(
-            "orbit.task.locks.reserve",
-            json!({
-                "task_ids": [task.id],
-                "ttl_seconds": 3600,
-                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
-            }),
-        )
-        .expect("reserve v2 task");
+    let reservation = run_tool_as_operator(
+        &runtime,
+        "orbit.task.locks.reserve",
+        json!({
+            "task_ids": [task.id],
+            "ttl_seconds": 3600,
+            "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+        }),
+    )
+    .expect("reserve v2 task");
     assert_eq!(reservation["reserved"], true);
 
     let locks = runtime
@@ -498,16 +503,16 @@ fn v2_task_locks_fail_when_workspace_binding_config_disappears() {
     std::fs::write(repo_root.join("src/lib.rs"), "pub fn ok() {}\n").expect("write source file");
     std::fs::remove_file(repo_root.join(".orbit/config.yaml")).expect("remove workspace config");
 
-    let err = runtime
-        .run_tool(
-            "orbit.task.locks.reserve",
-            json!({
-                "files": ["file:src/lib.rs"],
-                "ttl_seconds": 3600,
-                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
-            }),
-        )
-        .expect_err("missing v2 binding config should fail");
+    let err = run_tool_as_operator(
+        &runtime,
+        "orbit.task.locks.reserve",
+        json!({
+            "files": ["file:src/lib.rs"],
+            "ttl_seconds": 3600,
+            "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+        }),
+    )
+    .expect_err("missing v2 binding config should fail");
     assert!(matches!(
         err,
         OrbitError::Store(message)
@@ -522,19 +527,19 @@ fn files_shape_reservations_conflict_and_release_like_task_reservations() {
     std::fs::create_dir_all(repo_root.join("src")).expect("create src dir");
     std::fs::write(repo_root.join("src/lib.rs"), "pub fn ok() {}\n").expect("write source file");
 
-    let direct_reserve = runtime
-        .run_tool(
-            "orbit.task.locks.reserve",
-            json!({
-                "files": [
-                    format!("file:{}", repo_root.join("src/lib.rs").display()),
-                    "dir:src/auth/",
-                ],
-                "ttl_seconds": 3600,
-                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
-            }),
-        )
-        .expect("reserve direct file selectors");
+    let direct_reserve = run_tool_as_operator(
+        &runtime,
+        "orbit.task.locks.reserve",
+        json!({
+            "files": [
+                format!("file:{}", repo_root.join("src/lib.rs").display()),
+                "dir:src/auth/",
+            ],
+            "ttl_seconds": 3600,
+            "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+        }),
+    )
+    .expect("reserve direct file selectors");
     assert_eq!(direct_reserve["reserved"], true);
     assert_eq!(
         direct_reserve["reserved_files"],
@@ -566,16 +571,16 @@ fn files_shape_reservations_conflict_and_release_like_task_reservations() {
         TaskStatus::Backlog,
         &["file:src/lib.rs"],
     );
-    let blocked = runtime
-        .run_tool(
-            "orbit.task.locks.reserve",
-            json!({
-                "task_ids": [task.id.clone()],
-                "ttl_seconds": 3600,
-                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
-            }),
-        )
-        .expect("task reservation returns conflict");
+    let blocked = run_tool_as_operator(
+        &runtime,
+        "orbit.task.locks.reserve",
+        json!({
+            "task_ids": [task.id.clone()],
+            "ttl_seconds": 3600,
+            "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+        }),
+    )
+    .expect("task reservation returns conflict");
     assert_eq!(blocked["reserved"], false);
     assert_eq!(
         blocked["conflicts"],
@@ -597,16 +602,16 @@ fn files_shape_reservations_conflict_and_release_like_task_reservations() {
     .expect("release direct reservation");
     assert_eq!(release["released"], true);
 
-    let task_reserve = runtime
-        .run_tool(
-            "orbit.task.locks.reserve",
-            json!({
-                "task_ids": [task.id],
-                "ttl_seconds": 3600,
-                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
-            }),
-        )
-        .expect("task reservation succeeds after release");
+    let task_reserve = run_tool_as_operator(
+        &runtime,
+        "orbit.task.locks.reserve",
+        json!({
+            "task_ids": [task.id],
+            "ttl_seconds": 3600,
+            "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+        }),
+    )
+    .expect("task reservation succeeds after release");
     assert_eq!(task_reserve["reserved"], true);
 }
 
@@ -615,16 +620,16 @@ fn files_shape_reservations_reject_outside_workspace_before_persisting() {
     let _env = unmanaged_tool_env_guard();
     let (_root, runtime, _repo_root) = test_runtime();
 
-    let error = runtime
-        .run_tool(
-            "orbit.task.locks.reserve",
-            json!({
-                "files": ["file:/outside-workspace/lib.rs"],
-                "ttl_seconds": 3600,
-                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
-            }),
-        )
-        .expect_err("outside-workspace selector is rejected");
+    let error = run_tool_as_operator(
+        &runtime,
+        "orbit.task.locks.reserve",
+        json!({
+            "files": ["file:/outside-workspace/lib.rs"],
+            "ttl_seconds": 3600,
+            "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+        }),
+    )
+    .expect_err("outside-workspace selector is rejected");
     let message = invalid_input_message::<Value>(Err(error));
     assert!(
         message.contains("must remain inside workspace"),
@@ -640,6 +645,8 @@ fn files_shape_reservations_reject_outside_workspace_before_persisting() {
 use orbit_tools::{ReservationOwnerContext, ToolContext};
 use orbit_types::policy::Role;
 use orbit_types::telemetry::AuditEvent;
+use orbit_types::tool::{McpCapability, ToolSessionContext};
+use std::collections::BTreeSet;
 
 fn task_lock_audit_event(runtime: &OrbitRuntime, tool_name: &str, command: &str) -> AuditEvent {
     runtime
@@ -656,6 +663,10 @@ fn reserve_files(runtime: &OrbitRuntime, owner_run_id: Option<&str>) -> String {
         "ttl_seconds": 3600,
         "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
     });
+    let operator_session = ToolSessionContext {
+        effective_capabilities: BTreeSet::from([McpCapability::Operator]),
+        ..ToolSessionContext::default()
+    };
     let output = match owner_run_id {
         Some(owner_run_id) => runtime
             .run_tool_with_context_and_role(
@@ -663,6 +674,7 @@ fn reserve_files(runtime: &OrbitRuntime, owner_run_id: Option<&str>) -> String {
                 input,
                 Role::Admin,
                 ToolContext {
+                    session_context: operator_session,
                     reservation_owner: Some(ReservationOwnerContext {
                         owner_run_id: owner_run_id.to_string(),
                         owner_metadata_json: None,
@@ -672,7 +684,15 @@ fn reserve_files(runtime: &OrbitRuntime, owner_run_id: Option<&str>) -> String {
             )
             .expect("reserve direct file selectors with owner"),
         None => runtime
-            .run_tool("orbit.task.locks.reserve", input)
+            .run_tool_with_context_and_role(
+                "orbit.task.locks.reserve",
+                input,
+                Role::Admin,
+                ToolContext {
+                    session_context: operator_session,
+                    ..ToolContext::default()
+                },
+            )
             .expect("reserve direct file selectors"),
     };
 
@@ -754,16 +774,16 @@ fn reserve_audit_for_task_scope_records_first_task_id() {
         &["file:src/lib.rs"],
     );
 
-    let reserve = runtime
-        .run_tool(
-            "orbit.task.locks.reserve",
-            json!({
-                "task_ids": [task.id.clone()],
-                "ttl_seconds": 3600,
-                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
-            }),
-        )
-        .expect("reserve task scope");
+    let reserve = run_tool_as_operator(
+        &runtime,
+        "orbit.task.locks.reserve",
+        json!({
+            "task_ids": [task.id.clone()],
+            "ttl_seconds": 3600,
+            "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+        }),
+    )
+    .expect("reserve task scope");
     assert_eq!(reserve["reserved"], true);
     let reservation_id = reserve["reservation_id"]
         .as_str()
@@ -777,4 +797,146 @@ fn reserve_audit_for_task_scope_records_first_task_id() {
     );
     assert_eq!(row.target_id.as_deref(), Some(reservation_id.as_str()));
     assert_eq!(row.task_id.as_deref(), Some(task.id.as_str()));
+}
+
+/// ORB-12251: a caller could `reserve` with no capability at all and then be
+/// refused `release` on the very reservation it just created — an `unknown`
+/// caller could gate dispatch admission for a surface it was not itself
+/// trusted to clear. `reserve` must deny the same unprivileged caller
+/// `release` already denies, and admit the same `operator`/`runner` callers.
+#[test]
+fn reserve_requires_the_same_capability_as_release() {
+    let _env = unmanaged_tool_env_guard();
+    let (_root, runtime, repo_root) = test_runtime();
+    std::fs::create_dir_all(repo_root.join("src")).expect("create src dir");
+    std::fs::write(repo_root.join("src/lib.rs"), "pub fn ok() {}\n").expect("write source file");
+
+    let unprivileged = ToolContext::default();
+    let reserve_input = json!({
+        "files": ["file:src/lib.rs"],
+        "ttl_seconds": 3600,
+        "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+    });
+
+    let denied_reserve = runtime
+        .run_tool_with_context_and_role(
+            "orbit.task.locks.reserve",
+            reserve_input.clone(),
+            Role::Admin,
+            unprivileged.clone(),
+        )
+        .expect_err("an unprivileged caller must not be able to reserve");
+    let OrbitError::CapabilityDenied(reserve_message) = denied_reserve else {
+        panic!("expected capability denial, got {denied_reserve:?}");
+    };
+    assert!(reserve_message.contains("orbit.task.locks.reserve"));
+    assert!(reserve_message.contains("operator or runner"));
+
+    let denied_release = runtime
+        .run_tool_with_context_and_role(
+            "orbit.task.locks.release",
+            json!({
+                "reservation_id": "reservation-does-not-matter",
+                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+            }),
+            Role::Admin,
+            unprivileged,
+        )
+        .expect_err("an unprivileged caller must not be able to release");
+    let OrbitError::CapabilityDenied(release_message) = denied_release else {
+        panic!("expected capability denial, got {denied_release:?}");
+    };
+    assert!(release_message.contains("orbit.task.locks.release"));
+    assert!(release_message.contains("operator or runner"));
+
+    // The same caller that was refused above is admitted for both once it
+    // holds either half of the shared `operator or runner` requirement.
+    for capability in [McpCapability::Operator, McpCapability::Runner] {
+        let context = ToolContext {
+            session_context: ToolSessionContext {
+                effective_capabilities: BTreeSet::from([capability]),
+                ..ToolSessionContext::default()
+            },
+            ..ToolContext::default()
+        };
+        let reserved = runtime
+            .run_tool_with_context_and_role(
+                "orbit.task.locks.reserve",
+                reserve_input.clone(),
+                Role::Admin,
+                context.clone(),
+            )
+            .unwrap_or_else(|error| panic!("{capability} must be able to reserve: {error}"));
+        assert_eq!(reserved["reserved"], true);
+        let reservation_id = reserved["reservation_id"]
+            .as_str()
+            .expect("reservation id")
+            .to_string();
+
+        let released = runtime
+            .run_tool_with_context_and_role(
+                "orbit.task.locks.release",
+                json!({
+                    "reservation_id": reservation_id,
+                    "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+                }),
+                Role::Admin,
+                context,
+            )
+            .unwrap_or_else(|error| panic!("{capability} must be able to release: {error}"));
+        assert_eq!(released["released"], true);
+    }
+}
+
+/// ORB-12251: `locks list` reported "0 task(s)" for a reservation that named
+/// a task ID, because the count only walked active (in-progress/review)
+/// tasks. A task-bound reservation's `task_ids` must count too, even for a
+/// task that is not itself active — and a task counted both ways must not be
+/// double-counted.
+#[test]
+fn locks_list_counts_distinct_tasks_across_reservations_and_active_tasks() {
+    let _env = unmanaged_tool_env_guard();
+    let (_root, runtime, repo_root) = test_runtime();
+    std::fs::create_dir_all(repo_root.join("src")).expect("create src dir");
+    std::fs::write(repo_root.join("src/lib.rs"), "pub fn ok() {}\n").expect("write source file");
+    std::fs::write(repo_root.join("other.rs"), "pub fn other() {}\n")
+        .expect("write second source file");
+
+    // A backlog task reserved by ID: not active, so it contributes to the
+    // count only through the reservation's `task_ids`.
+    let backlog_task = create_context_task(
+        &runtime,
+        &repo_root,
+        TaskStatus::Backlog,
+        &["file:src/lib.rs"],
+    );
+    run_tool_as_operator(
+        &runtime,
+        "orbit.task.locks.reserve",
+        json!({
+            "task_ids": [backlog_task.id],
+            "ttl_seconds": 3600,
+            "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+        }),
+    )
+    .expect("reserve backlog task by id");
+
+    // An active task holding a different file, counted through `by_task`.
+    let active_task = create_context_task(
+        &runtime,
+        &repo_root,
+        TaskStatus::InProgress,
+        &["file:other.rs"],
+    );
+
+    let locks = runtime
+        .run_tool("orbit.task.locks", json!({}))
+        .expect("list task locks");
+    assert_eq!(
+        locks["total_tasks"],
+        json!(2),
+        "expected the backlog task named by the reservation and the active task, got {locks}"
+    );
+    assert_eq!(locks["by_task"].as_array().expect("by_task array").len(), 1);
+    assert_eq!(locks["by_task"][0]["id"], json!(active_task.id));
 }

--- a/crates/orbit-core/src/runtime/task/tests/reservation_cleanup.rs
+++ b/crates/orbit-core/src/runtime/task/tests/reservation_cleanup.rs
@@ -14,8 +14,17 @@ use orbit_tools::{ReservationOwnerContext, ToolContext};
 use orbit_types::policy::Role;
 use orbit_types::task::{TaskPriority, TaskStatus, TaskType};
 use orbit_types::telemetry::AuditEventStatus;
+use orbit_types::tool::{McpCapability, ToolSessionContext};
 use serde_json::Value;
+use std::collections::BTreeSet;
 use tempfile::tempdir;
+
+fn operator_session() -> ToolSessionContext {
+    ToolSessionContext {
+        effective_capabilities: BTreeSet::from([McpCapability::Operator]),
+        ..ToolSessionContext::default()
+    }
+}
 
 fn test_runtime() -> (tempfile::TempDir, OrbitRuntime, std::path::PathBuf) {
     let root = tempdir().expect("create tempdir");
@@ -144,6 +153,7 @@ fn reserve_via_tool_for_owner(runtime: &OrbitRuntime, owner_run_id: &str, task_i
             }),
             Role::Admin,
             ToolContext {
+                session_context: operator_session(),
                 reservation_owner: Some(ReservationOwnerContext {
                     owner_run_id: owner_run_id.to_string(),
                     owner_metadata_json: Some(r#"{"source":"test"}"#.to_string()),
@@ -460,13 +470,18 @@ fn task_reservation_reserve_pressure_reconciles_stale_running_owner() {
     reserve_via_tool_for_owner(&runtime, &stale_run.run_id, &stale_task);
 
     let output = runtime
-        .run_tool(
+        .run_tool_with_context_and_role(
             "orbit.task.locks.reserve",
             json!({
                 "task_ids": [waiter_task],
                 "ttl_seconds": 3600,
                 "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
             }),
+            Role::Admin,
+            ToolContext {
+                session_context: operator_session(),
+                ..ToolContext::default()
+            },
         )
         .expect("reserve after pressure");
 

--- a/crates/orbit-tools/src/builtin/orbit/tests/authorization.rs
+++ b/crates/orbit-tools/src/builtin/orbit/tests/authorization.rs
@@ -69,6 +69,7 @@ const GOVERNED_TOOL_PLACEMENT: &[(&str, Placement)] = &[
     ("orbit.semantic.uninstall", Placement::Unadvertised),
     ("orbit.task.delete", Placement::Unadvertised),
     ("orbit.task.locks.release", Placement::Unadvertised),
+    ("orbit.task.locks.reserve", Placement::Unadvertised),
     ("orbit.task.reject", Placement::Unadvertised),
     ("orbit.workspace.claim.release", Placement::Unadvertised),
 ];


### PR DESCRIPTION
## Task

[ORB-12251](https://orbit-cli.com/tasks/ORB-12251) — `task locks`: an `unknown` caller may `reserve` but not `release` its own reservation; `locks list` counts `0 task(s)` for a task-bound reservation

### Description

On 0.21.0, from a plain shell (no `ORBIT_OPERATOR`):

    orbit task locks reserve --task DANI-10327 --ttl 5m --json
    → reserved: true, reservation-1789182328665434000-13006-0, 5 files, actor "unknown"
    orbit task locks list
    → "5 file(s) locked across 0 task(s)."           ← the reservation names task_ids [DANI-10327]
    orbit task locks release reservation-1789182328665434000-13006-0 --confirm
    → capability denied: operation 'orbit.task.locks.release' requires the `operator or runner` capability … this caller was resolved as `unknown` holding [none]

So the same principal can create a dispatch-gating reservation that it is then not allowed to remove; the escape hatch is `ORBIT_OPERATOR=1`, which the reserve step never required. Either both need the capability or a caller may always release a reservation it created.

Also note `orbit task locks reserve DANI-10327` (positional) errors — the flag form `--task` is required, while `--task` and `--file` are mutually exclusive though the help lists both; document which form reserves an ad-hoc file surface.

## What to change

1. Make `reserve` require the same capability as `release` (`operator or runner`), **or** let `release` succeed when the caller identity matches the reservation's recorded actor (needs the actor fix in the sibling provenance task). Pick one and state it in the command help.
2. Fix the `across N task(s)` count in `locks list` to count distinct `task_ids` across reservations and active tasks.
3. Help text for `reserve`: show the two valid forms (`--task <id>` reserves that task's context_files; `--file <selector>` reserves an ad-hoc surface) and that they are exclusive.
4. Tests for reserve/release symmetry and the list count.

### Acceptance Criteria

- `reserve` and `release` require the same capability, or a caller can release its own reservation; documented in `--help`
- `orbit task locks list` reports the correct distinct task count for task-bound reservations
- `reserve --help` describes `--task` vs `--file` as mutually exclusive forms
- Tests cover the symmetry and the count

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented all four "What to change" items from the description.

1. Capability symmetry (criterion 1): `orbit.task.locks.reserve` is now a `GovernedOperation` in `orbit_common::governance::authorization::GOVERNED_OPERATIONS` requiring `operator or runner`, the same set `orbit.task.locks.release` already requires (crates/orbit-common/src/governance/authorization.rs). Chose "same capability for both" over the actor-match alternative because the actor field for an unauthenticated caller records `unknown`/no reliable identity today (the sibling provenance-fix task is not landed), so an identity-match rule would not be enforceable yet. Registered the new governed tool's placement (`Unadvertised`, matching `release`) in the pinning guardrail test `crates/orbit-tools/src/builtin/orbit/tests/authorization.rs`.

2. `locks list` count (criterion 2): fixed `total_tasks` in `crates/orbit-core/src/runtime/task/locks.rs::list()` to count distinct task IDs across both active (`by_task`) tasks and every reservation's `task_ids`, instead of only active tasks. A task-bound reservation on a backlog/not-yet-active task now counts.

3. `--help` documentation (criteria 1 and 3): updated `crates/orbit-cli/src/command/locks.rs` module doc and `LocksReserveArgs`'s `after_help` to state the `--task`/`--file` mutual exclusivity explicitly ("Exactly one of the two — they are mutually exclusive forms") and the shared `operator`/`runner` capability requirement with the `ORBIT_OPERATOR=1` escape hatch, mirroring `release`'s existing framing.

4. Tests (criterion 4): added `reserve_requires_the_same_capability_as_release` and `locks_list_counts_distinct_tasks_across_reservations_and_active_tasks` unit tests (crates/orbit-core/src/runtime/task/tests/locks.rs), plus a CLI-binary integration test `locks_reserve_requires_the_same_operator_capability_as_release` (crates/orbit-cli/tests/task_trimmed_surface.rs) mirroring the existing `locks_release_reaches_the_admin_tool_only_with_the_operator_capability` test. Updated ~15 pre-existing test call sites across `crates/orbit-core/src/runtime/task/tests/locks.rs` and `reservation_cleanup.rs` that called the reserve tool as an unprivileged caller (now denied) to use `run_tool_as_operator` / an explicit operator session, per the existing test-support convention.

Manually verified end-to-end against the exact repro in the bug report using the built `orbit` binary in a scratch workspace: an `unknown` caller is now denied `reserve` with the same "operator or runner" message `release` gives, `ORBIT_OPERATOR=1` admits it, and `task locks list` now reports "1 task(s)" (not "0") for a task-bound reservation on a non-active task.

Validation:
- `make ci-fast`: passed.
- `make ci-lint` (workspace clippy, `-D warnings`): passed.
- `cargo fmt --check` on touched crates: passed (ran `cargo fmt` once to fix one formatting diff in the new CLI test).
- `cargo test -p orbit-core --lib` (1426 tests): passed.
- `cargo test -p orbit-tools --lib` (126 tests): passed.
- `cargo test -p orbit-cli` (full, all binaries): passed.
- `cargo test -p orbit-web --lib denials`: passed (denial-filter test references `orbit.task.locks.reserve` by name; unaffected by the capability change).
- `git diff --check` and `git status --short`: clean, only the intended tracked files changed, no stray artifacts.

Scope: touched files beyond the three declared `context_files` were `crates/orbit-common/src/governance/authorization.rs` (the governed-operation registry, the only place a tool's required capability is declared), `crates/orbit-tools/src/builtin/orbit/tests/authorization.rs` (the placement-pinning guardrail that a new governed tool must update), `crates/orbit-cli/tests/task_trimmed_surface.rs` (new symmetry integration test), and `crates/orbit-core/src/runtime/task/tests/{locks,reservation_cleanup}.rs` (existing tests that exercised reserve as an unprivileged caller). All are direct, minimal consequences of the capability change requested by the task; none are speculative or out-of-scope restructuring.

No blockers, no deviations from the acceptance criteria.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12251-6aa4c607`
- Behind base: 0
- Ahead of base: 1