### PR TITLE
Human-driven surfaces record actor `unknown`: bare `orbit task add/archive/update --approve`, operation grants, lock reservations, auto-task definitions

### DIFF
--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -159,7 +159,7 @@ impl CommandOperation {
     /// direct commands must use the same actor identity as the runtime.
     pub fn attribute_to(mut self, actor: &ActorIdentity) -> Self {
         if let Some(meta) = self.audit_meta.as_mut() {
-            meta.role.clone_from(&actor.label);
+            meta.role = actor.audit_role().to_string();
         }
         self
     }

--- a/crates/orbit-cli/src/tests/audit_middleware.rs
+++ b/crates/orbit-cli/src/tests/audit_middleware.rs
@@ -88,13 +88,55 @@ fn cli_agent_envelope_records_canonical_actor_family() {
 }
 
 #[test]
-fn cli_without_agent_envelope_records_unknown_actor() {
-    let _env = test_env::unset(AGENT_IDENTITY_ENV.iter().copied().chain(["ORBIT_OPERATOR"]));
+fn cli_without_agent_envelope_records_os_user_actor() {
+    let _env = test_env::scoped(AGENT_IDENTITY_ENV.iter().map(|name| (*name, None)).chain([
+        ("ORBIT_OPERATOR", None),
+        ("USER", Some("qa-operator")),
+        ("USERNAME", None),
+        ("LOGNAME", None),
+    ]));
+
+    let actor = ActorIdentity::from_env();
+    assert_eq!(actor.kind, ActorKind::Human);
+    assert_eq!(actor.label, "human:qa-operator");
+    assert_eq!(actor.audit_role(), "human");
+    assert_eq!(audit_event_for_actor(actor).role, "human");
+}
+
+#[test]
+fn cli_without_any_identity_signal_records_unknown_actor() {
+    let _env = test_env::scoped(AGENT_IDENTITY_ENV.iter().map(|name| (*name, None)).chain([
+        ("ORBIT_OPERATOR", None),
+        ("USER", None),
+        ("USERNAME", None),
+        ("LOGNAME", None),
+    ]));
 
     let actor = ActorIdentity::from_env();
     assert_eq!(actor.kind, ActorKind::Unknown);
     assert_eq!(actor.label, "unknown");
+    assert_eq!(actor.audit_role(), "unknown");
     assert_eq!(audit_event_for_actor(actor).role, "unknown");
+}
+
+#[test]
+fn cli_orbit_actor_override_records_configured_identity() {
+    let _env = test_env::scoped(
+        AGENT_IDENTITY_ENV
+            .iter()
+            .filter(|name| **name != "ORBIT_ACTOR")
+            .map(|name| (*name, None))
+            .chain([
+                ("ORBIT_OPERATOR", None),
+                ("ORBIT_ACTOR", Some("human:desk")),
+                ("USER", Some("ignored")),
+            ]),
+    );
+
+    let actor = ActorIdentity::from_env();
+    assert_eq!(actor.kind, ActorKind::Human);
+    assert_eq!(actor.label, "human:desk");
+    assert_eq!(actor.audit_role(), "human");
 }
 
 #[test]

--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -471,6 +471,12 @@
         "name": "claim_token",
         "param_type": "string",
         "required": false
+      },
+      {
+        "description": "Preferred provenance field. Pass the canonical agent family (`codex`, `claude`, `gemini`, or `grok`); full model strings are accepted and auto-normalized.",
+        "name": "model",
+        "param_type": "string",
+        "required": false
       }
     ],
     "status": "active"
@@ -567,6 +573,12 @@
         "name": "claim_token",
         "param_type": "string",
         "required": false
+      },
+      {
+        "description": "Preferred provenance field. Pass the canonical agent family (`codex`, `claude`, `gemini`, or `grok`); full model strings are accepted and auto-normalized.",
+        "name": "model",
+        "param_type": "string",
+        "required": false
       }
     ],
     "status": "active"
@@ -599,6 +611,12 @@
       {
         "description": "Token for this workspace's exclusive claim, when another operator holds one",
         "name": "claim_token",
+        "param_type": "string",
+        "required": false
+      },
+      {
+        "description": "Preferred provenance field. Pass the canonical agent family (`codex`, `claude`, `gemini`, or `grok`); full model strings are accepted and auto-normalized.",
+        "name": "model",
         "param_type": "string",
         "required": false
       }

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -324,6 +324,16 @@
           "description": "Run-layer ceiling on concurrently live leaf runs",
           "type": "integer"
         },
+        "model": {
+          "description": "Preferred provenance field. Pass the canonical agent family (`codex`, `claude`, `gemini`, or `grok`); full model strings are accepted and auto-normalized.",
+          "enum": [
+            "codex",
+            "claude",
+            "gemini",
+            "grok"
+          ],
+          "type": "string"
+        },
         "preset": {
           "description": "Run-layer preset override: supervised or autonomous (resets the preset-managed fields)",
           "type": "string"
@@ -459,6 +469,16 @@
           "description": "Apply only if the grant is still at this revision",
           "type": "integer"
         },
+        "model": {
+          "description": "Preferred provenance field. Pass the canonical agent family (`codex`, `claude`, `gemini`, or `grok`); full model strings are accepted and auto-normalized.",
+          "enum": [
+            "codex",
+            "claude",
+            "gemini",
+            "grok"
+          ],
+          "type": "string"
+        },
         "reason": {
           "description": "Reason recorded with the revocation",
           "type": "string"
@@ -488,6 +508,16 @@
         "if_revision": {
           "description": "Apply only if the grant is still at this revision",
           "type": "integer"
+        },
+        "model": {
+          "description": "Preferred provenance field. Pass the canonical agent family (`codex`, `claude`, `gemini`, or `grok`); full model strings are accepted and auto-normalized.",
+          "enum": [
+            "codex",
+            "claude",
+            "gemini",
+            "grok"
+          ],
+          "type": "string"
         },
         "reason": {
           "description": "Reason recorded with the stop",

--- a/crates/orbit-cli/tests/task_trimmed_surface.rs
+++ b/crates/orbit-cli/tests/task_trimmed_surface.rs
@@ -331,7 +331,7 @@ fn task_add_attributes_from_model_flag_and_managed_identity_env() {
         "gpt-5.6-sol",
         "--json",
     ]);
-    assert_eq!(explicit["created_by"], json!("gpt-5.6-sol"));
+    assert_eq!(explicit["created_by"], json!("codex"));
 
     let ambient_registry = ambient.home.join(".orbit");
     let ambient_registry = ambient_registry
@@ -378,7 +378,7 @@ fn task_add_attributes_from_model_flag_and_managed_identity_env() {
             String::from_utf8_lossy(&output.stderr)
         );
         let managed: Value = serde_json::from_slice(&output.stdout).expect("managed task JSON");
-        assert_eq!(managed["created_by"], json!("gpt-5.6-terra"));
+        assert_eq!(managed["created_by"], json!("codex"));
     }
 
     let after = ambient.task_json(&["task", "list", "--json"]);
