### PR TITLE
`orbit.agent.invoke` should surface the effective provider sandbox and warn when it is `danger-full-access`

### DIFF
--- a/crates/orbit-cli/src/command/run/agent.rs
+++ b/crates/orbit-cli/src/command/run/agent.rs
@@ -36,7 +36,8 @@ Examples:
   orbit run agent 'why does the sweep clock keep restarting?'
   orbit run agent 'explain this failure' --cwd /srv/checkout --crew qa
   orbit run agent 'long investigation' --timeout 3600 --json
-  orbit run agent 'retryable submit' --idempotency-key incident-4821"
+  orbit run agent 'retryable submit' --idempotency-key incident-4821
+  orbit run agent 'read Cargo.toml' --provider-sandbox read-only"
 )]
 pub struct RunAgentArgs {
     /// What to investigate.
@@ -61,6 +62,12 @@ pub struct RunAgentArgs {
     /// resolves that run instead of starting a second agent.
     #[arg(long)]
     pub idempotency_key: Option<String>,
+
+    /// Per-invocation provider inner-sandbox override (Codex: read-only,
+    /// workspace-write, or danger-full-access). Values the provider does not
+    /// support are refused.
+    #[arg(long)]
+    pub provider_sandbox: Option<String>,
 
     /// Output as JSON.
     #[arg(long)]
@@ -90,6 +97,7 @@ impl Execute for RunAgentArgs {
             crew: self.crew.as_deref(),
             timeout_seconds: self.timeout,
             idempotency_key: self.idempotency_key.as_deref(),
+            provider_sandbox: self.provider_sandbox.as_deref(),
             actor: None,
             session_context: &session_context,
         })?;
@@ -106,6 +114,8 @@ impl Execute for RunAgentArgs {
             "workspace_path": submission.admission.workspace_path,
             "cwd": submission.admission.cwd,
             "sandboxed": false,
+            "provider_sandbox": submission.provider_sandbox,
+            "warnings": submission.warnings,
         });
         let mut lines = Vec::new();
         if submission.deduplicated {
@@ -130,6 +140,8 @@ impl Execute for RunAgentArgs {
                 submission.admission.authorized_by,
                 submission.admission.authorizer_provenance
             ));
