### PR TITLE
Review gate downgrades a fully-repaired, green review to `incomplete` when a reviewer repair touches a path outside `context_files`, instead of widening the selectors it already permits the reviewer to widen

### DIFF
--- a/crates/orbit-automation/src/review/tests/mod.rs
+++ b/crates/orbit-automation/src/review/tests/mod.rs
@@ -87,6 +87,7 @@ fn certificate(verdict: ReviewVerdict) -> ReviewCertificate {
         consumed: ReviewConsumption::default(),
         budget: ReviewBudget::default(),
         escalation: None,
+        selectors_widened: Vec::new(),
         issued_at: now(),
     }
 }

--- a/crates/orbit-core/assets/activities/agent_review_repair.yaml
+++ b/crates/orbit-core/assets/activities/agent_review_repair.yaml
@@ -63,8 +63,10 @@ spec:
       under your own reviewer identity after you return.
     - Do not change task status, acceptance criteria, plan, or description; do
       not approve, merge, dispatch, or invoke another agent. Adding a tightly
-      coupled `context_files` selector through `orbit.task.update` is the only
-      task edit allowed, and only when a repair needs it.
+      coupled `context_files` selector through `orbit.task.update` is still
+      allowed when a repair needs it. Listing every repaired path on a finding
+      with disposition `repaired` is sufficient for an out-of-selector coupled
+      repair; the gate widens `context_files` from that declaration.
     - Read broadly; write narrowly. Reading unrelated code does not authorize
       editing it.
     - Honor the remaining wall-time budget in the pinned manifest
@@ -90,9 +92,14 @@ spec:
        standards from the workspace AGENTS.md.
     3. Record each finding with a stable id, severity, summary, and paths. Repair
        directly only concrete correctness, test, or documentation defects that
-       stay inside the task's selectors and accepted intent. Requirement
-       changes, new dependency edges, substantial redesign, unrelated cleanup,
-       and anything you are unsure about stay open findings.
+       stay inside the accepted intent. A coupled repair of a derived artifact
+       (goldens, snapshots, lockfiles, generated mirrors) may land outside the
+       implementer's selectors: name every repaired path on the finding.
+       Listing those paths with disposition `repaired` is sufficient; the gate
+       widens `context_files` from that declaration, so you do not have to call
+       `orbit.task.update` first. Requirement changes, new dependency edges,
+       substantial redesign, unrelated cleanup, and anything you are unsure
+       about stay open findings.
     4. Run the repository's required validation on the final worktree state
        (for this repository at least `make ci-fast` and `make ci-lint`, plus the
        focused tests for the change). Record every command you ran or could not

--- a/crates/orbit-core/src/application/review/gate.rs
+++ b/crates/orbit-core/src/application/review/gate.rs
@@ -1,7 +1,7 @@
 //! The before-PR review gate: admit a fresh reviewer, then settle its
 //! report into an honest verdict and certificate [ORB-11333].
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use chrono::Utc;
@@ -629,7 +629,7 @@ fn settle(
         })?
         .unwrap_or_default();
     judgement.check_task_meaning(context, &attempt, &admitted_selectors)?;
-    let repair = judgement.commit_repairs(context, &reviewer, &attempt)?;
+    let repair = judgement.commit_repairs(runtime, context, &reviewer, &attempt)?;
     judgement.reconcile_verdict(&ledger, repair.as_ref());
     let now = Utc::now();
     let elapsed_seconds = attempt.elapsed_at(now);
@@ -676,6 +676,7 @@ fn settle(
         consumed: ledger.consumed(),
         budget: ledger.budget,
         escalation: judgement.escalation.clone(),
+        selectors_widened: judgement.selectors_widened.clone(),
         issued_at: now,
     };
     store.review_certificate_record(&context.workspace_id, &certificate)?;
@@ -762,6 +763,7 @@ struct Judgement {
     escalation: Option<String>,
     summary: String,
     task_meaning_digest: String,
+    selectors_widened: Vec<String>,
 }
 
 impl Judgement {
@@ -781,6 +783,7 @@ impl Judgement {
             escalation: Some(reason.to_string()),
             summary: String::new(),
             task_meaning_digest: task_meaning_digest.clone(),
+            selectors_widened: Vec::new(),
         };
         let first_task = &context.task_ids[0];
         let Some(artifact) = runtime.get_task_artifact(first_task, REVIEW_REPORT_ARTIFACT)? else {
@@ -823,6 +826,7 @@ impl Judgement {
             escalation: report.escalation,
             summary: report.summary,
             task_meaning_digest,
+            selectors_widened: Vec::new(),
         })
     }
 