@@ -387,12 +387,11 @@ fn task_add_attributes_from_model_flag_and_managed_identity_env() {
     let fixture_tasks = workspace.task_json(&["task", "list", "--json"]);
     let fixture_tasks = fixture_tasks.as_array().expect("fixture task list");
     assert_eq!(fixture_tasks.len(), 3);
-    assert_eq!(
+    assert!(
         fixture_tasks
             .iter()
-            .filter(|task| task["created_by"] == json!("gpt-5.6-terra"))
-            .count(),
-        2
+            .all(|task| task["created_by"] == json!("codex")),
+        "full model strings normalize to the canonical family"
     );
 }
 

--- a/crates/orbit-common/src/governance/operation_mode/operations.rs
+++ b/crates/orbit-common/src/governance/operation_mode/operations.rs
@@ -77,6 +77,7 @@ const REVIEW_POLICY_HELP: &str = "Run-layer review policy: none, before-pr (hold
 const CLAIM_TOKEN_HELP: &str =
     "Token for this workspace's exclusive claim, when another operator holds one";
 const GRANT_ID_HELP: &str = "Grant ID; defaults to the workspace's active grant";
+const MODEL_HELP: &str = "Preferred provenance field. Pass the canonical agent family (`codex`, `claude`, `gemini`, or `grok`); full model strings are accepted and auto-normalized.";
 
 const RUN_LAYER_PARAMS: [ParamSpec; 6] = [
     text_param("preset", PRESET_HELP),
@@ -180,6 +181,7 @@ const ENABLE: OperationModeOperation = OperationModeOperation {
         RUN_LAYER_PARAMS[4],
         RUN_LAYER_PARAMS[5],
         text_param_long("claim_token", "claim-token", CLAIM_TOKEN_HELP),
+        mcp_model_param(),
     ],
     rejects_agent_field: false,
     mcp_scope: Some(McpToolScope::WorkspaceRequired),
@@ -243,6 +245,7 @@ const STOP: OperationModeOperation = OperationModeOperation {
             "Apply only if the grant is still at this revision",
         ),
         text_param_long("claim_token", "claim-token", CLAIM_TOKEN_HELP),
+        mcp_model_param(),
     ],
     rejects_agent_field: false,
     mcp_scope: Some(McpToolScope::WorkspaceRequired),
@@ -265,12 +268,24 @@ const REVOKE: OperationModeOperation = OperationModeOperation {
             "Apply only if the grant is still at this revision",
         ),
         text_param_long("claim_token", "claim-token", CLAIM_TOKEN_HELP),
+        mcp_model_param(),
     ],
     rejects_agent_field: false,
     mcp_scope: Some(McpToolScope::WorkspaceRequired),
     cli_json_flag: true,
     cli_render: CliRender::Record,
 };
