### PR TITLE
`orbit.task.artifact.get` CLI surfaces (`orbit tool run`, `orbit task artifact get`) still resolve `id` cwd-locally, contradicting the "resolved globally by default" schema text

### DIFF
--- a/crates/orbit-cli/src/command/mcp/mod.rs
+++ b/crates/orbit-cli/src/command/mcp/mod.rs
@@ -16,6 +16,7 @@ mod setup;
 pub use command::{McpCommand, McpSubcommand};
 pub(crate) use command::{normalize_ssh_login_shell_args, verify_ssh_acceptance_launch_boundary};
 pub(crate) use orbit_mcp::safe_mcp_tool_names;
+pub(crate) use server::ID_RESOLVED_WORKSPACE_TOOLS;
 #[allow(unused_imports)]
 pub(crate) use setup::init_auto_for_workspace;
 

--- a/crates/orbit-cli/src/command/mcp/server.rs
+++ b/crates/orbit-cli/src/command/mcp/server.rs
@@ -29,7 +29,13 @@ use serde_json::Value;
 /// [ORB-12254]. `orbit.task.artifact.get` reads a payload owned by a task, so
 /// it resolves the same way `orbit.task.show` does — its own schema advertises
 /// `workspace` as an optional filter, and behavior must agree.
-const ID_RESOLVED_WORKSPACE_TOOLS: &[&str] = &["orbit.task.show", "orbit.task.artifact.get"];
+///
+/// `pub(crate)` and re-exported through `command::mcp` so the CLI path in
+/// `command/tool/run.rs` (and `command/operation.rs`'s task-artifact routing)
+/// share this single list instead of keeping a second one that can drift
+/// [ORB-12263].
+pub(crate) const ID_RESOLVED_WORKSPACE_TOOLS: &[&str] =
+    &["orbit.task.show", "orbit.task.artifact.get"];
 
 /// Serve one stdio MCP session.
 ///

