### PR TITLE
[code-review] `--workspace` resolution saves the global registry outside `with_registry_lock`, so a concurrent `workspace init` registration can be lost

### DIFF
--- a/crates/orbit-cli/src/command/workspace/list.rs
+++ b/crates/orbit-cli/src/command/workspace/list.rs
@@ -17,10 +17,13 @@ impl Execute for WorkspaceListArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
         let global_root = runtime.global_root();
         let registry_path = workspace_registry::registry_path_for(&global_root);
-        let mut registry = workspace_registry::load_registry_from(&registry_path)?;
-        if workspace_registry::validate_workspaces(&mut registry) {
-            workspace_registry::save_registry_to(&registry, &registry_path)?;
-        }
+        let registry = workspace_registry::with_registry_lock(&registry_path, || {
+            let mut registry = workspace_registry::load_registry_from(&registry_path)?;
+            if workspace_registry::validate_workspaces(&mut registry) {
+                workspace_registry::save_registry_to(&registry, &registry_path)?;
+            }
+            Ok(registry)
+        })?;
         Ok(Payload::detail(
             workspace_list_json(&registry, self.all),
             format_workspace_list(&registry, self.all),

--- a/crates/orbit-cmd/src/registry_routines.rs
+++ b/crates/orbit-cmd/src/registry_routines.rs
@@ -67,9 +67,12 @@ pub(crate) fn discover_registered_workspaces(
     workspace_filter: Option<&str>,
 ) -> Result<DiscoveredWorkspaces, OrbitError> {
     let registry_path = workspace_registry::registry_path_for(global_root);
-    let mut registry = workspace_registry::load_registry_from(&registry_path)?;
-    workspace_registry::validate_workspaces(&mut registry);
-    workspace_registry::save_registry_to(&registry, &registry_path)?;
+    let registry = workspace_registry::with_registry_lock(&registry_path, || {
+        let mut registry = workspace_registry::load_registry_from(&registry_path)?;
+        workspace_registry::validate_workspaces(&mut registry);
+        workspace_registry::save_registry_to(&registry, &registry_path)?;
+        Ok(registry)
+    })?;
 
     let mut discovered = DiscoveredWorkspaces::default();
     for (workspace, checkout) in workspace_registry::local_workspaces(&registry) {

--- a/crates/orbit-cmd/src/registry_runtime.rs
+++ b/crates/orbit-cmd/src/registry_runtime.rs
@@ -199,10 +199,13 @@ impl RegisteredRuntimeFactory {
         selector: &str,
     ) -> Result<ResolvedWorkspaceSelection, OrbitError> {
         let registry_path = workspace_registry::registry_path_for(global_root);
-        let mut registry = workspace_registry::load_registry_from(&registry_path)?;
-        if workspace_registry::validate_workspaces(&mut registry) {
-            let _ = workspace_registry::save_registry_to(&registry, &registry_path);
-        }
+        let registry = workspace_registry::with_registry_lock(&registry_path, || {
+            let mut registry = workspace_registry::load_registry_from(&registry_path)?;
+            if workspace_registry::validate_workspaces(&mut registry) {
+                let _ = workspace_registry::save_registry_to(&registry, &registry_path);
+            }
+            Ok(registry)
+        })?;
         let (workspace, checkout) = resolve_cli_workspace_binding(&registry, selector)?;
         if workspace.status != WorkspaceStatus::Active {
             return Err(inactive_cli_workspace(workspace, checkout));
@@ -340,10 +343,13 @@ impl RegisteredRuntimeFactory {
         };
         let global_root = runtime.global_root();
         let registry_path = workspace_registry::registry_path_for(&global_root);
-        let mut registry = workspace_registry::load_registry_from(&registry_path)?;
-        if workspace_registry::validate_workspaces(&mut registry) {
-            let _ = workspace_registry::save_registry_to(&registry, &registry_path);
-        }
+        let registry = workspace_registry::with_registry_lock(&registry_path, || {
+            let mut registry = workspace_registry::load_registry_from(&registry_path)?;
+            if workspace_registry::validate_workspaces(&mut registry) {
+                let _ = workspace_registry::save_registry_to(&registry, &registry_path);
+            }
+            Ok(registry)
+        })?;
         match resolve_cli_workspace_target(&registry, runtime, &selector)? {
             CliWorkspaceTarget::CurrentRuntime => Ok(None),
             CliWorkspaceTarget::Checkout {

--- a/crates/orbit-cmd/src/tests/registry_runtime.rs
+++ b/crates/orbit-cmd/src/tests/registry_runtime.rs
@@ -1,4 +1,6 @@
 use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::time::Duration;
 
 use chrono::Utc;
 use orbit_common::{NotFoundKind, OrbitError};
@@ -10,7 +12,9 @@ use orbit_types::workspace::{
 };
 use serde_json::{Value, json};
 
-use orbit_registry::workspace_registry::{registry_path_for, save_registry_to};
+use orbit_registry::workspace_registry::{
+    self, load_registry_from, registry_path_for, save_registry_to,
+};
 
 use crate::registry_runtime::{
     RegisteredRuntimeFactory, resolved_workspace_binding, select_workspace_for_cwd_and_roots,
@@ -421,6 +425,86 @@ fn registered_workspace(
     };
     let checkout = WorkspaceCheckout::owner(id.to_string(), repo, orbit_dir);
     (workspace, checkout)
+}
+
+#[test]
+fn workspace_registered_during_selector_resolution_survives_validation_save() {
+    let root = tempfile::tempdir().expect("root");
+    let global = root.path().join("global");
+    std::fs::create_dir_all(&global).expect("global root");
+
+    let mut stale_workspace = workspace("ws_stale", "local");
+    stale_workspace.name = "stale".to_string();
+    let stale_repo = root.path().join("missing");
+    let stale_checkout = WorkspaceCheckout::owner(
+        stale_workspace.id.clone(),
+        stale_repo.clone(),
+        stale_repo.join(".orbit"),
+    );
+    let registry_path = registry_path_for(&global);
+    save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![stale_workspace],
+            checkouts: vec![stale_checkout],
+            ..Default::default()
+        },
+        &registry_path,
+    )
+    .expect("initial registry");
+
+    let (started_tx, started_rx) = mpsc::channel();
+    let (finished_tx, finished_rx) = mpsc::channel();
+    let resolver_global = global.clone();
+    let (new_workspace, new_checkout) =
+        registered_workspace(root.path(), "ws_new", "new", "hm_owner");
+    let mut resolver = None;
+    workspace_registry::with_registry_lock(&registry_path, || {
+        resolver = Some(std::thread::spawn(move || {
+            started_tx.send(()).expect("announce resolution");
+            let result =
+                RegisteredRuntimeFactory::resolve_workspace_selector(&resolver_global, "ws_new");
+            finished_tx.send(()).expect("announce completion");
+            result
+        }));
+        started_rx.recv().expect("resolution started");
+        assert!(
+            finished_rx
+                .recv_timeout(Duration::from_millis(500))
+                .is_err(),
+            "selector resolution must wait for the registry lock"
+        );
+
+        let mut registry = load_registry_from(&registry_path)?;
+        registry.workspaces.push(new_workspace);
+        registry.checkouts.push(new_checkout);
+        save_registry_to(&registry, &registry_path)
+    })
+    .expect("register workspace while resolution waits");
+
+    let selected = resolver
+        .expect("selector thread started")
+        .join()
+        .expect("selector thread")
+        .expect("new workspace resolves after registration");
+    assert_eq!(selected.workspace.id, "ws_new");
+
+    let registry = load_registry_from(&registry_path).expect("final registry");
+    assert!(
+        registry
+            .workspaces
+            .iter()
+            .any(|workspace| workspace.id == "ws_new"),
+        "validation save must retain the concurrently registered workspace"
+    );
+    assert_eq!(
+        registry
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.id == "ws_stale")
+            .map(|workspace| workspace.status.clone()),
+        Some(WorkspaceStatus::Invalid),
+        "resolution must exercise and persist the validation write"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-12240](https://orbit-cli.com/tasks/ORB-12240) — [code-review] `--workspace` resolution saves the global registry outside `with_registry_lock`, so a concurrent `workspace init` registration can be lost

### Description

## Summary

ORB-12216 (commit `4a9613c01`, PR #1987) added a load → `validate_workspaces` → `save_registry_to` sequence to the two shared CLI/MCP workspace-selector seams, but did not wrap it in `workspace_registry::with_registry_lock`:

- `crates/orbit-cmd/src/registry_runtime.rs:200-204` (`RegisteredRuntimeFactory::resolve_workspace_selector`)
- `crates/orbit-cmd/src/registry_runtime.rs:341-345` (`RegisteredRuntimeFactory::bind_cli_tool_workspace`)

```rust
let mut registry = workspace_registry::load_registry_from(&registry_path)?;
if workspace_registry::validate_workspaces(&mut registry) {
    let _ = workspace_registry::save_registry_to(&registry, &registry_path);
}
```

This is precisely the read-modify-write hazard `with_registry_lock`'s own doc comment describes at `crates/orbit-registry/src/workspace_registry/io.rs:29-36`:

> `load_registry_from` and `save_registry_to` are each atomic on their own, but a caller that loads, edits, and saves is not: two such callers … interleave, and the second save silently drops the first one's edit. Wrap the whole read-modify-write in this.

`save_registry_to` writes the **whole** document (`io.rs:81-87` → `write_registry`), so the late save restores the snapshot this process loaded, dropping any workspace/checkout rows another process committed in between.

The counterparty is explicit in the codebase: `orbit workspace init` takes the lock for exactly this reason (`crates/orbit-cli/src/command/workspace/init.rs:183-186`, comment "the lock keeps a concurrent sweep or init from saving over this registration"), and the ship sweep does the same (`crates/orbit-cli/src/command/run/sweep.rs:114-119`). The two new sites are the odd ones out, and unlike `workspace list` they now run on **every** `--workspace`-carrying CLI verb and every CLI-transport tool call — the hot path on a machine running several agents at once.

## Failure scenario

1. Agent A runs `orbit workspace init` in a new checkout. It takes the registry lock, loads the registry, and is about to append workspace `ws_new` plus its checkout row.
2. Agent B concurrently runs `orbit --workspace ws_a task list`. `bind_cli_tool_workspace` loads the registry **without the lock** (pre-`ws_new` snapshot). A previously-`invalid` workspace's checkout directory now exists (or a registered checkout was just deleted), so `validate_workspaces` returns `true`.
3. A completes and saves; B then saves its stale snapshot over it.
4. `ws_new` is gone from `workspaces.json` while its `.orbit/` and its task-store partition remain. `orbit --workspace ws_new …` fails with "unknown workspace selector", and the partition needs `workspace init --force` / doctor to recover.

The same interleaving in reverse silently reverts a `workspace remove` (`crates/orbit-cli/src/command/workspace/remove.rs:22-41`, itself unlocked).

## Notes

- `workspace list` (`crates/orbit-cli/src/command/workspace/list.rs:19-22`) and `discover_registered_workspaces` (`crates/orbit-cmd/src/registry_routines.rs:94-96`) carry the same unlocked shape and predate this window; fixing them together is the cheaper change, but the two new hot-path sites are the reason to do it now.
- The conditional (`if validate_workspaces(...)`) and the ignored write error are both correct and should stay — they preserve ORB-10928's read-only-root behavior. Only the missing lock is at issue.

### Acceptance Criteria

- `RegisteredRuntimeFactory::resolve_workspace_selector` and `RegisteredRuntimeFactory::bind_cli_tool_workspace` perform their load/validate/save under `workspace_registry::with_registry_lock`, leaving the 'only write when a status changed' condition and the non-fatal treatment of a failed write intact.
- A test demonstrates that a workspace registered while a `--workspace` resolution is in flight still exists in `workspaces.json` after that resolution saves.
- Any other unlocked load/validate/save site that the fix leaves behind is either converted or explicitly justified in a comment next to it.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Wrapped both shared workspace-selector registry load/validate/conditional-save sequences in workspace_registry::with_registry_lock while preserving conditional writes and ignored save errors.
- Wrapped workspace list and registered routine discovery load/validate/save sequences in the same registry lock. The only remaining production validate_workspaces call outside a lock is orbit-web snapshot loading, which does not save the validated snapshot; ship sweep was already locked.
- Added a deterministic concurrency regression that holds the registry lock, starts selector resolution, registers a new workspace, then proves resolution's validation save preserves that registration and persists a separate stale-workspace status change.
Criteria:
1. Both RegisteredRuntimeFactory seams now lock the complete load/validate/save operation; conditional and non-fatal save behavior is unchanged.
2. The new registry_runtime test proves an in-flight --workspace resolution waits for concurrent registration and retains the new row after its validation write.
3. workspace list and routine discovery were converted; the source audit found no other unlocked production load/validate/save sequence.
Validation:
- passed: CARGO_TARGET_DIR=/tmp/orbit-jrun-20260912-0410-c9-target cargo test -p orbit-cmd workspace_registered_during_selector_resolution_survives_validation_save
- passed: CARGO_TARGET_DIR=/tmp/orbit-jrun-20260912-0410-c9-target cargo test -p orbit-cmd (159 passed, 1 ignored fixture)
- passed: CARGO_TARGET_DIR=/tmp/orbit-jrun-20260912-0410-c9-target make ci-fast (one namespace capability probe self-skipped because unprivileged namespaces are unavailable; gate exited successfully)
- passed: CARGO_TARGET_DIR=/tmp/orbit-jrun-20260912-0410-c9-target make ci-lint
- passed: CARGO_TARGET_DIR=/tmp/orbit-jrun-20260912-0410-c9-target make goldens
- passed: git diff --check
Assessment: The registry read-modify-write boundaries now match the lock contract without broadening the non-fatal read-only-root behavior. No known remaining risk or deviation.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12240-6aa4d0cf`
- Behind base: 0
- Ahead of base: 1