### PR TITLE
macOS sandbox hides keychain-backed provider logins (Copilot, Cursor); runs fail auth with no diagnosis

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -13,6 +13,7 @@ use orbit_exec::{
 };
 use orbit_types::policy::ResolvedFsProfile;
 use orbit_types::workflow::ExecutorSandboxKind;
+use orbit_types::workflow::activity_job::Provider;
 use tempfile::NamedTempFile;
 
 use super::super::dispatcher::ResolvedSandbox;
@@ -662,10 +663,19 @@ fn failed_write_path_candidates(line: &str) -> Vec<String> {
     candidates
 }
 
-/// Text a provider CLI emits when it cannot read its Keychain-backed OAuth
-/// session. The CLI cannot tell "the item is gone" from "the item is
-/// unreadable", so it reports both as an expiry.
-const KEYCHAIN_AUTH_FAILURE_MARKER: &str = "OAuth session expired";
+/// Text a provider CLI emits when it cannot read its Keychain-backed login.
+/// The CLI cannot tell "the item is gone" from "the item is unreadable", so
+/// each vendor reports both as a login failure in its own wording.
+fn keychain_auth_failure_marker(provider: &str) -> Option<&'static str> {
+    match Provider::parse(provider).ok()? {
+        Provider::Claude => Some("OAuth session expired"),
+        Provider::Copilot => Some("No authentication information found"),
+        // Matches both the documented quoted form (`run 'agent login' first`)
+        // and the live cursor-agent 2026.09.10 wording (`run agent login first`).
+        Provider::Cursor => Some("Authentication required. Please run"),
+        _ => None,
+    }
+}
 
 /// Distinguish a sandbox Keychain denial from a genuinely expired provider
 /// login.
@@ -680,6 +690,7 @@ const KEYCHAIN_AUTH_FAILURE_MARKER: &str = "OAuth session expired";
 /// reads the same profile the kernel enforced. Only the `Allowed` case may
 /// recommend re-authentication: the other cases are Orbit's own denial, which
 /// no amount of re-logging in outside the sandbox will clear. [ORB-10931]
+/// [ORB-12261]
 pub(super) fn macos_keychain_auth_diagnostic(
     provider: &str,
     sandbox: Option<&ResolvedSandbox>,
@@ -699,9 +710,8 @@ pub(crate) fn macos_keychain_auth_diagnostic_with(
     home: Option<&OsStr>,
 ) -> Option<String> {
     let sandbox = sandbox?;
-    if sandbox.kind != ExecutorSandboxKind::MacosSandboxExec
-        || !output.contains(KEYCHAIN_AUTH_FAILURE_MARKER)
-    {
+    let marker = keychain_auth_failure_marker(provider)?;
+    if sandbox.kind != ExecutorSandboxKind::MacosSandboxExec || !output.contains(marker) {
         return None;
     }
     match macos_login_keychain_access(provider, home, &sandbox.fs_profile) {
@@ -829,9 +839,9 @@ pub(crate) fn spawn_macos_sandboxed_with(
     // The sandboxed spawn itself goes through orbit-exec, which erases the
     // io::ErrorKind; classify it transient so retries are preserved.
     //
-    // `provider` reaches the compiler because the credential denylist has one
-    // provider-scoped exception: the confined CLI's own credential store. See
-    // `orbit_exec::macos_login_keychain_access`. [ORB-10929]
+    // `provider` reaches the compiler because the credential denylist has a
+    // provider-scoped exception: the confined CLI's own credential store.
+    // See `orbit_exec::macos_login_keychain_access`. [ORB-10929] [ORB-12261]
     let profile_text = compile_macos_sandbox_profile(&sandbox.fs_profile, provider)
         .map_err(|err| SpawnError::permanent(err.to_string()))?;
     let child_env = prepare_macos_codex_ca_environment_with(

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -503,6 +503,92 @@ fn run_cli_backend_rejects_copilot_trailing_terminal_prose() {
     assert_eq!(outcome.output["completion_envelope_satisfied"], false);
 }
 
+/// A Copilot CLI that cannot see its login-keychain item exits 1 with
+/// "No authentication information found". The step message — which becomes
+/// `job_run_steps.error_message` and the task's `workflow_run_failed` note —
+/// must carry Orbit's diagnosis, not only the exit code. [ORB-12261]
+#[test]
+fn run_cli_backend_copilot_keychain_auth_failure_reaches_the_step_message() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("copilot");
+    write_executable(
+        &script,
+        concat!(
+            "#!/bin/sh\ncat > /dev/null\n",
+            "printf '%s\\n' 'Error: No authentication information found.' >&2\n",
+            "exit 1\n",
+        ),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-copilot-keychain",
+        "copilot:claude-sonnet-4.5",
+        sink_for_writer,
+    ));
+    let mut sandbox = sandbox_for_test();
+    // Linux CI has no sandbox-exec; the diagnostic is about the compiled
+    // profile, not about whether the wrapper actually applied.
+    sandbox.allow_fallback = true;
+    let host = TestHost {
+        command: script.display().to_string(),
+        executor_args: Vec::new(),
+        provider_config: HashMap::new(),
+        sandbox: Some(sandbox),
+        task_context: None,
+        workspace_root: None,
+        orbit_registry_root: None,
+        orbit_workspace_selector: None,
+    };
+    let mut spec = test_agent_loop_spec(Duration::from_secs(5));
+    spec.provider = orbit_types::workflow::activity_job::Provider::Copilot;
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "implement_one",
+        "jrun-copilot-keychain",
+        audit,
+        &serde_json::json!({"prompt": "say ok"}),
+        None,
+    )
+    .expect("the invocation outcome should be classified");
+
+    assert!(!outcome.success);
+    let message = outcome
+        .message
+        .as_deref()
+        .expect("failed step carries a message");
+    assert!(
+        message.contains("exited with code"),
+        "the exit code still belongs in the step message: {message}"
+    );
+    assert!(
+        message.contains("macOS sandbox") && message.contains("copilot"),
+        "the persisted step message must carry the keychain diagnosis, not only the exit code: {message}"
+    );
+
+    let update = crate::context::blocked_workflow_failure_update(
+        "task_pr_pipeline",
+        "jrun-copilot-keychain",
+        Some("AGENT_INVOCATION_FAILED"),
+        Some(message),
+    );
+    assert_eq!(
+        update.status_event.as_deref(),
+        Some(crate::context::WORKFLOW_RUN_FAILED_EVENT)
+    );
+    let note = update
+        .status_note
+        .as_deref()
+        .expect("blocked update carries a note");
+    assert!(
+        note.contains("macOS sandbox") && note.contains("copilot"),
+        "workflow_run_failed must inline the diagnosis: {note}"
+    );
+}
+
 #[test]
 fn run_cli_backend_projects_prose_prefixed_claude_envelope_result() {
     let temp = tempdir().expect("tempdir");

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
@@ -457,7 +457,8 @@ fn keychain_auth_diagnostic_stays_silent_outside_its_exact_failure_shape() {
     let home = std::ffi::OsStr::new("/Users/test");
 
     // Providers that never read the keychain, unsandboxed runs, and unrelated
-    // failures must not collect a keychain explanation.
+    // failures must not collect a keychain explanation. A Copilot or Cursor
+    // failure also must not match Claude's wording, and vice versa.
     assert!(
         macos_keychain_auth_diagnostic_with("codex", Some(&sandbox), failure, Some(home)).is_none()
     );
@@ -480,6 +481,60 @@ fn keychain_auth_diagnostic_stays_silent_outside_its_exact_failure_shape() {
         )
         .is_none()
     );
+    assert!(
+        macos_keychain_auth_diagnostic_with("copilot", Some(&sandbox), failure, Some(home))
+            .is_none()
+    );
+    assert!(
+        macos_keychain_auth_diagnostic_with("cursor", Some(&sandbox), failure, Some(home))
+            .is_none()
+    );
+}
+
+/// Copilot and Cursor use different auth-failure wording from Claude. Each
+/// must still distinguish a reachable keychain (real logout) from an Orbit
+/// denyRead that hid the credential. [ORB-12261]
+#[test]
+fn keychain_auth_diagnostic_recognises_copilot_and_cursor_auth_failures() {
+    let home = std::ffi::OsStr::new("/Users/test");
+    let copilot_failure = "Error: No authentication information found.";
+    let cursor_quoted = "Error: Authentication required. Please run 'agent login' first, or set CURSOR_API_KEY environment variable.";
+    let cursor_live = "Error: Authentication required. Please run agent login first, or set CURSOR_API_KEY environment variable.";
+
+    for (provider, failure) in [
+        ("copilot", copilot_failure),
+        ("cursor", cursor_quoted),
+        ("cursor", cursor_live),
+    ] {
+        let sandbox = sandbox_for_test();
+        let reachable =
+            macos_keychain_auth_diagnostic_with(provider, Some(&sandbox), failure, Some(home))
+                .unwrap_or_else(|| panic!("{provider} under sandbox-exec must be attributed"));
+        assert!(
+            reachable.contains("real login failure") && reachable.contains(provider),
+            "a reachable keychain means re-authentication is the fix: {reachable}"
+        );
+
+        let mut denied = sandbox_for_test();
+        denied.fs_profile.name = "hardened".to_string();
+        denied
+            .fs_profile
+            .read
+            .push("!/Users/test/Library/Keychains".to_string());
+        let diagnostic =
+            macos_keychain_auth_diagnostic_with(provider, Some(&denied), failure, Some(home))
+                .unwrap_or_else(|| panic!("{provider} activity deny must be attributed"));
+        assert!(
+            diagnostic.contains("!/Users/test/Library/Keychains")
+                && diagnostic.contains("hardened")
+                && diagnostic.contains("Re-authenticating will not help"),
+            "an Orbit-authored denial must name the rule, not send the operator to re-login: {diagnostic}"
+        );
+        assert!(
+            !diagnostic.contains("real login failure"),
+            "a denied keychain must never be reported as reachable: {diagnostic}"
+        );
+    }
 }
 
 #[test]

--- a/crates/orbit-exec/src/macos_sandbox/compile.rs
+++ b/crates/orbit-exec/src/macos_sandbox/compile.rs
@@ -181,9 +181,11 @@ pub(super) fn compile_macos_sandbox_profile_with_env(
             ));
         }
     }