+
+/// MCP-only provenance field. CLI grant verbs record the process actor.
+const fn mcp_model_param() -> ParamSpec {
+    ParamSpec {
+        name: "model",
+        param_type: ParamType::String,
+        required: false,
+        mcp_description: Some(Description::Static(MODEL_HELP)),
+        cli: None,
+    }
+}
 
 /// A `--<name> <NAME>` string flag for a wire name without an underscore.
 const fn text_param(name: &'static str, description: &'static str) -> ParamSpec {

--- a/crates/orbit-common/src/test_env.rs
+++ b/crates/orbit-common/src/test_env.rs
@@ -30,7 +30,7 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 
 /// The identity pair consulted when a command carries no explicit
 /// `--agent`/`--model` and no input attribution.
-pub const AGENT_IDENTITY_ENV: &[&str] = &["ORBIT_AGENT_NAME", "ORBIT_AGENT_MODEL"];
+pub const AGENT_IDENTITY_ENV: &[&str] = &["ORBIT_AGENT_NAME", "ORBIT_AGENT_MODEL", "ORBIT_ACTOR"];
 
 /// The variables an `orbit-engine` managed run exports into every spawned
 /// activity (see `orbit-engine/src/context/env.rs`): job/task/session
@@ -92,6 +92,7 @@ pub const INHERITED_AUTHORITY_ENV: &[&str] = &[
     // Actor identity and audit role attributed to the child's writes.
     "ORBIT_AGENT_NAME",
     "ORBIT_AGENT_MODEL",
+    "ORBIT_ACTOR",
     "ORBIT_OPERATOR",
     "ORBIT_TASK_ACTOR_KIND",
     // Sandbox and tool grants leased to the host activity, not to a fixture.

--- a/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
@@ -910,7 +910,7 @@ fn apply_task_automation_update_under_lock(
             explicit_planned_by: None,
             explicit_implemented_by: None,
         },
-    );
+    )?;
     runtime.with_mutation(|| {
         let external_refs = if update.external_refs.is_empty() {
             None

--- a/crates/orbit-core/src/adapter/tool_host/operation_mode_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/operation_mode_tools.rs
@@ -12,7 +12,6 @@ use orbit_common::protocol::tool_input::{
     optional_u32_alias, required_string,
 };
 use orbit_config::{CompletionPreference, OperationLayer, OperationPreset, ReviewPolicy};
-use orbit_types::identity::normalize_optional_attribution_label;
 use orbit_types::workflow::{GrantRights, OperationGrant};
 use serde_json::{Value, json};
 
@@ -29,11 +28,9 @@ pub(super) fn dispatch(
     agent: Option<String>,
     model: Option<String>,
 ) -> Result<Value, OrbitError> {
-    let actor = normalize_optional_attribution_label(
-        model.as_deref().or(agent.as_deref()),
-        model.as_deref(),
-    )
-    .unwrap_or_else(|| runtime.actor_label().to_string());
+    let actor = runtime
+        .actor()
+        .resolve_write_label(agent.as_deref(), model.as_deref())?;
     match verb {
         OperationModeVerb::Explain => explain(runtime, &input),
         OperationModeVerb::Enable => enable(runtime, &input, &actor),

--- a/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
@@ -1487,8 +1487,29 @@ fn task_add_tool_infers_agent_from_model_only_input() {
     assert!(output.get("model").is_none_or(serde_json::Value::is_null));
     assert_eq!(
         output.get("created_by").and_then(Value::as_str),
-        Some(orbit_common::test_fixtures::TEST_CODEX_MODEL)
+        Some("codex")
     );
+}
+
+#[test]
+fn task_add_tool_refuses_unrecognized_model() {
+    let _env =
+        orbit_common::test_env::unset(orbit_common::test_env::AGENT_IDENTITY_ENV.iter().copied());
+    let (_root, runtime, _repo_root) = test_runtime();
+
+    let message = invalid_input_message(runtime.execute_tool_command(
+        "orbit.task.add",
+        json!({
+            "title": "Refuse llama provenance",
+            "description": "llama is not a family.",
+            "complexity": "low",
+            "workspace": ".",
+            "model": "llama",
+        }),
+        None,
+        None,
+    ));
+    assert!(message.contains("llama"), "{message}");
 }
 
 #[test]

--- a/crates/orbit-core/src/application/auto_tasks/crud.rs
+++ b/crates/orbit-core/src/application/auto_tasks/crud.rs
@@ -53,7 +53,7 @@ impl OrbitRuntime {
     ) -> Result<AutoTaskDefinition, OrbitError> {
         params.template.required_tools = normalize_required_tools(params.template.required_tools);
         let now = chrono::Utc::now().to_rfc3339();
-        let actor = self.actor_label().to_string();
+        let actor = self.actor().resolve_write_label(None, None)?;
         let definition = AutoTaskDefinition {
             schema_version: AUTO_TASK_SCHEMA_VERSION,
             name: params.name,
@@ -154,11 +154,12 @@ impl OrbitRuntime {
                 ));
             }
             let consumer = crate::application::automation::consumer_key(self, "auto-task", name)?;
+            let actor = self.actor().resolve_write_label(None, None)?;
             orbit_automation::delivery::waive(
                 self.automation_store()?.as_ref(),
                 &consumer,
                 request,
-                self.actor_label(),
+                &actor,
                 chrono::Utc::now(),
             )
             .map_err(orbit_automation::automation_error_to_orbit)?;
@@ -223,7 +224,7 @@ impl OrbitRuntime {
         &self,
         mut definition: AutoTaskDefinition,
     ) -> Result<AutoTaskDefinition, OrbitError> {
-        definition.updated_by = Some(self.actor_label().to_string());
+        definition.updated_by = Some(self.actor().resolve_write_label(None, None)?);
         definition.updated_at = chrono::Utc::now().to_rfc3339();
         self.validate_auto_task(&definition)?;
         self.write_auto_task(&definition)?;

--- a/crates/orbit-core/src/application/task/add.rs
+++ b/crates/orbit-core/src/application/task/add.rs
@@ -125,7 +125,7 @@ impl OrbitRuntime {
             &actor.label,
             canonical_agent.as_deref(),
             canonical_model.as_deref(),
-        );
+        )?;
         let (task_type, initial_status) = infer_task_create_type_and_status(
             params.task_type,
             params.status,

--- a/crates/orbit-core/src/application/task/helpers.rs
+++ b/crates/orbit-core/src/application/task/helpers.rs
@@ -3,6 +3,8 @@ use orbit_common::OrbitError;
 use orbit_types::identity::{normalize_attribution_label, normalize_optional_attribution_label};
 use orbit_types::task::{Task, TaskComment, TaskStatus};
 
+use crate::context::resolve_write_actor_label;
+
 pub(crate) const SYSTEM_ACTOR_LABEL: &str = "system";
 
 pub(crate) struct TaskAttributionInput<'a> {
@@ -26,20 +28,19 @@ pub(crate) struct TaskAttribution {
 /// Assemble mutation and authored-role attribution for human and automation updates.
 ///
 /// The mutation actor is an explicit override (automation uses `system`) or,
-/// otherwise, model > agent > runtime actor. Explicit authored-role mutations
-/// win; inferred role labels use model > agent > runtime model identity >
-/// mutation actor, while inferred `implemented_by` preserves an existing value.
-/// `implemented_by` inference is applied only while entering review or done.
+/// otherwise, the shared write-path resolver (canonical family, else the
+/// process actor). Explicit authored-role mutations win; inferred role labels
+/// use model > agent > runtime model identity > mutation actor, while inferred
+/// `implemented_by` preserves an existing value. `implemented_by` inference is
+/// applied only while entering review or done.
 pub(crate) fn assemble_task_attribution(
     task: &Task,
     input: TaskAttributionInput<'_>,
-) -> TaskAttribution {
-    let actor = input
-        .actor_override
-        .map(|label| normalize_attribution_label(label, None))
-        .unwrap_or_else(|| {
-            effective_actor_label(input.default_actor_label, input.agent, input.model)
-        });
+) -> Result<TaskAttribution, OrbitError> {
+    let actor = match input.actor_override {
+        Some(label) => normalize_attribution_label(label, None),
+        None => effective_actor_label(input.default_actor_label, input.agent, input.model)?,
+    };
     let authored_role_label = normalize_optional_attribution_label(input.model, input.model)
         .or_else(|| normalize_optional_attribution_label(input.agent, input.model))
         .or_else(|| normalize_optional_attribution_label(input.runtime_model_identity, None))
@@ -59,11 +60,11 @@ pub(crate) fn assemble_task_attribution(
         })
     });
 
-    TaskAttribution {
+    Ok(TaskAttribution {
         actor,
         planned_by,
         implemented_by,
-    }
+    })
 }
 
 pub(super) fn build_task_comments(
@@ -105,13 +106,8 @@ pub(super) fn effective_actor_label(
     default_label: &str,
     agent: Option<&str>,
     model: Option<&str>,
-) -> String {
-    let label = match (agent, model) {
-        (_, Some(model)) => model.to_string(),
-        (Some(agent), None) => agent.to_string(),
-        (None, None) => default_label.to_string(),
-    };
-    normalize_attribution_label(&label, model)
+) -> Result<String, OrbitError> {
+    resolve_write_actor_label(default_label, agent, model)
 }
 
 pub(super) fn implementation_label(

--- a/crates/orbit-core/src/application/task/tests/add.rs
+++ b/crates/orbit-core/src/application/task/tests/add.rs
@@ -1,3 +1,4 @@
+use crate::ActorIdentity;
 use crate::application::task::{TaskAddParams, compute_task_add_warnings};
 use orbit_common::OrbitError;
 use orbit_types::task::{TaskStatus, TaskType};
@@ -28,6 +29,67 @@ fn task_add_enters_proposed_and_requires_approval_before_backlog() {
         .start_task(&task.id, Some("start approved task".to_string()), None)
         .expect("backlog task starts directly");
     assert_eq!(started.status, TaskStatus::InProgress);
+}
+
+#[test]
+fn task_add_records_process_actor_when_no_model_is_supplied() {
+    let (_root, runtime) = test_runtime();
+    let runtime = runtime.with_actor(ActorIdentity::human("human:qa"));
+
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Bare CLI provenance".to_string(),
+            description: "Record the process actor.".to_string(),
+            ..Default::default()
+        })
+        .expect("task add succeeds");
+
+    assert_eq!(task.created_by.as_deref(), Some("human:qa"));
+    let history = runtime.get_task_history(&task.id).expect("load history");
+    assert_eq!(history[0].by, "human:qa");
+}
+
+#[test]
+fn task_add_normalizes_full_model_string_to_a_canonical_family() {
+    let (_root, runtime) = test_runtime();
+
+    let task = runtime
+        .add_task_with_identity(
+            TaskAddParams {
+                title: "Model family provenance".to_string(),
+                description: "Normalize gpt-5.5 to codex.".to_string(),
+                ..Default::default()
+            },
+            None,
+            Some("gpt-5.5".to_string()),
+        )
+        .expect("task add succeeds");
+
+    assert_eq!(task.created_by.as_deref(), Some("codex"));
+}
+
+#[test]
+fn task_add_refuses_an_unrecognized_model() {
+    let (_root, runtime) = test_runtime();
+
+    let error = runtime
+        .add_task_with_identity(
+            TaskAddParams {
+                title: "Refuse llama".to_string(),
+                description: "llama is not a family.".to_string(),
+                ..Default::default()
+            },
+            None,
+            Some("llama".to_string()),
+        )
+        .expect_err("llama is invalid_input");
+
+    match error {
+        OrbitError::InvalidInput(message) => {
+            assert!(message.contains("llama"), "{message}");
+        }
+        other => panic!("expected invalid_input, got {other}"),
+    }
 }
 
 #[test]

--- a/crates/orbit-core/src/application/task/transitions.rs
+++ b/crates/orbit-core/src/application/task/transitions.rs
@@ -74,7 +74,7 @@ impl OrbitRuntime {
             &actor.label,
             canonical_agent.as_deref(),
             canonical_model.as_deref(),
-        );
+        )?;
         let append_comments = build_task_comments(comment, effective_label.as_str())?;
         let mut result = None;
         self.stores().tasks().with_task_write_lock(id, &mut || {
@@ -297,13 +297,14 @@ impl OrbitRuntime {
         let (canonical_agent, canonical_model) =
             self.try_canonical_agent_model_identity(agent.as_deref(), model.as_deref())?;
         let actor = self.actor().clone();
-        let effective_label = actor_label_override.unwrap_or_else(|| {
-            effective_actor_label(
+        let effective_label = match actor_label_override {
+            Some(label) => label,
+            None => effective_actor_label(
                 &actor.label,
                 canonical_agent.as_deref(),
                 canonical_model.as_deref(),
-            )
-        });
+            )?,
+        };
         let append_comments = build_task_comments(comment, effective_label.as_str())?;
         let mut started = None;
         self.stores().tasks().with_task_write_lock(id, &mut || {
@@ -626,7 +627,7 @@ impl OrbitRuntime {
             &actor.label,
             canonical_agent.as_deref(),
             canonical_model.as_deref(),
-        );
+        )?;
         let reason = note.trim();
         if reason.is_empty() {
             return Err(OrbitError::InvalidInput(

--- a/crates/orbit-core/src/application/task/update.rs
+++ b/crates/orbit-core/src/application/task/update.rs
@@ -237,7 +237,7 @@ impl OrbitRuntime {
                 explicit_planned_by: params.planned_by.as_ref(),
                 explicit_implemented_by: params.implemented_by.as_ref(),
             },
-        );
+        )?;
         let effective_label = attribution.actor;
         let status_note = status_note
             .as_deref()

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use orbit_common::OrbitError;
 use orbit_engine::PrConfig;
 use orbit_policy::PolicyEngine;
 use orbit_search::{EmbedWorker, SemanticIndex};
@@ -13,7 +14,7 @@ use orbit_store::contracts::{
     V2AuditStoreBackend,
 };
 use orbit_tools::ToolRegistry;
-use orbit_types::identity::{Crew, normalize_agent_family_for_model};
+use orbit_types::identity::{Crew, require_canonical_agent_family};
 use orbit_types::workspace::WorkspacePaths;
 
 use crate::skill_catalog::SkillCatalog;
@@ -21,10 +22,14 @@ use orbit_config::{CodexExecutionPolicy, ExecutionEnvPolicy, PersistenceConfig};
 
 const ORBIT_AGENT_NAME: &str = "ORBIT_AGENT_NAME";
 const ORBIT_AGENT_MODEL: &str = "ORBIT_AGENT_MODEL";
+const ORBIT_ACTOR: &str = "ORBIT_ACTOR";
+const OS_USER_ENV: &[&str] = &["USER", "USERNAME", "LOGNAME"];
 
 /// Actor label recorded when [`OPERATOR_OVERRIDE_ENV`](orbit_common::governance::authorization::OPERATOR_OVERRIDE_ENV)
 /// is the only signal identifying the caller.
 const OPERATOR_ACTOR_LABEL: &str = "operator";
+const UNKNOWN_ACTOR_LABEL: &str = "unknown";
+const HUMAN_AUDIT_ROLE: &str = "human";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ActorKind {
@@ -43,7 +48,7 @@ impl ActorIdentity {
     pub fn unknown() -> Self {
         Self {
             kind: ActorKind::Unknown,
-            label: "unknown".to_string(),
+            label: UNKNOWN_ACTOR_LABEL.to_string(),
         }
     }
 
@@ -66,11 +71,12 @@ impl ActorIdentity {
     ///
     /// The environment is not an authentication boundary. Agent values are
     /// therefore reduced to the same canonical family used by tool dispatch.
-    /// Absent an agent envelope, an explicit operator override is recorded as
-    /// a named human actor rather than `unknown` — the override is itself a
-    /// deliberate, audited act, so the actor it authorizes (a grant, a task
-    /// mutation, …) should say who enabled it instead of claiming nobody did.
-    /// Only a caller with neither signal is recorded as `unknown`.
+    /// Absent an agent envelope, an explicit `ORBIT_ACTOR` or operator
+    /// override is recorded as a named human actor rather than `unknown` —
+    /// those overrides are themselves a deliberate, audited act. Bare CLI
+    /// otherwise records the OS user (`human:<username>`). Only a caller with
+    /// no remaining signal is recorded as `unknown`, and then only with a
+    /// warning: write paths must not construct that literal themselves.
     pub fn from_env() -> Self {
         let agent = std::env::var(ORBIT_AGENT_NAME)
             .ok()
@@ -79,7 +85,7 @@ impl ActorIdentity {
             .ok()
             .filter(|value| !value.trim().is_empty());
 
-        if let Some(actor) = normalize_agent_family_for_model(agent.as_deref(), model.as_deref())
+        if let Some(actor) = require_canonical_agent_family(agent.as_deref(), model.as_deref())
             .ok()
             .flatten()
             .map(Self::agent)
@@ -87,12 +93,78 @@ impl ActorIdentity {
             return actor;
         }
 
+        if let Some(label) = std::env::var(ORBIT_ACTOR)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+        {
+            return Self::human(label);
+        }
+
         if orbit_common::governance::authorization::operator_override_active() {
             return Self::human(OPERATOR_ACTOR_LABEL);
         }
 
-        Self::default()
+        if let Some(user) = os_user_name() {
+            return Self::human(format!("human:{user}"));
+        }
+
+        tracing::warn!(
+            target: "orbit.core.actor",
+            actor = UNKNOWN_ACTOR_LABEL,
+            "no actor identity resolved; recording last-resort unknown"
+        );
+        Self::unknown()
     }
+
+    /// Audit `role` for this process actor.
+    ///
+    /// Bare CLI records `human` (or `operator` when the operator override is
+    /// the identity). Agent envelopes keep the canonical family. The
+    /// last-resort unattributed label stays `unknown`.
+    pub fn audit_role(&self) -> &str {
+        match self.kind {
+            ActorKind::Agent => self.label.as_str(),
+            ActorKind::Human if self.label == OPERATOR_ACTOR_LABEL => OPERATOR_ACTOR_LABEL,
+            ActorKind::Human => HUMAN_AUDIT_ROLE,
+            ActorKind::Unknown => UNKNOWN_ACTOR_LABEL,
+        }
+    }
+
+    /// Resolve the actor label recorded on a write.
+    ///
+    /// Explicit `model`/`agent` wins and must be a canonical family (or a
+    /// full model string that infers one). Otherwise the process actor from
+    /// [`Self::from_env`] is used.
+    pub fn resolve_write_label(
+        &self,
+        agent: Option<&str>,
+        model: Option<&str>,
+    ) -> Result<String, OrbitError> {
+        resolve_write_actor_label(&self.label, agent, model)
+    }
+}
+
+/// Shared write-path actor resolution: explicit model/agent to a canonical
+/// family, otherwise the process actor already resolved by [`ActorIdentity::from_env`].
+pub(crate) fn resolve_write_actor_label(
+    process_label: &str,
+    agent: Option<&str>,
+    model: Option<&str>,
+) -> Result<String, OrbitError> {
+    match require_canonical_agent_family(agent, model)? {
+        Some(family) => Ok(family),
+        None => Ok(process_label.to_string()),
+    }
+}
+
+fn os_user_name() -> Option<String> {
+    OS_USER_ENV.iter().find_map(|key| {
+        std::env::var(key).ok().and_then(|value| {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        })
+    })
 }
 
 impl Default for ActorIdentity {
@@ -447,5 +519,49 @@ fn normalize_actor_label(label: String, default_label: &str) -> String {
         default_label.to_string()
     } else {
         label.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ActorIdentity, ActorKind, resolve_write_actor_label};
+    use orbit_common::OrbitError;
+
+    #[test]
+    fn resolve_write_actor_label_prefers_canonical_family() {
+        assert_eq!(
+            resolve_write_actor_label("human:qa", None, Some("gpt-5.5")).expect("normalize"),
+            "codex"
+        );
+        assert_eq!(
+            resolve_write_actor_label("human:qa", None, Some("claude")).expect("family"),
+            "claude"
+        );
+        assert_eq!(
+            resolve_write_actor_label("human:qa", None, None).expect("process actor"),
+            "human:qa"
+        );
+    }
+
+    #[test]
+    fn resolve_write_actor_label_refuses_unrecognized_model() {
+        let error =
+            resolve_write_actor_label("human:qa", None, Some("llama")).expect_err("llama refused");
+        match error {
+            OrbitError::InvalidInput(message) => {
+                assert!(message.contains("llama"), "{message}");
+            }
+            other => panic!("expected invalid_input, got {other}"),
+        }
+    }
+
+    #[test]
+    fn audit_role_is_kind_not_os_user_label() {
+        let human = ActorIdentity::human("human:qa");
+        assert_eq!(human.kind, ActorKind::Human);
+        assert_eq!(human.audit_role(), "human");
+        assert_eq!(ActorIdentity::human("operator").audit_role(), "operator");
+        assert_eq!(ActorIdentity::agent("codex").audit_role(), "codex");
+        assert_eq!(ActorIdentity::unknown().audit_role(), "unknown");
     }
 }

--- a/crates/orbit-core/src/runtime/task/locks.rs
+++ b/crates/orbit-core/src/runtime/task/locks.rs
@@ -17,7 +17,6 @@ use orbit_store::contracts::{
 };
 use orbit_store::maintenance::task_registry::read_workspace_config_optional;
 use orbit_tools::ReservationOwnerContext;
-use orbit_types::identity::normalize_optional_attribution_label;
 use orbit_types::task::{Task, TaskStatus};
 use orbit_types::telemetry::AuditEventStatus;
 use serde_json::{Value, json};
@@ -144,7 +143,7 @@ pub(crate) fn release(
                         runtime,
                         agent.as_deref(),
                         model.as_deref(),
-                    ),
+                    )?,
                 })
                 .to_string(),
             ),
@@ -175,7 +174,7 @@ pub(crate) fn release(
                     runtime,
                     agent.as_deref(),
                     model.as_deref(),
-                ),
+                )?,
             }),
         )?;
     }
@@ -257,7 +256,7 @@ pub(crate) fn reserve_with_index(
         ));
     }
 
