### PR TITLE
`config show`/`config get --scope workspace` report a workspace `config.toml` that does not exist; `workspace show` JSON has `checkout.owner_machine_id: null`

### DIFF
--- a/crates/orbit-cli/src/command/config/get.rs
+++ b/crates/orbit-cli/src/command/config/get.rs
@@ -38,14 +38,29 @@ impl Execute for ConfigGetArgs {
         }
 
         let store = open_store_for_scope(runtime, self.scope)?;
-        let value = store.effective_value(&self.key)?;
+        admit_config_key(&self.key)?;
+        let file_exists = store.exists_on_disk();
+        let (value, exists) = if file_exists {
+            match store.explicit_value(&self.key)? {
+                Some(value) => (value, true),
+                None => (serde_json::Value::Null, false),
+            }
+        } else {
+            (serde_json::Value::Null, false)
+        };
+        let path = if file_exists {
+            serde_json::Value::String(store.path().to_string_lossy().into_owned())
+        } else {
+            serde_json::Value::Null
+        };
         let text = format_value_for_display(&value);
         Ok(Payload::detail(
             json!({
                 "key": self.key,
                 "scope": store.scope().label(),
-                "path": store.path().to_string_lossy(),
+                "path": path,
                 "value": value,
+                "exists": exists,
             }),
             text,
         )

--- a/crates/orbit-cli/src/command/config/show.rs
+++ b/crates/orbit-cli/src/command/config/show.rs
@@ -56,7 +56,9 @@ pub(super) fn effective_json(runtime: &OrbitRuntime, values: &[EffectiveConfigVa
     }
     let global_path = global_config_path(runtime);
     let workspace_path = runtime.shared_root().join("config.toml");
-    let config_path = if workspace_path.exists() && runtime.shared_root() != runtime.global_root() {
+    let global_exists = global_path.exists();
+    let workspace_exists = workspace_path.exists();
+    let config_path = if workspace_exists && runtime.shared_root() != runtime.global_root() {
         &workspace_path
     } else {
         &global_path
@@ -66,7 +68,9 @@ pub(super) fn effective_json(runtime: &OrbitRuntime, values: &[EffectiveConfigVa
         "source": {
             "scope": "effective",
             "global_path": global_path.to_string_lossy(),
+            "global_exists": global_exists,
             "workspace_path": workspace_path.to_string_lossy(),
+            "workspace_exists": workspace_exists,
         },
         "shadowed_global_path": JsonValue::Null,
         "settings": settings,
@@ -84,21 +88,29 @@ pub(super) fn effective_text(runtime: &OrbitRuntime, values: &[EffectiveConfigVa
     use std::fmt::Write as _;
     let mut out = String::new();
     let _ = writeln!(out, "source: effective layered configuration");
+    let global_path = global_config_path(runtime);
+    let workspace_path = runtime.shared_root().join("config.toml");
+    let global_status = if global_path.exists() {
+        ""
+    } else {
+        " (absent)"
+    };
+    let workspace_status = if workspace_path.exists() {
+        ""
+    } else {
+        " (absent)"
+    };
     let _ = writeln!(
         out,
-        "  global:    {}",
-        redact_home_dir(&global_config_path(runtime).display().to_string())
+        "  global:    {}{}",
+        redact_home_dir(&global_path.display().to_string()),
+        global_status
     );
     let _ = writeln!(
         out,
-        "  workspace: {}",
-        redact_home_dir(
-            &runtime
-                .shared_root()
-                .join("config.toml")
-                .display()
-                .to_string()
-        )
+        "  workspace: {}{}",
+        redact_home_dir(&workspace_path.display().to_string()),
+        workspace_status
     );
     let _ = writeln!(out);
 
@@ -173,6 +185,7 @@ pub(super) fn scoped_json(
         "source": {
             "scope": store.scope().label(),
             "path": store.path().to_string_lossy(),
+            "exists": store.path().exists(),
         },
         "shadowed_global_path": JsonValue::Null,
         "settings": settings_obj,
@@ -193,11 +206,17 @@ pub(super) fn scoped_text(
 ) -> String {
     use std::fmt::Write as _;
     let mut out = String::new();
+    let store_status = if store.path().exists() {
+        ""
+    } else {
+        " (absent)"
+    };
     let _ = writeln!(
         out,
-        "source: {} ({})",
+        "source: {} ({}){}",
         store.scope().label(),
-        redact_home_dir(&store.path().display().to_string())
+        redact_home_dir(&store.path().display().to_string()),
+        store_status
     );
     let _ = writeln!(out);
 
@@ -248,6 +267,7 @@ pub(super) fn scoped_text(
 
 fn render_value(value: &JsonValue) -> String {
     match value {
+        JsonValue::Null => "[unset]".to_string(),
         JsonValue::String(s) => format!("\"{s}\""),
         other => other.to_string(),
     }

--- a/crates/orbit-cli/src/command/config/tests/get.rs
+++ b/crates/orbit-cli/src/command/config/tests/get.rs
@@ -155,3 +155,72 @@ fn get_without_json_flag_still_returns_a_payload() {
     assert_eq!(document["scope"], "effective");
     assert!(document.get("value").is_some(), "{document}");
 }
+
+#[test]
+fn get_scoped_workspace_without_config_file_returns_explicit_absent() {
+    let (_root, runtime, global_root, _workspace_root) = test_runtime();
+    fs::write(
+        global_root.join("config.toml"),
+        "[scoring]\nenabled = true\n\n[workflow]\nbase_branch = \"custom-global\"\n",
+    )
+    .expect("write global config");
+
+    let mut args = get_args("scoring.enabled", true);
+    args.scope = ConfigScopeArg::Workspace;
+    let output = args.execute(&runtime).expect("get workspace scoring");
+    let document = json_value(output);
+
+    assert_eq!(document["key"], "scoring.enabled");
+    assert_eq!(document["scope"], "workspace");
+    assert_eq!(document["value"], serde_json::Value::Null);
+    assert_eq!(document["exists"], false);
+    assert!(
+        document["path"].is_null(),
+        "path must be null when layer file is absent: {document}"
+    );
+
+    let mut text_args = get_args("scoring.enabled", false);
+    text_args.scope = ConfigScopeArg::Workspace;
+    let text_output = text_args.execute(&runtime).expect("get workspace text");
+    let CommandOutput::Payload(payload) = text_output else {
+        panic!("expected payload");
+    };
+    let (_, view) = payload.into_view();
+    let crate::output::payload::View::Blocks(blocks) = view else {
+        panic!("expected blocks");
+    };
+    let crate::output::payload::Block::Text(text) = &blocks[0] else {
+        panic!("expected text block");
+    };
+    assert_eq!(text, "null");
+}
+
+#[test]
+fn get_scoped_workspace_with_file_distinguishes_set_and_unset_keys() {
+    let (_root, runtime, global_root, workspace_root) = test_runtime();
+    fs::write(
+        global_root.join("config.toml"),
+        "[scoring]\nenabled = true\n\n[workflow]\nbase_branch = \"global-main\"\n",
+    )
+    .expect("write global config");
+    let ws_config = workspace_root.join("config.toml");
+    fs::write(&ws_config, "[scoring]\nenabled = false\n").expect("write workspace config");
+
+    let mut set_args = get_args("scoring.enabled", true);
+    set_args.scope = ConfigScopeArg::Workspace;
+    let set_doc = json_value(set_args.execute(&runtime).expect("get set key"));
+    assert_eq!(set_doc["key"], "scoring.enabled");
+    assert_eq!(set_doc["scope"], "workspace");
+    assert_eq!(set_doc["value"], false);
+    assert_eq!(set_doc["exists"], true);
+    assert_eq!(set_doc["path"], ws_config.to_string_lossy().as_ref());
+
+    let mut unset_args = get_args("workflow.base_branch", true);
+    unset_args.scope = ConfigScopeArg::Workspace;
+    let unset_doc = json_value(unset_args.execute(&runtime).expect("get unset key"));
+    assert_eq!(unset_doc["key"], "workflow.base_branch");
+    assert_eq!(unset_doc["scope"], "workspace");
+    assert_eq!(unset_doc["value"], serde_json::Value::Null);
+    assert_eq!(unset_doc["exists"], false);
+    assert_eq!(unset_doc["path"], ws_config.to_string_lossy().as_ref());
+}

--- a/crates/orbit-cli/src/command/config/tests/show.rs
+++ b/crates/orbit-cli/src/command/config/tests/show.rs
@@ -126,3 +126,63 @@ fn config_show_omits_the_retired_workspace_task_projection() {
         "scoped text must not advertise the removed task store: {scoped_text}"
     );
 }
+
+#[test]
+fn config_show_marks_absent_workspace_layer_and_lists_every_settable_key() {
+    let (_root, runtime, global_root, workspace_root) = test_runtime();
+    fs::write(
+        global_root.join("config.toml"),
+        "[workflow]\nbase_branch = \"integration\"\n",
+    )
+    .expect("write global config");
+
+    let effective = load_effective_config(&ConfigRoots::new(&global_root, &workspace_root))
+        .expect("load effective");
+    let json = effective_json(&runtime, effective.values());
+    let text = effective_text(&runtime, effective.values());
+
+    // 1. Marks absent workspace layer
+    assert_eq!(json["source"]["workspace_exists"], false);
+    assert_eq!(json["source"]["global_exists"], true);
+    assert!(text.contains("workspace:"));
+    assert!(
+        text.contains("(absent)"),
+        "text must mark absent layer: {text}"
+    );
+
+    // 2. Lists every settable key from CONFIG_KEY_REGISTRY
+    for descriptor in orbit_config::CONFIG_KEY_REGISTRY {
+        assert!(
+            json["settings"].get(descriptor.key).is_some(),
+            "settings must contain {}",
+            descriptor.key
+        );
+        assert!(
+            text.contains(descriptor.key),
+            "text must list {}",
+            descriptor.key
+        );
+    }
+
+    // 3. Unset keys render as [unset]
+    assert!(
+        text.contains("tasks.id_start"),
+        "tasks.id_start must be present: {text}"
+    );
+    assert!(
+        text.contains("[unset]"),
+        "unset keys must display [unset]: {text}"
+    );
+
+    // 4. Scoped show for workspace also marks absent
+    let scoped_store =
+        open_store_for_scope(&runtime, ConfigScopeArg::Workspace).expect("open workspace store");
+    let scoped_snapshot = scoped_store.snapshot().expect("snapshot");
+    let scoped_settings = scoped_snapshot.all_values();
+    let s_json = scoped_json(&runtime, &scoped_store, &scoped_snapshot, &scoped_settings);
+    let s_text = scoped_text(&runtime, &scoped_store, &scoped_snapshot, &scoped_settings);
+
+    assert_eq!(s_json["source"]["exists"], false);
+    assert!(s_text.contains("(absent)"));
+    assert!(s_text.contains("[unset]"));
+}

--- a/crates/orbit-cli/src/command/workspace/show.rs
+++ b/crates/orbit-cli/src/command/workspace/show.rs
@@ -93,7 +93,10 @@ pub(super) fn workspace_show_json(workspace: &Workspace, checkout: &WorkspaceChe
             "repo_root": checkout.repo_root.to_string_lossy(),
             "orbit_dir": checkout.orbit_dir.to_string_lossy(),
             "role": checkout.role.map(|role| role.to_string()),
-            "owner_machine_id": checkout.owner_machine_id,
+            "owner_machine_id": checkout
+                .owner_machine_id
+                .as_ref()
+                .or(workspace.owner_machine_id.as_ref()),
         },
     })
 }

--- a/crates/orbit-cli/src/command/workspace/tests/mod.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/mod.rs
@@ -3,5 +3,6 @@ mod init_report;
 mod publication;
 mod remove;
 mod shared_root;
+mod show;
 mod source_remote;
 mod teardown;

--- a/crates/orbit-cli/src/command/workspace/tests/show.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/show.rs
@@ -1,0 +1,75 @@
+use std::path::PathBuf;
+
+use chrono::Utc;
+use orbit_types::workspace::{
+    Workspace, WorkspaceCheckout, WorkspaceCheckoutRole, WorkspaceStatus,
+};
+
+use super::super::show::{format_workspace_show, workspace_show_json};
+
+#[test]
+fn workspace_show_json_populates_owner_machine_id_for_owned_workspace() {
+    let now = Utc::now();
+    let workspace = Workspace {
+        id: "ws_nebula".to_string(),
+        name: "nebula".to_string(),
+        owner_machine_id: Some("hm_ba054a1a8fbfb914".to_string()),
+        git_remote: None,
+        ship_mode: Some("pr".to_string()),
+        base_branch: "main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: now,
+        updated_at: now,
+    };
+    let checkout = WorkspaceCheckout::owner(
+        "ws_nebula".to_string(),
+        PathBuf::from("/home/user/nebula"),
+        PathBuf::from("/home/user/nebula/.orbit"),
+    );
+
+    let json = workspace_show_json(&workspace, &checkout);
+    assert_eq!(json["workspace"]["owner_machine_id"], "hm_ba054a1a8fbfb914");
+    assert_eq!(json["checkout"]["owner_machine_id"], "hm_ba054a1a8fbfb914");
+    assert_ne!(
+        json["checkout"]["owner_machine_id"],
+        serde_json::Value::Null
+    );
+
+    let text = format_workspace_show(&workspace, &checkout);
+    assert!(text.contains("owner:       hm_ba054a1a8fbfb914"));
+    assert!(text.contains("role:        owner"));
+    assert!(!text.contains("owner_mirror:"));
+}
+
+#[test]
+fn workspace_show_json_preserves_replica_owner_machine_id() {
+    let now = Utc::now();
+    let workspace = Workspace {
+        id: "ws_replica".to_string(),
+        name: "replica".to_string(),
+        owner_machine_id: Some("hm_primary_owner".to_string()),
+        git_remote: None,
+        ship_mode: Some("pr".to_string()),
+        base_branch: "main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: now,
+        updated_at: now,
+    };
+    let checkout = WorkspaceCheckout {
+        workspace_id: "ws_replica".to_string(),
+        repo_root: PathBuf::from("/home/user/replica"),
+        orbit_dir: PathBuf::from("/home/user/replica/.orbit"),
+        role: Some(WorkspaceCheckoutRole::Replica),
+        owner_machine_id: Some("hm_replica_mirror".to_string()),
+        path_overrides: Vec::new(),
+    };
+
+    let json = workspace_show_json(&workspace, &checkout);
+    assert_eq!(json["workspace"]["owner_machine_id"], "hm_primary_owner");
+    assert_eq!(json["checkout"]["owner_machine_id"], "hm_replica_mirror");
+
+    let text = format_workspace_show(&workspace, &checkout);
+    assert!(text.contains("owner:       hm_primary_owner"));
+    assert!(text.contains("role:        replica"));
+    assert!(text.contains("owner_mirror: hm_replica_mirror"));
+}

--- a/crates/orbit-config/src/store.rs
+++ b/crates/orbit-config/src/store.rs
@@ -128,6 +128,36 @@ impl ConfigStore {
         &self.path
     }
 
+    /// Whether the file backing this store exists on disk.
+    pub fn exists_on_disk(&self) -> bool {
+        self.path.exists()
+    }
+
+    /// Check if `key` is explicitly defined in this store's TOML document.
+    pub fn is_key_set(&self, key: &str) -> bool {
+        let mut item: &toml_edit::Item = self.doc.as_item();
+        for segment in key.split('.') {
+            let Some(table) = item.as_table_like() else {
+                return false;
+            };
+            let Some(next) = table.get(segment) else {
+                return false;
+            };
+            item = next;
+        }
+        !matches!(item, toml_edit::Item::None)
+    }
+
+    /// Look up the value of `key` if it was explicitly defined in this document,
+    /// returning `None` if the key is not set.
+    pub fn explicit_value(&self, key: &str) -> Result<Option<JsonValue>, OrbitError> {
+        registry::admit_config_key(key)?;
+        if !self.is_key_set(key) {
+            return Ok(None);
+        }
+        self.effective_value(key).map(Some)
+    }
+
     /// The fully resolved (defaulted) view of this document, as if it were
     /// loaded as the effective `config.toml`. Used by both `orbit config
     /// show` and `orbit config get` so they report identical values for the

--- a/crates/orbit-config/src/tests/store.rs
+++ b/crates/orbit-config/src/tests/store.rs
@@ -645,3 +645,59 @@ fn open_for_workspace_set_fresh_starts_empty() {
         .expect("get default");
     assert_eq!(value, serde_json::json!("main"));
 }
+
+#[test]
+fn exists_on_disk_and_explicit_value_for_missing_and_present_keys() {
+    let dir = tempdir().expect("tempdir");
+    let missing_path = config_path(dir.path());
+    let store = ConfigStore::open(ConfigScope::Workspace, &missing_path).expect("open store");
+
+    assert!(!store.exists_on_disk());
+    assert!(!store.is_key_set("scoring.enabled"));
+    assert_eq!(
+        store
+            .explicit_value("scoring.enabled")
+            .expect("query unset"),
+        None
+    );
+
+    let present_dir = tempdir().expect("present tempdir");
+    let present_path = config_path(present_dir.path());
+    fs::write(
+        &present_path,
+        "[scoring]\nenabled = false\n\n[crews.sol]\nmodel = \"gpt-5.6-sol\"\n",
+    )
+    .expect("write config");
+
+    let present_store =
+        ConfigStore::open(ConfigScope::Workspace, &present_path).expect("open present store");
+    assert!(present_store.exists_on_disk());
+    assert!(present_store.is_key_set("scoring.enabled"));
+    assert_eq!(
+        present_store
+            .explicit_value("scoring.enabled")
+            .expect("query set"),
+        Some(serde_json::json!(false))
+    );
+    assert!(!present_store.is_key_set("workflow.base_branch"));
+    assert_eq!(
+        present_store
+            .explicit_value("workflow.base_branch")
+            .expect("query unset in file"),
+        None
+    );
+    assert!(present_store.is_key_set("crews.sol.model"));
+    assert_eq!(
+        present_store
+            .explicit_value("crews.sol.model")
+            .expect("query crew model"),
+        Some(serde_json::json!("gpt-5.6-sol"))
+    );
+    assert!(!present_store.is_key_set("crews.sol.effort"));
+    assert_eq!(
+        present_store
+            .explicit_value("crews.sol.effort")
+            .expect("query unset crew effort"),
+        None
+    );
+}


### PR DESCRIPTION
## Task

[ORB-12258](https://orbit-cli.com/tasks/ORB-12258) — `config show`/`config get --scope workspace` report a workspace `config.toml` that does not exist; `workspace show` JSON has `checkout.owner_machine_id: null`

### Description

0.21.0, ws_nebula (which has `.orbit/config.yaml` with the workspace id but **no** `.orbit/config.toml`):

    orbit config show
    → header lists "workspace: ~/…/nebula/.orbit/config.toml" as a layered source (file absent)
    orbit config get --scope workspace --json scoring.enabled
    → {"scope":"workspace","path":"…/nebula/.orbit/config.toml","value":true}   ← value comes from global; file absent
    orbit config set scoring.enabled true
    → refuses: "no workspace config exists yet at …/.orbit/config.toml … --seed-from-global or --fresh"

So `get --scope workspace` claims a value and a path from a file that `set` says does not exist. Expected: `--scope workspace` returns `value: null` (unset) and `path: null` or `exists: false`; `config show` marks the workspace layer as "(absent)". Also `config keys` lists `routines.role`, `tasks.id_start`, `pr.task_url_template` etc. that `config show` never prints when unset — fine, but `show` should print every settable key with `[unset]` for parity with `keys`.

Separately, `orbit workspace show --format json` for the same workspace returns `checkout.owner_machine_id: null` while `workspace.owner_machine_id` and `orbit workspace list` carry `hm_ba054a1a8fbfb914`. Either populate it from the registry or drop the field from the checkout block.

## What to change

1. `config get --scope workspace|global` returns `value: null, exists: false` when the layer file is absent or the key is not set in that layer; `config show` labels absent layers.
2. `config show` prints every key from `config keys`, with `[unset]`/built-in defaults where applicable, so the two commands agree.
3. `workspace show` JSON: `checkout.owner_machine_id` populated or removed; the table view says the same as the JSON.
4. Tests for a workspace without a config.toml.

### Acceptance Criteria

- `config get --scope workspace` on a workspace with no config.toml returns an explicit unset/absent result, never a value copied from another layer
- `config show` marks the workspace layer absent and lists every settable key
- `workspace show --format json` no longer reports `checkout.owner_machine_id: null` for an owned workspace
- Tests cover the no-workspace-config case

## Execution Summary

<details>
<summary>Click to expand</summary>

### Criteria Mapping
- `config get --scope workspace` on a workspace with no config.toml returns an explicit unset/absent result, never a value copied from another layer: Passed. Scoped `config get` now inspects layer presence and key definition via `ConfigStore::explicit_value`, returning `value: null, exists: false, path: null` when absent/unset.
- `config show` marks the workspace layer absent and lists every settable key: Passed. Both text and JSON outputs label absent layer paths with `(absent)` and `exists: false`. Unset settings are rendered as `[unset]` via `render_value`, ensuring parity with `config keys`.
- `workspace show --format json` no longer reports `checkout.owner_machine_id: null` for an owned workspace: Passed. `workspace_show_json` falls back to `workspace.owner_machine_id` when `checkout.owner_machine_id` is None.
- Tests cover the no-workspace-config case: Passed. Comprehensive unit tests added in `crates/orbit-cli/src/command/config/tests/get.rs`, `crates/orbit-cli/src/command/config/tests/show.rs`, `crates/orbit-cli/src/command/workspace/tests/show.rs`, and `crates/orbit-config/src/tests/store.rs`.

### Validation Commands
- `cargo test -p orbit-config`: passed
- `cargo test -p orbit-cli -- command::config`: passed
- `cargo test -p orbit-cli -- command::workspace::tests::show`: passed
- `cargo test -p orbit-cli --test worktree_resolution`: passed
- `cargo test -p orbit-cli --test workspace_selector`: passed
- `make ci-fast`: passed
- `make goldens`: passed
- `make ci-lint`: passed
- `git diff --check`: passed

### Risks or Deviations
None.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12258-6aa4d3fc`
- Behind base: 0
- Ahead of base: 1