-    // Cursor's logged-in CLI state and permissions live in `$HOME/.cursor`.
-    // Grant the directory only to the active Cursor executor; API-key auth is
-    // an explicit environment opt-in and needs no additional path. [ORB-10945]
+    // Cursor's CLI configuration, permissions, and sessions live in
+    // `$HOME/.cursor`. On macOS the default login is the login keychain, not
+    // that directory; the write grant here is still required for the rest of
+    // the CLI state. API-key auth is an explicit environment opt-in and needs
+    // no additional path. [ORB-10945] [ORB-12261]
     if Provider::parse(provider).ok() == Some(Provider::Cursor)
         && let Some(state_dir) = super::provider_dirs::cursor_state_dir(home)
     {
@@ -265,18 +267,22 @@ pub(super) fn compile_macos_sandbox_profile_with_env(
 /// Whether `provider`'s CLI reads its own credentials from the macOS login
 /// Keychain, and therefore cannot run under the default Keychain read deny.
 ///
-/// Only Claude Code does today: it keeps its OAuth session in the login
-/// keychain item `Claude Code-credentials` and leaves
-/// `~/.claude/.credentials.json` as an empty stub. Codex, Gemini, and Grok keep
-/// credentials in plain files under their own state directories, which are
-/// already granted, so they keep the deny. Names that do not resolve to a
-/// canonical [`Provider`] keep the deny too — the carve-out fails closed.
-/// [ORB-10929]
+/// Claude Code, Copilot CLI, and Cursor Agent CLI do: each keeps its login
+/// session in a login-keychain item (`Claude Code-credentials`,
+/// `github-copilot-app`, `cursor-access-token` / `cursor-refresh-token`) and
+/// does not persist a readable token under its state directory by default.
+/// Codex, Gemini, and Grok keep credentials in plain files under their own
+/// state directories, which are already granted, so they keep the deny. Names
+/// that do not resolve to a canonical [`Provider`] keep the deny too — the
+/// carve-out fails closed. [ORB-10929] [ORB-12261]
 ///
 /// Internal: callers outside this crate want [`macos_login_keychain_access`],
 /// which answers the question the compiled profile actually settles.
 fn provider_reads_macos_login_keychain(provider: &str) -> bool {
-    Provider::parse(provider).ok() == Some(Provider::Claude)
+    matches!(
+        Provider::parse(provider).ok(),
+        Some(Provider::Claude | Provider::Copilot | Provider::Cursor)
+    )
 }
 
 /// What the compiled profile decides about `provider` reading the *user* login
@@ -339,12 +345,13 @@ pub fn macos_login_keychain_access(
 /// Re-allow the confined provider's own credential store after
 /// [`emit_default_credential_read_denies`], so last-match-wins grants it.
 ///
-/// Without this, a sandboxed `claude` cannot see its Keychain item and reports
-/// `OAuth session expired and could not be refreshed` — an authentication
-/// failure no re-login can clear, because the credential is present and simply
-/// unreadable. The carve-out is deliberately narrow:
-/// - it applies to one provider, so a Codex or Grok agent still cannot read any
-///   keychain;
+/// Without this, a sandboxed Claude, Copilot, or Cursor CLI cannot see its
+/// Keychain item and reports a fake login failure (Claude: OAuth expiry;
+/// Copilot: no authentication information; Cursor: authentication required) —
+/// an authentication failure no re-login can clear, because the credential is
+/// present and simply unreadable. The carve-out is deliberately narrow:
+/// - it applies only to those providers, so a Codex or Grok agent still cannot
+///   read any keychain;
 /// - it covers only the *user* keychain directory; `/Library/Keychains` and
 ///   `/System/Library/Keychains` stay denied for every provider;
 /// - it grants reads only. Nothing here makes the login keychain writable, so a

--- a/crates/orbit-exec/src/macos_sandbox/provider_dirs.rs
+++ b/crates/orbit-exec/src/macos_sandbox/provider_dirs.rs
@@ -128,10 +128,14 @@ pub(crate) fn copilot_cache_dir(
         .or_else(|| non_empty_env_path(home).map(|path| path.join(".cache").join("copilot")))
 }
 
-/// Cursor CLI stores login credentials, CLI configuration, permissions, and
-/// session state under `$HOME/.cursor`. The caller gates this directory on an
-/// active Cursor executor so other providers do not receive Cursor-specific
-/// write access. [ORB-10945]
+/// Cursor CLI stores configuration, permissions, and session state under
+/// `$HOME/.cursor`. On macOS the default logged-in credential lives in the
+/// login keychain (`cursor-access-token` / `cursor-refresh-token`); the file
+/// store at `$HOME/.cursor/auth.json` is used only when
+/// `AGENT_CLI_CREDENTIAL_STORE=file` was set at login time. `CURSOR_API_KEY`
+/// is the environment opt-in that skips both stores. The caller gates this
+/// directory on an active Cursor executor so other providers do not receive
+/// Cursor-specific write access. [ORB-10945] [ORB-12261]
 pub(crate) fn cursor_state_dir(home: Option<&OsStr>) -> Option<PathBuf> {
     non_empty_env_path(home).map(|path| path.join(".cursor"))
 }

--- a/crates/orbit-exec/src/macos_sandbox/tests/compile.rs
+++ b/crates/orbit-exec/src/macos_sandbox/tests/compile.rs
@@ -51,16 +51,11 @@ fn compile_default_profile_denies_well_known_credential_reads() {
     );
 }
 
-#[test]
-fn compile_for_claude_reallows_user_keychain_read_after_the_default_deny() {
-    // Claude Code's OAuth session lives in the macOS login keychain item
-    // `Claude Code-credentials`, not in `~/.claude/.credentials.json`. With the
-    // deny unqualified, every sandboxed Claude run on macOS died reporting an
-    // expired OAuth session that no re-login could clear.
+fn assert_user_keychain_reallow_for(provider: &str) {
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
     let text = compile_with_env(
         &resolved,
-        "claude",
+        provider,
         EnvOverrides {
             home: Some("/Users/test"),
             ..Default::default()
@@ -71,11 +66,11 @@ fn compile_for_claude_reallows_user_keychain_read_after_the_default_deny() {
     let allow = "(allow file-read* (subpath \"/Users/test/Library/Keychains\"))";
     let deny_pos = text.find(deny).expect("default user keychain read deny");
     let allow_pos = text.find(allow).unwrap_or_else(|| {
-        panic!("missing claude user keychain read re-allow: {text}");
+        panic!("missing {provider} user keychain read re-allow: {text}");
     });
     assert!(
         deny_pos < allow_pos,
-        "the re-allow must follow the deny for SBPL last-match-wins: {text}"
+        "the re-allow must follow the deny for SBPL last-match-wins ({provider}): {text}"
     );
 
     // The carve-out is the user's keychain only.
@@ -84,13 +79,13 @@ fn compile_for_claude_reallows_user_keychain_read_after_the_default_deny() {
             !text.contains(&format!(
                 "(allow file-read* (subpath \"{system_keychain}\"))"
             )),
-            "system keychain {system_keychain} must stay denied even for claude: {text}"
+            "system keychain {system_keychain} must stay denied even for {provider}: {text}"
         );
     }
     // Reading the credential never implies writing it.
     assert!(
         !text.contains("(allow file-write* (subpath \"/Users/test/Library/Keychains\"))"),
-        "keychain writes must stay denied: {text}"
+        "keychain writes must stay denied for {provider}: {text}"
     );
     // Unrelated credential stores keep their denies.
     for other in [
@@ -100,13 +95,49 @@ fn compile_for_claude_reallows_user_keychain_read_after_the_default_deny() {
     ] {
         assert!(
             text.contains(&format!("(deny file-read* (subpath \"{other}\"))")),
-            "missing credential read deny for {other}: {text}"
+            "missing credential read deny for {other} ({provider}): {text}"
         );
         assert!(
             !text.contains(&format!("(allow file-read* (subpath \"{other}\"))")),
-            "{other} must not be re-allowed: {text}"
+            "{other} must not be re-allowed for {provider}: {text}"
         );
     }
+
+    assert_eq!(
+        macos_login_keychain_access(
+            provider,
+            Some(std::ffi::OsStr::new("/Users/test")),
+            &resolved
+        ),
+        MacosLoginKeychainAccess::Allowed,
+        "{provider} must report the user keychain as reachable"
+    );
+}
+
+#[test]
+fn compile_for_claude_reallows_user_keychain_read_after_the_default_deny() {
+    // Claude Code's OAuth session lives in the macOS login keychain item
+    // `Claude Code-credentials`, not in `~/.claude/.credentials.json`. With the
+    // deny unqualified, every sandboxed Claude run on macOS died reporting an
+    // expired OAuth session that no re-login could clear.
+    assert_user_keychain_reallow_for("claude");
+}
+
+#[test]
+fn compile_for_copilot_reallows_user_keychain_read_after_the_default_deny() {
+    // Copilot CLI 1.0.84 keeps its only login in the keychain item
+    // `github-copilot-app`. Denying `$HOME/Library/Keychains` reproduces
+    // `No authentication information found` even when `/login` succeeded
+    // unsandboxed. [ORB-12261]
+    assert_user_keychain_reallow_for("copilot");
+}
+
+#[test]
+fn compile_for_cursor_reallows_user_keychain_read_after_the_default_deny() {
+    // Cursor Agent CLI defaults to the login keychain on darwin
+    // (`cursor-access-token` / `cursor-refresh-token`). `$HOME/.cursor/auth.json`
+    // is only the `AGENT_CLI_CREDENTIAL_STORE=file` opt-in. [ORB-12261]
+    assert_user_keychain_reallow_for("cursor");
 }
 
 /// [ORB-10931] The clause order *is* the policy under SBPL last-match-wins, so
@@ -114,58 +145,63 @@ fn compile_for_claude_reallows_user_keychain_read_after_the_default_deny() {
 /// then the activity's own negated `read` rules. An operator who denies a
 /// credential path must not be silently overridden by the carve-out.
 #[test]
-fn compile_orders_activity_read_denies_after_the_claude_keychain_reallow() {
+fn compile_orders_activity_read_denies_after_the_provider_keychain_reallow() {
     let allow = "(allow file-read* (subpath \"/Users/test/Library/Keychains\"))";
     let default_deny = "(deny file-read* (subpath \"/Users/test/Library/Keychains\"))";
 
-    // Both the exact keychain directory and a broader ancestor must win.
-    for activity_deny in [
-        "!/Users/test/Library/Keychains",
-        "!/Users/test/Library",
-        "!/Users/test/Library/**",
-    ] {
-        let resolved = profile(
-            "hardened",
-            &["/Users/test/repo", activity_deny],
-            &["/Users/test/repo/src"],
-        );
-        let text = compile_with_env(
-            &resolved,
-            "claude",
-            EnvOverrides {
-                home: Some("/Users/test"),
-                ..Default::default()
-            },
-        );
+    // Both the exact keychain directory and a broader ancestor must win, for
+    // every provider that receives the carve-out.
+    for provider in ["claude", "copilot", "cursor"] {
+        for activity_deny in [
+            "!/Users/test/Library/Keychains",
+            "!/Users/test/Library",
+            "!/Users/test/Library/**",
+        ] {
+            let resolved = profile(
+                "hardened",
+                &["/Users/test/repo", activity_deny],
+                &["/Users/test/repo/src"],
+            );
+            let text = compile_with_env(
+                &resolved,
+                provider,
+                EnvOverrides {
+                    home: Some("/Users/test"),
+                    ..Default::default()
+                },
+            );
 
-        let activity_clause = format!(
-            "(deny file-read* (subpath \"{}\"))",
-            activity_deny
-                .trim_start_matches('!')
-                .trim_end_matches("/**")
-        );
-        let default_deny_pos = text.find(default_deny).expect("default keychain read deny");
-        let allow_pos = text.find(allow).expect("claude keychain read re-allow");
-        let activity_pos = text
-            .rfind(&activity_clause)
-            .unwrap_or_else(|| panic!("missing activity read deny {activity_deny}: {text}"));
-        assert!(
-            default_deny_pos < allow_pos && allow_pos < activity_pos,
-            "order must be default deny -> provider re-allow -> activity deny for \
-             {activity_deny}: {text}"
-        );
+            let activity_clause = format!(
+                "(deny file-read* (subpath \"{}\"))",
+                activity_deny
+                    .trim_start_matches('!')
+                    .trim_end_matches("/**")
+            );
+            let default_deny_pos = text.find(default_deny).expect("default keychain read deny");
+            let allow_pos = text
+                .find(allow)
+                .unwrap_or_else(|| panic!("missing {provider} keychain read re-allow: {text}"));
+            let activity_pos = text.rfind(&activity_clause).unwrap_or_else(|| {
+                panic!("missing activity read deny {activity_deny} for {provider}: {text}")
+            });
+            assert!(
+                default_deny_pos < allow_pos && allow_pos < activity_pos,
+                "order must be default deny -> provider re-allow -> activity deny for \
+                 {provider} {activity_deny}: {text}"
+            );
 
-        assert_eq!(
-            macos_login_keychain_access(
-                "claude",
-                Some(std::ffi::OsStr::new("/Users/test")),
-                &resolved
-            ),
-            MacosLoginKeychainAccess::DeniedByActivityRule {
-                rule: activity_deny.to_string()
-            },
-            "the reported access must match the compiled clause order"
-        );
+            assert_eq!(
+                macos_login_keychain_access(
+                    provider,
+                    Some(std::ffi::OsStr::new("/Users/test")),
+                    &resolved
+                ),
+                MacosLoginKeychainAccess::DeniedByActivityRule {
+                    rule: activity_deny.to_string()
+                },
+                "the reported access must match the compiled clause order for {provider}"
+            );
+        }
     }
 }
 
@@ -179,17 +215,19 @@ fn keychain_access_stays_allowed_without_an_overlapping_activity_deny() {
         &["/Users/test/repo", "!/Users/test/.ssh", "!/Users/other"],
         &["/Users/test/repo/src"],
     );
-    assert_eq!(
-        macos_login_keychain_access("claude", Some(home), &unrelated),
-        MacosLoginKeychainAccess::Allowed
-    );
+    for provider in ["claude", "copilot", "cursor"] {
+        assert_eq!(
+            macos_login_keychain_access(provider, Some(home), &unrelated),
+            MacosLoginKeychainAccess::Allowed
+        );
+        assert_eq!(
+            macos_login_keychain_access(provider, None, &unrelated),
+            MacosLoginKeychainAccess::HomeUnresolved
+        );
+    }
     assert_eq!(
         macos_login_keychain_access("codex", Some(home), &unrelated),
         MacosLoginKeychainAccess::DeniedByDefaultPolicy
-    );
-    assert_eq!(
-        macos_login_keychain_access("claude", None, &unrelated),
-        MacosLoginKeychainAccess::HomeUnresolved
     );
     // A non-negated `read` entry naming the keychain is not a denial.
     let positive = profile(
@@ -197,17 +235,21 @@ fn keychain_access_stays_allowed_without_an_overlapping_activity_deny() {
         &["/Users/test/Library/Keychains"],
         &["/Users/test/repo/src"],
     );
-    assert_eq!(
-        macos_login_keychain_access("claude", Some(home), &positive),
-        MacosLoginKeychainAccess::Allowed
-    );
+    for provider in ["claude", "copilot", "cursor"] {
+        assert_eq!(
+            macos_login_keychain_access(provider, Some(home), &positive),
+            MacosLoginKeychainAccess::Allowed
+        );
+    }
 }
 
 #[test]
-fn compile_for_non_claude_providers_keeps_the_user_keychain_denied() {
+fn compile_for_providers_without_keychain_credentials_keeps_the_user_keychain_denied() {
     // The keychain grant is per-provider on purpose: it is the confined CLI's
-    // own credential store, not a shared allowance. Codex and Grok authenticate
-    // from files under their own state dirs and must never see the keychain.
+    // own credential store, not a shared allowance. Codex, Grok, and Gemini
+    // authenticate from files under their own state dirs and must never see
+    // the keychain. Claude, Copilot, and Cursor are the exceptions, covered
+    // above.
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
     let allow = "(allow file-read* (subpath \"/Users/test/Library/Keychains\"))";
     for provider in ["codex", "grok", "gemini", "ollama", "not-a-provider", ""] {
@@ -231,17 +273,19 @@ fn compile_for_non_claude_providers_keeps_the_user_keychain_denied() {
 }
 
 #[test]
-fn compile_for_claude_without_home_emits_no_keychain_reallow() {
+fn compile_for_keychain_backed_providers_without_home_emits_no_keychain_reallow() {
     // Without HOME there is no path to re-allow. The profile must not fall back
     // to a broader clause; the run fails the same way it did before instead.
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
-    let text = compile_with_env(&resolved, "claude", EnvOverrides::default());
-    assert!(
-        !text
-            .lines()
-            .any(|line| line.starts_with("(allow file-read*") && line.contains("Keychains")),
-        "no keychain read allow may be emitted without HOME: {text}"
-    );
+    for provider in ["claude", "copilot", "cursor"] {
+        let text = compile_with_env(&resolved, provider, EnvOverrides::default());
+        assert!(
+            !text
+                .lines()
+                .any(|line| line.starts_with("(allow file-read*") && line.contains("Keychains")),
+            "no keychain read allow may be emitted without HOME for {provider}: {text}"
+        );
+    }
 }
 
 #[test]
@@ -322,7 +366,7 @@ use orbit_types::policy::ResolvedFsProfile;
 
 #[cfg(target_os = "macos")]
 #[test]
-fn compiled_profile_lets_only_claude_read_the_user_keychain_directory() {
+fn compiled_profile_lets_keychain_backed_providers_read_the_user_keychain_directory() {
     // Kernel-level complement to the profile-text assertions: prove the
     // last-match-wins ordering actually resolves the way the clauses read. A
     // synthetic HOME stands in for the real login keychain so the test never
@@ -338,7 +382,12 @@ fn compiled_profile_lets_only_claude_read_the_user_keychain_directory() {
         modify: vec![],
     };
 
-    for (provider, should_read) in [("claude", true), ("codex", false)] {
+    for (provider, should_read) in [
+        ("claude", true),
+        ("copilot", true),
+        ("cursor", true),
+        ("codex", false),
+    ] {
         assert_eq!(
             fixture.credential_readable(&resolved, provider),
             should_read,
@@ -354,7 +403,7 @@ fn compiled_profile_lets_only_claude_read_the_user_keychain_directory() {
 /// kernel resolves it.
 #[cfg(target_os = "macos")]
 #[test]
-fn compiled_profile_honors_an_activity_keychain_deny_for_claude() {
+fn compiled_profile_honors_an_activity_keychain_deny_for_keychain_backed_providers() {
     if !sandbox_exec_can_apply() {
         return;
     }
@@ -367,33 +416,35 @@ fn compiled_profile_honors_an_activity_keychain_deny_for_claude() {
         read: vec![home_text.clone()],
         modify: vec![],
     };
-    assert!(
-        fixture.credential_readable(&default_allow, "claude"),
-        "without an overlapping deny, claude keeps its OAuth keychain read"
-    );
-
-    for deny in [
-        format!("!{home_text}/Library/Keychains"),
-        format!("!{home_text}/Library"),
-    ] {
-        let hardened = ResolvedFsProfile {
-            name: "hardened".to_string(),
-            read: vec![home_text.clone(), deny.clone()],
-            modify: vec![],
-        };
+    for provider in ["claude", "copilot", "cursor"] {
         assert!(
-            !fixture.credential_readable(&hardened, "claude"),
-            "activity rule {deny} must deny claude the keychain read"
+            fixture.credential_readable(&default_allow, provider),
+            "without an overlapping deny, {provider} keeps its keychain read"
         );
-        assert_eq!(
-            macos_login_keychain_access(
-                "claude",
-                Some(std::ffi::OsStr::new(&home_text)),
-                &hardened
-            ),
-            MacosLoginKeychainAccess::DeniedByActivityRule { rule: deny.clone() },
-            "the reported access must match what the kernel enforced for {deny}"
-        );
+
+        for deny in [
+            format!("!{home_text}/Library/Keychains"),
+            format!("!{home_text}/Library"),
+        ] {
+            let hardened = ResolvedFsProfile {
+                name: "hardened".to_string(),
+                read: vec![home_text.clone(), deny.clone()],
+                modify: vec![],
+            };
+            assert!(
+                !fixture.credential_readable(&hardened, provider),
+                "activity rule {deny} must deny {provider} the keychain read"
+            );
+            assert_eq!(
+                macos_login_keychain_access(
+                    provider,
+                    Some(std::ffi::OsStr::new(&home_text)),
+                    &hardened
+                ),
+                MacosLoginKeychainAccess::DeniedByActivityRule { rule: deny.clone() },
+                "the reported access must match what the kernel enforced for {provider} {deny}"
+            );
+        }
     }
 }
 

--- a/crates/orbit-exec/src/macos_sandbox/tests/provider_dirs.rs
+++ b/crates/orbit-exec/src/macos_sandbox/tests/provider_dirs.rs
@@ -792,11 +792,11 @@ fn compile_uses_the_copilot_home_override_for_the_active_executor() {
 }
 
 #[test]
-fn copilot_does_not_receive_the_macos_keychain_carve_out() {
-    // Copilot stores its credentials under COPILOT_HOME, not the login
-    // keychain, so it keeps the default credential deny. It also must not be
-    // handed the GitHub CLI's credential store: borrowing another tool's
-    // credentials is exactly what the auth contract forbids.
+fn copilot_reallows_the_user_keychain_but_not_github_cli_credentials() {
+    // Copilot's `/login` session lives in the macOS login keychain item
+    // `github-copilot-app`, so the confined Copilot profile re-allows that
+    // user directory. It must still not borrow the GitHub CLI's credential
+    // store: that is a different tool's secret. [ORB-12261]
     let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
 
     let text = compile_with_env(
@@ -808,9 +808,16 @@ fn copilot_does_not_receive_the_macos_keychain_carve_out() {
         },
     );
 
-    assert!(!text.contains("(allow file-read* (subpath \"/Users/test/Library/Keychains\"))"));
-    assert!(text.contains("(deny file-read* (subpath \"/Users/test/Library/Keychains\"))"));
+    let deny = "(deny file-read* (subpath \"/Users/test/Library/Keychains\"))";
+    let allow = "(allow file-read* (subpath \"/Users/test/Library/Keychains\"))";
+    let deny_pos = text.find(deny).expect("default user keychain deny");
+    let allow_pos = text.find(allow).expect("copilot user keychain re-allow");
+    assert!(
+        deny_pos < allow_pos,
+        "re-allow must follow the default deny"
+    );
     assert!(text.contains("(deny file-read* (subpath \"/Users/test/.config/gh\"))"));
+    assert!(!text.contains("(allow file-read* (subpath \"/Users/test/.config/gh\"))"));
 }
 
 #[test]

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,7 +1,7 @@
 ---
 type: context
 summary: Orbit Configuration
-last_validated: 2026-09-07
+last_validated: 2026-09-12
 ---
 
 # Orbit Configuration
@@ -292,14 +292,16 @@ Copilot resolves credentials in this documented order:
 1. `COPILOT_GITHUB_TOKEN`
 2. `GH_TOKEN`
 3. `GITHUB_TOKEN`
-4. Otherwise, the credentials stored by `copilot` itself via its `/login`
-   command, under `COPILOT_HOME` (default `$HOME/.copilot`).
+4. Otherwise the session stored by `copilot /login`. On macOS that session is
+   the login-keychain item `github-copilot-app`, not a file under
+   `COPILOT_HOME`. `COPILOT_HOME` (default `$HOME/.copilot`) still holds CLI
+   configuration, session history, `mcp-config.json`, and logs.
 
 **Orbit does not forward those token variables on the provider's behalf.**
 Agent subprocesses get an allowlist-composed environment, and credentials are
 admitted only when an operator names them, so an unrelated `GITHUB_TOKEN` left
-in the environment cannot be silently borrowed by a Copilot run. To use
-token-based authentication, add the variable explicitly:
+in the environment cannot be silently borrowed by a Copilot run. To skip the
+macOS keychain and use token-based authentication, add the variable explicitly:
 
 ```toml
 [execution.env]
@@ -307,8 +309,9 @@ pass = ["COPILOT_GITHUB_TOKEN"]
 ```
 
 Token *values* are never logged, recorded in audit argv, or included in error
-messages. The recommended setup is `copilot` `/login` once on the host, which
-needs no token in the environment at all.
+messages. The recommended setup on a Mac is `copilot` `/login` once on the
+host, which needs no token in the environment at all; Orbit's Copilot sandbox
+profile re-allows `$HOME/Library/Keychains` reads so that item is visible.
 
 `COPILOT_HOME` is forwarded to the provider subprocess and is also what the
 sandbox grants, so the directory the CLI writes to and the directory Orbit
@@ -349,8 +352,11 @@ package-extraction cache (`$XDG_CACHE_HOME/copilot`, default
 actually running** — other providers do not inherit them.
 
 Copilot is not granted read access to the GitHub CLI's credential store
-(`~/.config/gh`) or to the macOS login keychain; it authenticates from its own
-`COPILOT_HOME` or from an operator-passed token.
+(`~/.config/gh`). On macOS, the confined Copilot profile re-allows reads of
+`$HOME/Library/Keychains` so `/login` can see `github-copilot-app`;
+`/Library/Keychains` and `/System/Library/Keychains` stay denied, and an
+activity `denyRead` on the user keychain directory outranks the carve-out. To
+skip the keychain, pass `COPILOT_GITHUB_TOKEN` through `[execution.env].pass`.
 
 ### Prompt transport
 
@@ -389,10 +395,15 @@ never falls back to Codex or another model vendor.
 
 ### Authentication and credential handling
 
-Cursor supports two local CLI authentication paths:
+Cursor supports these local CLI authentication paths:
 
-1. Run `cursor-agent login` once and verify it with `cursor-agent status`. The
-   login state is stored under `$HOME/.cursor`.
+1. Run `cursor-agent login` once and verify it with `cursor-agent status`.
+   On macOS the default store is the login keychain (`cursor-access-token` /
+   `cursor-refresh-token`). `$HOME/.cursor/auth.json` is used only when
+   `AGENT_CLI_CREDENTIAL_STORE=file` was set **at login**; setting that
+   variable later does not migrate an existing keychain session. Orbit's
+   Cursor sandbox profile re-allows `$HOME/Library/Keychains` reads so the
+   default login is visible.
 2. Generate a Cursor user API key and explicitly pass `CURSOR_API_KEY` to the
    agent subprocess:
 
@@ -440,9 +451,10 @@ response envelope. A non-zero exit, malformed object, missing field, non-string
 result, or absent Orbit completion envelope fails closed.
 
 Only an active Cursor executor receives write access to `$HOME/.cursor` for
-login state, CLI settings, permissions, and sessions. Other providers do not
-inherit that write grant. The worktree and all other paths remain governed by
-the activity filesystem profile.
+CLI settings, permissions, and sessions. That directory is not the default
+macOS login store. Other providers do not inherit the write grant. The
+worktree and all other paths remain governed by the activity filesystem
+profile.
 
 ---
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -401,9 +401,18 @@ Cursor supports these local CLI authentication paths:
    On macOS the default store is the login keychain (`cursor-access-token` /
    `cursor-refresh-token`). `$HOME/.cursor/auth.json` is used only when
    `AGENT_CLI_CREDENTIAL_STORE=file` was set **at login**; setting that
-   variable later does not migrate an existing keychain session. Orbit's
-   Cursor sandbox profile re-allows `$HOME/Library/Keychains` reads so the
-   default login is visible.
+   variable later does not migrate an existing keychain session. The CLI picks
+   its store from that variable on every run, so a file-store login also has to
+   reach the agent subprocess — the child environment is cleared, and an
+   unlisted name is absent:
+
+   ```toml
+   [execution.env]
+   pass = ["AGENT_CLI_CREDENTIAL_STORE"]
+   ```
+
+   Orbit's Cursor sandbox profile re-allows `$HOME/Library/Keychains` reads, so
+   the default keychain login needs neither of those.
 2. Generate a Cursor user API key and explicitly pass `CURSOR_API_KEY` to the
    agent subprocess:
 

--- a/docs/runbooks/executor-onboarding.md
+++ b/docs/runbooks/executor-onboarding.md
@@ -102,7 +102,7 @@ On macOS, Orbit's `macos-sandbox-exec` profile denies `$HOME/Library/Keychains` 
 | --- | --- | --- |
 | `claude` | login keychain item `Claude Code-credentials` | `ANTHROPIC_API_KEY` via `[execution.env].pass` |
 | `copilot` | login keychain item `github-copilot-app` | `COPILOT_GITHUB_TOKEN` via `[execution.env].pass` |
-| `cursor` | login keychain items `cursor-access-token` / `cursor-refresh-token` | `CURSOR_API_KEY` via `[execution.env].pass`, or log in with `AGENT_CLI_CREDENTIAL_STORE=file` (writes `$HOME/.cursor/auth.json`; setting the variable later does not migrate an existing keychain login) |
+| `cursor` | login keychain items `cursor-access-token` / `cursor-refresh-token` | `CURSOR_API_KEY` via `[execution.env].pass`, or log in with `AGENT_CLI_CREDENTIAL_STORE=file` and pass that variable too (it writes `$HOME/.cursor/auth.json`, the CLI re-reads the variable on every run, and setting it later does not migrate an existing keychain login) |
 
 A failed keychain-backed step records Orbit's diagnosis — sandbox hid the item versus a real logout — on the run error and the task's `workflow_run_failed` note, not only `exited with code Some(1)`. Do not document a provider as file-backed on macOS from its state directory alone; inspect the CLI's credential store.
 

--- a/docs/runbooks/executor-onboarding.md
+++ b/docs/runbooks/executor-onboarding.md
@@ -1,7 +1,7 @@
 ---
 type: runbook
 summary: Add and validate a CLI-agent or deterministic local-shell executor without changing existing users' routing or state.
-last_validated: 2026-09-07
+last_validated: 2026-09-12
 tags: [contributors, executors, providers, testing]
 paths: ["crates/orbit-agent/**", "crates/orbit-core/assets/executors/**", "crates/orbit-core/src/application/executor.rs", "crates/orbit-core/src/adapter/engine_host/v2_host/cli_executor.rs", "crates/orbit-engine/src/activity_job/**"]
 related_features: [activity-job, policy-sandbox]
@@ -57,7 +57,7 @@ Verify the seams against the current checkout before editing. These are the auth
 | Provider terminal-output reduction | `crates/orbit-agent/src/providers/<provider>/<provider>_output.rs` | Reduce the provider protocol to trustworthy terminal response bytes before the common completion-envelope parser. Reject stale, partial, malformed, or failed frames. |
 | Child lifecycle, cancellation, and cleanup | `crates/orbit-engine/src/activity_job/cli_runner/`; `crates/orbit-exec/src/supervision/` | Reuse the v2 runner and supervisor. Do not add provider-owned process spawning or cleanup. |
 | Deterministic shell input and output | `crates/orbit-engine/src/executor/automation/shell.rs` — `local_shell`, `parse_shell_config`, `compose_argv` | Keep argv in static activity config. Run an actual shell only when `shell` and `script` are declared explicitly. |
-| OS sandbox / provider home grant | `crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs`; `crates/orbit-exec/src/macos_sandbox/provider_dirs.rs` | Give only the active provider's required state directory a write grant. Keep the activity `fsProfile` authoritative for the worktree. |
+| OS sandbox / provider home grant | `crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs`; `crates/orbit-exec/src/macos_sandbox/provider_dirs.rs`; `crates/orbit-exec/src/macos_sandbox/compile.rs` | Give only the active provider's required state directory a write grant. Keep the activity `fsProfile` authoritative for the worktree. On macOS, a state-directory grant is not a login: Claude, Copilot, and Cursor keep their default login in the user keychain and receive a narrow `$HOME/Library/Keychains` read carve-out. |
 | End-to-end fixtures | `crates/orbit-core/tests/pi_fake_agent.rs`, `crates/orbit-core/tests/antigravity_fake_agent.rs`, `crates/orbit-core/tests/opencode_fake_agent.rs`, `crates/orbit-engine/tests/v2_local_shell.rs` | Exercise the real v2 dispatch seam with fakes; add output/error/timeout/cancellation cases. |
 
 ## Add a CLI-agent executor
@@ -67,7 +67,7 @@ Verify the seams against the current checkout before editing. These are the auth
 3. Implement the provider runtime under `crates/orbit-agent/src/providers/<provider>/`. Follow the Pi or Antigravity split: a small argv/stdin transport, a runtime factory with only non-secret required environment, and an output normalizer. Pass optional model/effort only when the provider contract supports them; reject unsupported combinations during configuration resolution rather than silently dropping or remapping them.
 4. Add the bundled executor asset in `crates/orbit-core/assets/executors/<provider>.yaml` and register it in `DEFAULT_EXECUTOR_FILES`. Use static headless flags only. Keep the execution envelope and prompt off argv so process listings, audit argv, and spawn errors cannot expose task content or secrets.
 5. Wire provider discovery and init seeding through the current configuration/init seams. `orbit init` must add a crew only when the local CLI is detected; it must not replace a user-authored crew, credential, command override, or model pin. Check both a fresh seed and a legacy/customized asset through the migration path.
-6. Choose the sandbox posture deliberately. Shipped CLI agent assets opt in to the OS sandbox marker that becomes macOS `sandbox-exec` or Linux Bubblewrap when supported. The provider's own approval flag cannot grant filesystem access the enclosing sandbox denies. Do not use a provider's native sandbox flag as a substitute for Orbit's boundary.
+6. Choose the sandbox posture deliberately. Shipped CLI agent assets opt in to the OS sandbox marker that becomes macOS `sandbox-exec` or Linux Bubblewrap when supported. The provider's own approval flag cannot grant filesystem access the enclosing sandbox denies. Do not use a provider's native sandbox flag as a substitute for Orbit's boundary. If the CLI's default login lives in the macOS login keychain, add it to `provider_reads_macos_login_keychain` and teach `macos_keychain_auth_diagnostic` that CLI's auth-failure wording; a state-directory write grant does not make the keychain readable.
 7. State MCP and shell-tool reach precisely. If the provider has no MCP client, do not add one by implication: the execution envelope must direct the agent to the `orbit` binary supplied on its `PATH`, and tests must retain whatever provider shell capability this route needs. Tool grants and caller-role gates remain enforced by `orbit tool run`.
 
 ### Worked configuration: Pi
@@ -93,6 +93,18 @@ pi --list-models
 ```
 
 Do not put an API key in the executor asset or argv. An operator who deliberately uses an API key adds its variable name to `[execution.env].pass`; an interactive provider login is a separate, unsandboxed setup action and is never performed by an Orbit workflow turn.
+
+### macOS login-keychain credentials
+
+On macOS, Orbit's `macos-sandbox-exec` profile denies `$HOME/Library/Keychains` by default, then re-allows it only for the confined provider when that provider's CLI stores its login there. `/Library/Keychains` and `/System/Library/Keychains` stay denied. An activity `denyRead` on the user keychain directory outranks the carve-out.
+
+| Provider | Default macOS login store | How to skip the keychain |
+| --- | --- | --- |
+| `claude` | login keychain item `Claude Code-credentials` | `ANTHROPIC_API_KEY` via `[execution.env].pass` |
+| `copilot` | login keychain item `github-copilot-app` | `COPILOT_GITHUB_TOKEN` via `[execution.env].pass` |
+| `cursor` | login keychain items `cursor-access-token` / `cursor-refresh-token` | `CURSOR_API_KEY` via `[execution.env].pass`, or log in with `AGENT_CLI_CREDENTIAL_STORE=file` (writes `$HOME/.cursor/auth.json`; setting the variable later does not migrate an existing keychain login) |
+
+A failed keychain-backed step records Orbit's diagnosis — sandbox hid the item versus a real logout — on the run error and the task's `workflow_run_failed` note, not only `exited with code Some(1)`. Do not document a provider as file-backed on macOS from its state directory alone; inspect the CLI's credential store.
 
 ## Add a deterministic local-shell executor
 


### PR DESCRIPTION
## Task

[ORB-12261](https://orbit-cli.com/tasks/ORB-12261) — macOS sandbox hides keychain-backed provider logins (Copilot, Cursor); runs fail auth with no diagnosis

### Description

Observed on Daniels-Mac-mini (Orbit 0.21.0, ws_nebula, DANI-10333, run jrun-20260912-0336-c3). The `copilot` crew (provider copilot, executor `copilot`, sandbox `macos-sandbox-exec`) fails every dispatch in ~400 ms:

    Error: No authentication information found.
    Copilot can be authenticated with GitHub using an OAuth Token or a Fine-Grained Personal Access Token. ...

Outside Orbit `copilot -p "say ok" --output-format json --silent` succeeds on the same host. The Copilot CLI (1.0.84) keeps its only credential in the macOS login keychain (item `github-copilot-app`); `gh` on the host is keyring-backed too, and no COPILOT_GITHUB_TOKEN/GH_TOKEN/GITHUB_TOKEN is in `execution.env.pass`.

Root cause: `provider_reads_macos_login_keychain` in crates/orbit-exec/src/macos_sandbox/compile.rs returns true only for `Provider::Claude` (ORB-10929), so the compiled profile's default deny on `$HOME/Library/Keychains` stands for copilot. Reproduced with a minimal profile: denying `file-read*` on `$HOME/Library/Keychains` (or mach-lookup of com.apple.SecurityServer) yields the identical copilot error; the sonnet/claude crew runs fine in the same sandbox because it receives the carve-out.

Second defect: the failure is not classified. `macos_keychain_auth_diagnostic` (crates/orbit-engine/src/activity_job/cli_runner/spawn.rs) only matches KEYCHAIN_AUTH_FAILURE_MARKER = "OAuth session expired" (Claude's wording), so the run records only `step implement_one: cli subprocess exited with code Some(1)`, the task_pr -> task_gate -> task_auto cascade fails, and the task lands in `blocked` with an unactionable note pointing the operator at re-login, which cannot help.

Fix:
1. Extend the keychain carve-out to Copilot (`Provider::Copilot`), keeping the carve-out narrow (user keychain dir only; `/Library/Keychains` and `/System/Library/Keychains` stay denied; activity denyRead still outranks it). Update the doc comment that says only Claude reads the keychain.
2. Teach `macos_keychain_auth_diagnostic` the Copilot marker ("No authentication information found") so a sandbox denial is reported as Orbit's own denial vs a real logout, per provider.
3. Make the diagnostic reach the task: the `workflow_run_failed` history note / blocked reason should carry the diagnosis, not just the exit code.
4. Docs: the macOS sandbox / executor onboarding notes should list which providers are keychain-backed on macOS and the env-token alternative (`COPILOT_GITHUB_TOKEN` via `execution.env.pass`).

--- Cursor CLI has the same gap (added 2026-09-12) ---

Orbit's premise in crates/orbit-exec/src/macos_sandbox/provider_dirs.rs:131 ("Cursor CLI stores login credentials ... under $HOME/.cursor") is stale. Inspecting the shipped bundle of cursor-agent 2026.09.10-fd3934a (index.js, `src/utils/credential-store.ts` + the store factory):

    store = AGENT_CLI_CREDENTIAL_STORE  ("file" | "memory" | default)
    "memory" -> in-memory; "file" -> ~/.cursor/auth.json; otherwise on darwin -> macOS login keychain via /usr/bin/security add/find-generic-password; other platforms -> file

So on macOS the default logged-in state lives in the keychain, `$HOME/.cursor/auth.json` is only used when AGENT_CLI_CREDENTIAL_STORE=file, and the CLI reports `Error: Authentication required. Please run 'agent login' first, or set CURSOR_API_KEY environment variable.` when it cannot read the item. A cursor crew under `macos-sandbox-exec` will therefore fail exactly like copilot unless the operator logged in with AGENT_CLI_CREDENTIAL_STORE=file (and passes that variable through) or passes CURSOR_API_KEY.

Fix scope for Cursor: include `Provider::Cursor` in the keychain carve-out, add the Cursor auth-required marker to the diagnostic, and correct the provider_dirs.rs comment/docs (file store is opt-in via AGENT_CLI_CREDENTIAL_STORE=file). Empirical repro on the Mac mini pending a Cursor login; the copilot repro is confirmed.

### Acceptance Criteria

- Compiled macOS profile for provider `copilot` re-allows `$HOME/Library/Keychains` reads after the default deny; `macos_login_keychain_access("copilot", ...)` returns Allowed (test in crates/orbit-exec/src/macos_sandbox/tests/compile.rs mirroring the claude case).
- `/Library/Keychains` and `/System/Library/Keychains` remain denied for copilot; an activity denyRead on the user keychain dir still outranks the carve-out.
- `macos_keychain_auth_diagnostic_with("copilot", ...)` recognises the Copilot CLI's 'No authentication information found' output and distinguishes sandbox denial from a real logout (test in crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs).
- A failed copilot step's run error and the task's `workflow_run_failed` history note include the keychain diagnosis text, not only `exited with code Some(1)`.
- Docs updated: which providers are keychain-backed on macOS and how to pass a token instead via `execution.env.pass`.
- cargo test --workspace --no-fail-fast passes (macOS-gated tests may be cfg(target_os = "macos")).
- Compiled macOS profile for provider `cursor` also re-allows `$HOME/Library/Keychains` reads (same bounds as copilot/claude), with a test in macos_sandbox/tests/compile.rs.
- `macos_keychain_auth_diagnostic_with("cursor", ...)` recognises Cursor's 'Authentication required. Please run 'agent login' first' output.
- provider_dirs.rs comment and docs no longer claim Cursor keeps login credentials in $HOME/.cursor by default; they document AGENT_CLI_CREDENTIAL_STORE=file and CURSOR_API_KEY as the non-keychain alternatives.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `provider_reads_macos_login_keychain` now returns true for Claude, Copilot, and Cursor. Compiled macOS profiles re-allow `$HOME/Library/Keychains` reads after the default deny; `/Library/Keychains` and `/System/Library/Keychains` stay denied; activity denyRead still last-match-wins.
- `macos_keychain_auth_diagnostic_with` matches per-provider auth wording (Claude OAuth expiry, Copilot "No authentication information found", Cursor "Authentication required. Please run" covering both quoted and live unquoted forms) and still distinguishes Allowed vs activity deny vs HOME-unresolved.
- A failed Copilot CLI step under `macos-sandbox-exec` now puts that diagnosis on `outcome.message`, which `blocked_workflow_failure_update` inlines into the `workflow_run_failed` note instead of only `exited with code Some(1)`.
- Corrected `provider_dirs.rs`, `docs/CONFIG.md`, and `docs/runbooks/executor-onboarding.md`: Cursor default login is the keychain, not `$HOME/.cursor`; file store is `AGENT_CLI_CREDENTIAL_STORE=file` at login time; token alternatives are `COPILOT_GITHUB_TOKEN` / `CURSOR_API_KEY` via `execution.env.pass`.
Assessment: Scoped to the keychain carve-out, diagnostic markers, and docs. Copilot still cannot borrow `~/.config/gh`. Kernel-level sandbox-exec proofs are cfg(macos) and were not exercised on this Linux runner.

Criteria:
1. Copilot profile re-allows user keychain; `macos_login_keychain_access("copilot", ...)` is Allowed — passed (`compile_for_copilot_reallows_user_keychain_read_after_the_default_deny`).
2. System keychains stay denied; activity denyRead outranks — passed (`assert_user_keychain_reallow_for` + `compile_orders_activity_read_denies_after_the_provider_keychain_reallow`).
3. Copilot diagnostic recognises "No authentication information found" and splits sandbox deny vs real logout — passed (`keychain_auth_diagnostic_recognises_copilot_and_cursor_auth_failures`).
4. Failed Copilot step message and `workflow_run_failed` note include the diagnosis — passed (`run_cli_backend_copilot_keychain_auth_failure_reaches_the_step_message`).
5. Docs list keychain-backed providers and `execution.env.pass` token path — passed (CONFIG.md + executor-onboarding.md).
6. `cargo test --workspace --no-fail-fast` — passed (Linux; macOS-gated tests compiled out).
7. Cursor profile re-allows user keychain — passed (`compile_for_cursor_reallows_user_keychain_read_after_the_default_deny`).
8. Cursor diagnostic recognises auth-required output — passed (quoted AC form and live unquoted form).
9. provider_dirs.rs + docs no longer claim Cursor login lives in `$HOME/.cursor` by default — passed.

Validation:
- `cargo test -p orbit-exec --lib macos_sandbox::tests::compile` — passed (12 tests)
- `cargo test -p orbit-exec --lib copilot_reallows_the_user_keychain` — passed
- `cargo test -p orbit-engine --lib keychain` — passed (5 tests including orchestrator wiring)
- `make ci-fast` — passed
- `make ci-lint` — passed
- `make goldens` — passed
- `cargo test --workspace --no-fail-fast` — passed
- `git diff --check` — passed

Remaining risks:
- Real `sandbox-exec` kernel tests (`compiled_profile_lets_keychain_backed_providers_read_the_user_keychain_directory`, activity-deny counterpart) are cfg(target_os = "macos") and were not run on this Linux host.
- Cursor empirical repro used unquoted `run agent login first`; the marker is the shared prefix so both forms match.
- `AGENT_CLI_CREDENTIAL_STORE=file` does not migrate an existing keychain login (documented).

Unlisted files touched (declared on the task): `file:crates/orbit-exec/src/macos_sandbox/tests/provider_dirs.rs` (stale Copilot deny assertion inverted), `file:docs/CONFIG.md` (operator auth contract), `file:crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs` (step-message / workflow_run_failed wiring). `copilot_fake_agent.rs` unchanged: sandbox confinement stays in compile tests; dispatch fixtures keep sandbox off.

Friction: none filed. The stale file-store premise is the bug this task fixes and is now in code + docs.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12261-6aa4cd4e`
- Behind base: 0
- Ahead of base: 2