-    let actor = reservation_actor_label(runtime, agent.as_deref(), model.as_deref());
+    let actor = reservation_actor_label(runtime, agent.as_deref(), model.as_deref())?;
     let workspace_id = workspace_task_reservation_id(runtime)?;
     let repo_root = runtime.paths().repo_root.as_path();
     let (task_ids, requested_files) = match &reservation_scope {
@@ -804,9 +803,8 @@ fn reservation_actor_label(
     runtime: &OrbitRuntime,
     agent: Option<&str>,
     model: Option<&str>,
-) -> String {
-    normalize_optional_attribution_label(model.or(agent), model)
-        .unwrap_or_else(|| runtime.actor_label().to_string())
+) -> Result<String, OrbitError> {
+    runtime.actor().resolve_write_label(agent, model)
 }
 
 fn record_task_lock_audit_event(

--- a/crates/orbit-core/src/runtime/task/tests/locks.rs
+++ b/crates/orbit-core/src/runtime/task/tests/locks.rs
@@ -797,6 +797,9 @@ fn reserve_audit_for_task_scope_records_first_task_id() {
     );
     assert_eq!(row.target_id.as_deref(), Some(reservation_id.as_str()));
     assert_eq!(row.task_id.as_deref(), Some(task.id.as_str()));
+    let payload: Value = serde_json::from_str(row.arguments_json.as_deref().expect("payload"))
+        .expect("parse reservation audit payload");
+    assert_eq!(payload["actor"], json!("codex"));
 }
 
 /// ORB-12251: a caller could `reserve` with no capability at all and then be

--- a/crates/orbit-core/src/runtime/workspace_claim.rs
+++ b/crates/orbit-core/src/runtime/workspace_claim.rs
@@ -32,7 +32,7 @@ use orbit_store::contracts::{
     WorkspaceClaimAcquireParams, WorkspaceClaimCheckParams, WorkspaceClaimHolder,
     WorkspaceClaimReleaseParams,
 };
-use orbit_types::identity::normalize_optional_attribution_label;
+
 use orbit_types::telemetry::AuditEventStatus;
 use serde_json::{Value, json};
 
@@ -62,7 +62,7 @@ pub(crate) fn acquire(
             "`ttl_seconds` must be between 1 and {MAX_CLAIM_TTL_SECONDS} seconds"
         )));
     }
