### PR TITLE
`orbit.task.add` accepts unregistered `required_tools`, then the field is immutable — the task can never be admitted or repaired

### DIFF
--- a/crates/orbit-cli/src/command/auto_task/add.rs
+++ b/crates/orbit-cli/src/command/auto_task/add.rs
@@ -69,6 +69,7 @@ pub struct AutoTaskAddArgs {
 impl Execute for AutoTaskAddArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
         let schedule = require_schedule(self.cron, self.every_minutes, self.deliveries_landed)?;
+        let required_tool_warnings = runtime.validate_required_tools(&self.required_tools)?;
         // Minted tasks receive TaskComplexity::Unassessed (not a real
         // assessment). Definitions do not carry complexity; the mint path
         // stamps the explicit non-answer so create never produces a gap.
@@ -91,6 +92,15 @@ impl Execute for AutoTaskAddArgs {
             dedupe: self.dedupe,
         })?;
 
-        Ok(Payload::detail(definition_to_json(&definition), definition.name).into())
+        let mut document = definition_to_json(&definition);
+        if !required_tool_warnings.is_empty()
+            && let Some(object) = document.as_object_mut()
+        {
+            object.insert(
+                "warnings".to_string(),
+                serde_json::json!(required_tool_warnings),
+            );
+        }
+        Ok(Payload::detail(document, definition.name).into())
     }
 }

--- a/crates/orbit-cli/src/command/auto_task/update.rs
+++ b/crates/orbit-cli/src/command/auto_task/update.rs
@@ -143,6 +143,17 @@ impl Execute for AutoTaskUpdateArgs {
             },
         )?;
 
-        Ok(Payload::detail(definition_to_json(&definition), definition.name).into())
+        let required_tool_warnings =
+            runtime.validate_required_tools(&definition.template.required_tools)?;
+        let mut document = definition_to_json(&definition);
+        if !required_tool_warnings.is_empty()
+            && let Some(object) = document.as_object_mut()
+        {
+            object.insert(
+                "warnings".to_string(),
+                serde_json::json!(required_tool_warnings),
+            );
+        }
+        Ok(Payload::detail(document, definition.name).into())
     }
 }

--- a/crates/orbit-cli/src/command/task/add.rs
+++ b/crates/orbit-cli/src/command/task/add.rs
@@ -81,6 +81,7 @@ pub struct TaskAddArgs {
 
 impl Execute for TaskAddArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        let required_tool_warnings = runtime.validate_required_tools(&self.required_tools)?;
         let (agent, model) = super::mutation_identity(self.model);
         if !self.allow_missing_context {
             runtime.ensure_context_selectors_exist(&self.context)?;
@@ -122,6 +123,15 @@ impl Execute for TaskAddArgs {
             model,
         )?;
 
-        Ok(Payload::detail(task_to_json_for_runtime(runtime, &task)?, task.id).into())
+        let mut document = task_to_json_for_runtime(runtime, &task)?;
+        if !required_tool_warnings.is_empty()
+            && let Some(object) = document.as_object_mut()
+        {
+            object.insert(
+                "warnings".to_string(),
+                serde_json::json!(required_tool_warnings),
+            );
+        }
+        Ok(Payload::detail(document, task.id).into())
     }
 }

--- a/crates/orbit-cli/src/command/task/tests/add.rs
+++ b/crates/orbit-cli/src/command/task/tests/add.rs
@@ -1,7 +1,9 @@
 use clap::{CommandFactory, Parser};
+use orbit_core::OrbitRuntime;
 
 use crate::command::task::TaskSubcommand;
 use crate::command::{Cli, Commands};
