### PR TITLE
Run records are inconsistent: worker-spawned runs persist no steps, routine fires are audited as `cli`, state is spelled `succeeded` vs `success`

### DIFF
--- a/crates/orbit-automation/src/routines/sweep.rs
+++ b/crates/orbit-automation/src/routines/sweep.rs
@@ -39,12 +39,14 @@ pub trait RoutineDispatch {
     }
 
     /// Submit `job_name` in the source workspace rooted at `source_orbit_dir`
-    /// under `actor`, returning the dispatched run id.
+    /// under `actor`, returning the dispatched run id. `slot` is the RFC 3339
+    /// scheduled slot consumed by this fire [ORB-12255].
     fn submit(
         &self,
         source_orbit_dir: &Path,
         job_name: &str,
         actor: &str,
+        slot: &str,
     ) -> Result<String, OrbitError>;
 
     /// Current run state for a dispatched fire, when the run is queryable.
@@ -377,6 +379,7 @@ fn fire(
         &routine.source_orbit_dir,
         definition.target.job_name(),
         &actor,
+        slot,
     ) {
         Ok(run_id) => {
             store.routine_mark_fire_dispatched(name, slot, attempt, &run_id)?;

--- a/crates/orbit-automation/src/routines/tests/sweep.rs
+++ b/crates/orbit-automation/src/routines/tests/sweep.rs
@@ -108,7 +108,13 @@ impl FakeDispatch {
 }
 
 impl RoutineDispatch for FakeDispatch {
-    fn submit(&self, dir: &Path, job: &str, _actor: &str) -> Result<String, OrbitError> {
+    fn submit(
+        &self,
+        dir: &Path,
+        job: &str,
+        _actor: &str,
+        _slot: &str,
+    ) -> Result<String, OrbitError> {
         if self.fail_submit.get() {
             return Err(OrbitError::Execution("dispatch boom".to_string()));
         }

--- a/crates/orbit-cli/src/command/run/format.rs
+++ b/crates/orbit-cli/src/command/run/format.rs
@@ -1,4 +1,6 @@
-use orbit_types::workflow::{JobRunState, PipelineState, run_id_role};
+use orbit_types::workflow::{
+    JobRunState, JobRunTrigger, JobRunTriggerKind, PipelineState, run_id_role,
+};
 
 /// Which side of a parent/child relationship a run id declares.
 ///
@@ -8,6 +10,22 @@ use orbit_types::workflow::{JobRunState, PipelineState, run_id_role};
 /// role its suffix never encoded.
 pub(crate) fn format_run_role(run_id: &str) -> String {
     run_id_role(run_id).map_or_else(|| "unmarked".to_string(), |role| role.to_string())
+}
+
+/// ROLE column for `run history`: a routine-fired run names the routine
+/// instead of the id marker (`top-level` / `unmarked`) [ORB-12255].
+pub(crate) fn format_history_role(run_id: &str, trigger: Option<&JobRunTrigger>) -> String {
+    if let Some(trigger) = trigger
+        && trigger.kind == JobRunTriggerKind::Routine
+    {
+        return trigger
+            .routine
+            .as_deref()
+            .filter(|name| !name.is_empty())
+            .unwrap_or("routine")
+            .to_string();
+    }
+    format_run_role(run_id)
 }
 
 pub(crate) fn summarize_error_message(raw: Option<&str>) -> String {

--- a/crates/orbit-cli/src/command/run/history.rs
+++ b/crates/orbit-cli/src/command/run/history.rs
@@ -7,7 +7,7 @@ use crate::command::{Block, CommandOut, Execute, Payload};
 use crate::output::color::Domain;
 
 use super::format::{
-    format_run_role, format_timestamp, format_waiting_line, summarize_error_message,
+    format_history_role, format_timestamp, format_waiting_line, summarize_error_message,
 };
 use super::job::cli_job_run_to_json;
 
@@ -88,12 +88,15 @@ pub(crate) fn run_history_payload(
         Column::new("ERROR_MESSAGE"),
     ]);
     let mut table = Table::new(columns).empty_message("no runs recorded");
-    for run in &runs {
+    for (run, state) in runs.iter().zip(states.iter()) {
         use comfy_table::Cell;
         let last = run.steps.last();
         let mut row = vec![
             Cell::new(&run.run_id),
-            Cell::new(format_run_role(&run.run_id)),
+            Cell::new(format_history_role(
+                &run.run_id,
+                state.as_ref().and_then(|state| state.trigger.as_ref()),
+            )),
         ];
         if include_job_id {
             row.push(Cell::new(&run.job_id));

--- a/crates/orbit-cli/src/command/run/job.rs
+++ b/crates/orbit-cli/src/command/run/job.rs
@@ -91,6 +91,7 @@ pub(super) fn render_wait(invoke: &PipelineInvokeResult, entry: &PipelineWaitEnt
         "submitted_at": invoke.submitted_at,
         "waited": true,
         "finished_at": entry.finished_at,
+        "duration_ms": entry.duration_ms,
         "error": entry.error,
         "pipeline": entry.pipeline,
     });

--- a/crates/orbit-cli/src/command/run/tests/format.rs
+++ b/crates/orbit-cli/src/command/run/tests/format.rs
@@ -207,3 +207,19 @@ fn run_role_reads_the_id_and_admits_when_it_cannot() {
     assert_eq!(format_run_role("jrun-20260911-0146-2"), "unmarked");
     assert_eq!(format_run_role("jrun-20260911-0146"), "unmarked");
 }
+
+#[test]
+fn history_role_prints_the_routine_name_instead_of_the_id_marker() {
+    let trigger = orbit_types::workflow::JobRunTrigger::routine(
+        "auto-task-scheduler-nebula",
+        "2026-09-12T03:00:00Z",
+    );
+    assert_eq!(
+        format_history_role("jrun-20260912-0302-t1", Some(&trigger)),
+        "auto-task-scheduler-nebula"
+    );
+    assert_eq!(
+        format_history_role("jrun-20260911-0146-2", None),
+        "unmarked"
+    );
+}

--- a/crates/orbit-cli/src/command/run/tests/job.rs
+++ b/crates/orbit-cli/src/command/run/tests/job.rs
@@ -149,6 +149,7 @@ fn wait_entry(status: &str, error: Option<&str>) -> orbit_core::PipelineWaitEntr
         run_id: "jrun-20260815-0001".to_string(),
         status: status.to_string(),
         finished_at: Some("2026-08-15T00:01:00Z".to_string()),
+        duration_ms: Some(1000),
         pipeline: None,
         error: error.map(ToOwned::to_owned),
     }
@@ -238,12 +239,15 @@ fn wait_exits_nonzero_for_every_failing_terminal_state() {
 
 #[test]
 fn wait_exits_zero_when_the_run_succeeded() {
-    let output = render_wait(&invoke_result(false), &wait_entry("succeeded", None))
+    let output = render_wait(&invoke_result(false), &wait_entry("success", None))
         .expect("a successful run must exit zero");
     let crate::command::CommandOutput::Payload(payload) = output else {
         panic!("successful wait must return a payload, got {output:?}");
     };
     assert_eq!(payload.exit_code(), 0);
+    let (doc, _) = payload.into_view();
+    assert_eq!(doc["state"], "success");
+    assert_eq!(doc["duration_ms"], 1000);
 }
 
 /// Both text and the structured payload expose the terminal state and its

--- a/crates/orbit-cli/tests/worktree_gc_routing.rs
+++ b/crates/orbit-cli/tests/worktree_gc_routing.rs
@@ -311,7 +311,7 @@ spec:
         ],
     );
     assert_eq!(
-        run["state"], "succeeded",
+        run["state"], "success",
         "fixture job run did not settle: {run}"
     );
     let run_id = run["run_id"]

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/child_dispatch.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/child_dispatch.rs
@@ -167,7 +167,7 @@ pub(super) fn record_child_wait_outcome(
     status: &str,
     error_message: Option<&str>,
 ) -> Result<(), DispatchError> {
-    let succeeded = status == "succeeded";
+    let succeeded = crate::application::job::pipeline::pipeline_wait_status_is_success(status);
     record_child_audit(
         runtime,
         action,

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs
@@ -872,7 +872,11 @@ fn record_pipeline_results(action: &str, input: &Value) -> Result<Value, Dispatc
             ));
         }
         match status {
-            "succeeded" => succeeded_count += 1,
+            status
+                if crate::application::job::pipeline::pipeline_wait_status_is_success(status) =>
+            {
+                succeeded_count += 1
+            }
             "failed" | "cancelled" | "interrupted" | "timeout" => non_success_count += 1,
             other => {
                 return Err(action_failed(
@@ -973,7 +977,7 @@ fn pipeline_wait_entry_failure(label: &str, entry: &Value) -> Option<String> {
     let Some(status) = entry.get("status").and_then(Value::as_str) else {
         return Some(format!("{label} missing string status"));
     };
-    if status == "succeeded" {
+    if crate::application::job::pipeline::pipeline_wait_status_is_success(status) {
         return None;
     }
 

--- a/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
@@ -561,6 +561,88 @@ fn mcp_run_observation_names_the_child_a_blocked_parent_dispatched() {
     );
 }
 
+/// [ORB-12255] MCP run show/list reconstruct steps from the audit trail when
+/// the run record stores none, and name the source.
+#[test]
+fn mcp_run_show_and_list_reconstruct_empty_record_steps() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("task_auto_pipeline", 1, Utc::now(), None, None)
+        .expect("insert run");
+    runtime
+        .insert_v2_audit_event(&V2AuditEventInsertParams {
+            workspace_id: runtime.workspace_id().expect("workspace id"),
+            event_id: "evt-step-start".to_string(),
+            source: "v2_envelope".to_string(),
+            schema_version: 1,
+            event_type: "step.started".to_string(),
+            ts: chrono::DateTime::parse_from_rfc3339("2026-09-12T04:00:00Z")
+                .expect("fixture timestamp")
+                .with_timezone(&Utc),
+            run_id: run.run_id.clone(),
+            agent_identity: "codex".to_string(),
+            parent_event_id: None,
+            workspace_path: None,
+            payload_json: json!({
+                "schemaVersion": 1,
+                "event_type": "step.started",
+                "event_id": "evt-step-start",
+                "ts": "2026-09-12T04:00:00Z",
+                "run_id": run.run_id,
+                "agent_identity": "codex",
+                "body_kind": "step_started",
+                "step_id": "nap",
+            })
+            .to_string(),
+        })
+        .expect("insert step.started");
+    runtime
+        .insert_v2_audit_event(&V2AuditEventInsertParams {
+            workspace_id: runtime.workspace_id().expect("workspace id"),
+            event_id: "evt-step-finish".to_string(),
+            source: "v2_envelope".to_string(),
+            schema_version: 1,
+            event_type: "step.finished".to_string(),
+            ts: chrono::DateTime::parse_from_rfc3339("2026-09-12T04:00:01Z")
+                .expect("fixture timestamp")
+                .with_timezone(&Utc),
+            run_id: run.run_id.clone(),
+            agent_identity: "codex".to_string(),
+            parent_event_id: None,
+            workspace_path: None,
+            payload_json: json!({
+                "schemaVersion": 1,
+                "event_type": "step.finished",
+                "event_id": "evt-step-finish",
+                "ts": "2026-09-12T04:00:01Z",
+                "run_id": run.run_id,
+                "agent_identity": "codex",
+                "body_kind": "step_finished",
+                "step_id": "nap",
+                "outcome": "success",
+            })
+            .to_string(),
+        })
+        .expect("insert step.finished");
+
+    let shown = run_tool_as_operator(
+        &runtime,
+        "orbit.workflow.run.show",
+        json!({"id": run.run_id}),
+    )
+    .expect("operator run show");
+    assert_eq!(shown["steps_source"], json!("audit"));
+    assert_eq!(shown["steps"][0]["target_id"], json!("nap"));
+    assert_eq!(shown["steps"][0]["state"], json!("success"));
+
+    let listed = run_tool_as_operator(&runtime, "orbit.workflow.run.list", json!({}))
+        .expect("operator run list");
+    assert_eq!(listed["items"][0]["steps_source"], json!("audit"));
+    assert_eq!(listed["items"][0]["steps"][0]["target_id"], json!("nap"));
+}
+
 #[test]
 fn mcp_run_observation_carries_an_empty_lineage_for_a_run_without_children() {
     let (_root, runtime, _repo_root) = test_runtime();

--- a/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
@@ -178,6 +178,7 @@ pub(crate) fn project_workflow_run_list(
         .iter()
         .map(|run| {
             run_json_enriched(
+                Some(runtime),
                 run,
                 states.get(&run.run_id).and_then(Option::as_ref),
                 recoveries.get(&run.run_id),
@@ -291,6 +292,7 @@ fn run_json(run: &JobRun) -> Result<Value, OrbitError> {
     let mut value = serde_json::to_value(run).map_err(serialize_error("serialize workflow run"))?;
     value["steps"] = serde_json::to_value(&run.steps)
         .map_err(serialize_error("serialize workflow run steps"))?;
+    value["steps_source"] = json!("record");
     Ok(value)
 }
 
@@ -304,15 +306,23 @@ fn run_json(run: &JobRun) -> Result<Value, OrbitError> {
 fn run_json_with_lineage(runtime: &OrbitRuntime, run: &JobRun) -> Result<Value, OrbitError> {
     let state = runtime.read_run_state(&run.run_id).ok().flatten();
     let recovery = runtime.collect_run_recovery_attempts(&run.run_id).ok();
-    run_json_enriched(run, state.as_ref(), recovery.as_ref())
+    run_json_enriched(Some(runtime), run, state.as_ref(), recovery.as_ref())
 }
 
 fn run_json_enriched(
+    runtime: Option<&OrbitRuntime>,
     run: &JobRun,
     state: Option<&PipelineState>,
     recovery: Option<&RunRecoveryAttempts>,
 ) -> Result<Value, OrbitError> {
     let mut value = run_json(run)?;
+    if let Some(trigger) = state.and_then(|state| state.trigger.as_ref()) {
+        value["trigger"] =
+            serde_json::to_value(trigger).map_err(serialize_error("serialize run trigger"))?;
+    }
+    if let Some(runtime) = runtime {
+        attach_displayed_steps(runtime, run, &mut value)?;
+    }
     let dispatches = state
         .map(|state| state.child_dispatches.clone())
         .unwrap_or_default();
@@ -366,4 +376,55 @@ fn run_json_enriched(
         }),
     };
     Ok(value)
+}
+
+/// [ORB-12255] Prefer stored `JobRun::steps`; reconstruct from the v2 audit
+/// trail when the worker path left the record empty. `steps_source` names
+/// which one answered, matching CLI `run show --json`.
+fn attach_displayed_steps(
+    runtime: &OrbitRuntime,
+    run: &JobRun,
+    value: &mut Value,
+) -> Result<(), OrbitError> {
+    if !run.steps.is_empty() {
+        value["steps_source"] = json!("record");
+        return Ok(());
+    }
+    let audit = runtime
+        .collect_run_audit_steps(&run.run_id)
+        .unwrap_or_default();
+    if audit.is_empty() {
+        value["steps_source"] = json!("record");
+        return Ok(());
+    }
+    let steps = audit
+        .iter()
+        .map(|step| {
+            let duration_ms = match (step.started_at, step.finished_at) {
+                (Some(started), Some(finished)) => Some(
+                    finished
+                        .signed_duration_since(started)
+                        .num_milliseconds()
+                        .max(0) as u64,
+                ),
+                _ => None,
+            };
+            json!({
+                "step_index": step.step_index,
+                "target_type": "activity",
+                "target_id": step.step_id,
+                "started_at": step.started_at.map(|value| value.to_rfc3339()),
+                "finished_at": step.finished_at.map(|value| value.to_rfc3339()),
+                "duration_ms": duration_ms,
+                "exit_code": Value::Null,
+                "agent_response_json": Value::Null,
+                "state": step.state.as_deref().unwrap_or("running"),
+                "error_code": Value::Null,
+                "error_message": step.error_message,
+            })
+        })
+        .collect::<Vec<_>>();
+    value["steps"] = Value::Array(steps);
+    value["steps_source"] = json!("audit");
+    Ok(())
 }

--- a/crates/orbit-core/src/application/job/exec.rs
+++ b/crates/orbit-core/src/application/job/exec.rs
@@ -20,7 +20,7 @@ use orbit_types::workflow::activity_job::{
     validate_job_retired_sessions,
 };
 use orbit_types::workflow::{
-    JobRun, JobRunStartOutcome, JobRunState, JobTargetType, PipelineState,
+    JobRun, JobRunStartOutcome, JobRunState, JobRunTrigger, JobTargetType, PipelineState,
 };
 use serde_json::{Value, json};
 
@@ -154,7 +154,7 @@ impl OrbitRuntime {
             Some(input.clone()),
             retry_source_run_id.clone(),
         )?;
-        self.seed_v2_pipeline_run(&run, &input, resume)?;
+        self.seed_v2_pipeline_run(&run, &input, resume, JobRunTrigger::cli())?;
 
         let started_at = chrono::Utc::now();
         // [ORB-10965] This run was inserted moments ago by this very process,
@@ -285,8 +285,15 @@ impl OrbitRuntime {
         self.record_event(OrbitEvent::ActivityRunStarted {
             id: asset.name.clone(),
         })?;
+        let audit_job_name = self
+            .read_run_state(&run_id)
+            .ok()
+            .flatten()
+            .and_then(|state| state.trigger)
+            .unwrap_or_else(JobRunTrigger::cli)
+            .audit_job_name(&asset.name);
         let _ = writer.emit(V2AuditEventKind::RunStarted {
-            job_name: format!("cli:{}", asset.name),
+            job_name: audit_job_name,
             retry_source_run_id,
         });
 
@@ -331,11 +338,13 @@ impl OrbitRuntime {
         run: &JobRun,
         input: &Value,
         resume: Option<&ResumePlan>,
+        trigger: JobRunTrigger,
     ) -> Result<(), OrbitError> {
         let mut initial_state = match resume.and_then(|plan| plan.resume_state.as_ref()) {
             Some(source_state) => seeded_resume_state(source_state, run),
             None => PipelineState::new(run.run_id.clone(), run.job_id.clone(), input.clone()),
         };
+        initial_state.trigger = Some(trigger);
         // [ORB-11283] A queued drain can carry an operator stop (or worker
         // ceiling) written before the worker seeded this document. Replacing
         // the whole state would silently resume admissions.
@@ -348,6 +357,9 @@ impl OrbitRuntime {
             }
             if initial_state.child_dispatches.is_empty() {
                 initial_state.child_dispatches = existing.child_dispatches;
+            }
+            if existing.trigger.is_some() {
+                initial_state.trigger = existing.trigger;
             }
         }
         self.stores()
@@ -381,6 +393,8 @@ impl OrbitRuntime {
                 self.persist_v2_run_state(run, input, result, JobRunState::Success, options)?;
                 if options.record_synthetic_success_step {
                     self.record_synthetic_v2_success_step(run, started_at, finished_at, result)?;
+                } else {
+                    self.persist_detached_worker_steps(run, started_at, finished_at, result)?;
                 }
                 JobRunState::Success
             }
@@ -512,6 +526,75 @@ impl OrbitRuntime {
             },
         )?;
         Ok(())
+    }
+
+    /// Persist a step summary on the run record for the detached worker path
+    /// [ORB-12255]. Replay already writes a synthetic step 0; workers used to
+    /// leave `JobRun::steps` empty and only reconstruct from audit at `run
+    /// show`. MCP readers never reconstructed, so they saw `steps: []`.
+    ///
+    /// Audit-derived rows are preferred so the stored summary matches the
+    /// reconstructed view. The synthetic job-level step is the fallback when
+    /// the trail is empty, matching replay.
+    fn persist_detached_worker_steps(
+        &self,
+        run: &JobRun,
+        started_at: chrono::DateTime<chrono::Utc>,
+        finished_at: chrono::DateTime<chrono::Utc>,
+        result: &V2JobRunResult,
+    ) -> Result<(), OrbitError> {
+        let current = self.get_job_run_backend(&run.run_id)?;
+        if current.is_some_and(|stored| !stored.steps.is_empty()) {
+            return Ok(());
+        }
+
+        let audit_steps = self
+            .collect_run_audit_steps(&run.run_id)
+            .unwrap_or_default();
+        if audit_steps.is_empty() {
+            return self.record_synthetic_v2_success_step(run, started_at, finished_at, result);
+        }
+
+        for step in audit_steps {
+            let step_started = step.started_at.unwrap_or(started_at);
+            let step_finished = step.finished_at.unwrap_or(finished_at);
+            let duration_ms = Some(
+                step_finished
+                    .signed_duration_since(step_started)
+                    .num_milliseconds()
+                    .max(0) as u64,
+            );
+            let state = job_run_state_from_audit_outcome(step.state.as_deref());
+            self.stores().jobs().complete_job_run_step(
+                &run.run_id,
+                &JobRunStepParams {
+                    step_index: step.step_index as usize,
+                    target_type: JobTargetType::Activity,
+                    target_id: step.step_id,
+                    started_at: step_started,
+                    finished_at: step_finished,
+                    duration_ms,
+                    exit_code: None,
+                    agent_response_json: None,
+                    state,
+                    error_code: None,
+                    error_message: step.error_message,
+                },
+            )?;
+        }
+        Ok(())
+    }
+}
+
+fn job_run_state_from_audit_outcome(outcome: Option<&str>) -> JobRunState {
+    match outcome {
+        Some("success" | "succeeded" | "finished") => JobRunState::Success,
+        Some("failed" | "error" | "denied") => JobRunState::Failed,
+        Some("timeout") => JobRunState::Timeout,
+        Some("skipped") => JobRunState::Skipped,
+        Some("cancelled") => JobRunState::Cancelled,
+        Some("interrupted") => JobRunState::Interrupted,
+        _ => JobRunState::Success,
     }
 }
 

--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -27,7 +27,7 @@ use orbit_store::contracts::{
 use orbit_types::record::OrbitEvent;
 use orbit_types::telemetry::AuditEventStatus;
 use orbit_types::workflow::{
-    JobRun, JobRunStartOutcome, JobRunState, JobScheduleState, JobTargetType,
+    JobRun, JobRunStartOutcome, JobRunState, JobRunTrigger, JobScheduleState, JobTargetType,
 };
 use orbit_types::workspace::WorkspacePaths;
 use serde::Serialize;
@@ -124,6 +124,8 @@ struct PipelineSubmission<'a> {
     /// [ORB-11332]. Only it (and the parent-authorized child path, which
     /// copies the parent's snapshot) may carry [`OPERATION_ADMISSION_KEY`].
     operation_bound: bool,
+    /// How this run was submitted [ORB-12255].
+    trigger: JobRunTrigger,
 }
 
 /// What a parent-authorized child submission produced.
@@ -157,7 +159,13 @@ impl<'a> PipelineSubmission<'a> {
             action_key: None,
             trusted_host: false,
             operation_bound: false,
+            trigger: JobRunTrigger::cli(),
         }
+    }
+
+    fn with_trigger(mut self, trigger: JobRunTrigger) -> Self {
+        self.trigger = trigger;
+        self
     }
 }
 
@@ -216,9 +224,23 @@ pub struct PipelineWaitEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub finished_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pipeline: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+}
+
+/// Wait-envelope success token. Canonical spelling is `JobRunState::Success`
+/// (`success`); `succeeded` is accepted so in-flight synthetic skip results
+/// and older wait JSON keep matching [ORB-12255].
+pub fn pipeline_wait_status_is_success(status: &str) -> bool {
+    matches!(status, "success" | "succeeded")
+}
+
+pub fn pipeline_wait_status_is_settled(status: &str) -> bool {
+    pipeline_wait_status_is_success(status)
+        || matches!(status, "failed" | "cancelled" | "interrupted")
 }
 
 impl OrbitRuntime {
@@ -628,11 +650,26 @@ impl OrbitRuntime {
         priority: Option<&str>,
         actor: Option<&str>,
     ) -> Result<PipelineInvokeResult, OrbitError> {
-        let result = self.submit_persisted_pipeline_run(PipelineSubmission::catalog(
+        self.submit_pipeline_run_with_trigger(
             job_name,
-            input.clone(),
+            input,
+            priority,
             actor,
-        ));
+            JobRunTrigger::cli(),
+        )
+    }
+
+    pub(crate) fn submit_pipeline_run_with_trigger(
+        &self,
+        job_name: &str,
+        input: Value,
+        priority: Option<&str>,
+        actor: Option<&str>,
+        trigger: JobRunTrigger,
+    ) -> Result<PipelineInvokeResult, OrbitError> {
+        let result = self.submit_persisted_pipeline_run(
+            PipelineSubmission::catalog(job_name, input.clone(), actor).with_trigger(trigger),
+        );
 
         self.record_pipeline_audit(
             "pipeline.invoke",
@@ -670,7 +707,8 @@ impl OrbitRuntime {
         admission: &ChildPipelineAdmission,
     ) -> Result<ChildSubmission, OrbitError> {
         let result = self.submit_persisted_pipeline_run_with_admission(
-            PipelineSubmission::catalog(job_name, input.clone(), actor),
+            PipelineSubmission::catalog(job_name, input.clone(), actor)
+                .with_trigger(JobRunTrigger::child()),
             Some(admission),
         );
 
@@ -760,6 +798,7 @@ impl OrbitRuntime {
             action_key,
             trusted_host,
             operation_bound,
+            trigger,
         } = submission;
         // [ORB-11354] The reserved admission key is writable by exactly one
         // caller. Refusing it here — on the single path every submission
@@ -872,9 +911,16 @@ impl OrbitRuntime {
                     Some(input.clone()),
                     resume.map(|plan| plan.source.run_id.clone()),
                 )?;
-                self.seed_v2_pipeline_run(&run, &input, resume)?;
+                self.seed_v2_pipeline_run(&run, &input, resume, trigger.clone())?;
                 run
             };
+
+            let trigger = if admission.is_some() {
+                JobRunTrigger::child()
+            } else {
+                trigger
+            };
+            self.record_run_trigger(&run.run_id, &trigger)?;
 
             // Pin the definition before the worker can exist. A direct-path
             // submission must not depend on the source file surviving
@@ -1001,12 +1047,10 @@ impl OrbitRuntime {
 
         loop {
             let snapshot = self.collect_pipeline_wait_entries(run_ids, false)?;
-            if snapshot.iter().all(|entry| {
-                matches!(
-                    entry.status.as_str(),
-                    "succeeded" | "failed" | "cancelled" | "interrupted"
-                )
-            }) {
+            if snapshot
+                .iter()
+                .all(|entry| pipeline_wait_status_is_settled(&entry.status))
+            {
                 let result = PipelineWaitResult { results: snapshot };
                 self.record_pipeline_wait_finished(actor, &result)?;
                 return Ok(result);
@@ -1210,6 +1254,18 @@ impl OrbitRuntime {
         })
     }
 
+    pub(crate) fn record_run_trigger(
+        &self,
+        run_id: &str,
+        trigger: &JobRunTrigger,
+    ) -> Result<(), OrbitError> {
+        let Some(mut state) = self.read_run_state(run_id)? else {
+            return Ok(());
+        };
+        state.trigger = Some(trigger.clone());
+        self.write_run_state(run_id, &state)
+    }
+
     fn execute_pipeline_run_now(&self, run: &JobRun, yaml_path: &Path) -> Result<(), OrbitError> {
         let started_at = Utc::now();
         // [ORB-10965] The state read in `execute_pipeline_run_worker` and this
@@ -1406,6 +1462,7 @@ impl OrbitRuntime {
                             run_id: run_id.clone(),
                             status: "failed".to_string(),
                             finished_at: None,
+                            duration_ms: None,
                             pipeline: None,
                             error: Some("unknown run".to_string()),
                         });
@@ -1414,14 +1471,14 @@ impl OrbitRuntime {
                 };
 
                 let terminal = match run.state {
-                    JobRunState::Success => Some("succeeded"),
-                    JobRunState::Failed => Some("failed"),
-                    JobRunState::Cancelled => Some("cancelled"),
-                    JobRunState::Interrupted => Some("interrupted"),
+                    JobRunState::Success => Some(JobRunState::Success.to_string()),
+                    JobRunState::Failed => Some(JobRunState::Failed.to_string()),
+                    JobRunState::Cancelled => Some(JobRunState::Cancelled.to_string()),
+                    JobRunState::Interrupted => Some(JobRunState::Interrupted.to_string()),
                     _ => None,
                 };
                 let status = match (terminal, timeout_incomplete) {
-                    (Some(status), _) => status.to_string(),
+                    (Some(status), _) => status,
                     (None, true) => "timeout".to_string(),
                     (None, false) => run.state.to_string(),
                 };
@@ -1451,6 +1508,7 @@ impl OrbitRuntime {
                     run_id: run_id.clone(),
                     status,
                     finished_at: run.finished_at.map(|value| value.to_rfc3339()),
+                    duration_ms: run.duration_ms,
                     pipeline,
                     error,
                 })
@@ -1873,7 +1931,7 @@ impl OrbitRuntime {
         let mut timeout = 0usize;
         for entry in &result.results {
             match entry.status.as_str() {
-                "succeeded" => succeeded += 1,
+                status if pipeline_wait_status_is_success(status) => succeeded += 1,
                 "failed" => failed += 1,
                 "cancelled" => cancelled += 1,
                 "timeout" => timeout += 1,

--- a/crates/orbit-core/src/application/job/run/projection.rs
+++ b/crates/orbit-core/src/application/job/run/projection.rs
@@ -77,6 +77,7 @@ pub fn job_run_to_json(run: &JobRun, state: Option<&PipelineState>) -> Value {
         "drain_admissions_stop": drain_admissions_stop,
         "run_id": run.run_id,
         "run_role": run_id_role(&run.run_id).map(|role| role.to_string()),
+        "trigger": state_for_agent_result.and_then(|state| state.trigger.as_ref()),
         "job_id": run.job_id,
         "attempt": run.attempt,
         "state": run.state.to_string(),

--- a/crates/orbit-core/src/application/job/run/tests/projection.rs
+++ b/crates/orbit-core/src/application/job/run/tests/projection.rs
@@ -2,8 +2,8 @@
 
 use chrono::Utc;
 use orbit_types::workflow::{
-    ChildDispatch, ChildDispatchPhase, JobRun, JobRunState, JobRunStep, JobTargetType,
-    PipelineState,
+    ChildDispatch, ChildDispatchPhase, JobRun, JobRunState, JobRunStep, JobRunTrigger,
+    JobTargetType, PipelineState,
 };
 use serde_json::{Value, json};
 
@@ -69,6 +69,25 @@ fn active_run_projects_waiting_reasons_and_child_dispatches() {
         json!("jrun-child")
     );
     assert_eq!(value["drain_admissions_stop"], Value::Null);
+}
+
+#[test]
+fn projection_includes_routine_trigger_on_a_terminal_run() {
+    let run = test_run(JobRunState::Success);
+    let mut state = PipelineState::new(run.run_id.clone(), run.job_id.clone(), json!({}));
+    state.trigger = Some(JobRunTrigger::routine(
+        "auto-task-scheduler-nebula",
+        "2026-09-12T03:00:00Z",
+    ));
+
+    let value = job_run_to_json(&run, Some(&state));
+
+    assert_eq!(value["trigger"]["kind"], json!("routine"));
+    assert_eq!(
+        value["trigger"]["routine"],
+        json!("auto-task-scheduler-nebula")
+    );
+    assert_eq!(value["trigger"]["slot"], json!("2026-09-12T03:00:00Z"));
 }
 
 #[test]

--- a/crates/orbit-core/src/application/job/tests/exec.rs
+++ b/crates/orbit-core/src/application/job/tests/exec.rs
@@ -1729,6 +1729,124 @@ fn replay_job_run_records_lineage_and_preserves_source_bundle() {
     );
 }
 
+/// [ORB-12255] Detached workers used to leave `JobRun::steps` empty. The
+/// worker path now persists the step summary, and `--wait` uses the same
+/// `success` token and `duration_ms` as `run show`.
+#[test]
+fn worker_path_persists_steps_and_wait_agrees_on_state_and_duration() {
+    let (_root, runtime, _repo_root, global_root) = test_runtime();
+    let jobs_dir = global_root.join("resources/jobs");
+    std::fs::create_dir_all(&jobs_dir).expect("create jobs dir");
+    let yaml_path = jobs_dir.join("qa_worker_steps.yaml");
+    write_job(&yaml_path, "qa_worker_steps", "sleep");
+
+    let input = json!({ "seconds": 0 });
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("qa_worker_steps", 1, Utc::now(), Some(input.clone()), None)
+        .expect("insert worker run");
+    runtime
+        .seed_v2_pipeline_run(
+            &run,
+            &input,
+            None,
+            orbit_types::workflow::JobRunTrigger::cli(),
+        )
+        .expect("seed worker run");
+    runtime
+        .execute_pipeline_run_worker(&run.run_id)
+        .expect("worker executes");
+
+    let stored = runtime.show_job_run(&run.run_id).expect("show worker run");
+    assert_eq!(stored.state, JobRunState::Success);
+    assert!(
+        !stored.steps.is_empty(),
+        "worker-spawned run must persist steps, got none"
+    );
+    assert!(
+        stored.duration_ms.is_some(),
+        "worker-spawned run must record duration_ms"
+    );
+
+    let waited = runtime
+        .wait_pipeline_runs(std::slice::from_ref(&run.run_id), 1, 1, Some("test"))
+        .expect("wait on terminal run");
+    assert_eq!(waited.results[0].status, "success");
+    assert_eq!(waited.results[0].duration_ms, stored.duration_ms);
+
+    let state = runtime
+        .read_run_state(&stored.run_id)
+        .expect("read state")
+        .expect("pipeline state");
+    let projection = crate::application::job::job_run_to_json(&stored, Some(&state));
+    assert_eq!(projection["state"], "success");
+    assert_eq!(projection["duration_ms"], json!(stored.duration_ms));
+}
+
+/// [ORB-12255] A routine fire records trigger provenance on the run document
+/// and uses `routine:<name>` on `run.started`.
+#[test]
+fn routine_submit_records_trigger_and_audit_prefix() {
+    let (_root, runtime, _repo_root, global_root) = test_runtime();
+    let jobs_dir = global_root.join("resources/jobs");
+    std::fs::create_dir_all(&jobs_dir).expect("create jobs dir");
+    let yaml_path = jobs_dir.join("qa_routine_trigger.yaml");
+    write_job(&yaml_path, "qa_routine_trigger", "sleep");
+
+    let slot = "2026-09-12T03:00:00Z";
+    let input = json!({ "seconds": 0 });
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run(
+            "qa_routine_trigger",
+            1,
+            Utc::now(),
+            Some(input.clone()),
+            None,
+        )
+        .expect("insert routine run");
+    runtime
+        .seed_v2_pipeline_run(
+            &run,
+            &input,
+            None,
+            orbit_types::workflow::JobRunTrigger::routine("auto-task-scheduler-nebula", slot),
+        )
+        .expect("seed routine run");
+
+    let state = runtime
+        .read_run_state(&run.run_id)
+        .expect("read state")
+        .expect("pipeline state");
+    let trigger = state.trigger.expect("trigger recorded");
+    assert_eq!(
+        trigger.kind,
+        orbit_types::workflow::JobRunTriggerKind::Routine
+    );
+    assert_eq!(
+        trigger.routine.as_deref(),
+        Some("auto-task-scheduler-nebula")
+    );
+    assert_eq!(trigger.slot.as_deref(), Some(slot));
+
+    runtime
+        .execute_pipeline_run_worker(&run.run_id)
+        .expect("worker executes");
+    let event: serde_json::Value = serde_json::from_str(
+        &v2_events(&runtime, &run.run_id, "run.started")
+            .first()
+            .expect("run.started audit event")
+            .payload_json,
+    )
+    .expect("parse run.started");
+    assert_eq!(
+        event.get("job_name").and_then(serde_json::Value::as_str),
+        Some("routine:auto-task-scheduler-nebula")
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn v2_cli_agent_loop_persists_invocation_metrics() {

--- a/crates/orbit-core/src/application/review/tests/admission.rs
+++ b/crates/orbit-core/src/application/review/tests/admission.rs
@@ -229,7 +229,12 @@ fn pr_bound_epic_submits_a_local_child_then_gates_the_combined_candidate() {
     let child = seed_task(runtime, "child");
     let parent = super::admitted_run(runtime, "epic_pipeline", std::slice::from_ref(&epic.id));
     runtime
-        .seed_v2_pipeline_run(&parent, parent.input.as_ref().expect("parent input"), None)
+        .seed_v2_pipeline_run(
+            &parent,
+            parent.input.as_ref().expect("parent input"),
+            None,
+            orbit_types::workflow::JobRunTrigger::cli(),
+        )
         .expect("parent pipeline state");
     implement_candidate(&fixture.repo, &epic.id);
 

--- a/crates/orbit-core/src/application/routines/sweep.rs
+++ b/crates/orbit-core/src/application/routines/sweep.rs
@@ -63,6 +63,7 @@ impl RoutineDispatch for RuntimeDispatch<'_> {
         source_orbit_dir: &Path,
         job_name: &str,
         actor: &str,
+        slot: &str,
     ) -> Result<String, OrbitError> {
         let runtime = self.runtimes.get(source_orbit_dir).ok_or_else(|| {
             OrbitError::WorkspaceError(format!(
@@ -77,8 +78,15 @@ impl RoutineDispatch for RuntimeDispatch<'_> {
         let mut input = json!({});
         input[crate::application::job::pipeline::ROUTINE_DISPATCH_ORBIT_DIR_FIELD] =
             json!(source_orbit_dir.to_string_lossy());
+        let routine = actor.strip_prefix("routine/").unwrap_or(actor);
         runtime
-            .submit_pipeline_run(job_name, input, None, Some(actor))
+            .submit_pipeline_run_with_trigger(
+                job_name,
+                input,
+                None,
+                Some(actor),
+                orbit_types::workflow::JobRunTrigger::routine(routine, slot),
+            )
             .map(|invoke| invoke.run_id)
     }
 

--- a/crates/orbit-core/src/application/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/application/tests/job_pipeline.rs
@@ -817,7 +817,12 @@ spec:
         )
         .expect("insert mixed-crew run");
     runtime
-        .seed_v2_pipeline_run(&run, &input, None)
+        .seed_v2_pipeline_run(
+            &run,
+            &input,
+            None,
+            orbit_types::workflow::JobRunTrigger::cli(),
+        )
         .expect("seed pipeline state");
 
     let error = runtime

--- a/crates/orbit-types/src/workflow/job.rs
+++ b/crates/orbit-types/src/workflow/job.rs
@@ -432,6 +432,96 @@ pub struct Job {
     pub updated_at: DateTime<Utc>,
 }
 
+/// How a job run was submitted [ORB-12255].
+///
+/// Stored on the run's pipeline document and projected on every operator-facing
+/// run JSON so MCP, CLI, and audit agree on provenance. Older runs have none.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum JobRunTriggerKind {
+    Routine,
+    Cli,
+    Mcp,
+    Child,
+}
+
+impl JobRunTriggerKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Routine => "routine",
+            Self::Cli => "cli",
+            Self::Mcp => "mcp",
+            Self::Child => "child",
+        }
+    }
+}
+
+impl Display for JobRunTriggerKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct JobRunTrigger {
+    pub kind: JobRunTriggerKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub routine: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slot: Option<String>,
+}
+
+impl JobRunTrigger {
+    pub fn cli() -> Self {
+        Self {
+            kind: JobRunTriggerKind::Cli,
+            routine: None,
+            slot: None,
+        }
+    }
+
+    pub fn mcp() -> Self {
+        Self {
+            kind: JobRunTriggerKind::Mcp,
+            routine: None,
+            slot: None,
+        }
+    }
+
+    pub fn child() -> Self {
+        Self {
+            kind: JobRunTriggerKind::Child,
+            routine: None,
+            slot: None,
+        }
+    }
+
+    pub fn routine(name: impl Into<String>, slot: impl Into<String>) -> Self {
+        Self {
+            kind: JobRunTriggerKind::Routine,
+            routine: Some(name.into()),
+            slot: Some(slot.into()),
+        }
+    }
+
+    /// Value written on the v2 `run.started` audit event's `job_name`.
+    pub fn audit_job_name(&self, job_name: &str) -> String {
+        match self.kind {
+            JobRunTriggerKind::Routine => {
+                let name = self
+                    .routine
+                    .as_deref()
+                    .filter(|name| !name.is_empty())
+                    .unwrap_or(job_name);
+                format!("routine:{name}")
+            }
+            JobRunTriggerKind::Mcp => format!("mcp:{job_name}"),
+            JobRunTriggerKind::Child => format!("child:{job_name}"),
+            JobRunTriggerKind::Cli => format!("cli:{job_name}"),
+        }
+    }
+}
+
 /// Per-step execution record stored in a step file inside the run bundle directory.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct JobRunStep {

--- a/crates/orbit-types/src/workflow/mod.rs
+++ b/crates/orbit-types/src/workflow/mod.rs
@@ -51,9 +51,9 @@ pub use executor_def::{
 };
 pub use job::{
     AgentCommitRequest, AgentResponseEnvelope, AgentRunError, Job, JobRun, JobRunStartOutcome,
-    JobRunState, JobRunStep, JobScheduleState, JobStep, JobTargetType, KnowledgeRunMetrics,
-    RunEvent, RunStateUpdate, StepCondition, default_job_max_active_runs, default_max_iterations,
-    default_retry_backoff_seconds,
+    JobRunState, JobRunStep, JobRunTrigger, JobRunTriggerKind, JobScheduleState, JobStep,
+    JobTargetType, KnowledgeRunMetrics, RunEvent, RunStateUpdate, StepCondition,
+    default_job_max_active_runs, default_max_iterations, default_retry_backoff_seconds,
 };
 pub use operation::{
     GrantAdmission, GrantLimits, GrantRights, GrantStatus, GrantTransition, MAX_GRANT_SCOPE_TASKS,

--- a/crates/orbit-types/src/workflow/run_state.rs
+++ b/crates/orbit-types/src/workflow/run_state.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::workflow::JobRunState;
+use crate::workflow::JobRunTrigger;
 use crate::workflow::child_dispatch::{
     ChildCancellation, ChildCancellationPolicy, ChildDispatch, ChildDispatchPhase,
 };
@@ -142,6 +143,10 @@ pub struct PipelineState {
     /// evidence on its own.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub rebase_recovery_checkpoints: BTreeMap<String, Value>,
+    /// How this run was submitted [ORB-12255]. Absent on runs recorded before
+    /// trigger provenance existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger: Option<JobRunTrigger>,
     pub updated_at: DateTime<Utc>,
 }
 
@@ -166,6 +171,7 @@ impl PipelineState {
             drain_admissions_stop: None,
             failure_activity_checkpoint: None,
             rebase_recovery_checkpoints: BTreeMap::new(),
+            trigger: None,
             updated_at: Utc::now(),
         }
     }


### PR DESCRIPTION
## Task

[ORB-12255](https://orbit-cli.com/tasks/ORB-12255) — Run records are inconsistent: worker-spawned runs persist no steps, routine fires are audited as `cli`, state is spelled `succeeded` vs `success`

### Description

Observed on 0.21.0 (ws_nebula):

1. **Steps.** `orbit run job worktree_gc_pipeline --wait --json` → `steps: []`; MCP `orbit_workflow_run_show`/`run_list` → `steps: []` for every worker-spawned run; the CLI `run show` prints "Steps: reconstructed from the run audit trail; the run record stores none". But `orbit job replay <run>` (inline) persisted `steps: [{step_index:0, target_type:"job", state:"success", agent_response_json:{…}}]`. Two persistence paths, two shapes; MCP readers get nothing for the common case.
2. **Trigger provenance.** A run fired by `orbit sweep` for routine `auto-task-scheduler-nebula` (`jrun-20260912-0302-t1`, input `{__routine_dispatch_orbit_dir: …}`) has audit `run.started cli:auto_task_scheduler_pipeline`, and `orbit run history` labels it `unmarked` in the column where operator runs say `top-level`. The routine name is not on the run at all; only the private `__routine_dispatch_orbit_dir` input hints at it.
3. **State vocabulary.** `run job --wait --json` reports `state: "succeeded"`; `run show`, `run history`, and MCP report `"success"`. `run cancel` on a finished run prints "was already terminal (success)". One state, two spellings.
4. `run job --wait --json` reports `duration_ms: null` although `run show` has the duration.

## What to change

- Persist the step summary on the run record from the worker path too (what `replay` already does), so `steps` is populated for MCP readers; keep audit reconstruction as the fallback and say which one was used (`steps_source`, which the CLI JSON already has).
- Record the trigger on the run: `trigger: {kind: "routine"|"cli"|"mcp"|"child", routine: "<name>", slot: "<rfc3339>"}`; audit `run.started routine:<name>`; `run history` prints the routine name instead of `unmarked`.
- One `RunState` serialization everywhere (`success`), with `--wait` mapping through the same type; fix `duration_ms` in the wait envelope.
- Tests: worker-spawned run has `steps`; routine-fired run carries `trigger.routine`; `--wait` JSON and `run show` JSON agree on `state` and `duration_ms`.

### Acceptance Criteria

- MCP `workflow_run_show`/`run_list` return populated `steps` for worker-spawned runs, with `steps_source` saying whether they were stored or reconstructed
- A routine-fired run records `trigger.kind = routine` and the routine name; audit and `run history` show it instead of `cli`/`unmarked`
- `run job --wait --json`, `run show --json` and MCP agree on the `state` token and `duration_ms`
- Tests cover the three cases

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Detached worker finalization now persists JobRun steps from the v2 audit trail (synthetic job-level step 0 only if the trail is empty), so MCP readers see stored steps.
- MCP workflow run.show/run.list emit steps_source (record|audit) and reconstruct from audit when the record is empty.
- PipelineState.trigger records {kind, routine, slot}; sweep writes kind=routine plus name and slot; child admission writes kind=child; other submissions default to cli. Shared run JSON projects trigger. run.started uses routine:<name>. run history ROLE prints the routine name.
- Wait envelope maps JobRunState::Success as success (not succeeded) and includes duration_ms so --wait --json, run show --json, and MCP agree. Wait consumers still accept succeeded for synthetic skip results.
Assessment: scoped to run records, wait envelope, and MCP projection. Resume checkpoints remain PipelineState.step_states, not JobRun.steps.

Criteria:
1. MCP populated steps + steps_source — met. Worker path persists steps (steps_source=record). Empty records reconstruct from audit (steps_source=audit). Tests: worker_path_persists_steps_and_wait_agrees_on_state_and_duration, mcp_run_show_and_list_reconstruct_empty_record_steps.
2. Routine trigger + audit + history — met. Tests: routine_submit_records_trigger_and_audit_prefix, projection_includes_routine_trigger_on_a_terminal_run, history_role_prints_the_routine_name_instead_of_the_id_marker.
3. Wait/show/MCP state and duration_ms — met. Wait status is JobRunState Display (success); duration_ms is copied from the run. Tests: worker_path_persists_steps_and_wait_agrees_on_state_and_duration, wait_exits_zero_when_the_run_succeeded, worktree_gc_routing assertion updated.
4. Tests cover the three cases — met.

Validation:
- cargo test -p orbit-core --lib worker_path_persists: passed
- cargo test -p orbit-core --lib routine_submit_records: passed
- cargo test -p orbit-core --lib mcp_run_show_and_list_reconstruct: passed
- cargo test -p orbit-core --lib projection_includes_routine: passed
- cargo test -p orbit-cli history_role_prints: passed
- cargo test -p orbit-cli wait_exits_zero: passed
- cargo test -p orbit-cli wait_exits_nonzero: passed
- cargo test -p orbit-automation sweep: passed (17)
- cargo test -p orbit-core --lib replay_job_run_records: passed
- cargo test -p orbit-core --lib pipeline_success_guard: passed (6)
- cargo test -p orbit-core --lib waiting_surfaces: passed
- cargo fmt --all -- --check: passed
- cargo clippy -p orbit-types -p orbit-automation -p orbit-core --lib --tests -- -D warnings: passed
- cargo clippy -p orbit-cli --all-targets -- -D warnings: passed
- make ci-fast: passed
- git diff --check: passed
- make ci-lint (workspace-wide all-target): not run; crate-scoped clippy with -D warnings was run instead
- make goldens: not run; no Clap help or MCP parameter-description changes

Risks:
- MCP ship still records trigger.kind=cli (routine/child/cli are the exercised kinds). JobRunTrigger::mcp exists for a follow-up at the MCP ship surface.
- Wait consumers accept both success and succeeded so synthetic admission-stop results that still say succeeded keep working.
- Older worker-spawned runs stay empty on the record; MCP reconstructs them when audit exists.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12255-6aa4d0d0`
- Behind base: 0
- Ahead of base: 1