-    let actor = claim_actor_label(runtime, agent.as_deref(), model.as_deref());
+    let actor = claim_actor_label(runtime, agent.as_deref(), model.as_deref())?;
     let result = runtime
         .stores()
         .task_reservations()
@@ -139,7 +139,7 @@ pub(crate) fn release(
                 .to_string(),
         ));
     }
-    let released_by = claim_actor_label(runtime, agent.as_deref(), model.as_deref());
+    let released_by = claim_actor_label(runtime, agent.as_deref(), model.as_deref())?;
     let result = runtime
         .stores()
         .task_reservations()
@@ -306,9 +306,12 @@ fn holder_json(claim: &WorkspaceClaimHolder) -> Value {
     })
 }
 
-fn claim_actor_label(runtime: &OrbitRuntime, agent: Option<&str>, model: Option<&str>) -> String {
-    normalize_optional_attribution_label(model.or(agent), model)
-        .unwrap_or_else(|| runtime.actor_label().to_string())
+fn claim_actor_label(
+    runtime: &OrbitRuntime,
+    agent: Option<&str>,
+    model: Option<&str>,
+) -> Result<String, OrbitError> {
+    runtime.actor().resolve_write_label(agent, model)
 }
 
 fn record_expired_claims(

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -13,9 +13,7 @@ pub mod workflow;
 pub mod workspace_claim;
 
 use orbit_common::OrbitError;
-use orbit_types::identity::{
-    normalize_agent_family_for_model, normalize_optional_attribution_label,
-};
+use orbit_types::identity::{normalize_agent_family_for_model, require_canonical_agent_family};
 use orbit_types::tool::{McpToolScope, ToolParam};
 use serde_json::Value;
 
@@ -138,10 +136,6 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register_inactive(semantic::index::OrbitSemanticIndexTool);
 }
 
-fn build_actor_label(agent: Option<&str>, model: Option<&str>) -> Option<String> {
-    normalize_optional_attribution_label(model.or(agent), model)
-}
-
 fn trimmed_optional(value: Option<String>) -> Option<String> {
     value
         .map(|value| value.trim().to_string())
@@ -177,12 +171,11 @@ pub(super) fn resolve_identity(
     } else {
         (None, None)
     };
-    let agent = normalize_agent_family_for_model(agent.as_deref(), model.as_deref())?;
-    let actor_label = build_actor_label(agent.as_deref(), model.as_deref());
+    let family = require_canonical_agent_family(agent.as_deref(), model.as_deref())?;
     Ok(OrbitIdentity {
-        agent,
-        model,
-        actor_label,
+        agent: family.clone(),
+        model: family.clone(),
+        actor_label: family,
     })
 }
 

--- a/crates/orbit-tools/src/builtin/orbit/operation_mode/tests/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/operation_mode/tests/mod.rs
@@ -53,6 +53,7 @@ fn derived_schema_carries_the_declared_parameters_in_order() {
             "recovery_minutes",
             "review_policy",
             "claim_token",
+            "model",
         ]
     );
     assert_eq!(schema.parameters[0].param_type, "string_list");