+            lines.push(format!("provider sandbox: {}", submission.provider_sandbox));
+            lines.extend(submission.warnings.iter().cloned());
         }
         lines.push(format!(
             "track it: orbit run show {run_id}  |  orbit run logs {run_id}  |  orbit run cancel {run_id}",

--- a/crates/orbit-cli/src/command/run/command.rs
+++ b/crates/orbit-cli/src/command/run/command.rs
@@ -26,7 +26,7 @@ Workflow entrypoints:
   orbit run ship-sweep [--dry-run] [--json]
   orbit run triage [task_id ...]
   orbit run job <job_id> [--input key=value] [--json] [--debug]
-  orbit run agent <prompt> [--cwd DIR] [--crew NAME] [--timeout SECONDS]
+  orbit run agent <prompt> [--cwd DIR] [--crew NAME] [--timeout SECONDS] [--provider-sandbox MODE]
 
 Run history:
   orbit run history [--limit 50]

--- a/crates/orbit-cli/src/command/run/show.rs
+++ b/crates/orbit-cli/src/command/run/show.rs
@@ -138,7 +138,7 @@ fn agent_invocation_lines(value: &Value) -> String {
     };
     let text = |key: &str| result.get(key).and_then(Value::as_str);
     let mut lines = format!(
-        "\n{} outcome={} envelope_completed={} timed_out={} exit_code={}",
+        "\n{} outcome={} envelope_completed={} timed_out={} exit_code={} provider_sandbox={}",
         crate::output::color::bold("Invocation:"),
         text("outcome").unwrap_or("-"),
         result
@@ -153,6 +153,7 @@ fn agent_invocation_lines(value: &Value) -> String {
             .get("exit_code")
             .and_then(Value::as_i64)
             .map_or_else(|| "-".to_string(), |code| code.to_string()),
+        text("provider_sandbox").unwrap_or("-"),
     );
     if let Some(reason) = text("failure_reason") {
         lines.push_str(&format!("\n  reason: {reason}"));

--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -188,6 +188,12 @@
         "required": false
       },
       {
+        "description": "Per-invocation inner-sandbox override for the selected crew's provider (Codex: `read-only`, `workspace-write`, or `danger-full-access`). Tightens or names the provider sandbox for this run only; values the provider does not support are refused. The submission result reports the effective mode as `provider:mode`.",
+        "name": "provider_sandbox",
+        "param_type": "string",
+        "required": false
+      },
+      {
         "description": "Preferred provenance field. Pass the canonical agent family (codex, claude, gemini, or grok); full model strings are accepted and auto-normalized.",
         "name": "model",
         "param_type": "string",

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -30,6 +30,10 @@
           "description": "What to investigate. The invoked agent reports back; it makes no Orbit task, lifecycle, commit, or pull-request change.",
           "type": "string"
         },
+        "provider_sandbox": {
+          "description": "Per-invocation inner-sandbox override for the selected crew's provider (Codex: `read-only`, `workspace-write`, or `danger-full-access`). Tightens or names the provider sandbox for this run only; values the provider does not support are refused. The submission result reports the effective mode as `provider:mode`.",
+          "type": "string"
+        },
         "timeout_seconds": {
           "description": "Wall-clock bound for the invocation. Defaults to 1800 and may not exceed 7200.",
           "type": "integer"

--- a/crates/orbit-config/src/registry.rs
+++ b/crates/orbit-config/src/registry.rs
@@ -16,7 +16,7 @@ use orbit_common::OrbitError;
 use orbit_common::observability::log_rotation::LogRotationConfig;
 use orbit_common::security::redaction::redact_home_dir;
 use orbit_types::identity::{Crew, CrewAssignment, resolve_crew};
-use orbit_types::workflow::Provider;
+use orbit_types::workflow::{CODEX_PROVIDER_SANDBOX_MODES, Provider};
 
 use crate::operation::{
     self, CompletionPreference, DeliveryCap, OperationPreset, PreparationPreference,
@@ -155,7 +155,7 @@ define_config_settings! {
     codex_sandbox: String => String {
         key: "execution.codex.sandbox", value_type: "string",
         description: "Codex sandbox mode: one of read-only, workspace-write, danger-full-access.",
-        resolve: |raw: Option<String>| resolve_choice(raw, "workspace-write", "execution.codex.sandbox", &["read-only", "workspace-write", "danger-full-access"]),
+        resolve: |raw: Option<String>| resolve_choice(raw, "workspace-write", "execution.codex.sandbox", CODEX_PROVIDER_SANDBOX_MODES),
     },
     execution_env_pass: Vec<String> => Vec<String> {
         key: "execution.env.pass", value_type: "array<string>",

--- a/crates/orbit-core/assets/activities/agent_invoke.yaml
+++ b/crates/orbit-core/assets/activities/agent_invoke.yaml
@@ -58,6 +58,8 @@ spec:
       # raise it, so the asset remains the ceiling.
       timeout_seconds:
         type: number
+      provider_sandbox:
+        type: string
       trusted_host_admission:
         type: object
   output_schema_json:

--- a/crates/orbit-core/assets/jobs/agent_invoke_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/agent_invoke_pipeline.yaml
@@ -34,4 +34,5 @@ spec:
         cwd: "{{ input.cwd }}"
         crew: "{{ input.crew }}"
         timeout_seconds: "{{ input.timeout_seconds }}"
+        provider_sandbox: "{{ input.provider_sandbox }}"
         trusted_host_admission: "{{ input.trusted_host_admission }}"

--- a/crates/orbit-core/assets/skills/orbit/references/run-debugging.md
+++ b/crates/orbit-core/assets/skills/orbit/references/run-debugging.md
@@ -146,6 +146,9 @@ tail when triaging one.
 `--json` carries the same facts under `agent_invocation`:
 
 - `outcome` is the run's own state, never the provider's exit code.
+- `provider_sandbox` is the provider's own inner sandbox at submission
+  (`codex:danger-full-access`, `claude:default`, …), distinct from Orbit's
+  executor sandbox (`sandboxed: false` on the submit result).
 - `envelope_completed: false` on an otherwise-clean exit means the agent stopped
   mid-turn: exit zero is not evidence the investigation succeeded.
 - `timed_out: true` means the wall-clock bound killed it — resubmit with a

--- a/crates/orbit-core/assets/skills/orbit/references/tool-surface.md
+++ b/crates/orbit-core/assets/skills/orbit/references/tool-surface.md
@@ -87,12 +87,25 @@ checkout or a linked worktree under `.orbit/state/worktrees/`. `crew` selects th
 (default 1800, maximum 7200), and `idempotency_key` makes a resubmission resolve
 the run the first attempt created rather than starting a second agent.
 
+`provider_sandbox` is an optional per-invocation override of the provider's own
+inner sandbox (not Orbit's executor sandbox — that is already off, reported as
+`sandboxed: false`). Pass a mode the provider accepts, such as Codex
+`read-only` or `workspace-write`, to run an exploration tighter than the crew
+default without editing config. Values the provider does not support are
+refused. The submission result and `orbit run show` report the effective mode
+as `provider:mode` (for example `codex:danger-full-access`, `claude:default`).
+When that mode is the provider's least-restrictive inner sandbox
+(`danger-full-access` for Codex), the result includes a `warnings` entry and
+Orbit logs the same at WARN: the provider may use host integrations (browser,
+computer use, …) beyond the working directory.
+
 Track it with the ordinary run surfaces — `orbit_workflow_run_show`, or
 `orbit run show|logs|cancel <RUN_ID>`. `show` carries the invocation's outcome,
 whether it terminated its response envelope, a bounded preview of the answer,
-and a durable reference to the full captured output. A provider that exits zero
-without terminating its envelope stopped mid-turn: the run records `failed`, and
-the exit code alone is never evidence the investigation succeeded.
+the effective `provider_sandbox`, and a durable reference to the full captured
+output. A provider that exits zero without terminating its envelope stopped
+mid-turn: the run records `failed`, and the exit code alone is never evidence
+the investigation succeeded.
 
 Remote sessions are additionally capped by the destination's caller policy.
 The durable admission and `trusted_host.execution_admitted` event retain the

--- a/crates/orbit-core/src/adapter/tool_host/agent_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/agent_tools.rs
@@ -23,6 +23,7 @@ pub(super) fn invoke(
     let cwd = required_string(&input, &["cwd"], "cwd")?;
     let crew = optional_string(&input, "crew")?;
     let idempotency_key = optional_string(&input, "idempotency_key")?;
+    let provider_sandbox = optional_string(&input, "provider_sandbox")?;
     let timeout_seconds = parse_timeout(&input)?;
     let actor = orbit_types::identity::normalize_optional_attribution_label(
         model.as_deref().or(agent.as_deref()),
@@ -35,6 +36,7 @@ pub(super) fn invoke(
         crew: crew.as_deref(),
         timeout_seconds,
         idempotency_key: idempotency_key.as_deref(),
+        provider_sandbox: provider_sandbox.as_deref(),
         actor: actor.as_deref(),
         session_context,
     })?;
@@ -54,6 +56,8 @@ pub(super) fn invoke(
         "workspace_path": submission.admission.workspace_path,
         "cwd": submission.admission.cwd,
         "sandboxed": false,
+        "provider_sandbox": submission.provider_sandbox,
+        "warnings": submission.warnings,
     }))
 }
 

--- a/crates/orbit-core/src/application/job/agent_invoke.rs
+++ b/crates/orbit-core/src/application/job/agent_invoke.rs
@@ -33,7 +33,12 @@ use chrono::Utc;
 use orbit_common::OrbitError;
 use orbit_types::tool::ToolSessionContext;
 use orbit_types::workflow::JobRun;
-use orbit_types::workflow::activity_job::{TRUSTED_HOST_ADMISSION_KEY, TrustedHostAdmission};
+use orbit_types::workflow::Provider;
+use orbit_types::workflow::activity_job::{
+    DEFAULT_PROVIDER_SANDBOX, TRUSTED_HOST_ADMISSION_KEY, TrustedHostAdmission,
+    admit_provider_sandbox_mode, format_provider_sandbox, is_least_restrictive_provider_sandbox,
+    least_restrictive_provider_sandbox_warning,
+};
 use serde::Serialize;
 use serde_json::{Value, json};
 
@@ -74,6 +79,10 @@ pub struct AgentInvokeRequest<'a> {
     /// Caller-supplied retry key. Two submissions carrying the same key resolve
     /// to the same run rather than starting a second subprocess.
     pub idempotency_key: Option<&'a str>,
+    /// Per-invocation inner-sandbox override (`read-only`, `workspace-write`,
+    /// `danger-full-access` for Codex). `None` uses the crew provider's
+    /// configured default. Values the provider does not support are refused.
+    pub provider_sandbox: Option<&'a str>,
     /// Attribution label for the authorizing operator.
     pub actor: Option<&'a str>,
     /// The caller's session, resolved at the admission chokepoint.
@@ -96,6 +105,12 @@ pub struct AgentInvokeSubmission {
     pub admission: TrustedHostAdmission,
     /// Effective wall-clock bound for the invocation.
     pub timeout_seconds: u64,
+    /// Effective provider inner sandbox, as `provider:mode` (for example
+    /// `codex:danger-full-access`). Distinct from Orbit's executor sandbox.
+    pub provider_sandbox: String,
+    /// Operator-facing warnings. Non-empty when `provider_sandbox` is the
+    /// provider's least-restrictive inner sandbox.
+    pub warnings: Vec<String>,
 }
 
 /// A finished (or running) invocation, rendered for an operator.
@@ -127,6 +142,9 @@ pub struct AgentInvokeResult {
     /// Durable reference to the complete captured stdout, readable with
     /// `orbit run logs <RUN_ID>` after the preview is exhausted.
     pub stdout_blob_ref: Option<String>,
+    /// Effective provider inner sandbox persisted at submission, as
+    /// `provider:mode`. Absent on runs submitted before this field existed.
+    pub provider_sandbox: Option<String>,
 }
 
 impl OrbitRuntime {
@@ -145,6 +163,8 @@ impl OrbitRuntime {
         let cwd = self.resolve_workspace_cwd("cwd", request.cwd)?;
         let crew = self.canonical_crew_name(request.crew)?;
         let timeout_seconds = resolve_timeout(request.timeout_seconds)?;
+        let provider_sandbox =
+            self.resolve_invocation_provider_sandbox(request.crew, request.provider_sandbox)?;
         let requested_actor = request
             .actor
             .map(str::trim)
@@ -181,6 +201,7 @@ impl OrbitRuntime {
             "cwd": cwd.display().to_string(),
             "crew": crew,
             "timeout_seconds": timeout_seconds,
+            "provider_sandbox": provider_sandbox.label,
             TRUSTED_HOST_ADMISSION_KEY: serde_json::to_value(&admission)
                 .map_err(|error| OrbitError::Execution(format!("encode admission: {error}")))?,
         });
@@ -194,9 +215,18 @@ impl OrbitRuntime {
             authorized_by = %admission.authorized_by,
             authorizer_provenance = %admission.authorizer_provenance,
             cwd = %admission.cwd,
+            provider_sandbox = %provider_sandbox.label,
             deduplicated,
             "admitted an operator agent invocation outside the executor sandbox"
         );
+        if let Some(warning) = provider_sandbox.warning.as_deref() {
+            tracing::warn!(
+                target: "orbit.trusted_host",
+                run_id = %invoke.run_id,
+                provider_sandbox = %provider_sandbox.label,
+                "{warning}"
+            );
+        }
 
         Ok(AgentInvokeSubmission {
             run_id: invoke.run_id,
@@ -206,8 +236,52 @@ impl OrbitRuntime {
             deduplicated,
             admission,
             timeout_seconds,
+            provider_sandbox: provider_sandbox.label,
+            warnings: provider_sandbox.warning.into_iter().collect(),
         })
     }
+
+    /// Resolve the provider inner sandbox for this invocation.
+    ///
+    /// The crew selects the provider; Codex then reads
+    /// `[execution.codex].sandbox` unless the caller overrode the mode.
+    /// Other providers have no configurable inner sandbox, so the label is
+    /// `{provider}:default` and any other override is refused.
+    fn resolve_invocation_provider_sandbox(
+        &self,
+        crew: Option<&str>,
+        override_mode: Option<&str>,
+    ) -> Result<ResolvedProviderSandbox, OrbitError> {
+        let resolved_crew = self.resolve_crew_for_task(crew, None)?;
+        let provider = Provider::parse(&resolved_crew.assignment.provider).map_err(|error| {
+            OrbitError::InvalidInput(format!(
+                "crew '{}' names an unknown provider: {error}",
+                resolved_crew.name
+            ))
+        })?;
+        let default_mode = match provider {
+            Provider::Codex => self.codex_execution_policy().sandbox().to_string(),
+            _ => DEFAULT_PROVIDER_SANDBOX.to_string(),
+        };
+        let mode = match override_mode
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            Some(requested) => admit_provider_sandbox_mode(provider, requested)
+                .map(str::to_string)
+                .map_err(OrbitError::InvalidInput)?,
+            None => default_mode,
+        };
+        let label = format_provider_sandbox(provider, &mode);
+        let warning = is_least_restrictive_provider_sandbox(provider, &mode)
+            .then(|| least_restrictive_provider_sandbox_warning(&label));
+        Ok(ResolvedProviderSandbox { label, warning })
+    }
+}
+
+struct ResolvedProviderSandbox {
+    label: String,
+    warning: Option<String>,
 }
 
 /// Read a finished or in-flight invocation for an operator [ORB-11354].
@@ -263,6 +337,12 @@ pub fn agent_invoke_result(
         preview,
         preview_truncated,
         stdout_blob_ref: field("stdout_blob_ref")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        provider_sandbox: run
+            .input
+            .as_ref()
+            .and_then(|input| input.get("provider_sandbox"))
             .and_then(Value::as_str)
             .map(ToOwned::to_owned),
     })

--- a/crates/orbit-core/src/application/job/tests/agent_invoke.rs
+++ b/crates/orbit-core/src/application/job/tests/agent_invoke.rs
@@ -23,9 +23,12 @@ use serde_json::{Value, json};
 use tempfile::{TempDir, tempdir};
 
 use crate::OrbitRuntime;
+use crate::application::job::pipeline::worker_command_override;
 use crate::application::job::{
     AGENT_INVOKE_JOB_ID, AgentInvokeRequest, MAX_AGENT_INVOKE_TIMEOUT_SECONDS, agent_invoke_result,
+    seed_default_jobs,
 };
+use crate::bootstrap::activity::seed_default_activities;
 
 /// A runtime plus the checkout an invocation is admitted against.
 fn test_runtime() -> (TempDir, OrbitRuntime, PathBuf) {
@@ -38,6 +41,61 @@ fn test_runtime() -> (TempDir, OrbitRuntime, PathBuf) {
     let runtime =
         OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build test runtime");
     (root, runtime, repo_root)
+}
+
+fn test_runtime_with_codex_crew(sandbox: &str) -> (TempDir, OrbitRuntime, PathBuf) {
+    let root = tempdir().expect("create tempdir");
+    let global_root = root.path().join("global");
+    let repo_root = root.path().join("repo");
+    let workspace_root = repo_root.join(".orbit");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    std::fs::write(
+        workspace_root.join("config.toml"),
+        format!(
+            r#"[workflow]
+default_crew = "system"
+
+[crews.system]
+provider = "codex"
+model = "gpt-5.4"
+backend = "cli"
+
+[crews.opus]
+provider = "claude"
+model = "claude-opus-4-6"
+backend = "cli"
+
+[execution.codex]
+sandbox = "{sandbox}"
+"#
+        ),
+    )
+    .expect("write crew config");
+    let runtime =
+        OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build test runtime");
+    seed_default_jobs(&runtime.paths().global_dir.join("resources/jobs"), true).expect("seed jobs");
+    seed_default_activities(
+        &runtime.paths().global_dir.join("resources/activities"),
+        true,
+    )
+    .expect("seed activities");
+    (root, runtime, repo_root)
+}
+
+struct IdleWorker;
+
+impl IdleWorker {
+    fn install() -> Self {
+        worker_command_override::set(["sh", "-c", "sleep 1"]);
+        Self
+    }
+}
+
+impl Drop for IdleWorker {
+    fn drop(&mut self) {
+        worker_command_override::clear();
+    }
 }
 
 /// A session an MCP operator surface would present.
@@ -92,6 +150,7 @@ fn request<'a>(cwd: &'a str, session: &'a ToolSessionContext) -> AgentInvokeRequ
         crew: None,
         timeout_seconds: None,
         idempotency_key: None,
+        provider_sandbox: None,
         actor: Some("human"),
         session_context: session,
     }
@@ -515,6 +574,19 @@ fn an_unrelated_run_has_no_agent_invocation_projection() {
     assert!(agent_invoke_result(&run, Some(&outputs)).is_none());
 }
 
+#[test]
+fn run_show_projects_the_persisted_provider_sandbox() {
+    let (mut run, outputs) = finished_run(JobRunState::Success, json!({}));
+    run.input = Some(json!({
+        "provider_sandbox": "codex:danger-full-access",
+    }));
+    let result = agent_invoke_result(&run, Some(&outputs)).expect("result");
+    assert_eq!(
+        result.provider_sandbox.as_deref(),
+        Some("codex:danger-full-access")
+    );
+}
+
 // ---------------------------------------------------- restart and retry
 
 /// A run that carries an admission cannot be resumed: the admission covered one
@@ -641,4 +713,117 @@ fn a_blank_idempotency_key_is_treated_as_absent() {
         matches!(error, OrbitError::NotFound { .. }),
         "expected the submission to reach catalog resolution, got {error:?}"
     );
+}
+
+// ------------------------------------------------------ provider sandbox
+
+#[test]
+fn a_danger_full_access_codex_invocation_warns_and_records_provider_sandbox() {
+    let _worker = IdleWorker::install();
+    let (_root, runtime, repo_root) = test_runtime_with_codex_crew("danger-full-access");
+    let session = operator_session();
+    let cwd = repo_root.display().to_string();
+    let submission = runtime
+        .submit_agent_invoke_run(request(&cwd, &session))
+        .expect("submit");
+
+    assert_eq!(submission.provider_sandbox, "codex:danger-full-access");
+    assert_eq!(
+        submission.warnings,
+        vec![
+            "provider runs with codex:danger-full-access; it may use host integrations \
+             (browser, computer use, …) beyond the working directory"
+                .to_string()
+        ]
+    );
+
+    let run = runtime
+        .stores()
+        .jobs()
+        .get_job_run(&submission.run_id)
+        .expect("load run")
+        .expect("run exists");
+    assert_eq!(
+        run.input
+            .as_ref()
+            .and_then(|input| input.get("provider_sandbox"))
+            .and_then(Value::as_str),
+        Some("codex:danger-full-access")
+    );
+    let result = agent_invoke_result(&run, None).expect("projection");
+    assert_eq!(
+        result.provider_sandbox.as_deref(),
+        Some("codex:danger-full-access")
+    );
+}
+
+#[test]
+fn a_codex_read_only_override_is_honoured_and_does_not_warn() {
+    let _worker = IdleWorker::install();
+    let (_root, runtime, repo_root) = test_runtime_with_codex_crew("danger-full-access");
+    let session = operator_session();
+    let cwd = repo_root.display().to_string();
+    let mut request = request(&cwd, &session);
+    request.provider_sandbox = Some("read-only");
+    let submission = runtime
+        .submit_agent_invoke_run(request)
+        .expect("submit with override");
+
+    assert_eq!(submission.provider_sandbox, "codex:read-only");
+    assert!(submission.warnings.is_empty());
+    let run = runtime
+        .stores()
+        .jobs()
+        .get_job_run(&submission.run_id)
+        .expect("load run")
+        .expect("run exists");
+    assert_eq!(
+        run.input
+            .as_ref()
+            .and_then(|input| input.get("provider_sandbox"))
+            .and_then(Value::as_str),
+        Some("codex:read-only")
+    );
+}
+
+#[test]
+fn an_unsupported_provider_sandbox_override_is_refused() {
+    let (_root, runtime, repo_root) = test_runtime_with_codex_crew("workspace-write");
+    let session = operator_session();
+    let cwd = repo_root.display().to_string();
+    let mut request = request(&cwd, &session);
+    request.provider_sandbox = Some("unrestricted");
+    match runtime
+        .submit_agent_invoke_run(request)
+        .expect_err("unsupported mode")
+    {
+        OrbitError::InvalidInput(message) => {
+            assert!(message.contains("`provider_sandbox`"), "{message}");
+            assert!(message.contains("unrestricted"), "{message}");
+            assert!(message.contains("read-only"), "{message}");
+        }
+        other => panic!("expected invalid input, got {other:?}"),
+    }
+    assert_no_run_created(&runtime);
+}
+
+#[test]
+fn a_codex_sandbox_mode_is_refused_for_claude() {
+    let (_root, runtime, repo_root) = test_runtime_with_codex_crew("workspace-write");
+    let session = operator_session();
+    let cwd = repo_root.display().to_string();
+    let mut request = request(&cwd, &session);
+    request.crew = Some("opus");
+    request.provider_sandbox = Some("read-only");
+    match runtime
+        .submit_agent_invoke_run(request)
+        .expect_err("claude has no inner-sandbox override")
+    {
+        OrbitError::InvalidInput(message) => {
+            assert!(message.contains("claude"), "{message}");
+            assert!(message.contains("default"), "{message}");
+        }
+        other => panic!("expected invalid input, got {other:?}"),
+    }
+    assert_no_run_created(&runtime);
 }

--- a/crates/orbit-engine/src/activity_job/cli_runner/argv.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/argv.rs
@@ -7,6 +7,7 @@ use orbit_exec::{
     sandbox_exec_program_for_audit,
 };
 use orbit_types::workflow::ExecutorSandboxKind;
+use serde_json::Value;
 
 use super::super::dispatcher::ResolvedSandbox;
 
@@ -74,6 +75,27 @@ pub(super) fn try_audit_argv_for_dispatch(
 /// `--sandbox` toggle, and drop grok's `--sandbox <profile>` value so the
 /// inner CLI sandbox does not double-encode the outer orbit-exec sandbox.
 /// Claude has no native sandbox flag — nothing to neutralize.
+/// Apply a trusted-host `provider_sandbox` label to the provider CLI config.
+///
+/// Codex is the only provider whose inner sandbox is a dynamic `--sandbox`
+/// flag. Other providers ignore the label here because they have no
+/// configurable inner sandbox to honour.
+pub(super) fn apply_trusted_host_provider_sandbox(
+    provider: &str,
+    input: &Value,
+    provider_config: &mut HashMap<String, String>,
+) {
+    let Some(label) = input.get("provider_sandbox").and_then(Value::as_str) else {
+        return;
+    };
+    let Some((_, mode)) = orbit_types::workflow::parse_provider_sandbox_label(label) else {
+        return;
+    };
+    if provider == "codex" {
+        provider_config.insert("sandbox".to_string(), mode.to_string());
+    }
+}
+
 pub(super) fn neutralize_inner_sandbox(
     provider: &str,
     provider_config: &mut HashMap<String, String>,

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -23,8 +23,8 @@ use super::super::workspace::{
     WorktreeBoundaryGuard, resolve_subprocess_cwd, validate_declared_worktree_pair,
 };
 use super::argv::{
-    apply_provider_runtime_arg_fixups, apply_provider_static_arg_fixups, neutralize_inner_sandbox,
-    try_audit_argv_for_dispatch,
+    apply_provider_runtime_arg_fixups, apply_provider_static_arg_fixups,
+    apply_trusted_host_provider_sandbox, neutralize_inner_sandbox, try_audit_argv_for_dispatch,
 };
 use super::envelope::{
     cli_agent_envelope_json, parse_cli_invocation_trace, parse_cli_response_result,
@@ -188,6 +188,9 @@ pub fn run_cli_backend(
     )?;
 
     let mut provider_config = host.provider_cli_config(&provider);
+    if trusted_host.is_some() {
+        apply_trusted_host_provider_sandbox(&provider, input, &mut provider_config);
+    }
 
     // Provider-specific static-arg fixups that are independent of whether the
     // outer sandbox is active. Today this only rewrites Claude's `--debug-file`

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/argv.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/argv.rs
@@ -27,8 +27,8 @@ use orbit_types::workflow::{ActivityV2Spec, ExecutorSandboxKind};
 #[cfg(target_os = "linux")]
 use super::super::argv::try_audit_argv_for_dispatch;
 use super::super::argv::{
-    apply_provider_runtime_arg_fixups, audit_argv_for_dispatch, neutralize_inner_sandbox,
-    rewrite_debug_file_value,
+    apply_provider_runtime_arg_fixups, apply_trusted_host_provider_sandbox,
+    audit_argv_for_dispatch, neutralize_inner_sandbox, rewrite_debug_file_value,
 };
 use super::test_support::sandbox_for_test;
 #[cfg(target_os = "linux")]
@@ -400,6 +400,29 @@ fn absolutize_test_rule(workspace_root: &str, rule: &str) -> String {
     } else {
         absolute
     }
+}
+
+#[test]
+fn apply_trusted_host_provider_sandbox_pins_codex_to_the_persisted_mode() {
+    let mut config = HashMap::new();
+    config.insert("sandbox".to_string(), "danger-full-access".to_string());
+    apply_trusted_host_provider_sandbox(
+        "codex",
+        &serde_json::json!({ "provider_sandbox": "codex:read-only" }),
+        &mut config,
+    );
+    assert_eq!(config.get("sandbox").map(String::as_str), Some("read-only"));
+}
+
+#[test]
+fn apply_trusted_host_provider_sandbox_ignores_non_codex_providers() {
+    let mut config = HashMap::new();
+    apply_trusted_host_provider_sandbox(
+        "claude",
+        &serde_json::json!({ "provider_sandbox": "claude:default" }),
+        &mut config,
+    );
+    assert!(config.is_empty());
 }
 
 #[test]

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/trusted_host.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/trusted_host.rs
@@ -4,6 +4,7 @@
 //! submission admits it — and these tests pin each combination, because only
 //! one of them may run an unsandboxed process.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -284,6 +285,58 @@ fn an_admission_alone_does_not_remove_an_ordinary_activitys_sandbox() {
         })
         .expect("started event");
     assert_eq!(backend, None);
+}
+
+/// A persisted Codex override reaches `--sandbox` instead of the host default.
+#[test]
+fn a_trusted_host_codex_override_reaches_the_provider_argv() {
+    let temp = tempdir().expect("tempdir");
+    let script = echoing_provider(temp.path());
+    let mut provider_config = HashMap::new();
+    provider_config.insert("sandbox".to_string(), "danger-full-access".to_string());
+    let host = TestHost {
+        command: script.clone(),
+        executor_args: Vec::new(),
+        provider_config,
+        sandbox: None,
+        task_context: None,
+        workspace_root: None,
+        orbit_registry_root: None,
+        orbit_workspace_selector: None,
+    };
+    let mut spec = test_agent_loop_spec(Duration::from_secs(10));
+    spec.trusted_host_execution = true;
+    let (audit, _sink) = writer("job-trusted-sandbox-override");
+    let mut input = admitted_input();
+    input["provider_sandbox"] = serde_json::json!("codex:read-only");
+
+    run_cli_backend(
+        &host,
+        &spec,
+        "agent_invoke",
+        "job-trusted-sandbox-override",
+        audit.clone(),
+        &input,
+        None,
+    )
+    .expect("admitted invocation runs");
+
+    let argv = audit
+        .events_snapshot()
+        .expect("events snapshot")
+        .iter()
+        .find_map(|event| match &event.kind {
+            V2AuditEventKind::CliInvocationStarted { argv_redacted, .. } => {
+                Some(argv_redacted.clone())
+            }
+            _ => None,
+        })
+        .expect("started event");
+    assert!(
+        argv.windows(2)
+            .any(|pair| pair[0] == "--sandbox" && pair[1] == "read-only"),
+        "expected --sandbox read-only in {argv:?}"
+    );
 }
 
 /// An operator may shorten the activity's bound, never extend it.

--- a/crates/orbit-tools/src/builtin/orbit/agent.rs
+++ b/crates/orbit-tools/src/builtin/orbit/agent.rs
@@ -66,6 +66,18 @@ impl Tool for OrbitAgentInvokeTool {
                 param_type: "string".to_string(),
                 required: false,
             },
+            ToolParam {
+                name: "provider_sandbox".to_string(),
+                description: "Per-invocation inner-sandbox override for the selected crew's \
+                     provider (Codex: `read-only`, `workspace-write`, or \
+                     `danger-full-access`). Tightens or names the provider sandbox for \
+                     this run only; values the provider does not support are refused. \
+                     The submission result reports the effective mode as \
+                     `provider:mode`."
+                    .to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
         ];
         parameters.extend(super::model_identity_params());
         ToolSchema {

--- a/crates/orbit-types/src/workflow/activity_job/mod.rs
+++ b/crates/orbit-types/src/workflow/activity_job/mod.rs
@@ -7,10 +7,18 @@ pub mod activity_roles;
 pub mod activity_v2;
 pub mod audit_envelope;
 pub mod job_v2;
+pub mod provider_sandbox;
 pub mod retired;
 pub mod schema_header;
 pub mod tool_allowlist;
 pub mod trusted_host;
+
+pub use provider_sandbox::{
+    CODEX_LEAST_RESTRICTIVE_SANDBOX, CODEX_PROVIDER_SANDBOX_MODES, DEFAULT_PROVIDER_SANDBOX,
+    admit_provider_sandbox_mode, format_provider_sandbox, is_least_restrictive_provider_sandbox,
+    least_restrictive_provider_sandbox, least_restrictive_provider_sandbox_warning,
+    parse_provider_sandbox_label, provider_sandbox_modes,
+};
 
 /// The single declaration of the deterministic action catalog. The generated
 /// typed actions make the core/engine ownership boundary exhaustive at compile

--- a/crates/orbit-types/src/workflow/activity_job/provider_sandbox.rs
+++ b/crates/orbit-types/src/workflow/activity_job/provider_sandbox.rs
@@ -1,0 +1,88 @@
+//! Inner sandbox modes a provider CLI accepts.
+//!
+//! Distinct from Orbit's OS executor sandbox (`ExecutorSandboxKind`). Codex is
+//! the only shipped provider whose inner sandbox is dynamically configured
+//! (`codex exec --sandbox`); other providers have no named inner-sandbox flag
+//! Orbit can tighten per invocation, so their mode is `default`.
+
+use super::Provider;
+
+/// Mode used when a provider has no configurable inner sandbox.
+pub const DEFAULT_PROVIDER_SANDBOX: &str = "default";
+
+/// Codex `--sandbox` values admitted by `[execution.codex].sandbox`.
+pub const CODEX_PROVIDER_SANDBOX_MODES: &[&str] =
+    &["read-only", "workspace-write", "danger-full-access"];
+
+/// Codex's least-restrictive inner sandbox. Enables host integrations such as
+/// Computer Use and the browser, which is why an operator invocation must
+/// name it.
+pub const CODEX_LEAST_RESTRICTIVE_SANDBOX: &str = "danger-full-access";
+
+/// Inner-sandbox modes the named provider accepts on `orbit.agent.invoke`.
+pub fn provider_sandbox_modes(provider: Provider) -> &'static [&'static str] {
+    match provider {
+        Provider::Codex => CODEX_PROVIDER_SANDBOX_MODES,
+        _ => &[DEFAULT_PROVIDER_SANDBOX],
+    }
+}
+
+/// The provider's least-restrictive inner sandbox, when it has a named one.
+///
+/// Codex is `danger-full-access`. Providers without a configurable inner
+/// sandbox return `None`: `default` is not a sandbox mode that can be
+/// tightened, so it does not trigger the host-integration warning.
+pub fn least_restrictive_provider_sandbox(provider: Provider) -> Option<&'static str> {
+    match provider {
+        Provider::Codex => Some(CODEX_LEAST_RESTRICTIVE_SANDBOX),
+        _ => None,
+    }
+}
+
+/// Format the operator-facing label stored on the run and returned by
+/// `orbit.agent.invoke` / `orbit run show`.
+pub fn format_provider_sandbox(provider: Provider, mode: &str) -> String {
+    format!("{}:{mode}", provider.as_str())
+}
+
+/// Split a persisted `provider:mode` label.
+pub fn parse_provider_sandbox_label(label: &str) -> Option<(Provider, &str)> {
+    let (provider, mode) = label.split_once(':')?;
+    let provider = Provider::parse(provider).ok()?;
+    if mode.is_empty() {
+        return None;
+    }
+    Some((provider, mode))
+}
+
+/// Admit an override mode for this provider, or name the supported values.
+pub fn admit_provider_sandbox_mode(provider: Provider, mode: &str) -> Result<&str, String> {
+    let trimmed = mode.trim();
+    if trimmed.is_empty() {
+        return Err(format!(
+            "`provider_sandbox` is empty; expected one of {}",
+            provider_sandbox_modes(provider).join(", ")
+        ));
+    }
+    if provider_sandbox_modes(provider).contains(&trimmed) {
+        return Ok(trimmed);
+    }
+    Err(format!(
+        "`provider_sandbox` `{trimmed}` is not supported for {}; expected one of {}",
+        provider.as_str(),
+        provider_sandbox_modes(provider).join(", ")
+    ))
+}
+
+/// Whether `mode` is this provider's least-restrictive inner sandbox.
+pub fn is_least_restrictive_provider_sandbox(provider: Provider, mode: &str) -> bool {
+    least_restrictive_provider_sandbox(provider) == Some(mode)
+}
+
+/// Operator-facing warning when the provider inner sandbox is least-restrictive.
+pub fn least_restrictive_provider_sandbox_warning(label: &str) -> String {
+    format!(
+        "provider runs with {label}; it may use host integrations (browser, computer use, …) \
+         beyond the working directory"
+    )
+}