+use crate::command::{CommandOutput, Execute};
 
 #[test]
 fn task_add_parses_repeat_and_comma_delimited_lists() {
@@ -252,4 +254,79 @@ fn removed_task_flags_are_rejected() {
         argv.extend(args);
         assert!(Cli::try_parse_from(argv).is_err());
     }
+}
+
+#[test]
+fn task_add_execution_rejects_unknown_required_tools() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let cli = Cli::try_parse_from([
+        "orbit",
+        "task",
+        "add",
+        "--title",
+        "Unknown tool",
+        "--complexity",
+        "low",
+        "--required-tools",
+        "orbit.task.shwo",
+    ])
+    .expect("parse task add");
+    let Commands::Task(task) = cli.command else {
+        panic!("expected task command");
+    };
+    let TaskSubcommand::Add(args) = task.command else {
+        panic!("expected task add command");
+    };
+
+    let error = args
+        .execute(&runtime)
+        .expect_err("unknown required tool must be rejected");
+    assert!(
+        error
+            .to_string()
+            .contains("unregistered tool 'orbit.task.shwo'")
+    );
+    assert!(
+        error
+            .did_you_mean()
+            .is_some_and(|names| { names.iter().any(|name| name == "orbit.task.show") })
+    );
+}
+
+#[test]
+fn task_add_execution_reports_disabled_required_tool_warning() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    runtime
+        .disable_tool("orbit.task.list")
+        .expect("disable tool");
+    let cli = Cli::try_parse_from([
+        "orbit",
+        "task",
+        "add",
+        "--title",
+        "Disabled tool",
+        "--complexity",
+        "low",
+        "--required-tools",
+        "orbit.task.list",
+    ])
+    .expect("parse task add");
+    let Commands::Task(task) = cli.command else {
+        panic!("expected task command");
+    };
+    let TaskSubcommand::Add(args) = task.command else {
+        panic!("expected task add command");
+    };
+
+    let CommandOutput::Payload(payload) = args.execute(&runtime).expect("task add") else {
+        panic!("task add should return a payload");
+    };
+    let (document, _) = payload.into_view();
+    assert!(document["warnings"].as_array().is_some_and(|warnings| {
+        warnings.iter().any(|warning| {
+            warning.as_str().is_some_and(|message| {
+                message.contains("orbit.task.list") && message.contains("disabled")
+            })
+        })
+    }));
 }

--- a/crates/orbit-cli/src/command/tests/auto_task.rs
+++ b/crates/orbit-cli/src/command/tests/auto_task.rs
@@ -6,7 +6,7 @@ use orbit_types::task::{TaskPriority, TaskStatus, TaskType};
 use orbit_types::workflow::automation::{CoverageClass, DeliveryTrigger};
 
 use crate::command::auto_task::AutoTaskSubcommand;
-use crate::command::{Cli, Commands};
+use crate::command::{Cli, CommandOutput, Commands, Execute};
 
 #[test]
 fn auto_task_add_accepts_required_tools_and_legacy_alias() {
@@ -60,6 +60,85 @@ fn auto_task_update_accepts_required_tools() {
         args.required_tools.as_deref(),
         Some("proc.spawn,orbit.task.show")
     );
+}
+
+#[test]
+fn auto_task_add_execution_rejects_unknown_required_tools() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let cli = Cli::try_parse_from([
+        "orbit",
+        "auto-task",
+        "add",
+        "--name",
+        "invalid-tools",
+        "--every-minutes",
+        "5",
+        "--title",
+        "Invalid requirement",
+        "--required-tools",
+        "orbit.task.shwo",
+    ])
+    .expect("parse auto-task add");
+    let Commands::AutoTask(auto_task) = cli.command else {
+        panic!("expected auto-task command");
+    };
+    let AutoTaskSubcommand::Add(args) = auto_task.command else {
+        panic!("expected auto-task add command");
+    };
+
+    let error = args
+        .execute(&runtime)
+        .expect_err("unknown template tool must be rejected");
+    assert!(
+        error
+            .to_string()
+            .contains("unregistered tool 'orbit.task.shwo'")
+    );
+    assert!(
+        error
+            .did_you_mean()
+            .is_some_and(|names| { names.iter().any(|name| name == "orbit.task.show") })
+    );
+}
+
+#[test]
+fn auto_task_add_execution_reports_disabled_required_tool_warning() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    runtime
+        .disable_tool("orbit.task.list")
+        .expect("disable tool");
+    let cli = Cli::try_parse_from([
+        "orbit",
+        "auto-task",
+        "add",
+        "--name",
+        "disabled-tool",
+        "--every-minutes",
+        "5",
+        "--title",
+        "Disabled requirement",
+        "--required-tools",
+        "orbit.task.list",
+    ])
+    .expect("parse auto-task add");
+    let Commands::AutoTask(auto_task) = cli.command else {
+        panic!("expected auto-task command");
+    };
+    let AutoTaskSubcommand::Add(args) = auto_task.command else {
+        panic!("expected auto-task add command");
+    };
+
+    let CommandOutput::Payload(payload) = args.execute(&runtime).expect("auto-task add") else {
+        panic!("auto-task add should return a payload");
+    };
+    let (document, _) = payload.into_view();
+    assert!(document["warnings"].as_array().is_some_and(|warnings| {
+        warnings.iter().any(|warning| {
+            warning.as_str().is_some_and(|message| {
+                message.contains("orbit.task.list") && message.contains("disabled")
+            })
+        })
+    }));
 }
 
 #[test]

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/required_tools.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/required_tools.rs
@@ -1,18 +1,44 @@
 use orbit_engine::{DispatchError, RuntimeHost};
