### PR TITLE
`doctor` and clock status are blind to a sweep unit that runs a different Orbit binary; a sweep that loads zero workspaces exits 0

### DIFF
--- a/crates/orbit-automation/src/routines/sweep.rs
+++ b/crates/orbit-automation/src/routines/sweep.rs
@@ -112,6 +112,10 @@ pub struct SweepOutcome {
     pub reports: Vec<RoutineSweepReport>,
     /// Fail-closed definition/load failures (those routines were absent).
     pub load_errors: Vec<RoutineLoadError>,
+    /// Set when every discovered workspace failed to open, so this pass
+    /// loaded nothing. The CLI prints this one row and exits non-zero.
+    /// Partial load errors leave this `None`.
+    pub no_workspace_loaded: Option<String>,
 }
 
 /// The dispatch-agnostic core of one sweep pass: outcome-sync

--- a/crates/orbit-cli/src/command/doctor.rs
+++ b/crates/orbit-cli/src/command/doctor.rs
@@ -133,6 +133,7 @@ impl Execute for DoctorCommand {
         // `orbit-cmd` does not know about MCP and must not learn, and this is
         // the one crate that already assembles both [ORB-11053].
         results.extend(caller_authorization_rows());
+        results.push(clock_unit_row());
         let failures = results
             .iter()
             .filter(|row| row.status == WorkspaceDoctorStatus::Error)
@@ -286,6 +287,43 @@ fn caller_authorization_rows() -> Vec<WorkspaceDoctorResult> {
         },
     };
     vec![callers, keys]
+}
+
+/// Whether the OS sweep-clock unit invokes this binary [ORB-12244].
+fn clock_unit_row() -> WorkspaceDoctorResult {
+    match orbit_core::application::routines::inspect_clock_unit() {
+        Ok(inspection) => clock_unit_row_from_inspection(&inspection),
+        Err(error) => WorkspaceDoctorResult {
+            check_name: "clock-unit".to_string(),
+            status: WorkspaceDoctorStatus::Warning,
+            message: format!("could not inspect the sweep clock unit: {error}"),
+            remediation: Some(
+                "Fix the home-directory or unit-file error named above, then rerun `orbit doctor`."
+                    .to_string(),
+            ),
+        },
+    }
+}
+
+pub(crate) fn clock_unit_row_from_inspection(
+    inspection: &orbit_core::application::routines::ClockUnitInspection,
+) -> WorkspaceDoctorResult {
+    use orbit_core::application::routines::ClockUnitVerdict;
+
+    let status = match inspection.verdict {
+        ClockUnitVerdict::Matching => WorkspaceDoctorStatus::Ok,
+        ClockUnitVerdict::NoUnitInstalled => WorkspaceDoctorStatus::Skipped,
+        ClockUnitVerdict::PathMismatch | ClockUnitVerdict::Unrunnable { .. } => {
+            WorkspaceDoctorStatus::Warning
+        }
+        ClockUnitVerdict::VersionMismatch => WorkspaceDoctorStatus::Error,
+    };
+    WorkspaceDoctorResult {
+        check_name: "clock-unit".to_string(),
+        status,
+        message: inspection.doctor_message(),
+        remediation: inspection.doctor_remediation(),
+    }
 }
 
 fn status_label(status: WorkspaceDoctorStatus) -> &'static str {

--- a/crates/orbit-cli/src/command/routine/clock.rs
+++ b/crates/orbit-cli/src/command/routine/clock.rs
@@ -1,7 +1,9 @@
 use std::path::Path;
 
 use clap::{Args, Subcommand};
-use orbit_core::application::routines::{clock_status, set_clock_cadence, set_clock_enabled};
+use orbit_core::application::routines::{
+    clock_status, inspect_clock_unit, set_clock_cadence, set_clock_enabled,
+};
 
 use crate::command::{CommandOut, CommandOutput};
 
@@ -34,6 +36,9 @@ impl RoutineClockArgs {
         match self.command {
             RoutineClockSubcommand::Status => {
                 let status = clock_status(global_root)?;
+                let program = inspect_clock_unit()
+                    .map(|inspection| inspection.status_line_suffix())
+                    .unwrap_or_default();
                 let state = if !status.enabled {
                     "paused"
                 } else if status.schedulable {
@@ -42,14 +47,15 @@ impl RoutineClockArgs {
                     "unhealthy"
                 };
                 println!(
-                    "clock: {} | configured cadence: {}s | effective cadence: {} | platform: {}",
+                    "clock: {} | configured cadence: {}s | effective cadence: {} | platform: {}{}",
                     state,
                     status.configured_cadence_seconds,
                     status
                         .effective_cadence_seconds
                         .map(|value| format!("{value}s"))
                         .unwrap_or_else(|| "inactive".to_string()),
-                    status.platform
+                    status.platform,
+                    program
                 );
                 if let Some(issue) = status.health_issue {
                     println!("clock health: {issue}");

--- a/crates/orbit-cli/src/command/sweep.rs
+++ b/crates/orbit-cli/src/command/sweep.rs
@@ -3,9 +3,10 @@
 //! Invoked every minute by the OS clock (launchd / systemd; see
 //! `orbit routine init --install-clock`). Like `orbit run ship-sweep`, it
 //! resolves everything from the global registry, never bootstraps a
-//! `.orbit/` in the caller's cwd, and exits non-zero only on infrastructure
-//! errors — an unconfigured host logs one line and exits 0, because the OS
-//! clock will invoke it forever.
+//! `.orbit/` in the caller's cwd, and exits non-zero on infrastructure
+//! errors or when every discovered workspace fails to load. An unconfigured
+//! host logs one line and exits 0, because the OS clock will invoke it
+//! forever. Partial workspace load errors stay on stderr and still exit 0.
 
 use std::path::Path;
 
@@ -90,21 +91,30 @@ impl SweepCommand {
         let doc = outcome_json(&outcome, self.dry_run);
 
         // Load errors are diagnostics, not records: they stay on stderr in
-        // every mode so a `--format json` consumer still sees them.
-        for error in &outcome.load_errors {
-            let path = error
-                .path
-                .as_ref()
-                .map(|path| format!(" ({})", path.display()))
-                .unwrap_or_default();
-            eprintln!(
-                "load error [{}]{}: {}",
-                error.source_workspace, path, error.message
-            );
+        // every mode so a `--format json` consumer still sees them. A pass
+        // that opened zero workspaces collapses those rows into one
+        // `sweep.no_workspace_loaded` line and exits non-zero [ORB-12244].
+        if let Some(row) = &outcome.no_workspace_loaded {
+            eprintln!("{row}");
+        } else {
+            for error in &outcome.load_errors {
+                let path = error
+                    .path
+                    .as_ref()
+                    .map(|path| format!(" ({})", path.display()))
+                    .unwrap_or_default();
+                eprintln!(
+                    "load error [{}]{}: {}",
+                    error.source_workspace, path, error.message
+                );
+            }
         }
 
         let lines = self.human_lines(&outcome);
-        Ok(Payload::blocks(doc, vec![Block::text(lines.join("\n"))]).into())
+        let exit_code = i32::from(outcome.no_workspace_loaded.is_some());
+        Ok(Payload::blocks(doc, vec![Block::text(lines.join("\n"))])
+            .with_exit_code(exit_code)
+            .into())
     }
 
     /// The `table`/plain lines for one pass.
@@ -181,5 +191,6 @@ pub(crate) fn outcome_json(outcome: &SweepOutcome, dry_run: bool) -> serde_json:
             "path": e.path.as_ref().map(|p| p.display().to_string()),
             "message": e.message,
         })).collect::<Vec<_>>(),
+        "no_workspace_loaded": outcome.no_workspace_loaded,
     })
 }