--- a/crates/orbit-tools/src/builtin/orbit/tests/identity.rs
+++ b/crates/orbit-tools/src/builtin/orbit/tests/identity.rs
@@ -17,6 +17,35 @@ fn runtime_identity_overwrites_self_reported_model_at_tool_boundary() {
     assert_eq!(identity.actor_label.as_deref(), Some("claude"));
 }
 
+#[test]
+fn input_model_normalizes_full_strings_and_refuses_unrecognized_families() {
+    let ctx = ToolContext {
+        cwd: None,
+        session_context: Default::default(),
+        allowed_tools: Vec::new(),
+        workspace_root: None,
+        agent_name: None,
+        model_name: None,
+        proc_allowed_programs: Vec::new(),
+        proc_spawn_environment: None,
+        proc_spawn_activity_scoped: false,
+        policy_engine: None,
+        fs_profile: None,
+        fs_audit: None,
+        reservation_owner: None,
+        orbit_host: None,
+    };
+
+    let identity = resolve_identity(&ctx, &json!({ "model": "gpt-5.5" })).expect("normalize");
+    assert_eq!(identity.agent.as_deref(), Some("codex"));
+    assert_eq!(identity.model.as_deref(), Some("codex"));
+    assert_eq!(identity.actor_label.as_deref(), Some("codex"));
+
+    let error = resolve_identity(&ctx, &json!({ "model": "llama" })).expect_err("llama refused");
+    let message = error.to_string();
+    assert!(message.contains("llama"), "{message}");
+}
+
 fn tool_context(agent: &str, model: &str) -> ToolContext {
     ToolContext {
         cwd: None,

--- a/crates/orbit-types/src/identity/agent_pair.rs
+++ b/crates/orbit-types/src/identity/agent_pair.rs
@@ -270,6 +270,10 @@ pub fn infer_agent_family_from_model(model: &str) -> Option<String> {
         return None;
     }
 
+    if all_agent_families().iter().any(|family| model == *family) {
+        return Some(model);
+    }
+
     if model.starts_with("gpt-") || model.starts_with("o1") || model.starts_with("o3") {
         return Some("codex".to_string());
     }
@@ -322,6 +326,34 @@ pub fn normalize_agent_family_for_model(
     }
 
     Ok(agent.or(inferred))
+}
+
+/// Resolve an optional agent/model pair to a canonical write-attribution family.
+///
+/// A present `model` (or `agent`) must name `codex`, `claude`, `gemini`, or
+/// `grok`, or be a full model string those families can infer. Unrecognized
+/// values such as `llama` are refused rather than stored verbatim.
+pub fn require_canonical_agent_family(
+    agent_cli: Option<&str>,
+    model: Option<&str>,
+) -> Result<Option<String>, IdentityError> {
+    let family = normalize_agent_family_for_model(agent_cli, model)?;
+    let shown = model
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| agent_cli.map(str::trim).filter(|value| !value.is_empty()));
+    let Some(shown) = shown else {
+        return Ok(None);
+    };
+
+    match family {
+        Some(family) if all_agent_families().iter().any(|known| family == *known) => {
+            Ok(Some(family))
+        }
+        _ => Err(IdentityError::Invalid(format!(
+            "`model` '{shown}' is not a canonical agent family (codex, claude, gemini, grok) or a recognized full model string"
+        ))),
+    }
 }
 
 fn is_antigravity_cli(name: &str) -> bool {

--- a/crates/orbit-types/src/identity/mod.rs
+++ b/crates/orbit-types/src/identity/mod.rs
@@ -20,7 +20,7 @@ pub use agent_family::AgentFamily;
 pub use agent_pair::{
     AgentModelPair, Crew, CrewAssignment, ReasoningEffort, agent_family_from_cli,
     all_agent_families, infer_agent_family_from_model, normalize_agent_family_for_model,
-    resolve_crew, validate_antigravity_model,
+    require_canonical_agent_family, resolve_crew, validate_antigravity_model,
 };
 pub use artifact_ids::{is_valid_adr_id, is_valid_friction_id, validate_friction_id};
 pub use host::{

--- a/crates/orbit-types/src/identity/tests/agent_pair.rs
+++ b/crates/orbit-types/src/identity/tests/agent_pair.rs
@@ -96,6 +96,52 @@ mod resolution {
             infer_agent_family_from_model("gemini-3.8-flash-high").as_deref(),
             Some("gemini")
         );
+        for family in ["codex", "claude", "gemini", "grok"] {
+            assert_eq!(
+                infer_agent_family_from_model(family).as_deref(),
+                Some(family),
+                "{family} is itself a canonical family"
+            );
+        }
+        assert_eq!(infer_agent_family_from_model("llama"), None);
+    }
+
+    #[test]
+    fn require_canonical_agent_family_normalizes_or_refuses() {
+        assert_eq!(
+            require_canonical_agent_family(None, Some("gpt-5.5"))
+                .expect("full model string")
+                .as_deref(),
+            Some("codex")
+        );
+        assert_eq!(
+            require_canonical_agent_family(None, Some("claude-opus-4-7"))
+                .expect("full model string")
+                .as_deref(),
+            Some("claude")
+        );
+        assert_eq!(
+            require_canonical_agent_family(None, Some("codex"))
+                .expect("canonical family")
+                .as_deref(),
+            Some("codex")
+        );
+        assert_eq!(
+            require_canonical_agent_family(None, None).expect("absent identity"),
+            None
+        );
+
+        let error = require_canonical_agent_family(None, Some("llama"))
+            .expect_err("unrecognized model is refused");
+        let message = error.to_string();
+        assert!(
+            message.contains("llama"),
+            "names the refused value: {message}"
+        );
+        assert!(
+            message.contains("canonical agent family"),
+            "explains the contract: {message}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Task

[ORB-12250](https://orbit-cli.com/tasks/ORB-12250) — Human-driven surfaces record actor `unknown`: bare `orbit task add/archive/update --approve`, operation grants, lock reservations, auto-task definitions

### Description

The skill says provenance follows the surface: `orbit tool run …` is agent-driven, bare `orbit task …` is human-driven. But on 0.21.0 the human-driven surface records nobody:

- `orbit task add …` → `created_by: "unknown"`, history `by: "unknown"` (DANI-10333)
- `orbit task archive DANI-10329` → history `by: "unknown"`
- `orbit task update DANI-10333 --approve` → `proposal_approved … by: "unknown"`
- `orbit_operation_enable/stop/revoke` (MCP) → `actor: "unknown"` on the grant, on `stopped.actor`, on `revoked.actor` (`ogrant-1789182208975289000-7294-66`)
- `orbit task locks reserve --task …` → reservation `actor: "unknown"`
- `orbit auto-task add …` → `created_by: unknown`, `updated_by: unknown`
- `orbit tool run orbit.task.add` without `model` → `created_by: "unknown"`
- `orbit tool run orbit.task.add --input '{…,"model":"llama"}'` → `created_by: "llama"` stored verbatim (not a canonical family, neither rejected nor normalized, contradicting the schema text)
- `orbit audit list` rows for bare CLI show `Role: unknown`

"unknown" on a governance record (a grant that authorises promotion; a lock that gates dispatch) is the one place an actor must be present.

## What to change

1. Define one `Actor` resolution used by every write path: explicit `model` → canonical agent family; else `ORBIT_ACTOR`/operator identity if set; else for bare CLI the OS user (`human:<username>`); else `unknown` only as a last resort and only with a WARN.
2. Operation grant tools (`enable/stop/revoke`) gain the standard `model` argument and record the resolved actor; MCP sessions without `model` use the session's initialize identity (`orbit mcp serve --orchestrator` crew or the caller row).
3. `task locks reserve/release`, `auto-task add/update/toggle`, `task archive`, `task update --approve` all go through the same resolver.
4. `model` values outside `codex|claude|gemini|grok` are normalized where the schema promises it (full model strings) and refused with `invalid_input` otherwise (`llama`).
5. Audit `role` for bare CLI becomes `human` (or `operator` when `ORBIT_OPERATOR=1`).

Keep the history `by` field's existing shape; just stop writing `unknown` when an actor is knowable.

### Acceptance Criteria

- Bare `orbit task add/archive/update --approve` record `human:<os-user>` (or the configured operator identity) instead of `unknown`
- Operation grants and their stop/revoke records carry a non-`unknown` actor; the MCP tools accept `model`
- Lock reservations and auto-task definitions record the resolved actor
- `model:"llama"` on task.add is refused with `invalid_input`; full model strings still normalize to a family
- One shared actor resolver with unit tests; no write path constructs the literal `unknown` directly

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `require_canonical_agent_family` in orbit-types: full model strings (`gpt-5.5`, `claude-opus-4-7`) and family names normalize to `codex|claude|gemini|grok`; `llama` is `invalid_input`.
- `ActorIdentity::from_env` now resolves agent envelope → `ORBIT_ACTOR` → `ORBIT_OPERATOR=1` (`operator`) → OS user (`human:<USER/USERNAME/LOGNAME>`) → last-resort `unknown` with a warn. Write paths call `resolve_write_actor_label` / `resolve_write_label` instead of constructing `unknown`.
- Audit `role` for bare CLI is `human` (or `operator`); history `by` / `created_by` keep the string label (`human:<user>`, family, or configured identity).
- `orbit.operation.enable/stop/revoke` advertise `model`; grant/stop/revoke, lock reserve/release, auto-task add/update/toggle, task add/archive/approve all use the same resolver.

Criteria:
1. Bare `orbit task add/archive/update --approve` record `human:<os-user>` (or configured identity): met — process actor from `from_env`; tests `task_add_records_process_actor_when_no_model_is_supplied`, `cli_without_agent_envelope_records_os_user_actor`, `cli_orbit_actor_override_records_configured_identity`.
2. Operation grants/stop/revoke carry a non-`unknown` actor; MCP tools accept `model`: met — dispatch uses `resolve_write_label`; MCP snapshots and `tool_list.json` include `model` on enable/stop/revoke.
3. Lock reservations and auto-task definitions record the resolved actor: met — `reservation_actor_label` / auto-task CRUD go through the resolver; lock audit payload actor is the canonical family when `model` is a full string.
4. `model:"llama"` refused with `invalid_input`; full model strings normalize: met — unit tests in orbit-types, orbit-core, orbit-tools, and `task_add_tool_refuses_unrecognized_model`.
5. One shared actor resolver with unit tests; no write path constructs the literal `unknown` directly: met — `resolve_write_actor_label` plus `from_env`; `unknown` exists only as the last-resort constructor used by `from_env` after a warn.

Validation:
- `cargo test -p orbit-types --lib identity`: passed
- `cargo test -p orbit-core --lib` (context, task add, task_tools, locks, auto_tasks): passed
- `cargo test -p orbit-tools --lib identity` and `operation_mode`: passed
- `cargo test -p orbit-cli --bin orbit -- audit_middleware`: passed
- `make goldens UPDATE=1`: passed (MCP `orbit_operation_enable/stop/revoke` gained `model`)
- `make ci-fast`: passed
- `make ci-lint`: passed
- `git diff --check`: passed
- Integration `task_trimmed_surface` assertions updated for family normalization; that test binary was not re-run after a later comment-only edit in helpers.rs

Remaining risks:
- Agents that shell out to bare `orbit task …` without `ORBIT_AGENT_*` are now attributed as `human:<os-user>` (the human-driven surface contract). Use `orbit tool run` for agent provenance.
- MCP calls without `model` fall back to the process actor, not `self_reported_actor` (that field remains audit-only).
- `planned_by`/`implemented_by` inference can still store a full model string via authored-role labels; mutation `by`/`created_by`/`actor` use the canonical family.
- Last-resort `unknown` remains possible if USER/USERNAME/LOGNAME and all other signals are unset.

Deviations: none from the filed plan. Uncommitted; pipeline owns commit/PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12250-6aa4d39f`
- Behind base: 0
- Ahead of base: 1