@@ -848,8 +852,15 @@ impl Judgement {
     }
 
     /// Commit whatever the reviewer changed as its own attributed work.
+    ///
+    /// An out-of-selector path listed on a repaired finding is a declared
+    /// coupled repair: the gate widens `context_files` the same way the
+    /// reviewer already may, and does not abandon the review. A changed
+    /// path named by no finding stays a silent drive-by and still
+    /// downgrades.
     fn commit_repairs(
         &mut self,
+        runtime: &OrbitRuntime,
         context: &GateContext,
         reviewer: &ReviewerIdentity,
         attempt: &ReviewAttempt,
@@ -858,11 +869,22 @@ impl Judgement {
         if changed.is_empty() {
             return Ok(None);
         }
-        let out_of_scope = changed
-            .iter()
-            .filter(|path| !path_in_scope(path, &context.tasks))
-            .cloned()
-            .collect::<Vec<_>>();
+        let declared = declared_repair_paths(&self.findings);
+        let mut declared_out_of_scope = Vec::new();
+        let mut undeclared = Vec::new();
+        for path in &changed {
+            if path_in_scope(path, &context.tasks) {
+                continue;
+            }
+            if declared.contains(&normalize_git_path(path)) {
+                declared_out_of_scope.push(path.clone());
+            } else {
+                undeclared.push(path.clone());
+            }
+        }
+        if !declared_out_of_scope.is_empty() {
+            self.widen_declared_selectors(runtime, context, &declared_out_of_scope)?;
+        }
         let finding_ids = self
             .findings
             .iter()
@@ -895,13 +917,62 @@ impl Judgement {
         // to; the model alone may carry no family hint.
         let reviewer_label = format!("{} / {}", reviewer.provider, reviewer.model);
         let commit = commit_reviewer_repairs(&context.workspace_path, &reviewer_label, &message)?;
-        if !out_of_scope.is_empty() {
-            self.downgrade(&format!(
-                "repair_out_of_scope: reviewer changed paths outside the task scope: {}",
-                out_of_scope.join(", ")
-            ));
+        if !undeclared.is_empty() {
+            self.downgrade(&undeclared_repair_reason(&undeclared));
         }
         Ok(commit)
+    }
+
+    /// Append `file:<path>` selectors for declared coupled repairs, then bind
+    /// the certificate to the post-widening task-meaning digest.
+    fn widen_declared_selectors(
+        &mut self,
+        runtime: &OrbitRuntime,
+        context: &GateContext,
+        paths: &[String],
+    ) -> Result<(), OrbitError> {
+        let mut widened = Vec::new();
+        for path in paths {
+            let selector = format!("file:{}", normalize_git_path(path));
+            for task_id in &context.task_ids {
+                let task = runtime.get_task(task_id)?;
+                if path_in_scope(path, std::slice::from_ref(&task))
+                    || task
+                        .context_files
+                        .iter()
+                        .any(|existing| existing == &selector)
+                {
+                    continue;
+                }
+                let mut selectors = task.context_files;
+                selectors.push(selector.clone());
+                runtime.update_task(
+                    task_id,
+                    TaskUpdateParams {
+                        context_files: Some(selectors),
+                        ..TaskUpdateParams::default()
+                    },
+                )?;
+                if !widened.contains(&selector) {
+                    widened.push(selector.clone());
+                }
+            }
+        }
+        if widened.is_empty() {
+            return Ok(());
+        }
+        let mut digests = Vec::with_capacity(context.task_ids.len());
+        for task_id in &context.task_ids {
+            let task = runtime.get_task(task_id)?;
+            digests.push((
+                task.id.to_string(),
+                task_meaning_digest(&task).map_err(automation_error)?,
+            ));
+        }
+        self.task_meaning_digest =
+            combined_task_meaning_digest(&digests).map_err(automation_error)?;
+        self.selectors_widened = widened;
+        Ok(())
     }
 
     /// Cross-check the claimed verdict against what actually happened.
@@ -1018,6 +1089,44 @@ fn path_in_scope(path: &str, tasks: &[Task]) -> bool {
     })
 }
 
+/// Git-relative paths listed on findings the reviewer marked repaired.
+fn declared_repair_paths(findings: &[orbit_types::workflow::ReviewFinding]) -> BTreeSet<String> {
+    findings
+        .iter()
+        .filter(|finding| finding.disposition == FindingDisposition::Repaired)
+        .flat_map(|finding| finding.paths.iter())
+        .map(|path| normalize_finding_path(path))
+        .filter(|path| !path.is_empty())
+        .collect()
+}
+
+fn normalize_git_path(path: &str) -> String {
+    path.trim().trim_start_matches("./").to_string()
+}
+
+fn normalize_finding_path(path: &str) -> String {
+    let trimmed = path.trim().trim_start_matches("./");
+    trimmed
+        .strip_prefix("file:")
+        .unwrap_or(trimmed)
+        .trim()
+        .trim_start_matches("./")
+        .to_string()
+}
+
+fn undeclared_repair_reason(paths: &[String]) -> String {
+    let listed = paths
+        .iter()
+        .map(|path| normalize_git_path(path))
+        .collect::<Vec<_>>()
+        .join(", ");
+    if paths.len() == 1 {
+        format!("repair_out_of_scope: {listed} was changed but named by no finding")
+    } else {
+        format!("repair_out_of_scope: {listed} were changed but named by no finding")
+    }
+}
+
 fn verdict_comment(certificate: &ReviewCertificate, reviewed: &CandidateIdentity) -> String {
     let assurance = certificate
         .assurance
@@ -1039,6 +1148,7 @@ fn verdict_comment(certificate: &ReviewCertificate, reviewed: &CandidateIdentity
          - Reviewed candidate: `{}` on base `{}` ({} implementation commit(s))\n\
          - Final candidate: `{}`\n\
          - Reviewer repair commits: {}\n\
+         - Selectors widened from repaired findings: {}\n\
          - Findings: {} ({} open)\n\
          - Validation on final candidate: {} record(s) [{}], complete: {}\n\
          - Consumed: {} reviewer start(s), {} repair cycle(s), {}s of {} min\n\
@@ -1061,6 +1171,11 @@ fn verdict_comment(certificate: &ReviewCertificate, reviewed: &CandidateIdentity
         reviewed.commits.len(),
         certificate.final_candidate.commit,
         repairs,
+        if certificate.selectors_widened.is_empty() {
+            "none".to_string()
+        } else {
+            certificate.selectors_widened.join(", ")
+        },
         certificate.findings.len(),
         certificate
             .findings

--- a/crates/orbit-core/src/application/review/tests/gate.rs
+++ b/crates/orbit-core/src/application/review/tests/gate.rs
@@ -278,6 +278,52 @@ fn reviewer_repairs_land_as_separate_attributed_commits_and_bind_the_final_tree(
 }
 
 #[test]
+fn a_declared_out_of_selector_repair_widens_context_files_and_passes() {
+    let gated = gated_fixture(GATED_CONFIG);
+    let admission = gated.admit().expect("admit");
+    let attempt_id = admission["attempt_id"].as_str().expect("attempt id");
+
+    fs::write(
+        gated.fixture.repo.join("README.md"),
+        "coupled repair of derived artifact\n",
+    )
+    .expect("repair");
+    let mut claim = report(attempt_id, ReviewVerdict::PassedWithRepairs, true);
+    claim.findings[0].paths = vec!["README.md".to_string()];
+    write_report(&gated.fixture.runtime, &gated.task_id, &claim);
+
+    let settled = gated.settle(&admission).expect("settle");
+    assert_eq!(settled["gate"], "passed");
+    assert_eq!(settled["verdict"], "passed_with_repairs");
+    assert!(
+        gated
+            .context_files()
+            .iter()
+            .any(|selector| selector == "file:README.md"),
+        "the gate widens the declared repair path: {:?}",
+        gated.context_files()
+    );
+
+    let certificate = gated.certificate();
+    assert_eq!(
+        certificate.selectors_widened,
+        vec!["file:README.md".to_string()]
+    );
+    let comments = gated
+        .fixture
+        .runtime
+        .get_task_comments(&gated.task_id)
+        .expect("comments");
+    assert!(
+        comments
+            .last()
+            .is_some_and(|comment| comment.message.contains("file:README.md")),
+        "the verdict comment mentions the widened selector: {:?}",
+        comments.last().map(|comment| &comment.message)
+    );
+}
+
+#[test]
 fn a_repair_in_a_canonical_symbol_selector_file_passes_without_a_redundant_file_selector() {
     let gated = gated_fixture(GATED_CONFIG);
     gated.rescope(&["symbol:src.txt#run:function"]);
@@ -342,8 +388,16 @@ fn qualified_rust_symbol_selectors_share_the_file_anchor_and_unrelated_paths_sti
     let error = unrelated.settle(&admission).expect_err("out of scope");
     let message = error.to_string();
     assert!(message.contains("repair_out_of_scope"), "{message}");
-    assert!(message.contains("README.md"), "{message}");
+    assert!(
+        message.contains("README.md was changed but named by no finding"),
+        "{message}"
+    );
     assert_eq!(unrelated.certificate().verdict, ReviewVerdict::Incomplete);
+    assert_eq!(
+        unrelated.context_files(),
+        vec!["symbol:src.txt#orbit_core::run:function".to_string()],
+        "an undeclared repair must not widen selectors"
+    );
 }
 
 #[test]

--- a/crates/orbit-store/src/driver/sqlite/review/tests/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/review/tests/mod.rs
@@ -97,6 +97,7 @@ fn certificate(attempt_id: &str, verdict: ReviewVerdict) -> ReviewCertificate {
         consumed: ReviewConsumption::default(),
         budget: ReviewBudget::default(),
         escalation: None,
+        selectors_widened: Vec::new(),
         issued_at: Utc::now(),
     }
 }

--- a/crates/orbit-types/src/workflow/review.rs
+++ b/crates/orbit-types/src/workflow/review.rs
@@ -421,6 +421,12 @@ pub struct ReviewCertificate {
     /// The reason the gate stopped, for non-pass verdicts.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub escalation: Option<String>,
+    /// Selectors the gate appended because a repaired finding declared an
+    /// out-of-scope repair path. Empty when the reviewer already widened
+    /// through the task API or no such repair occurred. Absent on certificates
+    /// issued before this field existed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub selectors_widened: Vec<String>,
     pub issued_at: DateTime<Utc>,
 }
 


### PR DESCRIPTION
## Task

[ORB-12265](https://orbit-cli.com/tasks/ORB-12265) — Review gate downgrades a fully-repaired, green review to `incomplete` when a reviewer repair touches a path outside `context_files`, instead of widening the selectors it already permits the reviewer to widen

### Description

## Problem

The before-PR review gate treats a reviewer repair on a path outside the task's `context_files` as a hard verdict downgrade (`repair_out_of_scope` → `Incomplete`), even when every finding is repaired, all required validation passed, and the reviewer explicitly declared the repaired paths in a finding.

Observed on ORB-12246 (run `jrun-20260912-0323-c5`, attempt `rvw-f9aef77e0e8c-1`): the implementer changed two tool-parameter description strings but not the checked-in goldens, so `make goldens` failed. The reviewer recorded F1 (medium) naming exactly `crates/orbit-cli/tests/output_goldens/tool_list.json` and `crates/orbit-cli/tests/snapshots/mcp_tools_list.json`, regenerated them (4-line diff, description strings only), re-ran `make goldens` green, and reported `passed_with_repairs` with 0 open findings and 7/7 required validation records passed. `commit_repairs` in `crates/orbit-core/src/application/review/gate.rs` committed the repair and then called `downgrade("repair_out_of_scope: …")` because neither golden was in the task's 15 selectors. Result: `verdict: incomplete`, delivery stopped, no PR, task `blocked`, 864s of reviewer time spent on a candidate that is by every recorded measure mergeable.

The gate is inconsistent with itself. `check_task_meaning` / `selectors_only_grew` already accept the reviewer *adding* selectors via `orbit.task.update` mid-review, and `agent_review_repair.yaml` tells the reviewer this is the one permitted task edit. So the same repair either passes or blocks depending on whether the reviewer remembered a bookkeeping side-call before editing. The gate has the information to do that widening itself: the reviewer's finding lists the paths, and the repair commit is attributed to the reviewer.

## Why It Matters

- Every `repair_out_of_scope` block burns a reviewer start + repair cycle from the lineage budget and requires a human decision to resume, for a candidate that is already reviewed green.
- Generated/derived artifacts (goldens, snapshots, lockfiles, docs mirrors under `crates/orbit-core/assets/skills/`) are the common case for coupled repairs and are almost never in an implementer's selectors, so this fires precisely on the most legitimate reviewer repairs.
- `context_files` exists for conflict detection between concurrent runs, not as a reviewer permission boundary; using it as the latter makes selector completeness at task-authoring time a hidden gate on delivery.

## Intended behaviour

A reviewer repair outside the admitted selectors must not, by itself, abandon the review. When the repair is *declared* — the out-of-scope path is listed in `paths` of a finding whose disposition is `repaired` — the gate should:

1. Widen the task's `context_files` with `file:<path>` selectors for those paths, the same edit the reviewer is already allowed to make, attributed to the gate/reviewer identity and recorded in the task history.
2. Record the widening in the certificate (e.g. a `selectors_widened: [...]` field and/or a line in the verdict comment) so it is auditable evidence, not silent.
3. Leave the verdict as the reviewer reported it and continue through `reconcile_verdict` / validation as normal.

An *undeclared* out-of-scope change (a changed path named by no finding) is a different situation — a silent drive-by edit — and may keep the downgrade, but the escalation text should say the path was unnamed by any finding, so the operator knows the fix is a bookkeeping gap and not a scope violation.

## Constraints / Notes

- `selectors_only_grew` must keep working for reviewers that widen via `orbit.task.update` explicitly; the gate-side widening is an additional path to the same end state, not a replacement.
- Do not relax `verdict_inconsistent`, `review_repair_cycles_exhausted`, or the wall-time checks.
- Update `agent_review_repair.yaml` (and the mirror under `plugin/` if one exists) so the reviewer knows declaring repaired paths in the finding is sufficient.
- Keep the existing out-of-scope test in `crates/orbit-core/src/application/review/tests/gate.rs` for the undeclared case; add the declared case as a pass.
- Do not add `## Unreleased` CHANGELOG bullets during execution (RELEASING.md).
- Follow-up context: ORB-12242 (#2005) documented `make goldens` as a pre-review gate; this task makes the gate tolerant when the reviewer fixes exactly that omission.

### Acceptance Criteria

- Gate fixture: task with selectors [`file:src.txt`], reviewer report `passed_with_repairs` with one finding disposition `repaired` whose `paths` include `README.md`, README.md modified in the worktree, validation green → `review_gate_settle` returns `gate: passed`, `verdict: passed_with_repairs`, and the task's `context_files` afterwards contains `file:README.md`
- Same fixture but the finding's `paths` do not name README.md → verdict is `incomplete` with escalation text stating the path was changed but named by no finding (existing test in `tests/gate.rs` updated to this wording)
- The certificate JSON (`review-gate.json` artifact) for the passing case records the widened selectors, and the verdict comment on the task mentions them
- A reviewer that widens selectors itself via `orbit.task.update` before repairing still passes (existing `selectors_only_grew` path unchanged, covered by test)
- `agent_review_repair.yaml` procedure text states that listing repaired paths in the finding is sufficient for an out-of-selector coupled repair
- `cargo test -p orbit-core --lib application::review` passes; `make ci-fast` and `make ci-lint` pass

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `commit_repairs` now splits out-of-selector reviewer edits into declared vs undeclared. A path listed on a finding with disposition `repaired` is widened onto the task as `file:<path>` (same `orbit.task.update` the reviewer already may make), rebound onto the certificate via a recomputed `task_meaning_digest`, recorded as `selectors_widened`, and mentioned in the verdict comment; the reported pass is left intact.
- An undeclared out-of-selector change still downgrades to `incomplete` with `repair_out_of_scope: <path> was changed but named by no finding`.
- `ReviewCertificate.selectors_widened` is optional (serde default, omitted when empty); no contract version bump. Test helpers in orbit-store and orbit-automation were updated because they construct the struct.
- `agent_review_repair.yaml` now states that listing repaired paths on the finding is sufficient; `orbit.task.update` selector growth remains allowed. No plugin activity mirror exists. `selectors_only_grew` is unchanged.

Why extra selectors: `file:crates/orbit-store/src/driver/sqlite/review/tests/mod.rs` and `file:crates/orbit-automation/src/review/tests/mod.rs` compile `ReviewCertificate { ... }` and needed the new field.

Assessment: scoped to the gate's existing repair path; validation, wall-time, and verdict-inconsistency checks were not relaxed.

Criteria:
1. Declared README.md repair on `file:src.txt` fixture → `gate: passed`, `verdict: passed_with_repairs`, task contains `file:README.md` — covered by `a_declared_out_of_selector_repair_widens_context_files_and_passes`.
2. Same fixture without README.md on the finding → incomplete, escalation names the unnamed path — `qualified_rust_symbol_selectors_share_the_file_anchor_and_unrelated_paths_still_downgrade` updated.
3. Certificate `selectors_widened` and verdict comment mention `file:README.md` — same declared test.
4. Reviewer-side `orbit.task.update` growth still passes — `task_drift_during_review_invalidates_the_gate_but_selector_additions_do_not` unchanged.
5. Procedure text states listing repaired paths is sufficient — `agent_review_repair.yaml`.
6. Required checks below.

Validation:
- `cargo test -p orbit-core --lib application::review` — passed (30 tests, including the new declared-repair case)
- `make ci-fast` — passed
- `make ci-lint` — passed

Remaining risks: path matching is git-relative after stripping `./` and an optional `file:` prefix on finding paths; a finding that names a directory rather than the changed file still counts as undeclared. Mixed declared+undeclared repairs widen the declared paths then still downgrade for the unnamed ones.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12265-6aa4d871`
- Behind base: 0
- Ahead of base: 1