--- a/crates/orbit-cli/src/command/tests/doctor.rs
+++ b/crates/orbit-cli/src/command/tests/doctor.rs
@@ -2,8 +2,108 @@ use clap::CommandFactory;
 use orbit_cmd::{OrphanTaskStoreRemoval, WorkspaceDoctorResult, WorkspaceDoctorStatus};
 use orbit_core::OrbitRuntime;
 
-use super::super::doctor::{doctor_row_json, human_detail, orphan_task_store_removal_message};
+use std::path::PathBuf;
+
+use orbit_core::application::routines::{ClockUnitInspection, ClockUnitVerdict};
+
+use super::super::doctor::{
+    clock_unit_row_from_inspection, doctor_row_json, human_detail,
+    orphan_task_store_removal_message,
+};
 use super::super::{Cli, CommandOutput, Execute};
+
+fn clock_unit_inspection(
+    verdict: ClockUnitVerdict,
+    program_version: Option<&str>,
+) -> ClockUnitInspection {
+    ClockUnitInspection {
+        unit_path: Some(PathBuf::from(
+            "/Users/daniel/Library/LaunchAgents/com.orbit.sweep.plist",
+        )),
+        program_path: Some(PathBuf::from("/opt/homebrew/bin/orbit")),
+        program_version: program_version.map(ToString::to_string),
+        running_path: PathBuf::from("/Users/daniel/.cargo/bin/orbit"),
+        running_version: "0.21.0".to_string(),
+        verdict,
+    }
+}
+
+#[test]
+fn clock_unit_version_mismatch_is_a_named_failure() {
+    let row = clock_unit_row_from_inspection(&clock_unit_inspection(
+        ClockUnitVerdict::VersionMismatch,
+        Some("0.20.0"),
+    ));
+    assert_eq!(row.check_name, "clock-unit");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Error);
+    assert!(
+        row.message.contains("/opt/homebrew/bin/orbit"),
+        "{}",
+        row.message
+    );
+    assert!(
+        row.message.contains("/Users/daniel/.cargo/bin/orbit"),
+        "{}",
+        row.message
+    );
+    assert!(row.message.contains("0.20.0"), "{}", row.message);
+    assert!(row.message.contains("0.21.0"), "{}", row.message);
+    assert!(
+        row.remediation
+            .as_deref()
+            .expect("remediation")
+            .contains("orbit routine init --install-clock")
+    );
+}
+
+#[test]
+fn clock_unit_path_only_mismatch_is_a_warning() {
+    let row = clock_unit_row_from_inspection(&clock_unit_inspection(
+        ClockUnitVerdict::PathMismatch,
+        Some("0.21.0"),
+    ));
+    assert_eq!(row.status, WorkspaceDoctorStatus::Warning);
+    assert!(row.message.contains("Two installs"), "{}", row.message);
+}
+
+#[test]
+fn clock_unit_matching_is_ok() {
+    let row = clock_unit_row_from_inspection(&clock_unit_inspection(
+        ClockUnitVerdict::Matching,
+        Some("0.21.0"),
+    ));
+    assert_eq!(row.status, WorkspaceDoctorStatus::Ok);
+    assert!(row.remediation.is_none());
+}
+
+#[test]
+fn clock_unit_absent_is_skipped() {
+    let row = clock_unit_row_from_inspection(&ClockUnitInspection {
+        unit_path: None,
+        program_path: None,
+        program_version: None,
+        running_path: PathBuf::from("/Users/daniel/.cargo/bin/orbit"),
+        running_version: "0.21.0".to_string(),
+        verdict: ClockUnitVerdict::NoUnitInstalled,
+    });
+    assert_eq!(row.status, WorkspaceDoctorStatus::Skipped);
+}
+
+#[test]
+fn clock_unit_unrunnable_is_a_warning() {
+    let row = clock_unit_row_from_inspection(&clock_unit_inspection(
+        ClockUnitVerdict::Unrunnable {
+            reason: "program does not exist: /opt/homebrew/bin/orbit".to_string(),
+        },
+        None,
+    ));
+    assert_eq!(row.status, WorkspaceDoctorStatus::Warning);
+    assert!(
+        row.message.contains("could not report a version"),
+        "{}",
+        row.message
+    );
+}
 
 #[test]
 fn doctor_warning_renders_structured_and_human_remediation() {

--- a/crates/orbit-cli/src/command/tests/sweep.rs
+++ b/crates/orbit-cli/src/command/tests/sweep.rs
@@ -62,6 +62,7 @@ fn json_shape_is_stable() {
             run_id: Some("run-1".to_string()),
         }],
         load_errors: Vec::new(),
+        no_workspace_loaded: None,
     };
 
     let value = outcome_json(&outcome, false);
@@ -74,6 +75,7 @@ fn json_shape_is_stable() {
         "fired",
         "reports",
         "load_errors",
+        "no_workspace_loaded",
     ] {
         assert!(object.contains_key(key), "missing top-level key {key}");
     }
@@ -87,4 +89,26 @@ fn json_shape_is_stable() {
         assert!(report_obj.contains_key(key), "missing report key {key}");
     }
     assert_eq!(first["action"], "fired");
+    assert!(object["no_workspace_loaded"].is_null());
+}
+
+#[test]
+fn json_includes_the_no_workspace_loaded_row() {
+    let outcome = SweepOutcome {
+        host_id: "dk-mac".to_string(),
+        machine_id: "hm_dk_mac".to_string(),
+        lock_busy: false,
+        reports: Vec::new(),
+        load_errors: Vec::new(),
+        no_workspace_loaded: Some(
+            "sweep.no_workspace_loaded: orbit 0.21.0 loaded 0/2 workspaces; first error [nebula]: schema migration failed"
+                .to_string(),
+        ),
+    };
+
+    let value = outcome_json(&outcome, false);
+    assert_eq!(
+        value["no_workspace_loaded"],
+        "sweep.no_workspace_loaded: orbit 0.21.0 loaded 0/2 workspaces; first error [nebula]: schema migration failed"
+    );
 }