--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -558,6 +558,17 @@ impl Commands {
                     TaskSubcommand::Show(args) => RuntimeNeed::TaskOwner {
                         task_id: args.id.clone(),
                     },
+                    // `orbit.task.artifact.get` shares `orbit.task.show`'s
+                    // resolved-globally-by-default schema wording, so `orbit
+                    // task artifact get` must resolve the same way rather than
+                    // reporting a routing refusal as `task_not_found`
+                    // [ORB-12263].
+                    TaskSubcommand::Artifact(command) => match &command.command {
+                        TaskArtifactSubcommand::Get(args) => RuntimeNeed::TaskOwner {
+                            task_id: args.id.clone(),
+                        },
+                        TaskArtifactSubcommand::Put(_) => RuntimeNeed::Required,
+                    },
                     // Every other task verb keeps cwd (or `--workspace`) as its
                     // binding: only a read addressed by a globally unique ID can
                     // be routed from the ID alone.
@@ -830,7 +841,7 @@ impl Commands {
                         }
                     };
                 let runtime_need = match &command.command {
-                    ToolSubcommand::Run(args) => match args.task_show_id() {
+                    ToolSubcommand::Run(args) => match args.id_resolved_task_id() {
                         Some(task_id) => RuntimeNeed::TaskOwner { task_id },
                         None => RuntimeNeed::Required,
                     },

--- a/crates/orbit-cli/src/command/tests/operation.rs
+++ b/crates/orbit-cli/src/command/tests/operation.rs
@@ -102,6 +102,55 @@ fn tool_run_task_show_bootstraps_the_task_owner_from_id_only_input() {
 }
 
 #[test]
+fn tool_run_and_task_artifact_get_bootstrap_the_task_owner_from_id_only_input() {
+    assert_eq!(
+        operation_for(&[
+            "orbit",
+            "tool",
+            "run",
+            "orbit.task.artifact.get",
+            "--input",
+            r#"{"id":"ORB-12263","path":"qa/note.md"}"#,
+        ])
+        .runtime_need,
+        RuntimeNeed::TaskOwner {
+            task_id: "ORB-12263".to_string()
+        }
+    );
+    assert_eq!(
+        operation_for(&[
+            "orbit",
+            "tool",
+            "run",
+            "orbit.task.artifact.put",
+            "--input",
+            r#"{"id":"ORB-12263","source_path":"note.md"}"#,
+        ])
+        .runtime_need,
+        RuntimeNeed::Required,
+        "artifact.put's schema does not advertise global id resolution"
+    );
+    assert_eq!(
+        operation_for(&[
+            "orbit",
+            "task",
+            "artifact",
+            "get",
+            "ORB-12263",
+            "qa/note.md",
+        ])
+        .runtime_need,
+        RuntimeNeed::TaskOwner {
+            task_id: "ORB-12263".to_string()
+        }
+    );
+    assert_eq!(
+        operation_for(&["orbit", "task", "artifact", "put", "ORB-12263", "note.md",]).runtime_need,
+        RuntimeNeed::Required,
+    );
+}
+
+#[test]
 fn json_error_preferences_are_derived_from_operations() {
     assert_eq!(
         operation_for(&["orbit", "tool", "run", "orbit.task.show"]).json_error_preference,

--- a/crates/orbit-cli/src/command/tool/run.rs
+++ b/crates/orbit-cli/src/command/tool/run.rs
@@ -71,13 +71,16 @@ impl ToolRunArgs {
         }
     }
 
-    /// Globally unique task ID from `orbit tool run orbit.task.show` input.
+    /// Globally unique task ID from an id-resolved tool's `orbit tool run`
+    /// input.
     ///
-    /// The CLI bootstraps that one tool through the host task registry rather
-    /// than cwd, matching `orbit task show` [ORB-10961]. Other tools keep the
-    /// ordinary workspace runtime.
-    pub(crate) fn task_show_id(&self) -> Option<String> {
-        if self.name != "orbit.task.show" {
+    /// The CLI bootstraps `command::mcp::ID_RESOLVED_WORKSPACE_TOOLS` through
+    /// the host task registry rather than cwd, matching `orbit task show`
+    /// [ORB-10961] and `orbit task artifact get` [ORB-12263]. Sharing that
+    /// list with the MCP server's own routing keeps the two surfaces from
+    /// drifting apart. Other tools keep the ordinary workspace runtime.
+    pub(crate) fn id_resolved_task_id(&self) -> Option<String> {
+        if !crate::command::mcp::ID_RESOLVED_WORKSPACE_TOOLS.contains(&self.name.as_str()) {
             return None;
         }
         let value = self.parsed_input().ok()?;

--- a/crates/orbit-cli/src/command/tool/tests/run.rs
+++ b/crates/orbit-cli/src/command/tool/tests/run.rs
@@ -8,7 +8,7 @@ use super::super::run::{
 };
 
 #[test]
-fn task_show_id_is_read_only_from_orbit_task_show_input() {
+fn id_resolved_task_id_is_read_from_id_resolved_tool_input() {
     let show = ToolRunArgs {
         name: "orbit.task.show".to_string(),
         input: Some(r#"{"id":" ORB-10961 ","model":"codex"}"#.to_string()),
@@ -21,14 +21,31 @@ fn task_show_id_is_read_only_from_orbit_task_show_input() {
         pretty: false,
         parsed_input: OnceLock::new(),
     };
-    assert_eq!(show.task_show_id().as_deref(), Some("ORB-10961"));
+    assert_eq!(show.id_resolved_task_id().as_deref(), Some("ORB-10961"));
+
+    let artifact_get = ToolRunArgs {
+        name: "orbit.task.artifact.get".to_string(),
+        input: Some(r#"{"id":" ORB-12263 ","path":"qa/note.md"}"#.to_string()),
+        input_file: None,
+        agent: None,
+        model: None,
+        dry_run: false,
+        fields: Vec::new(),
+        full: false,
+        pretty: false,
+        parsed_input: OnceLock::new(),
+    };
+    assert_eq!(
+        artifact_get.id_resolved_task_id().as_deref(),
+        Some("ORB-12263")
+    );
 
     let list = ToolRunArgs {
         name: "orbit.task.list".to_string(),
         input: Some(r#"{"id":"ORB-10961"}"#.to_string()),
         ..show
     };
-    assert_eq!(list.task_show_id(), None);
+    assert_eq!(list.id_resolved_task_id(), None);
 }
 
 #[test]

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -2334,6 +2334,192 @@ fn mcp_task_artifact_get_follows_the_global_id_and_explicit_workspace_stays_a_fi
     );
 }
 
+/// [ORB-12263] `orbit.task.artifact.get`'s schema advertises the identical
+/// "resolved globally by default" wording `orbit.task.show` does, and
+/// ORB-12254 made the MCP surface honor it, but left the CLI surfaces
+/// (`orbit tool run` and `orbit task artifact get`) resolving `id`
+/// cwd-locally and reporting the mismatch as `task_not_found`. Modelled on
+/// `task_show_is_global_by_default_across_tool_run_and_mcp`: a task owned by
+/// a sibling checkout B must still be readable by ID alone from checkout A on
+/// every surface, and an explicit foreign `workspace` selector must stay a
+/// fail-closed filter on all three. This must fail if the CLI routing change
+/// in `command/operation.rs` is reverted.
+#[test]
+fn task_artifact_get_is_global_by_default_across_tool_run_task_cli_and_mcp() {
+    let workspace = McpWorkspace::init();
+
+    let checkout_b = workspace.home.join("checkout-b");
+    std::fs::create_dir_all(&checkout_b).expect("create the second checkout");
+    let output = Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(&checkout_b)
+        .output()
+        .expect("initialize the second Git checkout");
+    assert!(output.status.success(), "git init failed: {output:?}");
+    let output = McpWorkspace::orbit_command(&checkout_b, &workspace.home)
+        .args(["workspace", "init", "--name", "checkout-b"])
+        .output()
+        .expect("register checkout B");
+    assert!(
+        output.status.success(),
+        "checkout B init failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let checkout_b_selector = checkout_b.to_str().expect("utf8 checkout path");
+    let add_input = json!({
+        "title": "Owned by checkout B, read from checkout A",
+        "description": "The artifact payload is addressed by task ID alone",
+        "workspace": checkout_b_selector,
+        "complexity": "low",
+        "model": "codex",
+    })
+    .to_string();
+    let output = McpWorkspace::orbit_command(&checkout_b, &workspace.home)
+        .args(["tool", "run", "orbit.task.add", "--input", &add_input])
+        .output()
+        .expect("author a task owned by checkout B");
+    assert!(
+        output.status.success(),
+        "task add failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let created: Value = serde_json::from_slice(&output.stdout).expect("parse created task");
+    let task_id = created["id"].as_str().expect("task id").to_string();
+
+    std::fs::write(
+        checkout_b.join("qa-note.md"),
+        "globally addressable payload",
+    )
+    .expect("write the artifact source");
+    let put_input = json!({
+        "id": task_id,
+        "source_path": "qa-note.md",
+        "path": "qa/note.md",
+        "workspace": checkout_b_selector,
+        "model": "codex",
+    })
+    .to_string();
+    let output = McpWorkspace::orbit_command(&checkout_b, &workspace.home)
+        .args([
+            "tool",
+            "run",
+            "orbit.task.artifact.put",
+            "--input",
+            &put_input,
+        ])
+        .output()
+        .expect("attach the artifact from checkout B");
+    assert!(
+        output.status.success(),
+        "artifact put failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Checkout A (`workspace.work`) does not own the task. An id-only read
+    // must follow the id past cwd on every surface.
+    let checkout_a_selector = workspace.work.to_str().expect("utf8 checkout path");
+    let get_input = json!({ "id": task_id, "path": "qa/note.md" }).to_string();
+
+    let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args([
+            "tool",
+            "run",
+            "orbit.task.artifact.get",
+            "--input",
+            &get_input,
+        ])
+        .output()
+        .expect("run id-only tool artifact get from checkout A");
+    assert!(
+        output.status.success(),
+        "`orbit tool run orbit.task.artifact.get` must follow the task id from a sibling \
+         checkout\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let via_tool_run: Value = serde_json::from_slice(&output.stdout).expect("parse tool run get");
+    assert_eq!(via_tool_run["content"], "globally addressable payload");
+
+    let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args(["task", "artifact", "get", &task_id, "qa/note.md"])
+        .output()
+        .expect("run id-only task artifact get from checkout A");
+    assert!(
+        output.status.success(),
+        "`orbit task artifact get` must follow the task id from a sibling checkout\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("globally addressable payload"),
+        "`orbit task artifact get` must print the artifact content: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    // The MCP session announces checkout A at initialize and must still
+    // follow the task id, matching ORB-12254.
+    let mut client = workspace.serve();
+    let read = client.call_tool_ok(
+        "orbit_task_artifact_get",
+        json!({ "id": task_id, "path": "qa/note.md" }),
+    );
+    assert_eq!(read["content"], "globally addressable payload");
+    drop(client);
+
+    // An explicit foreign `workspace` selector stays a fail-closed filter on
+    // every surface: checkout A does not own the task.
+    let missed = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args([
+            "tool",
+            "run",
+            "orbit.task.artifact.get",
+            "--input",
+            &json!({
+                "id": task_id,
+                "path": "qa/note.md",
+                "workspace": checkout_a_selector,
+            })
+            .to_string(),
+        ])
+        .output()
+        .expect("run tool artifact get with an explicit foreign workspace");
+    assert!(
+        !missed.status.success(),
+        "an explicit foreign `workspace` input must filter rather than follow the id"
+    );
+    let missed_stderr = String::from_utf8_lossy(&missed.stderr);
+    assert!(
+        missed_stderr.contains(&task_id),
+        "the not-found error must name the task id: {missed_stderr}"
+    );
+
+    let missed = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args([
+            "--workspace",
+            checkout_a_selector,
+            "task",
+            "artifact",
+            "get",
+            &task_id,
+            "qa/note.md",
+        ])
+        .output()
+        .expect("run task artifact get with an explicit foreign --workspace");
+    assert!(
+        !missed.status.success(),
+        "an explicit foreign `--workspace` must filter rather than follow the id"
+    );
+    let missed_stderr = String::from_utf8_lossy(&missed.stderr);
+    assert!(
+        missed_stderr.contains(&task_id),
+        "the not-found error must name the task id: {missed_stderr}"
+    );
+}
+
 /// [ORB-12254] Regression guard for the class of bug this task fixed: a tool
 /// whose schema advertises `workspace` as resolved-globally-by-default text
 /// must actually resolve globally when a session carries no selector, and a


### PR DESCRIPTION
## Task

[ORB-12263](https://orbit-cli.com/tasks/ORB-12263) — `orbit.task.artifact.get` CLI surfaces (`orbit tool run`, `orbit task artifact get`) still resolve `id` cwd-locally, contradicting the "resolved globally by default" schema text

### Description

## Problem

ORB-12254 (merged in PR #2007, `09e1855`) made the MCP host resolve `orbit.task.artifact.get`'s `id` through the host task registry, matching the tool's schema sentence "`id` is resolved globally by default; when supplied, `workspace` is a fail-closed filter". The reviewer (review gate `rvw-372f1f20876f-1`, finding F2, left open as out-of-scope) showed the same schema text is still false on the CLI surfaces.

Reproduced on a disposable `HOME` with two registered checkouts A and B and a task owned by B that carries artifact `qa/note.md`. From checkout A:

- `orbit task show <id>` → returns the task and lists `qa/note.md` (global resolution, correct)
- `orbit tool run orbit.task.show --input '{"id":"<id>"}'` → succeeds
- `orbit tool run orbit.task.artifact.get --input '{"id":"<id>","path":"qa/note.md"}'` → `{"code":"task_not_found"}`
- `orbit task artifact get <id> qa/note.md` → `error: task not found`

`orbit tool show orbit.task.artifact.get` prints the same "resolved globally by default" wording, so the CLI promises global resolution and delivers cwd-local resolution — the identical documented/behaviour mismatch ORB-12254 fixed, one surface over.

## Why It Matters

`task.show` and `task.artifact.get` share the same contract (the artifact belongs to the task; the task is a machine-global primary key). Having one surface honour it and the other not means an agent that reads a task from a sibling checkout can list its artifacts but cannot fetch them, and the failure is reported as `task_not_found` rather than a routing refusal, which misleads.

## Approach

Mirror the existing `task.show` treatment (decision recorded on ORB-12254: option A — extend, not narrow the schema):

- `crates/orbit-cli/src/command/operation.rs`: `RuntimeNeed::TaskOwner { task_id }` is already produced for `TaskSubcommand::Show` and for `ToolSubcommand::Run` when `args.task_show_id()` is `Some`. Extend it to `orbit tool run orbit.task.artifact.get` and to the `orbit task artifact get` subcommand.
- `crates/orbit-cli/src/command/tool/run.rs`: generalize `ToolRunArgs::task_show_id` (currently hard-coded to `"orbit.task.show"`) into an id-resolved-tool check covering both tools — ideally sharing one allowlist with `ID_RESOLVED_WORKSPACE_TOOLS` in `command/mcp/server.rs` so the MCP and CLI surfaces cannot drift again.
- `crates/orbit-cli/src/command/task/artifact.rs`: route the `get` subcommand through the owner-resolved runtime.
- An explicit `--workspace` / `workspace` input stays a fail-closed filter, exactly as for `task.show`.

## Constraints / Notes

- Do not change the schema wording in `crates/orbit-tools/src/builtin/orbit/task/artifact_get.rs`; the wording is the contract, the CLI is what moves.
- Follow the shape of the existing test `task_show_is_global_by_default_across_tool_run_and_mcp` in `crates/orbit-cli/tests/mcp_roundtrip.rs` (and the ORB-12254 test `mcp_task_artifact_get_follows_the_global_id_and_explicit_workspace_stays_a_filter`) rather than inventing a new harness.
- Other workspace-scoped tools (`orbit.task.list`, etc.) must keep their cwd/session-bound behaviour; only tools whose schema advertises global id resolution move.
- No `## Unreleased` CHANGELOG edits during execution (RELEASING.md).

### Acceptance Criteria

- With two registered checkouts A and B on a throwaway HOME and a task owned by B carrying artifact `qa/note.md`, running from A: `orbit tool run orbit.task.artifact.get --input '{"id":"<id>","path":"qa/note.md"}'` returns the artifact payload (not `task_not_found`)
- Same setup: `orbit task artifact get <id> qa/note.md` from checkout A prints the artifact content and exits 0
- Same setup with an explicit foreign workspace selector (`--workspace A` / `"workspace":"A"`): both CLI surfaces return not-found — `workspace` remains a fail-closed filter
- A test in `crates/orbit-cli/tests/mcp_roundtrip.rs` modelled on `task_show_is_global_by_default_across_tool_run_and_mcp` asserts global-by-default id resolution for `orbit.task.artifact.get` across `orbit tool run`, `orbit task artifact get`, and MCP, and fails when the CLI routing change is reverted
- The set of tools that get owner-resolved routing is defined once and shared (or asserted equal by test) between `command/mcp/server.rs::ID_RESOLVED_WORKSPACE_TOOLS` and the CLI path in `command/tool/run.rs`, so the two surfaces cannot drift independently
- `cargo test -p orbit-cli --test mcp_roundtrip` and `make ci-lint` pass; `orbit tool run orbit.task.list` without a selector is unchanged (still cwd/session-bound)

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed: `orbit.task.artifact.get`'s CLI surfaces now resolve `id` globally by default, matching `orbit.task.show` and the schema's "resolved globally by default" wording.

Changes:
- `command/mcp/server.rs`: made `ID_RESOLVED_WORKSPACE_TOOLS` `pub(crate)`, re-exported through `command/mcp/mod.rs` — one shared list.
- `command/tool/run.rs`: generalized `ToolRunArgs::task_show_id` into `id_resolved_task_id`, which checks membership in the shared `ID_RESOLVED_WORKSPACE_TOOLS` list instead of hardcoding `"orbit.task.show"`, so `orbit tool run orbit.task.artifact.get` now bootstraps `RuntimeNeed::TaskOwner`.
- `command/operation.rs`: `ToolSubcommand::Run` calls the renamed method; added a `TaskArtifactSubcommand::Get` arm producing `RuntimeNeed::TaskOwner { task_id: args.id }` (Put is unaffected, stays `Required`), so `orbit task artifact get` gets the same routing.
- `command/task/artifact.rs`: unchanged — `TaskArtifactGetArgs::execute` already just calls `runtime.get_task(&id)` on whichever runtime it's handed, so routing at the operation.rs bootstrap level is sufficient.
- No change to `crates/orbit-tools/src/builtin/orbit/task/artifact_get.rs` schema wording, per constraint.

Tests:
- New `crates/orbit-cli/tests/mcp_roundtrip.rs::task_artifact_get_is_global_by_default_across_tool_run_task_cli_and_mcp`, modelled on `task_show_is_global_by_default_across_tool_run_and_mcp`: task owned by checkout B, read from checkout A via `orbit tool run orbit.task.artifact.get`, `orbit task artifact get`, and MCP `orbit_task_artifact_get` all succeed; an explicit foreign `workspace` (JSON input) / `--workspace` (global flag) on both CLI surfaces fails not-found, naming the task id.
- Updated `command/tool/tests/run.rs` (renamed test, added an `orbit.task.artifact.get` case) and `command/tests/operation.rs` (new `tool_run_and_task_artifact_get_bootstrap_the_task_owner_from_id_only_input`) to cover the renamed/generalized routing at the unit level.
- Manually reproduced the exact repro steps from the task description end-to-end against the built binary on a disposable HOME with two registered checkouts: all four scenarios now behave as required (payload returned, exit 0 + printed content, both foreign-workspace forms fail closed as not-found).

Validation:
- `cargo test -p orbit-cli --bin orbit` — 563 passed.
- `cargo test -p orbit-cli --test mcp_roundtrip` — 58 passed (one unrelated loopback-socket test flaked once under parallel load; passed both standalone and in a clean full re-run).
- `make ci-fast` — passed (after `cargo fmt -p orbit-cli`).
- `make ci-lint` — passed, no clippy warnings.
- `make goldens` — passed; `orbit.task.artifact.get`/`orbit.task.show` schema and MCP snapshot goldens unchanged, confirming no schema wording drift.
- `git status --short` / `git diff --check` — only the intended files changed, no whitespace issues.

No blockers, no scope deviations beyond the context_files appended (mcp/mod.rs re-export, and the two sibling unit-test files), which were declared via `orbit.task.update` with rationale.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12263-6aa4d9e6`
- Behind base: 0
- Ahead of base: 1