+use orbit_store::contracts::TaskCreateParams;
+use orbit_types::task::{TaskPriority, TaskStatus, TaskType};
 
 use crate::OrbitRuntime;
-use crate::application::task::TaskAddParams;
 
+// These tests exercise admission of legacy persisted tasks, so they bypass
+// the current creation boundary to retain deliberately invalid requirements.
 fn add_task(runtime: &OrbitRuntime, title: &str, required_tools: &[&str]) -> String {
     runtime
-        .add_task(TaskAddParams {
+        .stores()
+        .task_records()
+        .create(TaskCreateParams {
+            actor: "test".to_string(),
+            parent_id: None,
             title: title.to_string(),
             description: "Exercise task-scoped activity tools.".to_string(),
+            acceptance_criteria: Vec::new(),
+            dependencies: Vec::new(),
+            relations: Vec::new(),
+            tags: Vec::new(),
             required_tools: required_tools
                 .iter()
                 .map(|tool| (*tool).to_string())
                 .collect(),
-            ..Default::default()
+            plan: String::new(),
+            execution_summary: String::new(),
+            context_files: Vec::new(),
+            repo_root: None,
+            created_by: Some("test".to_string()),
+            planned_by: None,
+            implemented_by: None,
+            status: TaskStatus::Backlog,
+            priority: TaskPriority::Medium,
+            complexity: None,
+            task_type: TaskType::Chore,
+            external_refs: Vec::new(),
+            source_task_id: None,
+            crew: None,
+            orchestrator: None,
+            comments: Vec::new(),
         })
         .expect("add task")
         .id

--- a/crates/orbit-core/src/adapter/tool_host/auto_task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/auto_task_tools.rs
@@ -5,7 +5,7 @@
 
 use orbit_common::OrbitError;
 use orbit_types::workflow::{AutoTaskSchedule, AutoTaskTemplate, DedupePolicy};
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
 use crate::application::auto_tasks::crud::{AutoTaskAddParams, AutoTaskUpdateParams};
@@ -26,7 +26,14 @@ pub(super) fn add(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitEr
         template,
         dedupe,
     })?;
-    to_json(&definition)
+    let mut response = to_json(&definition)?;
+    let warnings = runtime.validate_required_tools(&definition.template.required_tools)?;
+    if !warnings.is_empty()
+        && let Some(object) = response.as_object_mut()
+    {
+        object.insert("warnings".to_string(), json!(warnings));
+    }
+    Ok(response)
 }
 
 pub(super) fn list(runtime: &OrbitRuntime, _input: Value) -> Result<Value, OrbitError> {
@@ -88,7 +95,14 @@ pub(super) fn update(runtime: &OrbitRuntime, input: Value) -> Result<Value, Orbi
         template: parse_field(&input, "template", false)?,
     };
     let definition = runtime.auto_task_update(&name, params)?;
-    to_json(&definition)
+    let mut response = to_json(&definition)?;
+    let warnings = runtime.validate_required_tools(&definition.template.required_tools)?;
+    if !warnings.is_empty()
+        && let Some(object) = response.as_object_mut()
+    {
+        object.insert("warnings".to_string(), json!(warnings));
+    }
+    Ok(response)
 }
 
 pub(super) fn toggle(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {

--- a/crates/orbit-core/src/adapter/tool_host/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/task_tools.rs
@@ -35,6 +35,12 @@ pub(super) fn add(
     if !allows_missing_context(&input)? {
         runtime.ensure_context_selectors_exist(&raw_context_files)?;
     }
+    let raw_required_tools = optional_csv_or_string_list_alias(
+        &input,
+        &["required_tools", "requiredTools", "required-tool"],
+    )?
+    .unwrap_or_default();
+    let mut warnings = runtime.validate_required_tools(&raw_required_tools)?;
     let task = runtime.add_task_with_identity(
         TaskAddParams {
             parent_id: None,
@@ -52,11 +58,7 @@ pub(super) fn add(
             dependencies: Vec::new(),
             relations: parse_relations(&input)?.unwrap_or_default(),
             tags: optional_csv_or_string_list_alias(&input, &["tags", "tag"])?.unwrap_or_default(),
-            required_tools: optional_csv_or_string_list_alias(
-                &input,
-                &["required_tools", "requiredTools", "required-tool"],
-            )?
-            .unwrap_or_default(),
+            required_tools: raw_required_tools,
             plan: String::new(),
             comment: None,
             context_files: raw_context_files.clone(),
@@ -82,7 +84,10 @@ pub(super) fn add(
         model,
     )?;
     let mut response = serialize_task(runtime, &task)?;
-    let warnings = compute_task_add_warnings(&raw_context_files, task.task_type);
+    warnings.extend(compute_task_add_warnings(
+        &raw_context_files,
+        task.task_type,
+    ));
     if !warnings.is_empty()
         && let Some(obj) = response.as_object_mut()
     {

--- a/crates/orbit-core/src/adapter/tool_host/tests/auto_task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/auto_task_tools.rs
@@ -102,3 +102,84 @@ fn mint_requires_a_definition_name_and_names_an_unknown_one() {
     ));
     assert!(unknown.contains("nope"), "{unknown}");
 }
+
+#[test]
+fn auto_task_add_rejects_unknown_required_tools_with_suggestions() {
+    let (_temp, runtime, _repo) = test_runtime();
+
+    let error = run_tool_as_operator(
+        &runtime,
+        "orbit.auto_task.add",
+        json!({
+            "name": "invalid-tools",
+            "schedule": {"every_minutes": 60},
+            "template": {
+                "title": "Invalid requirement",
+                "required_tools": ["orbit.task.shwo"]
+            }
+        }),
+    )
+    .expect_err("unknown template tool must be rejected");
+
+    assert!(
+        error
+            .to_string()
+            .contains("unregistered tool 'orbit.task.shwo'")
+    );
+    assert!(
+        error
+            .did_you_mean()
+            .is_some_and(|names| { names.iter().any(|name| name == "orbit.task.show") })
+    );
+}
+
+#[test]
+fn auto_task_update_rejects_unknown_required_tools_with_suggestions() {
+    let (_temp, runtime) = with_definition("update-tools");
+    let existing = runtime
+        .auto_task_show("update-tools")
+        .expect("show definition")
+        .expect("definition exists");
+    let mut template = serde_json::to_value(existing.template).expect("serialize template");
+    template["required_tools"] = json!(["orbit.task.shwo"]);
+
+    let error = run_tool_as_operator(
+        &runtime,
+        "orbit.auto_task.update",
+        json!({"name": "update-tools", "template": template}),
+    )
+    .expect_err("unknown template tool must be rejected on update");
+
+    assert!(
+        error
+            .to_string()
+            .contains("unregistered tool 'orbit.task.shwo'")
+    );
+    assert!(
+        error
+            .did_you_mean()
+            .is_some_and(|names| { names.iter().any(|name| name == "orbit.task.show") })
+    );
+}
+
+#[test]
+fn auto_task_mint_rechecks_persisted_template_requirements() {
+    let (_temp, runtime, _repo) = test_runtime();
+    let path = runtime.paths().local_dir.join("auto_tasks/drift.yaml");
+    std::fs::create_dir_all(path.parent().expect("auto-task parent")).expect("create directory");
+    std::fs::write(
+        &path,
+        "schemaVersion: 1\nname: drift\nschedule:\n  every_minutes: 60\ntemplate:\n  title: Drift\n  required_tools:\n    - orbit.task.shwo\n",
+    )
+    .expect("write drift definition");
+
+    let error = run_tool_as_operator(&runtime, "orbit.auto_task.mint", json!({"name": "drift"}))
+        .expect_err("mint must revalidate template requirements");
+    assert!(
+        error
+            .to_string()
+            .contains("unregistered tool 'orbit.task.shwo'")
+    );
+    assert!(error.did_you_mean().is_some());
+    assert!(runtime.list_tasks().expect("list tasks").is_empty());
+}

--- a/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
@@ -165,6 +165,70 @@ fn task_add_tool_creates_proposed_tasks_for_agents() {
     );
 }
 
+#[test]
+fn task_add_tool_rejects_unknown_required_tools_with_suggestions() {
+    let (_root, runtime, _repo_root) = test_runtime();
+
+    let error = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Reject unknown tool",
+                "description": "An invalid requirement must not be persisted.",
+                "complexity": "low",
+                "workspace": ".",
+                "required_tools": ["orbit.task.shwo"],
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect_err("unknown required tool must be rejected");
+
+    assert!(
+        error
+            .to_string()
+            .contains("unregistered tool 'orbit.task.shwo'")
+    );
+    assert!(
+        error
+            .did_you_mean()
+            .is_some_and(|names| { names.iter().any(|name| name == "orbit.task.show") })
+    );
+    assert!(runtime.list_tasks().expect("list tasks").is_empty());
+}
+
+#[test]
+fn task_add_tool_accepts_disabled_required_tools_with_a_warning() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    runtime
+        .disable_tool("orbit.task.list")
+        .expect("disable tool");
+
+    let output = runtime
+        .execute_tool_command(
+            "orbit.task.add",
+            json!({
+                "title": "Keep disabled tool requirement",
+                "description": "The requirement remains durable.",
+                "complexity": "low",
+                "workspace": ".",
+                "required_tools": ["orbit.task.list"],
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("disabled registered tool is accepted");
+
+    assert_eq!(output["required_tools"], json!(["orbit.task.list"]));
+    assert!(output["warnings"].as_array().is_some_and(|warnings| {
+        warnings.iter().any(|warning| {
+            warning.as_str().is_some_and(|message| {
+                message.contains("orbit.task.list") && message.contains("disabled")
+            })
+        })
+    }));
+}
+
 /// ORB-12208: `orbit.task.add` must validate `context_files` against the same
 /// root `add_task` stores them relative to (the repository root), not against
 /// a sub-directory path-form `workspace` selector. `orbit.task.update`

--- a/crates/orbit-core/src/application/auto_tasks/crud.rs
+++ b/crates/orbit-core/src/application/auto_tasks/crud.rs
@@ -210,6 +210,7 @@ impl OrbitRuntime {
     /// An unknown name is an `InvalidInput` error naming the definition.
     pub fn auto_task_mint(&self, name: &str) -> Result<Task, OrbitError> {
         let definition = self.require_auto_task(name)?;
+        self.validate_required_tools(&definition.template.required_tools)?;
         mint_task(self, &definition)
     }
 
@@ -231,6 +232,7 @@ impl OrbitRuntime {
 
     fn validate_auto_task(&self, definition: &AutoTaskDefinition) -> Result<(), OrbitError> {
         definition.validate()?;
+        self.validate_required_tools(&definition.template.required_tools)?;
         // Load-time cron validation happens in the scheduler, but validating
         // here too means CRUD never persists a schedule the scheduler would
         // reject at fire time.

--- a/crates/orbit-core/src/application/task/add.rs
+++ b/crates/orbit-core/src/application/task/add.rs
@@ -27,38 +27,36 @@ const TASK_PROVENANCE_TITLE_PREFIXES: &[(&str, &str)] = &[
 impl OrbitRuntime {
     /// Validate task-scoped tool requirements against the current registry.
     ///
-    /// A requirement is durable metadata, so a registered tool may be kept
-    /// even when it is currently disabled or not exposed on the agent surface.
-    /// Those states are warnings; an unknown name is rejected before the task
-    /// record can become impossible to admit.
+    /// A requirement is durable metadata, so a name an operator has disabled is
+    /// kept: `orbit tool enable` restores it, so that state is only a warning.
+    /// An unknown name, and a registered tool that is not on the agent surface
+    /// at all, are both rejected — activity admission refuses them and
+    /// `required_tools` is immutable after creation, so the record would be
+    /// impossible to dispatch and impossible to repair.
     pub fn validate_required_tools(
         &self,
         required_tools: &[String],
     ) -> Result<Vec<String>, OrbitError> {
-        let mut registered_names = self
-            .tool_registry()
-            .all_schemas()
-            .into_iter()
-            .map(|schema| schema.name)
-            .collect::<Vec<_>>();
-        registered_names.sort();
-
         let mut warnings = Vec::new();
         for name in normalize_required_tools(required_tools.to_vec()) {
             if !self.tool_registry().has(&name) {
-                return Err(OrbitError::invalid_input_with_suggestions(
-                    format!("required_tools contains unregistered tool '{name}'"),
-                    registered_names,
-                ));
+                return Err(self.ungrantable_required_tool(format!(
+                    "required_tools contains unregistered tool '{name}'"
+                )));
+            }
+            if !self.tool_registry().is_active(&name) {
+                return Err(self.ungrantable_required_tool(format!(
+                    "required_tools contains tool '{name}', which is an admin/human-only \
+                     operation that is never granted to an agent"
+                )));
             }
 
-            let registry_inactive = !self.tool_registry().is_active(&name);
             let stored_disabled = self
                 .stores()
                 .tools()
                 .get_tool(&name)?
                 .is_some_and(|tool| !tool.enabled);
-            if registry_inactive || stored_disabled {
+            if stored_disabled {
                 warnings.push(format!(
                     "required_tools includes registered tool '{name}', which is currently disabled"
                 ));
@@ -66,6 +64,20 @@ impl OrbitRuntime {
         }
 
         Ok(warnings)
+    }
+
+    /// Reject one requirement an agent could never be granted, suggesting the
+    /// agent-facing tool names instead.
+    fn ungrantable_required_tool(&self, message: String) -> OrbitError {
+        let mut agent_facing_names = self
+            .tool_registry()
+            .schemas()
+            .into_iter()
+            .map(|schema| schema.name)
+            .collect::<Vec<_>>();
+        agent_facing_names.sort();
+
+        OrbitError::invalid_input_with_suggestions(message, agent_facing_names)
     }
 
     pub fn add_task(&self, params: TaskAddParams) -> Result<Task, OrbitError> {

--- a/crates/orbit-core/src/application/task/add.rs
+++ b/crates/orbit-core/src/application/task/add.rs
@@ -25,6 +25,49 @@ const TASK_PROVENANCE_TITLE_PREFIXES: &[(&str, &str)] = &[
 ];
 
 impl OrbitRuntime {
+    /// Validate task-scoped tool requirements against the current registry.
+    ///
+    /// A requirement is durable metadata, so a registered tool may be kept
+    /// even when it is currently disabled or not exposed on the agent surface.
+    /// Those states are warnings; an unknown name is rejected before the task
+    /// record can become impossible to admit.
+    pub fn validate_required_tools(
+        &self,
+        required_tools: &[String],
+    ) -> Result<Vec<String>, OrbitError> {
+        let mut registered_names = self
+            .tool_registry()
+            .all_schemas()
+            .into_iter()
+            .map(|schema| schema.name)
+            .collect::<Vec<_>>();
+        registered_names.sort();
+
+        let mut warnings = Vec::new();
+        for name in normalize_required_tools(required_tools.to_vec()) {
+            if !self.tool_registry().has(&name) {
+                return Err(OrbitError::invalid_input_with_suggestions(
+                    format!("required_tools contains unregistered tool '{name}'"),
+                    registered_names,
+                ));
+            }
+
+            let registry_inactive = !self.tool_registry().is_active(&name);
+            let stored_disabled = self
+                .stores()
+                .tools()
+                .get_tool(&name)?
+                .is_some_and(|tool| !tool.enabled);
+            if registry_inactive || stored_disabled {
+                warnings.push(format!(
+                    "required_tools includes registered tool '{name}', which is currently disabled"
+                ));
+            }
+        }
+
+        Ok(warnings)
+    }
+
     pub fn add_task(&self, params: TaskAddParams) -> Result<Task, OrbitError> {
         self.add_task_with_identity(params, None, None)
     }
@@ -46,6 +89,8 @@ impl OrbitRuntime {
         action_key: Option<&str>,
     ) -> Result<Task, OrbitError> {
         self.ensure_coordination_task_write_permitted()?;
+        self.validate_required_tools(&params.required_tools)?;
+
         // [ORB-00417] Redact secrets at the single task-creation choke point
         // (shared by the dashboard POST, CLI `task add`, and the MCP task tool)
         // so a pasted key never lands in the task registry or the audit trail.

--- a/crates/orbit-core/src/application/task/tests/add.rs
+++ b/crates/orbit-core/src/application/task/tests/add.rs
@@ -440,3 +440,49 @@ fn task_add_accepts_valid_context_selectors() {
         ]
     );
 }
+
+#[test]
+fn task_add_rejects_a_requirement_agents_can_never_be_granted() {
+    let (_root, runtime) = test_runtime();
+
+    // `orbit.auto_task.add` is registered but admin/human-only, so activity
+    // admission refuses it and `required_tools` cannot be edited afterwards.
+    let error = runtime
+        .add_task(TaskAddParams {
+            title: "Require a human-only tool".to_string(),
+            required_tools: vec!["orbit.auto_task.add".to_string()],
+            ..Default::default()
+        })
+        .expect_err("a never-grantable requirement must be rejected at creation");
+
+    let OrbitError::InvalidInputDiagnostic {
+        message,
+        did_you_mean,
+    } = error
+    else {
+        panic!("expected an invalid-input diagnostic with suggestions");
+    };
+    assert!(message.contains("orbit.auto_task.add"), "{message}");
+    assert!(message.contains("admin/human-only"), "{message}");
+    assert!(
+        !did_you_mean.contains(&"orbit.auto_task.add".to_string()),
+        "suggestions must only offer agent-facing tools: {did_you_mean:?}"
+    );
+    assert!(did_you_mean.contains(&"orbit.task.show".to_string()));
+}
+
+#[test]
+fn task_add_keeps_a_disabled_requirement_with_a_warning() {
+    let (_root, runtime) = test_runtime();
+    runtime
+        .disable_tool("github.run.list")
+        .expect("disable a registered agent-facing tool");
+
+    let warnings = runtime
+        .validate_required_tools(&["github.run.list".to_string()])
+        .expect("an operator-disabled requirement stays durable");
+
+    assert_eq!(warnings.len(), 1, "{warnings:?}");
+    assert!(warnings[0].contains("github.run.list"), "{warnings:?}");
+    assert!(warnings[0].contains("disabled"), "{warnings:?}");
+}


### PR DESCRIPTION
## Task

[ORB-12247](https://orbit-cli.com/tasks/ORB-12247) — `orbit.task.add` accepts unregistered `required_tools`, then the field is immutable — the task can never be admitted or repaired

### Description

Reproduced on 0.21.0 via `orbit tool run` (ws_nebula):

    orbit tool run orbit.task.add --input '{"title":"x","description":"y","complexity":"low","required_tools":["not.a.tool"]}'
    → created DANI-10328 with required_tools ["not.a.tool"]
    orbit tool run orbit.task.update --input '{"id":"DANI-10328","required_tools":["orbit.task.show"]}'
    → invalid input: orbit.task.update does not accept `required_tools`; task tool requirements are immutable after creation

The workflows reference says "Admission rejects invalid required names before provider launch", so such a task is guaranteed to fail at dispatch, and because the field is immutable the only remedy is reject-and-refile. Every other enumerated field on `task.add` (`crew`, `type`, `complexity`, `priority`, `relations`, `context_files`) is validated at creation; `required_tools` is the odd one out. Recorded as friction F2026-09-004 on the Mac mini.

## What to change

In `crates/orbit-tools/src/builtin/orbit/task/add.rs` (and the bare CLI `orbit task add --required-tools`, and `auto-task add --required-tools` templates):

1. Resolve each name against the active tool registry at creation time. Unknown → `invalid_input: required_tools contains unregistered tool 'not.a.tool'` with a `did_you_mean` list like the crew error already provides.
2. Disabled tools: accept (the requirement is durable; the tool may be re-enabled) but include a `warnings` entry.
3. Names are exact canonical names; do not accept provider-prefixed forms.
4. Auto-task definitions: validate at `auto-task add/update` time and again at mint time (registry may have changed); a mint whose template names an unregistered tool fails that mint with a clear reason rather than creating an unadmittable task.
5. Tests for add (registered / unregistered / disabled), CLI add, and auto-task mint.

### Acceptance Criteria

- `orbit.task.add` and `orbit task add` refuse an unregistered tool name in `required_tools` with `invalid_input` and a `did_you_mean` list
- A disabled-but-registered tool is accepted with a warning
- `auto-task add/update` and mint validate template `required_tools` the same way
- Tests cover all three surfaces

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: complete.

Implementation:
- Added shared runtime-boundary validation for task and auto-task required_tools. Unknown names, including provider-prefixed/non-canonical names, return invalid_input with the registry-backed did_you_mean list before persistence.
- Registered but disabled/inactive tools remain durable and produce a warnings entry on task add and auto-task add/update tool and CLI responses.
- Auto-task definition CRUD validates requirements, and auto-task mint revalidates the persisted template so registry drift cannot create an unadmittable task.
- Added boundary tests for tool-host task add, CLI task add, tool-host auto-task add/update/mint, and CLI auto-task add. Updated the existing engine admission fixture to seed legacy malformed persisted requirements directly through the record store.

Acceptance criteria:
1. orbit.task.add and orbit task add reject unregistered required_tools with invalid_input and did_you_mean: passed by tool-host and CLI regression tests.
2. Disabled-but-registered tools are accepted with warnings: passed by tool-host and CLI task/auto-task tests.
3. auto-task add/update and mint validate template requirements: passed by tool-host add/update tests and mint-time persisted-registry-drift test; CLI add/update paths route through the same validation.
4. Tests cover all three surfaces: passed; task tool/CLI and auto-task tool/CLI/mint coverage is present.

Validation:
- cargo test -p orbit-core --lib task_add_tool_ -- --nocapture: passed (13).
- cargo test -p orbit-core --lib auto_task -- --nocapture: passed (49).
- cargo test -p orbit-cli --bin orbit command::task::tests::add::task_add_execution -- --nocapture: passed (2).
- cargo test -p orbit-cli --bin orbit command::tests::auto_task::auto_task_ -- --nocapture: passed (4).
- cargo test -p orbit-core --lib application::task::tests::add -- --nocapture: passed (17).
- cargo test -p orbit-cli --bin orbit command::task::tests::add -- --nocapture: passed (9).
- cargo test -p orbit-core --lib adapter::tool_host::tests::auto_task_tools -- --nocapture: passed (6).
- cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::required_tools -- --nocapture: passed (2).
- cargo test -p orbit-core --lib: passed (1,429 passed, 2 ignored).
- cargo fmt --all -- --check: passed.
- make ci-fast: passed. The compiler-cache namespace probe was skipped because bubblewrap cannot create an unprivileged mount namespace in this environment; all other fast guardrails passed.
- make ci-lint: passed with workspace clippy and warnings denied.
- git diff --check: passed.
- git status --short: passed; only the 12 declared task-scoped files are modified.

Risks or deviations:
- The legacy admission test intentionally bypasses the new creation validation to model already-persisted malformed records; production creation and auto-task persistence remain guarded at the shared runtime boundary.
- Full make ci was not run because workspace guidance reserves it for the PR merge gate. No other checks were skipped.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12247-6aa4c5c8`
- Behind base: 0
- Ahead of base: 2