--- a/crates/orbit-core/src/application/routines/clock.rs
+++ b/crates/orbit-core/src/application/routines/clock.rs
@@ -227,13 +227,13 @@ pub struct ClockStatus {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum ClockPlatform {
+pub(crate) enum ClockPlatform {
     Launchd,
     Systemd,
 }
 
 impl ClockPlatform {
-    fn current() -> Self {
+    pub(crate) fn current() -> Self {
         if cfg!(target_os = "macos") {
             Self::Launchd
         } else {
@@ -430,7 +430,7 @@ fn install_launchd(
 
     let agents_dir = home.join("Library/LaunchAgents");
     fs::create_dir_all(&agents_dir).map_err(|error| OrbitError::Io(error.to_string()))?;
-    let plist_path = agents_dir.join(format!("{LAUNCHD_LABEL}.plist"));
+    let plist_path = launchd_plist_path(home);
     fs::write(&plist_path, plist).map_err(|error| {
         OrbitError::Io(format!(
             "failed to write '{}': {error}",
@@ -537,7 +537,14 @@ fn systemd_user_unit_dir(home: &Path) -> PathBuf {
     home.join(".config/systemd/user")
 }
 
-fn systemd_service_path(home: &Path) -> PathBuf {
+/// Per-user launchd agent path written by [`install_clock`].
+pub(crate) fn launchd_plist_path(home: &Path) -> PathBuf {
+    home.join("Library/LaunchAgents")
+        .join(format!("{LAUNCHD_LABEL}.plist"))
+}
+
+/// Per-user systemd service path written by [`install_clock`].
+pub(crate) fn systemd_service_path(home: &Path) -> PathBuf {
     systemd_user_unit_dir(home).join(format!("{SYSTEMD_UNIT}.service"))
 }
 
@@ -643,20 +650,14 @@ fn manager_set_enabled_command(
             program: "launchctl",
             args: vec![
                 "load".into(),
-                home.join("Library/LaunchAgents")
-                    .join(format!("{LAUNCHD_LABEL}.plist"))
-                    .display()
-                    .to_string(),
+                launchd_plist_path(home).display().to_string(),
             ],
         },
         (ClockPlatform::Launchd, false) => ManagerCommand {
             program: "launchctl",
             args: vec![
                 "unload".into(),
-                home.join("Library/LaunchAgents")
-                    .join(format!("{LAUNCHD_LABEL}.plist"))
-                    .display()
-                    .to_string(),
+                launchd_plist_path(home).display().to_string(),
             ],
         },
         (ClockPlatform::Systemd, true) => systemd_enable_command(),

--- a/crates/orbit-core/src/application/routines/clock_unit.rs
+++ b/crates/orbit-core/src/application/routines/clock_unit.rs
@@ -1,0 +1,398 @@
+//! Inspect the installed OS sweep-clock unit and compare it to this binary.
+//!
+//! `orbit doctor` and `orbit routine clock status` share this helper so a
+//! launchd/systemd unit that still points at an older package-manager install
+//! is visible without talking to the unit manager.
+
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use orbit_common::OrbitError;
+
+use super::clock::{ClockPlatform, launchd_plist_path, systemd_service_path};
+
+/// How long to wait for `<program> --version` before treating it as unrunnable.
+const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// The binary this process is, used as the comparison baseline.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunningBinary {
+    /// `std::env::current_exe()`, not necessarily canonical.
+    pub path: PathBuf,
+    /// `CARGO_PKG_VERSION` of this crate / workspace.
+    pub version: String,
+}
+
+impl RunningBinary {
+    /// Snapshot the running Orbit process.
+    pub fn current() -> Result<Self, OrbitError> {
+        let path = std::env::current_exe().map_err(|error| {
+            OrbitError::Io(format!("resolve current orbit executable: {error}"))
+        })?;
+        Ok(Self {
+            path,
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        })
+    }
+}
+
+/// Outcome of comparing the installed clock unit to this binary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClockUnitVerdict {
+    /// No launchd plist or systemd service is present.
+    NoUnitInstalled,
+    /// Canonical path and version both match.
+    Matching,
+    /// Two different installs report the same version.
+    PathMismatch,
+    /// The unit's program reports a different version than this binary.
+    VersionMismatch,
+    /// The unit exists but its program could not be probed.
+    Unrunnable {
+        /// Why `--version` did not yield a version string.
+        reason: String,
+    },
+}
+
+/// Facts about the installed clock unit relative to this binary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClockUnitInspection {
+    /// Unit file that named the program, when one was found.
+    pub unit_path: Option<PathBuf>,
+    /// Program path as written in the unit, when parsed.
+    pub program_path: Option<PathBuf>,
+    /// Version reported by the unit program, when `--version` succeeded.
+    pub program_version: Option<String>,
+    /// Path of the running binary.
+    pub running_path: PathBuf,
+    /// Version of the running binary.
+    pub running_version: String,
+    /// Comparison result.
+    pub verdict: ClockUnitVerdict,
+}
+
+impl ClockUnitInspection {
+    /// Fragment appended after `platform:` on `orbit routine clock status`.
+    pub fn status_line_suffix(&self) -> String {
+        let Some(program_path) = &self.program_path else {
+            return String::new();
+        };
+        let program = program_path.display();
+        match &self.verdict {
+            ClockUnitVerdict::NoUnitInstalled => String::new(),
+            ClockUnitVerdict::Matching | ClockUnitVerdict::PathMismatch => {
+                let version = self
+                    .program_version
+                    .as_deref()
+                    .unwrap_or(&self.running_version);
+                format!(" | program: {program} {version}")
+            }
+            ClockUnitVerdict::VersionMismatch => {
+                let unit_version = self.program_version.as_deref().unwrap_or("unknown");
+                format!(
+                    " | program: {program} {unit_version} (mismatch: running {} at {})",
+                    self.running_version,
+                    self.running_path.display()
+                )
+            }
+            ClockUnitVerdict::Unrunnable { reason } => {
+                format!(" | program: {program} (version unavailable: {reason})")
+            }
+        }
+    }
+
+    /// Operator-facing doctor detail for this inspection.
+    pub fn doctor_message(&self) -> String {
+        match &self.verdict {
+            ClockUnitVerdict::NoUnitInstalled => {
+                "no sweep clock unit is installed on this host".to_string()
+            }
+            ClockUnitVerdict::Matching => format!(
+                "clock unit {} runs this binary ({}, {})",
+                display_opt_path(&self.unit_path),
+                self.running_path.display(),
+                self.running_version
+            ),
+            ClockUnitVerdict::PathMismatch => format!(
+                "clock unit {} runs {} ({}); this binary is {} (same version). Two installs; the clock can drift",
+                display_opt_path(&self.unit_path),
+                display_opt_path(&self.program_path),
+                self.program_version
+                    .as_deref()
+                    .unwrap_or(&self.running_version),
+                self.running_path.display()
+            ),
+            ClockUnitVerdict::VersionMismatch => format!(
+                "clock unit {} runs {} ({}); this binary is {} ({})",
+                display_opt_path(&self.unit_path),
+                display_opt_path(&self.program_path),
+                self.program_version.as_deref().unwrap_or("unknown"),
+                self.running_path.display(),
+                self.running_version
+            ),
+            ClockUnitVerdict::Unrunnable { reason } => format!(
+                "clock unit {} names {}, which could not report a version: {reason}",
+                display_opt_path(&self.unit_path),
+                display_opt_path(&self.program_path)
+            ),
+        }
+    }
+
+    /// Repair hint for warning and failure rows.
+    pub fn doctor_remediation(&self) -> Option<String> {
+        match self.verdict {
+            ClockUnitVerdict::VersionMismatch | ClockUnitVerdict::PathMismatch => Some(
+                "Run `orbit routine init --install-clock` so the clock unit invokes this binary, or repoint the package-manager install the unit names so it is this version."
+                    .to_string(),
+            ),
+            ClockUnitVerdict::Unrunnable { .. } => Some(
+                "Restore the orbit binary the clock unit names, or run `orbit routine init --install-clock` to rewrite the unit to this binary."
+                    .to_string(),
+            ),
+            ClockUnitVerdict::NoUnitInstalled | ClockUnitVerdict::Matching => None,
+        }
+    }
+}
+
+/// Inspect the installed clock unit on this host against the running binary.
+pub fn inspect_clock_unit() -> Result<ClockUnitInspection, OrbitError> {
+    let home = orbit_common::fs::path::home_dir()?;
+    let running = RunningBinary::current()?;
+    Ok(inspect_clock_unit_at(
+        &home,
+        ClockPlatform::current(),
+        &running,
+        probe_program_version,
+    ))
+}
+
+/// Inspect a clock unit under an explicit home and platform.
+///
+/// `probe` is injected so unit tests can cover matching and mismatch without
+/// spawning; production passes [`probe_program_version`].
+pub(crate) fn inspect_clock_unit_at(
+    home: &Path,
+    platform: ClockPlatform,
+    running: &RunningBinary,
+    probe: impl Fn(&Path) -> Result<String, String>,
+) -> ClockUnitInspection {
+    match discover_clock_unit_program(home, platform) {
+        None => ClockUnitInspection {
+            unit_path: None,
+            program_path: None,
+            program_version: None,
+            running_path: running.path.clone(),
+            running_version: running.version.clone(),
+            verdict: ClockUnitVerdict::NoUnitInstalled,
+        },
+        Some(Err((unit_path, reason))) => ClockUnitInspection {
+            unit_path: Some(unit_path),
+            program_path: None,
+            program_version: None,
+            running_path: running.path.clone(),
+            running_version: running.version.clone(),
+            verdict: ClockUnitVerdict::Unrunnable { reason },
+        },
+        Some(Ok((unit_path, program_path))) => match probe(&program_path) {
+            Err(reason) => ClockUnitInspection {
+                unit_path: Some(unit_path),
+                program_path: Some(program_path),
+                program_version: None,
+                running_path: running.path.clone(),
+                running_version: running.version.clone(),
+                verdict: ClockUnitVerdict::Unrunnable { reason },
+            },
+            Ok(raw_version) => {
+                let program_version = normalize_version(&raw_version);
+                let running_version = normalize_version(&running.version);
+                let verdict = if program_version != running_version {
+                    ClockUnitVerdict::VersionMismatch
+                } else if same_program(&program_path, &running.path) {
+                    ClockUnitVerdict::Matching
+                } else {
+                    ClockUnitVerdict::PathMismatch
+                };
+                ClockUnitInspection {
+                    unit_path: Some(unit_path),
+                    program_path: Some(program_path),
+                    program_version: Some(program_version),
+                    running_path: running.path.clone(),
+                    running_version: running.version.clone(),
+                    verdict,
+                }
+            }
+        },
+    }
+}
+
+/// Run `<program> --version` with a short timeout. Never panics.
+pub fn probe_program_version(program: &Path) -> Result<String, String> {
+    if !program.exists() {
+        return Err(format!("program does not exist: {}", program.display()));
+    }
+
+    let mut child = Command::new(program)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| format!("could not start {}: {error}", program.display()))?;
+
+    let deadline = Instant::now() + VERSION_PROBE_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let mut stdout = String::new();
+                let mut stderr = String::new();
+                if let Some(mut pipe) = child.stdout.take() {
+                    let _ = pipe.read_to_string(&mut stdout);
+                }
+                if let Some(mut pipe) = child.stderr.take() {
+                    let _ = pipe.read_to_string(&mut stderr);
+                }
+                if !status.success() {
+                    let detail = first_line(&stderr).or_else(|| first_line(&stdout));
+                    return Err(match detail {
+                        Some(detail) => format!("exited {status}: {detail}"),
+                        None => format!("exited {status}"),
+                    });
+                }
+                let output = if stdout.trim().is_empty() {
+                    stderr
+                } else {
+                    stdout
+                };
+                let version = normalize_version(&output);
+                if version.is_empty() {
+                    return Err("empty --version output".to_string());
+                }
+                return Ok(version);
+            }
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!(
+                    "--version timed out after {}s",
+                    VERSION_PROBE_TIMEOUT.as_secs()
+                ));
+            }
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!("wait for --version failed: {error}"));
+            }
+        }
+    }
+}
+
+fn discover_clock_unit_program(
+    home: &Path,
+    platform: ClockPlatform,
+) -> Option<Result<(PathBuf, PathBuf), (PathBuf, String)>> {
+    let unit_path = match platform {
+        ClockPlatform::Launchd => launchd_plist_path(home),
+        ClockPlatform::Systemd => systemd_service_path(home),
+    };
+    if !unit_path.exists() {
+        return None;
+    }
+    let contents = match fs::read_to_string(&unit_path) {
+        Ok(contents) => contents,
+        Err(error) => {
+            return Some(Err((
+                unit_path,
+                format!("could not read unit file: {error}"),
+            )));
+        }
+    };
+    let program = match platform {
+        ClockPlatform::Launchd => parse_launchd_program(&contents),
+        ClockPlatform::Systemd => parse_systemd_exec_start(&contents),
+    };
+    match program {
+        Some(program) if !program.is_empty() => Some(Ok((unit_path, PathBuf::from(program)))),
+        _ => Some(Err((
+            unit_path,
+            "unit file does not name an orbit program path".to_string(),
+        ))),
+    }
+}
+
+fn parse_launchd_program(plist: &str) -> Option<String> {
+    if let Some(args) = plist.split("<key>ProgramArguments</key>").nth(1)
+        && let Some(array) = args.split("<array>").nth(1)
+        && let Some(array) = array.split("</array>").next()
+        && let Some(program) = first_plist_string(array)
+    {
+        return Some(program);
+    }
+    plist
+        .split("<key>Program</key>")
+        .nth(1)
+        .and_then(first_plist_string)
+}
+
+fn first_plist_string(fragment: &str) -> Option<String> {
+    let start = fragment.find("<string>")? + "<string>".len();
+    let end = fragment[start..].find("</string>")?;
+    let value = fragment[start..start + end].trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+fn parse_systemd_exec_start(unit: &str) -> Option<String> {
+    for line in unit.lines() {
+        let line = line.trim();
+        let Some(rest) = line.strip_prefix("ExecStart=") else {
+            continue;
+        };
+        let rest = rest.trim();
+        if let Some(stripped) = rest.strip_prefix('"') {
+            return stripped.split('"').next().map(str::to_string);
+        }
+        let program = rest.split_whitespace().next()?.to_string();
+        if !program.is_empty() {
+            return Some(program);
+        }
+    }
+    None
+}
+
+fn same_program(left: &Path, right: &Path) -> bool {
+    match (fs::canonicalize(left), fs::canonicalize(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
+    }
+}
+
+fn normalize_version(raw: &str) -> String {
+    let line = raw
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or("");
+    line.split_whitespace()
+        .rev()
+        .find(|token| token.chars().next().is_some_and(|c| c.is_ascii_digit()))
+        .unwrap_or(line.trim())
+        .trim_start_matches('v')
+        .to_string()
+}
+
+fn first_line(text: &str) -> Option<String> {
+    text.lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(ToString::to_string)
+}
+
+fn display_opt_path(path: &Option<PathBuf>) -> String {
+    path.as_ref()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| "<unknown>".to_string())
+}

--- a/crates/orbit-core/src/application/routines/mod.rs
+++ b/crates/orbit-core/src/application/routines/mod.rs
@@ -16,6 +16,7 @@ use orbit_common::OrbitError;
 use orbit_store::contracts::RoutineStoreBackend;
 
 pub mod clock;
+pub mod clock_unit;
 pub use orbit_automation::routines::due;
 pub mod loader;
 pub mod status;
@@ -24,6 +25,9 @@ pub mod sweep;
 pub use clock::{
     ClockInstallReport, ClockSettings, ClockStatus, DEFAULT_CLOCK_CADENCE_SECONDS, clock_status,
     install_clock, load_clock_settings, save_clock_settings, set_clock_cadence, set_clock_enabled,
+};
+pub use clock_unit::{
+    ClockUnitInspection, ClockUnitVerdict, RunningBinary, inspect_clock_unit, probe_program_version,
 };
 pub use due::{DueDecision, due_decision, parse_cron};
 pub use loader::{

--- a/crates/orbit-core/src/application/routines/sweep.rs
+++ b/crates/orbit-core/src/application/routines/sweep.rs
@@ -166,6 +166,7 @@ pub fn run_sweep_at_with_providers(
     let discovered = workspace_provider.discover_workspaces(global_root)?;
     refresh_discovered_token_scoreboards(&discovered.entries);
     let mut load_errors: Vec<RoutineLoadError> = discovered.errors.clone();
+    let no_workspace_loaded = no_workspace_loaded_row(&discovered);
 
     let mut collection = collect_routines(&discovered.entries);
     load_errors.append(&mut collection.errors);
@@ -186,7 +187,30 @@ pub fn run_sweep_at_with_providers(
         lock_busy: false,
         reports,
         load_errors,
+        no_workspace_loaded,
     })
+}
+
+/// One fail-loud row when discovery found workspaces but opened none.
+fn no_workspace_loaded_row(discovered: &super::loader::DiscoveredWorkspaces) -> Option<String> {
+    if !discovered.entries.is_empty() || discovered.errors.is_empty() {
+        return None;
+    }
+    let first = &discovered.errors[0];
+    let binary_version = env!("CARGO_PKG_VERSION");
+    tracing::error!(
+        target: "orbit.core.sweep",
+        binary_version,
+        source_workspace = first.source_workspace.as_str(),
+        first_error = first.message.as_str(),
+        "sweep.no_workspace_loaded"
+    );
+    Some(format!(
+        "sweep.no_workspace_loaded: orbit {binary_version} loaded 0/{} workspaces; first error [{}]: {}",
+        discovered.errors.len(),
+        first.source_workspace,
+        first.message
+    ))
 }
 
 /// Bind a routine sweep to the same cadence the host clock installer renders.

--- a/crates/orbit-core/src/application/routines/tests/clock_unit.rs
+++ b/crates/orbit-core/src/application/routines/tests/clock_unit.rs
@@ -1,0 +1,292 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use tempfile::tempdir;
+
+use super::super::clock::ClockPlatform;
+use super::super::clock_unit::{
+    ClockUnitVerdict, RunningBinary, inspect_clock_unit_at, probe_program_version,
+};
+
+fn running(path: &str, version: &str) -> RunningBinary {
+    RunningBinary {
+        path: PathBuf::from(path),
+        version: version.to_string(),
+    }
+}
+
+fn write_launchd_unit(home: &Path, program: &str) -> PathBuf {
+    let agents = home.join("Library/LaunchAgents");
+    fs::create_dir_all(&agents).expect("launchd agents dir");
+    let path = agents.join("com.orbit.sweep.plist");
+    fs::write(
+        &path,
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.orbit.sweep</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{program}</string>
+        <string>sweep</string>
+    </array>
+</dict>
+</plist>
+"#
+        ),
+    )
+    .expect("write launchd plist");
+    path
+}
+
+fn write_systemd_unit(home: &Path, program: &str) -> PathBuf {
+    let unit_dir = home.join(".config/systemd/user");
+    fs::create_dir_all(&unit_dir).expect("systemd user dir");
+    let path = unit_dir.join("orbit-sweep.service");
+    fs::write(
+        &path,
+        format!("[Service]\nType=oneshot\nExecStart={program} sweep\n"),
+    )
+    .expect("write systemd service");
+    path
+}
+
+fn inspect_with_version(
+    home: &Path,
+    platform: ClockPlatform,
+    running: &RunningBinary,
+    version: &str,
+) -> super::super::clock_unit::ClockUnitInspection {
+    inspect_clock_unit_at(home, platform, running, |_| Ok(version.to_string()))
+}
+
+#[test]
+fn no_unit_installed_is_skipped() {
+    let home = tempdir().expect("home");
+    let inspection = inspect_clock_unit_at(
+        home.path(),
+        ClockPlatform::Systemd,
+        &running("/opt/orbit/bin/orbit", "0.21.0"),
+        |_| panic!("probe must not run when no unit is installed"),
+    );
+    assert_eq!(inspection.verdict, ClockUnitVerdict::NoUnitInstalled);
+    assert!(inspection.status_line_suffix().is_empty());
+    assert!(inspection.doctor_message().contains("no sweep clock unit"));
+    assert!(inspection.doctor_remediation().is_none());
+}
+
+#[test]
+fn matching_path_and_version_is_ok() {
+    let home = tempdir().expect("home");
+    let program = home.path().join("orbit");
+    fs::write(&program, "binary").expect("touch running binary");
+    let unit = write_systemd_unit(home.path(), &program.to_string_lossy());
+    let running = RunningBinary {
+        path: program.clone(),
+        version: "0.21.0".to_string(),
+    };
+
+    let inspection = inspect_with_version(
+        home.path(),
+        ClockPlatform::Systemd,
+        &running,
+        "orbit 0.21.0",
+    );
+
+    assert_eq!(inspection.verdict, ClockUnitVerdict::Matching);
+    assert_eq!(inspection.unit_path.as_deref(), Some(unit.as_path()));
+    assert_eq!(inspection.program_path.as_deref(), Some(program.as_path()));
+    assert_eq!(inspection.program_version.as_deref(), Some("0.21.0"));
+    assert!(
+        inspection
+            .status_line_suffix()
+            .contains(&format!(" | program: {} 0.21.0", program.display())),
+        "{}",
+        inspection.status_line_suffix()
+    );
+    assert!(inspection.doctor_message().contains("runs this binary"));
+}
+
+#[test]
+fn path_only_mismatch_is_a_warning() {
+    let home = tempdir().expect("home");
+    let unit_program = home.path().join("homebrew/orbit");
+    let running_program = home.path().join("cargo/orbit");
+    fs::create_dir_all(unit_program.parent().expect("parent")).expect("unit parent");
+    fs::create_dir_all(running_program.parent().expect("parent")).expect("running parent");
+    fs::write(&unit_program, "homebrew").expect("unit binary");
+    fs::write(&running_program, "cargo").expect("running binary");
+    write_launchd_unit(home.path(), &unit_program.to_string_lossy());
+
+    let running = RunningBinary {
+        path: running_program.clone(),
+        version: "0.21.0".to_string(),
+    };
+    let inspection = inspect_with_version(home.path(), ClockPlatform::Launchd, &running, "0.21.0");
+
+    assert_eq!(inspection.verdict, ClockUnitVerdict::PathMismatch);
+    let message = inspection.doctor_message();
+    assert!(
+        message.contains(&unit_program.display().to_string()),
+        "{message}"
+    );
+    assert!(
+        message.contains(&running_program.display().to_string()),
+        "{message}"
+    );
+    assert!(message.contains("Two installs"), "{message}");
+    assert!(
+        inspection
+            .doctor_remediation()
+            .expect("path mismatch remediation")
+            .contains("orbit routine init --install-clock")
+    );
+}
+
+#[test]
+fn version_mismatch_is_a_failure_naming_both_paths_and_versions() {
+    let home = tempdir().expect("home");
+    let unit_program = home.path().join("homebrew/orbit");
+    let running_program = home.path().join("cargo/orbit");
+    fs::create_dir_all(unit_program.parent().expect("parent")).expect("unit parent");
+    fs::create_dir_all(running_program.parent().expect("parent")).expect("running parent");
+    fs::write(&unit_program, "homebrew").expect("unit binary");
+    fs::write(&running_program, "cargo").expect("running binary");
+    let unit = write_launchd_unit(home.path(), &unit_program.to_string_lossy());
+
+    let running = RunningBinary {
+        path: running_program.clone(),
+        version: "0.21.0".to_string(),
+    };
+    let inspection = inspect_with_version(
+        home.path(),
+        ClockPlatform::Launchd,
+        &running,
+        "orbit 0.20.0",
+    );
+
+    assert_eq!(inspection.verdict, ClockUnitVerdict::VersionMismatch);
+    let message = inspection.doctor_message();
+    assert!(message.contains(&unit.display().to_string()), "{message}");
+    assert!(
+        message.contains(&unit_program.display().to_string()),
+        "{message}"
+    );
+    assert!(
+        message.contains(&running_program.display().to_string()),
+        "{message}"
+    );
+    assert!(message.contains("0.20.0"), "{message}");
+    assert!(message.contains("0.21.0"), "{message}");
+    let suffix = inspection.status_line_suffix();
+    assert!(suffix.contains("mismatch: running 0.21.0"), "{suffix}");
+    assert!(
+        inspection
+            .doctor_remediation()
+            .expect("version mismatch remediation")
+            .contains("orbit routine init --install-clock")
+    );
+}
+
+#[test]
+fn missing_program_is_unrunnable_without_panic() {
+    let home = tempdir().expect("home");
+    let missing = home.path().join("gone/orbit");
+    write_systemd_unit(home.path(), &missing.to_string_lossy());
+
+    let inspection = inspect_clock_unit_at(
+        home.path(),
+        ClockPlatform::Systemd,
+        &running("/opt/orbit/bin/orbit", "0.21.0"),
+        probe_program_version,
+    );
+
+    match &inspection.verdict {
+        ClockUnitVerdict::Unrunnable { reason } => {
+            assert!(reason.contains("does not exist"), "{reason}");
+        }
+        other => panic!("expected unrunnable, got {other:?}"),
+    }
+    assert!(
+        inspection
+            .doctor_message()
+            .contains("could not report a version")
+    );
+    assert!(inspection.doctor_remediation().is_some());
+}
+
+#[test]
+fn unexecutable_program_is_unrunnable_without_panic() {
+    let home = tempdir().expect("home");
+    let program = home.path().join("not-executable");
+    fs::write(&program, "not a binary").expect("write junk");
+    let mut permissions = fs::metadata(&program).expect("metadata").permissions();
+    permissions.set_mode(0o644);
+    fs::set_permissions(&program, permissions).expect("chmod");
+    write_systemd_unit(home.path(), &program.to_string_lossy());
+
+    let inspection = inspect_clock_unit_at(
+        home.path(),
+        ClockPlatform::Systemd,
+        &running("/opt/orbit/bin/orbit", "0.21.0"),
+        probe_program_version,
+    );
+
+    match inspection.verdict {
+        ClockUnitVerdict::Unrunnable { reason } => {
+            assert!(
+                reason.contains("could not start")
+                    || reason.contains("exited")
+                    || reason.contains("Permission"),
+                "{reason}"
+            );
+        }
+        other => panic!("expected unrunnable, got {other:?}"),
+    }
+}
+
+#[test]
+fn parses_quoted_systemd_exec_start() {
+    let home = tempdir().expect("home");
+    let unit_dir = home.path().join(".config/systemd/user");
+    fs::create_dir_all(&unit_dir).expect("systemd user dir");
+    fs::write(
+        unit_dir.join("orbit-sweep.service"),
+        "[Service]\nExecStart=\"/opt/orbit with spaces/orbit\" sweep\n",
+    )
+    .expect("write quoted service");
+
+    let inspection = inspect_clock_unit_at(
+        home.path(),
+        ClockPlatform::Systemd,
+        &running("/opt/orbit/bin/orbit", "0.21.0"),
+        |_| Ok("0.21.0".to_string()),
+    );
+    assert_eq!(
+        inspection.program_path.as_deref(),
+        Some(Path::new("/opt/orbit with spaces/orbit"))
+    );
+}
+
+#[test]
+fn live_version_script_is_normalized() {
+    let home = tempdir().expect("home");
+    let program = home.path().join("fake-orbit");
+    fs::write(&program, "#!/bin/sh\necho 'orbit 0.20.0'\n").expect("write script");
+    let mut permissions = fs::metadata(&program).expect("metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&program, permissions).expect("chmod");
+    write_systemd_unit(home.path(), &program.to_string_lossy());
+
+    let inspection = inspect_clock_unit_at(
+        home.path(),
+        ClockPlatform::Systemd,
+        &running("/opt/orbit/bin/orbit", "0.21.0"),
+        probe_program_version,
+    );
+    assert_eq!(inspection.verdict, ClockUnitVerdict::VersionMismatch);
+    assert_eq!(inspection.program_version.as_deref(), Some("0.20.0"));
+}

--- a/crates/orbit-core/src/application/routines/tests/mod.rs
+++ b/crates/orbit-core/src/application/routines/tests/mod.rs
@@ -1,4 +1,5 @@
 mod clock;
+mod clock_unit;
 mod loader;
 mod status;
 mod sweep;

--- a/crates/orbit-core/src/application/routines/tests/sweep.rs
+++ b/crates/orbit-core/src/application/routines/tests/sweep.rs
@@ -6,11 +6,13 @@ use crate::application::routines::sweep::{
     run_sweep_at_with_providers,
 };
 use chrono::Utc;
+use orbit_automation::routines::loader::RoutineLoadError;
 use orbit_common::OrbitError;
 use orbit_store::InvocationInsertParams;
 use orbit_types::telemetry::{InvocationTrace, TokenUsage};
 use orbit_types::workspace::{Workspace, WorkspaceStatus};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 struct MustNotLoad;
 
 impl RoutineWorkspaceProvider for MustNotLoad {
@@ -108,4 +110,202 @@ fn sweep_refreshes_token_scoreboard_for_each_discovered_workspace() {
     let tokens = std::fs::read_to_string(workspace_root.join("state/scoreboard/tokens.json"))
         .expect("scoreboard refreshed during sweep");
     assert!(tokens.contains("codex"), "{tokens}");
+}
+
+struct ScriptedWorkspaces {
+    result: DiscoveredWorkspaces,
+}
+
+impl RoutineWorkspaceProvider for ScriptedWorkspaces {
+    fn discover_workspaces(&self, _global_root: &Path) -> Result<DiscoveredWorkspaces, OrbitError> {
+        Ok(DiscoveredWorkspaces {
+            entries: Vec::new(),
+            errors: self.result.errors.clone(),
+        })
+    }
+}
+
+fn host() -> RoutineHostIdentity {
+    RoutineHostIdentity {
+        machine_id: "hm_local".to_string(),
+        host_id: "local".to_string(),
+    }
+}
+
+fn prepared_global_root() -> (tempfile::TempDir, PathBuf) {
+    let root = tempfile::tempdir().expect("root");
+    let global = root.path().join("global");
+    let workspace_root = root.path().join("repo/.orbit");
+    std::fs::create_dir_all(&global).expect("global root");
+    std::fs::create_dir_all(&workspace_root).expect("workspace root");
+    let _runtime = crate::OrbitRuntime::from_roots(&global, &workspace_root).expect("runtime");
+    (root, global)
+}
+
+fn load_error(name: &str, message: &str) -> RoutineLoadError {
+    RoutineLoadError {
+        source_workspace: name.to_string(),
+        path: Some(PathBuf::from(format!("/tmp/{name}/.orbit"))),
+        message: message.to_string(),
+    }
+}
+
+fn capture_errors<F, T>(f: F) -> (T, String)
+where
+    F: FnOnce() -> T,
+{
+    use std::io::{self, Write};
+    use tracing_subscriber::filter::LevelFilter;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    #[derive(Clone)]
+    struct CaptureMakeWriter(Arc<Mutex<Vec<u8>>>);
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl<'a> MakeWriter<'a> for CaptureMakeWriter {
+        type Writer = CaptureWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            CaptureWriter(Arc::clone(&self.0))
+        }
+    }
+
+    impl Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().expect("capture lock").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(CaptureMakeWriter(Arc::clone(&buffer)))
+        .with_max_level(LevelFilter::ERROR)
+        .with_ansi(false)
+        .without_time()
+        .finish();
+    let result = tracing::subscriber::with_default(subscriber, f);
+    let logs =
+        String::from_utf8(buffer.lock().expect("capture buffer lock").clone()).expect("utf8 logs");
+    (result, logs)
+}
+
+#[test]
+fn every_workspace_load_error_sets_a_single_no_workspace_loaded_row() {
+    let (_root, global) = prepared_global_root();
+    let provider = ScriptedWorkspaces {
+        result: DiscoveredWorkspaces {
+            entries: Vec::new(),
+            errors: vec![
+                load_error(
+                    "nebula",
+                    "failed to open workspace runtime: schema migration failed",
+                ),
+                load_error(
+                    "polaris",
+                    "failed to open workspace runtime: schema migration failed",
+                ),
+            ],
+        },
+    };
+
+    let (outcome, logs) = capture_errors(|| {
+        run_sweep_at_with_providers(&global, SweepOptions::default(), host(), &provider)
+            .expect("sweep outcome")
+    });
+
+    let row = outcome
+        .no_workspace_loaded
+        .as_deref()
+        .expect("no_workspace_loaded row");
+    assert!(row.contains("sweep.no_workspace_loaded"), "{row}");
+    assert!(row.contains(env!("CARGO_PKG_VERSION")), "{row}");
+    assert!(row.contains("nebula"), "{row}");
+    assert!(row.contains("schema migration failed"), "{row}");
+    assert_eq!(outcome.load_errors.len(), 2);
+    assert!(
+        logs.contains("sweep.no_workspace_loaded"),
+        "expected a single tracing row, got: {logs}"
+    );
+    assert_eq!(
+        logs.matches("sweep.no_workspace_loaded").count(),
+        1,
+        "{logs}"
+    );
+}
+
+#[test]
+fn partial_workspace_load_errors_do_not_fail_the_pass() {
+    let root = tempfile::tempdir().expect("root");
+    let global = root.path().join("global");
+    let workspace_root = root.path().join("repo/.orbit");
+    std::fs::create_dir_all(&global).expect("global root");
+    std::fs::create_dir_all(&workspace_root).expect("workspace root");
+    let runtime = crate::OrbitRuntime::from_roots(&global, &workspace_root).expect("runtime");
+
+    struct Partial {
+        workspace: Workspace,
+        runtime: crate::OrbitRuntime,
+        errors: Vec<RoutineLoadError>,
+    }
+    impl RoutineWorkspaceProvider for Partial {
+        fn discover_workspaces(
+            &self,
+            _global_root: &Path,
+        ) -> Result<DiscoveredWorkspaces, OrbitError> {
+            Ok(DiscoveredWorkspaces {
+                entries: vec![(self.workspace.clone(), self.runtime.clone())],
+                errors: self.errors.clone(),
+            })
+        }
+    }
+
+    let provider = Partial {
+        workspace: Workspace {
+            id: "ws-ok".to_string(),
+            name: "ok".to_string(),
+            owner_machine_id: None,
+            git_remote: None,
+            ship_mode: None,
+            base_branch: "agent-main".to_string(),
+            status: WorkspaceStatus::Active,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        },
+        runtime,
+        errors: vec![load_error("broken", "failed to open workspace runtime")],
+    };
+
+    let (outcome, logs) = capture_errors(|| {
+        run_sweep_at_with_providers(&global, SweepOptions::default(), host(), &provider)
+            .expect("sweep outcome")
+    });
+
+    assert!(
+        outcome.no_workspace_loaded.is_none(),
+        "{:?}",
+        outcome.no_workspace_loaded
+    );
+    assert_eq!(outcome.load_errors.len(), 1);
+    assert!(
+        !logs.contains("sweep.no_workspace_loaded"),
+        "partial load errors must not emit the fail-loud row: {logs}"
+    );
+}
+
+#[test]
+fn unconfigured_host_does_not_report_no_workspace_loaded() {
+    let (_root, global) = prepared_global_root();
+    let provider = ScriptedWorkspaces {
+        result: DiscoveredWorkspaces::default(),
+    };
+
+    let outcome = run_sweep_at_with_providers(&global, SweepOptions::default(), host(), &provider)
+        .expect("sweep outcome");
+    assert!(outcome.no_workspace_loaded.is_none());
+    assert!(outcome.load_errors.is_empty());
 }

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -4,7 +4,7 @@ summary: Check Orbit workspace, database, dashboard, log-sink, job-run, and rout
 tags: [operations, health, doctor, dashboard, routines]
 paths: ["crates/orbit-cmd/src/doctor.rs", "crates/orbit-core/src/application/job/run/reconcile.rs"]
 related_features: [orbit-core, activity-job, routines]
-related_artifacts: [ORB-10005, ORB-10070, ORB-10473, ORB-10501, ORB-10558, ORB-10986, ORB-11791, ORB-12109, ORB-12223, ORB-12259]
+related_artifacts: [ORB-10005, ORB-10070, ORB-10473, ORB-10501, ORB-10558, ORB-10986, ORB-11791, ORB-12109, ORB-12223, ORB-12244, ORB-12259]
 last_validated: 2026-09-12
 ---
 
@@ -31,6 +31,7 @@ Every check degrades to a row rather than aborting unless the store itself canno
 | `task-relations` | unresolved relation/dependency targets that would block a task-index rebuild |
 | `orphan-task-stores` | task-store partitions (`~/.orbit/tasks/workspaces/<ws_id>/`) that no workspace binding on this host claims |
 | `artifacts-*` | skills, jobs, activities, auto-tasks, and routines on disk: stale, deprecated, residual, catalog-invalid, or a previously reconciled shipped default that is missing |
+| `clock-unit` | the installed launchd/systemd sweep unit invokes this Orbit binary (path and `--version`); skipped when no unit is installed |
 
 Example:
 
@@ -244,7 +245,31 @@ state:
 orbit routine clock status
 orbit routine list
 orbit sweep --json
+orbit doctor
 ```
+
+`orbit routine clock status` prints the unit's program path and the version that program
+reports next to `platform:`. A version that does not match this binary is flagged on the
+same line as `mismatch: running <version> at <path>`. `orbit doctor`'s `clock-unit` row is
+the same comparison in check form:
+
+- **ok** — the unit invokes this binary (canonical path and version match)
+- **warning** — the unit's program path differs but `--version` matches (two installs; the
+  clock can drift), or the named program is missing/unrunnable
+- **ERROR** — the unit's program reports a different version than this binary. The row names
+  the unit file, both program paths, and both versions. Rewrite the unit with
+  `orbit routine init --install-clock`, or repoint the package-manager install the unit
+  names so it is this version
+- **skipped** — no launchd plist or systemd user service is installed
+
+`orbit update --check` reports the binary on `PATH` / the cargo install; it does not inspect
+what the clock unit invokes. After an upgrade, run `orbit doctor` or `orbit routine clock
+status` before assuming unattended sweeps are running the new binary.
+
+A sweep that discovers workspaces but fails to open every one of them exits non-zero and
+prints a single `sweep.no_workspace_loaded` row naming this binary's version and the first
+load error. Partial load errors still print one `load error […]` line per workspace and
+exit 0. An unconfigured host (no registered workspaces) remains a clean no-op.
 
 On Linux, a healthy enabled status includes an active timer, a finite next systemd trigger,
 and an effective cadence. `clock: unhealthy` with an inactive effective cadence means the


### PR DESCRIPTION
## Task

[ORB-12244](https://orbit-cli.com/tasks/ORB-12244) — `doctor` and clock status are blind to a sweep unit that runs a different Orbit binary; a sweep that loads zero workspaces exits 0

### Description

Observed on Daniels-Mac-mini (hm_ba054a1a8fbfb914) during the 0.21.0 QA sweep, 2026-09-11.

`~/Library/LaunchAgents/com.orbit.sweep.plist` (installed by `orbit routine init`) has `ProgramArguments = /opt/homebrew/bin/orbit sweep`. That path is a Homebrew symlink to **0.20.0**. The binary the operator actually uses is `~/.cargo/bin/orbit` **0.21.0**, which migrated every workspace to `.orbit` layout v3. Result: every launchd-driven sweep since 2026-09-11T01:39Z wrote

    load error [nebula] (…/.orbit): failed to open workspace runtime: schema migration failed: workspace … has .orbit layout version 3, newer than the newest version this orbit binary supports (2); upgrade orbit to open this workspace

for all six registered workspaces, and **exited 0** (`launchctl print gui/$UID/com.orbit.sweep` → `runs = 34`, `last exit code = 0`). Nothing scheduled ran for ~25 hours. Meanwhile:

- `orbit routine clock status` → `clock: enabled | configured cadence: 300s | effective cadence: 300s | platform: launchd` — reported healthy.
- `orbit doctor` → 0 failures, 1 unrelated warning.
- `orbit update --check` → `install: /Users/daniel/.cargo/bin/orbit (cargo)` — never looks at what the clock unit invokes.
- `orbit routine list` showed the last fire of every routine stuck at `dispatched @ 2026-09-11T01:39` (the 0.20.0 sweeps could not reconcile it either).

A manual `orbit --workspace ws_nebula sweep` with the 0.21.0 binary reconciled the stale fire and dispatched normally, so the store was fine — only the clock's binary was wrong.

## What to change

1. **Doctor check `clock-unit`** (in `crates/orbit-cli/src/command/doctor.rs`, alongside `mcp-callers`): when a clock unit is installed (launchd plist / systemd unit, as `routine clock status` already discovers), resolve its program path, run `<program> --version` (bounded), and compare both the canonical path and the version with `std::env::current_exe()` / the running version. Different path but same version → `warning` (two installs, drift risk). Different version → `failure`, with the unit path, the two program paths, the two versions, and the remediation (`orbit routine init` with the clock flag, or repoint the package-manager install).
2. **Clock status shows the program.** `orbit routine clock status` (and its successor `orbit clock status`, see ORB-12237) prints the unit's program path and its reported version next to `platform:`; mismatched version is flagged in the same line.
3. **A tick that loads nothing fails loud.** In the sweep path (`crates/orbit-core/src/application/routines/sweep.rs`, and `orbit clock tick` once ORB-12237 lands), if every discovered workspace produced a load error, exit non-zero and emit one `sweep.no_workspace_loaded` log/audit row that names the binary version and the first error. Partial load errors keep today's behaviour (row per error, exit 0).
4. **Sweep log rotation is separate** — do not touch it here.

Coordinate with ORB-12236/ORB-12237 (clock consolidation): implement the doctor check against the discovery helper those tasks keep, not against the removed `routine clock` module. If ORB-12237 has already moved the code, put the check where `orbit clock status` lives.

### Acceptance Criteria

- `orbit doctor` reports a `clock-unit` failure when the installed clock unit's program reports a different version than the running binary, naming both paths and both versions, and a warning when only the path differs
- `orbit routine clock status` (or `orbit clock status`) prints the unit's program path and version
- A sweep/tick in which every discovered workspace fails to load exits non-zero and logs a single `no_workspace_loaded` row; partial load errors are unchanged
- Unit tests cover: matching, path-only mismatch, version mismatch, no unit installed, program missing/unrunnable (warning, not panic)
- `docs/runbooks/health-checks.md` documents the new check

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `orbit-core` clock-unit inspection (`clock_unit.rs`) that reads the installed launchd plist / systemd service, probes `<program> --version` with a 3s bound, and compares canonical path + version to `current_exe()` / `CARGO_PKG_VERSION`.
- `orbit doctor` emits a machine-global `clock-unit` row: error on version mismatch (names unit path, both program paths, both versions, and `orbit routine init --install-clock` / repoint remediation), warning on path-only mismatch or unrunnable program, skipped when no unit is installed.
- `orbit routine clock status` appends `program: <path> <version>` next to `platform:`; version mismatch is flagged on the same line.
- A sweep that discovers workspaces but opens none sets `SweepOutcome.no_workspace_loaded`, emits one `sweep.no_workspace_loaded` tracing/stderr row (binary version + first error), and exits 1. Partial load errors and unconfigured hosts are unchanged. Sweep log rotation was not touched.
- Documented `clock-unit` and the fail-loud sweep in `docs/runbooks/health-checks.md`.

Assessment: Shared inspection lives in orbit-core against the existing clock unit paths (ORB-12237 is still backlog, so this did not wait for `orbit clock`). Doctor mapping stays in orbit-cli next to `mcp-callers`.

Strategic decisions:
- Discover by reading unit files rather than querying launchd/systemd, so a running-but-wrong binary is visible even when the manager reports healthy.
- Compare canonical paths, display the unit's written path and `current_exe()` so Homebrew vs cargo installs are recognizable.

Deviations from original plan: none material. `orbit clock status` / `orbit clock tick` were not added; those belong to ORB-12237. Status remains on `orbit routine clock status`.

Criteria:
1. Doctor `clock-unit` failure on version mismatch naming both paths and versions, warning on path-only mismatch — met (core inspection + CLI mapping tests).
2. `orbit routine clock status` prints program path and version — met (`status_line_suffix`).
3. All-workspace load failure exits non-zero with one `no_workspace_loaded` row; partial errors unchanged — met (core sweep tests + CLI JSON/exit wiring).
4. Unit tests: matching, path-only, version mismatch, no unit, missing/unrunnable (warning, not panic) — met.
5. `docs/runbooks/health-checks.md` documents the check — met.

Validation:
- `cargo test -p orbit-core --lib application::routines::tests` — passed (46 tests)
- `cargo test -p orbit-cli --bin orbit command::tests` — passed (115 tests, including new doctor/sweep cases)
- `make ci-fast` — passed
- `make ci-lint` — passed
- `make goldens` — passed (no clap help change)
- `git diff --check` — passed

Remaining risks:
- Doctor execute tests still probe the real `$HOME` unit, same as `mcp-callers`. A host whose clock unit reports a different version than this workspace (0.21.0) would fail those exit-0 doctor tests; this host did not.
- `orbit clock tick` fail-loud will need the same `no_workspace_loaded` wiring when ORB-12237 lands.

New source files declared via context_files: `file:crates/orbit-core/src/application/routines/clock_unit.rs`, `file:crates/orbit-core/src/application/routines/tests/clock_unit.rs`, `file:crates/orbit-automation/src/routines/sweep.rs`.
Friction: none filed.
Changes left uncommitted.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12244-6aa4d8ad`
- Behind base: 0
- Ahead of base: 1