--- a/crates/orbit-types/src/workflow/activity_job/tests/mod.rs
+++ b/crates/orbit-types/src/workflow/activity_job/tests/mod.rs
@@ -2,5 +2,6 @@ mod activity_roles;
 mod activity_v2;
 mod audit_envelope;
 mod job_v2;
+mod provider_sandbox;
 mod tool_allowlist;
 mod trusted_host;

--- a/crates/orbit-types/src/workflow/activity_job/tests/provider_sandbox.rs
+++ b/crates/orbit-types/src/workflow/activity_job/tests/provider_sandbox.rs
@@ -1,0 +1,89 @@
+use super::super::Provider;
+use super::super::provider_sandbox::{
+    CODEX_LEAST_RESTRICTIVE_SANDBOX, DEFAULT_PROVIDER_SANDBOX, admit_provider_sandbox_mode,
+    format_provider_sandbox, is_least_restrictive_provider_sandbox,
+    least_restrictive_provider_sandbox, least_restrictive_provider_sandbox_warning,
+    parse_provider_sandbox_label, provider_sandbox_modes,
+};
+
+#[test]
+fn codex_admits_the_three_cli_sandbox_modes_and_names_danger_full_access() {
+    assert_eq!(
+        provider_sandbox_modes(Provider::Codex),
+        &["read-only", "workspace-write", "danger-full-access"]
+    );
+    assert_eq!(
+        least_restrictive_provider_sandbox(Provider::Codex),
+        Some(CODEX_LEAST_RESTRICTIVE_SANDBOX)
+    );
+    assert!(is_least_restrictive_provider_sandbox(
+        Provider::Codex,
+        "danger-full-access"
+    ));
+    assert!(!is_least_restrictive_provider_sandbox(
+        Provider::Codex,
+        "read-only"
+    ));
+}
+
+#[test]
+fn other_providers_only_admit_default_and_have_no_named_least_restrictive_mode() {
+    for provider in [
+        Provider::Claude,
+        Provider::Gemini,
+        Provider::Grok,
+        Provider::Copilot,
+        Provider::Cursor,
+        Provider::Pi,
+        Provider::Antigravity,
+        Provider::Opencode,
+        Provider::Ollama,
+        Provider::OpenaiCompat,
+    ] {
+        assert_eq!(
+            provider_sandbox_modes(provider),
+            &[DEFAULT_PROVIDER_SANDBOX],
+            "{provider}"
+        );
+        assert_eq!(
+            least_restrictive_provider_sandbox(provider),
+            None,
+            "{provider}"
+        );
+        assert!(
+            !is_least_restrictive_provider_sandbox(provider, DEFAULT_PROVIDER_SANDBOX),
+            "{provider}"
+        );
+    }
+}
+
+#[test]
+fn admit_refuses_an_unsupported_codex_or_claude_mode() {
+    assert_eq!(
+        admit_provider_sandbox_mode(Provider::Codex, "read-only").as_deref(),
+        Ok("read-only")
+    );
+    let error = admit_provider_sandbox_mode(Provider::Codex, "unrestricted").expect_err("refuse");
+    assert!(error.contains("unrestricted"), "{error}");
+    assert!(error.contains("read-only"), "{error}");
+
+    let error = admit_provider_sandbox_mode(Provider::Claude, "read-only").expect_err("refuse");
+    assert!(error.contains("claude"), "{error}");
+    assert!(error.contains("default"), "{error}");
+    assert_eq!(
+        admit_provider_sandbox_mode(Provider::Claude, "default").as_deref(),
+        Ok("default")
+    );
+}
+
+#[test]
+fn labels_round_trip_and_the_warning_names_the_mode() {
+    let label = format_provider_sandbox(Provider::Codex, "danger-full-access");
+    assert_eq!(label, "codex:danger-full-access");
+    let (provider, mode) = parse_provider_sandbox_label(&label).expect("parse");
+    assert_eq!(provider, Provider::Codex);
+    assert_eq!(mode, "danger-full-access");
+    let warning = least_restrictive_provider_sandbox_warning(&label);
+    assert!(warning.contains("codex:danger-full-access"), "{warning}");
+    assert!(warning.contains("host integrations"), "{warning}");
+}

--- a/crates/orbit-types/src/workflow/mod.rs
+++ b/crates/orbit-types/src/workflow/mod.rs
@@ -20,7 +20,8 @@ mod tests;
 
 pub use activity_job::{
     AUDIT_ENVELOPE_SCHEMA_VERSION, ActivityV2, ActivityV2Spec, AgentLoopSpec, BackoffStrategy,
-    BranchOutcome, CoreDeterministicAction, DeterministicAction, DeterministicSpec,
+    BranchOutcome, CODEX_LEAST_RESTRICTIVE_SANDBOX, CODEX_PROVIDER_SANDBOX_MODES,
+    CoreDeterministicAction, DEFAULT_PROVIDER_SANDBOX, DeterministicAction, DeterministicSpec,
     EngineDeterministicAction, FanInSpec, FanOutBlock, JobActivityRoles, JobKind, JobV2, JobV2Step,
     JobV2StepBody, JoinMode, LoopBlock, OnDenial, ParallelBlock, PipelineRef, Provider,
     ProviderAlias, ProviderDeprecation, ProviderDiagnostic, ProviderEntryPoint, ProviderIdentity,
@@ -29,7 +30,10 @@ pub use activity_job::{
     TargetRef, TargetStep, ToolAllowlistError, V2_DENIAL_EVENT_TYPES, V2_EVENT_TYPE_FS_CALL_DENIED,
     V2_EVENT_TYPE_STEP_DENIED, V2_EVENT_TYPE_TOOL_DENIED,
     V2_INTENTIONALLY_EMPTY_TOOL_WILDCARD_ROOTS, V2_TOOL_WILDCARD_ROOTS, V2AuditEnvelope,
-    V2AuditEvent, V2AuditEventKind, check_retired_backend_value, tool_allowed,
+    V2AuditEvent, V2AuditEventKind, admit_provider_sandbox_mode, check_retired_backend_value,
+    format_provider_sandbox, is_least_restrictive_provider_sandbox,
+    least_restrictive_provider_sandbox, least_restrictive_provider_sandbox_warning,
+    parse_provider_sandbox_label, provider_sandbox_modes, tool_allowed,
     validate_activity_tool_allowlist, validate_activity_tool_allowlist_against_registered_tools,
     validate_job_retired_sessions, validate_tool_allowlist,
     validate_tool_allowlist_against_registered_tools,

--- a/plugin/skills/orbit/references/run-debugging.md
+++ b/plugin/skills/orbit/references/run-debugging.md
@@ -146,6 +146,9 @@ tail when triaging one.
 `--json` carries the same facts under `agent_invocation`:
 
 - `outcome` is the run's own state, never the provider's exit code.
+- `provider_sandbox` is the provider's own inner sandbox at submission
+  (`codex:danger-full-access`, `claude:default`, …), distinct from Orbit's
+  executor sandbox (`sandboxed: false` on the submit result).
 - `envelope_completed: false` on an otherwise-clean exit means the agent stopped
   mid-turn: exit zero is not evidence the investigation succeeded.
 - `timed_out: true` means the wall-clock bound killed it — resubmit with a

--- a/plugin/skills/orbit/references/tool-surface.md
+++ b/plugin/skills/orbit/references/tool-surface.md
@@ -87,12 +87,25 @@ checkout or a linked worktree under `.orbit/state/worktrees/`. `crew` selects th
 (default 1800, maximum 7200), and `idempotency_key` makes a resubmission resolve
 the run the first attempt created rather than starting a second agent.
 
+`provider_sandbox` is an optional per-invocation override of the provider's own
+inner sandbox (not Orbit's executor sandbox — that is already off, reported as
+`sandboxed: false`). Pass a mode the provider accepts, such as Codex
+`read-only` or `workspace-write`, to run an exploration tighter than the crew
+default without editing config. Values the provider does not support are
+refused. The submission result and `orbit run show` report the effective mode
+as `provider:mode` (for example `codex:danger-full-access`, `claude:default`).
+When that mode is the provider's least-restrictive inner sandbox
+(`danger-full-access` for Codex), the result includes a `warnings` entry and
+Orbit logs the same at WARN: the provider may use host integrations (browser,
+computer use, …) beyond the working directory.
+
 Track it with the ordinary run surfaces — `orbit_workflow_run_show`, or
 `orbit run show|logs|cancel <RUN_ID>`. `show` carries the invocation's outcome,
 whether it terminated its response envelope, a bounded preview of the answer,
-and a durable reference to the full captured output. A provider that exits zero
-without terminating its envelope stopped mid-turn: the run records `failed`, and
-the exit code alone is never evidence the investigation succeeded.
+the effective `provider_sandbox`, and a durable reference to the full captured
+output. A provider that exits zero without terminating its envelope stopped
+mid-turn: the run records `failed`, and the exit code alone is never evidence
+the investigation succeeded.
 
 Remote sessions are additionally capped by the destination's caller policy.
 The durable admission and `trusted_host.execution_admitted` event retain the


### PR DESCRIPTION
## Task

[ORB-12249](https://orbit-cli.com/tasks/ORB-12249) — `orbit.agent.invoke` should surface the effective provider sandbox and warn when it is `danger-full-access`

### Description

On the Mac mini the default crew is `system` → provider `codex`, and `execution.codex.sandbox = "danger-full-access"` (global config). During the 0.21.0 QA sweep a single `orbit_agent_invoke` with a read-only prompt (`jrun-20260912-0303-t2`, "read Cargo.toml and reply with the crate name") launched `codex exec --json` unsandboxed on the host and macOS immediately raised a **"Codex Computer Use" permission prompt** — the operator noticed it and asked why Orbit was requesting computer use. The run itself was fine (10 s, envelope completed), but nothing in the tool's result or description tells the operator that the provider will run with its own desktop integrations enabled.

The result envelope already carries `sandboxed: false`. That describes Orbit's executor sandbox, not the provider's own sandbox mode, which is the thing that matters here.

## What to change

1. In the `agent.invoke` submission result and in `orbit run show` for `agent_invoke_pipeline` runs, add `provider_sandbox` (e.g. `codex:danger-full-access`, `claude:default`, …) resolved from the crew's provider config at submission time.
2. When the resolved provider sandbox is the provider's least-restrictive mode (`danger-full-access` for codex; the equivalents for other providers, as the executor definitions know them), add a `warnings` entry to the tool result: "provider runs with <mode>; it may use host integrations (browser, computer use, …) beyond the working directory". Log the same at WARN under `orbit.trusted_host`, next to the existing "admitted an operator agent invocation outside the executor sandbox" line.
3. Accept an optional `provider_sandbox` override on `agent.invoke` (e.g. `read-only`, `workspace-write`) that is passed to the provider for this invocation only, so an exploration prompt can be run tighter than the crew default without editing config. Refuse values the provider does not support.
4. Document in `references/tool-surface.md` §Host agent invocation.

### Acceptance Criteria

- `orbit.agent.invoke` result and `orbit run show` for the run include `provider_sandbox`
- A `warnings` entry and a WARN log line are emitted when the provider sandbox is its least-restrictive mode
- `provider_sandbox` override on `agent.invoke` is honoured for codex and refused for unsupported values
- tool-surface.md documents the field and the override

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Catalogued provider inner-sandbox modes in orbit-types (`codex`: read-only / workspace-write / danger-full-access; others: `default`).
- `orbit.agent.invoke` / `orbit run agent` resolve `provider_sandbox` as `provider:mode` at submission, persist it on run input, return it on the tool result, and project it from `orbit run show` / `agent_invocation`.
- Least-restrictive Codex (`danger-full-access`) adds a `warnings` entry and a WARN log on `orbit.trusted_host` next to the existing unsandboxed-admission line.
- Optional `provider_sandbox` override is honoured for Codex (`codex exec --sandbox`) and refused for unsupported values (including Codex modes on Claude).
- Documented in tool-surface.md §Host agent invocation; MCP/tool goldens regenerated.

Assessment: scoped to the invocation result and trusted-host spawn path; `sandboxed: false` remains Orbit's executor sandbox.

Criteria:
1. `provider_sandbox` on invoke result and run show — passed. Submission JSON includes the field; run input persists it; `agent_invoke_result` / `orbit run show` project it.
2. Warnings + WARN log for least-restrictive mode — passed. Codex `danger-full-access` emits the specified warning text in `warnings` and logs it at WARN target `orbit.trusted_host`.
3. Override honoured for Codex, refused otherwise — passed. `read-only` is persisted and applied to trusted-host Codex argv; unsupported values and Claude `read-only` are InvalidInput before a run is created.
4. tool-surface.md documents field and override — passed.

Validation:
- `cargo test -p orbit-types --lib workflow::activity_job::tests::provider_sandbox` — passed (4)
- `cargo test -p orbit-core --lib application::job::tests::agent_invoke` — passed (27)
- `cargo test -p orbit-engine --lib activity_job::cli_runner::tests::argv::apply_trusted_host` — passed (2)
- `cargo test -p orbit-engine --lib activity_job::cli_runner::tests::trusted_host::a_trusted_host_codex_override` — passed (1)
- `make goldens UPDATE=1` — passed (schema snapshots updated)
- `make ci-fast` — passed
- `make ci-lint` — passed
- `git diff --check` — passed

Remaining risks:
- Providers without a configurable inner sandbox report `{provider}:default` and do not warn; Claude/Grok `bypassPermissions` in executor YAML is unchanged.
- Deduplicated submissions report the current request's resolved sandbox the same way timeout already did, not a re-read of the original run input.
- Live `orbit.agent.invoke` against a danger-full-access Codex host was not exercised (unit/spawn coverage only).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12249-6aa4d0d1`
- Behind base: 0
- Ahead of base: 1