### PR TITLE
Minted auto-tasks carry `complexity: "unassessed"`, a value the task enums reject; `dedupe` has three spellings across CLI, file, and show

### DIFF
--- a/crates/orbit-cli/src/command/auto_task/show.rs
+++ b/crates/orbit-cli/src/command/auto_task/show.rs
@@ -72,7 +72,7 @@ impl Execute for AutoTaskShowArgs {
             "  schedule: {}",
             super::output::schedule_summary(&definition)
         );
-        let _ = writeln!(out, "  dedupe: {:?}", definition.dedupe);
+        let _ = writeln!(out, "  dedupe: {}", definition.dedupe);
         let _ = writeln!(out, "  template: {}", definition.template.title);
         if let Some(automation) = doc.get("automation") {
             let _ = writeln!(

--- a/crates/orbit-cli/src/command/tests/auto_task.rs
+++ b/crates/orbit-cli/src/command/tests/auto_task.rs
@@ -7,6 +7,7 @@ use orbit_types::workflow::automation::{CoverageClass, DeliveryTrigger};
 
 use crate::command::auto_task::AutoTaskSubcommand;
 use crate::command::{Cli, CommandOutput, Commands, Execute};
+use crate::output::payload::{Block, View};
 
 #[test]
 fn auto_task_add_accepts_required_tools_and_legacy_alias() {
@@ -139,6 +140,82 @@ fn auto_task_add_execution_reports_disabled_required_tool_warning() {
             })
         })
     }));
+}
+
+#[test]
+fn dedupe_accepts_both_spellings_and_agrees_across_file_json_and_show() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    for (flag_value, name) in [
+        ("skip-if-open", "dedupe-kebab"),
+        ("skip_if_open", "dedupe-snake"),
+    ] {
+        let cli = Cli::try_parse_from([
+            "orbit",
+            "auto-task",
+            "add",
+            "--name",
+            name,
+            "--every-minutes",
+            "5",
+            "--title",
+            "Dedupe token",
+            "--dedupe",
+            flag_value,
+        ])
+        .unwrap_or_else(|error| panic!("parse auto-task add --dedupe {flag_value}: {error}"));
+        let Commands::AutoTask(auto_task) = cli.command else {
+            panic!("expected auto-task command");
+        };
+        let AutoTaskSubcommand::Add(args) = auto_task.command else {
+            panic!("expected auto-task add command");
+        };
+        assert_eq!(args.dedupe, DedupePolicy::SkipIfOpen);
+
+        let CommandOutput::Payload(payload) = args.execute(&runtime).expect("auto-task add") else {
+            panic!("auto-task add should return a payload");
+        };
+        let (document, _) = payload.into_view();
+        assert_eq!(document["dedupe"], "skip_if_open");
+
+        let file_path = runtime
+            .paths()
+            .local_dir
+            .join("auto_tasks")
+            .join(format!("{name}.yaml"));
+        let file_contents = std::fs::read_to_string(&file_path).expect("definition file");
+        assert!(
+            file_contents.contains("dedupe: skip_if_open"),
+            "{file_contents}"
+        );
+
+        let show_cli = Cli::try_parse_from(["orbit", "auto-task", "show", name])
+            .expect("parse auto-task show");
+        let Commands::AutoTask(auto_task) = show_cli.command else {
+            panic!("expected auto-task command");
+        };
+        let AutoTaskSubcommand::Show(show_args) = auto_task.command else {
+            panic!("expected auto-task show command");
+        };
+        let CommandOutput::Payload(show_payload) =
+            show_args.execute(&runtime).expect("auto-task show")
+        else {
+            panic!("auto-task show should return a payload");
+        };
+        let (_, view) = show_payload.into_view();
+        let View::Blocks(blocks) = view else {
+            panic!("expected block view");
+        };
+        let text = blocks
+            .into_iter()
+            .find_map(|block| match block {
+                Block::Text(text) => Some(text),
+                Block::Table(_) => None,
+            })
+            .expect("text block");
+        assert!(text.contains("dedupe: skip_if_open"), "{text}");
+        assert!(!text.contains("SkipIfOpen"), "{text}");
+    }
 }
 
 #[test]

--- a/crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md
@@ -45,7 +45,27 @@ review it in a PR like any other definition.
 | `--required-tool` | Repeatable exact canonical tool name. Scheduled fires and manual `mint` copy the normalized list onto each task. |
 | `--status` | Status the minted task enters. Defaults to `backlog`; use `proposed` when a human should approve each instance before it becomes shippable work. |
 | `--crew` | Crew override for minted tasks. |
-| `--dedupe` | `skip-if-open` (default) or `always`. |
+| `--dedupe` | `skip-if-open` (default) or `always`. `skip_if_open` is also accepted. The definition file, the JSON document, and `show` all print the canonical `skip_if_open` / `always` token. |
+
+## Minted tasks carry `complexity: "unassessed"`
+
+A definition's template does not carry `complexity` — minting is the one create
+path allowed to leave the assessment unset, and it always does, storing the
+explicit non-answer `unassessed` rather than defaulting to `medium` or leaving
+the field blank. `unassessed` is a full `TaskComplexity` value: it round-trips
+through `task.show`, `task.list`, and every persisted store, and it is exactly
+the value `task.add`/`task.update` reject on the `complexity` field — those two
+surfaces only accept `low`/`medium`/`hard`, so a human or agent can assess a
+minted task but can never re-clear that assessment. This does not block
+ordinary updates: `complexity` is patched only when a `task.update` call
+supplies it, so filing a comment, changing status, or any other no-op on
+`complexity` succeeds on a minted task exactly as it would on any other.
+
+Auto crew-pool selection (`workflow.*_complexity_crews`) has no pool for
+`unassessed`: the configured pools only cover `low` / `medium` / `hard`, so a
+minted task always falls through to the default crew, never a complexity-keyed
+pool. Assess the task through `task.update --complexity` first if it should
+draw from a pool.
 
 ## Dedupe is the important field
 

--- a/crates/orbit-core/src/adapter/tool_host/tests/auto_task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/auto_task_tools.rs
@@ -84,6 +84,36 @@ fn mint_returns_the_minted_task_with_its_provenance_tag() {
     );
 }
 
+/// ORB-12253: a minted task's `complexity: "unassessed"` must never block a
+/// later update that leaves complexity untouched — the value auto-task mint
+/// writes has to round-trip through ordinary `task.update` calls, since
+/// `complexity` on that surface is patched only when the caller supplies it
+/// (ORB-12116 rejects `unassessed` only when a caller explicitly names it).
+#[test]
+fn minted_tasks_unassessed_complexity_survives_a_later_no_op_update() {
+    let (_temp, runtime) = with_definition("chore");
+    runtime
+        .auto_task_toggle("chore", false)
+        .expect("disable the definition");
+
+    let minted = run_tool_as_operator(&runtime, "orbit.auto_task.mint", json!({ "name": "chore" }))
+        .expect("mint");
+    assert_eq!(minted["complexity"], json!("unassessed"));
+    let task_id = minted["id"].as_str().expect("task id").to_string();
+
+    let updated = run_tool_as_operator(
+        &runtime,
+        "orbit.task.update",
+        json!({ "id": task_id, "comment": "no-op touch" }),
+    )
+    .expect("an update that omits complexity must succeed on a minted task");
+    assert_eq!(updated["complexity"], json!("unassessed"));
+
+    let shown =
+        run_tool_as_operator(&runtime, "orbit.task.show", json!({ "id": task_id })).expect("show");
+    assert_eq!(shown["complexity"], json!("unassessed"));
+}
+
 #[test]
 fn mint_requires_a_definition_name_and_names_an_unknown_one() {
     let (_temp, runtime) = with_definition("chore");

--- a/crates/orbit-types/src/workflow/auto_task.rs
+++ b/crates/orbit-types/src/workflow/auto_task.rs
@@ -171,6 +171,13 @@ pub struct AutoTaskTemplate {
 
 /// Dedupe policy for firing while a prior instance created by this definition
 /// is still open.
+///
+/// The canonical spelling — on the wire, on disk, and in `show` — is
+/// `snake_case` (`skip_if_open`, `always`), matching every other persisted
+/// auto-task field. The CLI's `--dedupe` flag additionally accepts the
+/// `clap`-default kebab-case spelling (`skip-if-open`) as an alias, since that
+/// is what `--help` advertises as the possible values; it still normalizes to
+/// the snake_case token before anything is persisted.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "snake_case")]
@@ -178,9 +185,26 @@ pub enum DedupePolicy {
     /// Skip the fire while a previously-created instance is still open, so a
     /// stalled backlog never accumulates identical tasks (the default).
     #[default]
+    #[cfg_attr(feature = "clap", value(alias = "skip_if_open"))]
     SkipIfOpen,
     /// Always fire, even if a prior instance is still open.
     Always,
+}
+
+impl DedupePolicy {
+    /// The canonical `snake_case` token, matching the persisted/`show` form.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DedupePolicy::SkipIfOpen => "skip_if_open",
+            DedupePolicy::Always => "always",
+        }
+    }
+}
+
+impl std::fmt::Display for DedupePolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
 }
 
 const fn default_true() -> bool {

--- a/crates/orbit-types/src/workflow/tests/auto_task.rs
+++ b/crates/orbit-types/src/workflow/tests/auto_task.rs
@@ -1,5 +1,5 @@
 use crate::task::{TaskPriority, TaskStatus, TaskType};
-use crate::workflow::{AutoTaskDefinition, AutoTaskSchedule, AutoTaskTemplate};
+use crate::workflow::{AutoTaskDefinition, AutoTaskSchedule, AutoTaskTemplate, DedupePolicy};
 
 fn definition_with_interval(every_minutes: u64) -> AutoTaskDefinition {
     AutoTaskDefinition {
@@ -30,4 +30,19 @@ fn definition_with_interval(every_minutes: u64) -> AutoTaskDefinition {
 #[test]
 fn validation_rejects_out_of_range_interval() {
     assert!(definition_with_interval(u64::MAX).validate().is_err());
+}
+
+#[test]
+fn dedupe_policy_display_matches_its_serialized_wire_token() {
+    for (policy, token) in [
+        (DedupePolicy::SkipIfOpen, "skip_if_open"),
+        (DedupePolicy::Always, "always"),
+    ] {
+        assert_eq!(policy.to_string(), token);
+        assert_eq!(policy.as_str(), token);
+        assert_eq!(
+            serde_json::to_value(policy).expect("serialize dedupe policy"),
+            serde_json::Value::String(token.to_string())
+        );
+    }
 }

--- a/plugin/skills/orbit/references/setup/auto-tasks.md
+++ b/plugin/skills/orbit/references/setup/auto-tasks.md
@@ -45,7 +45,27 @@ review it in a PR like any other definition.
 | `--required-tool` | Repeatable exact canonical tool name. Scheduled fires and manual `mint` copy the normalized list onto each task. |
 | `--status` | Status the minted task enters. Defaults to `backlog`; use `proposed` when a human should approve each instance before it becomes shippable work. |
 | `--crew` | Crew override for minted tasks. |
-| `--dedupe` | `skip-if-open` (default) or `always`. |
+| `--dedupe` | `skip-if-open` (default) or `always`. `skip_if_open` is also accepted. The definition file, the JSON document, and `show` all print the canonical `skip_if_open` / `always` token. |
+
+## Minted tasks carry `complexity: "unassessed"`
+
+A definition's template does not carry `complexity` — minting is the one create
+path allowed to leave the assessment unset, and it always does, storing the
+explicit non-answer `unassessed` rather than defaulting to `medium` or leaving
+the field blank. `unassessed` is a full `TaskComplexity` value: it round-trips
+through `task.show`, `task.list`, and every persisted store, and it is exactly
+the value `task.add`/`task.update` reject on the `complexity` field — those two
+surfaces only accept `low`/`medium`/`hard`, so a human or agent can assess a
+minted task but can never re-clear that assessment. This does not block
+ordinary updates: `complexity` is patched only when a `task.update` call
+supplies it, so filing a comment, changing status, or any other no-op on
+`complexity` succeeds on a minted task exactly as it would on any other.
+
+Auto crew-pool selection (`workflow.*_complexity_crews`) has no pool for
+`unassessed`: the configured pools only cover `low` / `medium` / `hard`, so a
+minted task always falls through to the default crew, never a complexity-keyed
+pool. Assess the task through `task.update --complexity` first if it should
+draw from a pool.
 
 ## Dedupe is the important field
 


### PR DESCRIPTION
## Task

[ORB-12253](https://orbit-cli.com/tasks/ORB-12253) — Minted auto-tasks carry `complexity: "unassessed"`, a value the task enums reject; `dedupe` has three spellings across CLI, file, and show

### Description

0.21.0, ws_nebula:

- `orbit_auto_task_mint {name:"qa-sweep"}` → DANI-10331 with `complexity: "unassessed"`. `task.add`/`task.update` schemas enumerate `low|medium|hard` only, so a later `task.update` that echoes the record back, or any client validating against the schema, fails on a value Orbit itself wrote. Either `unassessed` is a legitimate fourth value (then add it to the enums, the CLI `--complexity` parser, and the docs, and say what the auto-drain crew pools do with it) or minting must assess/default it (template gains an optional `complexity`, default `medium`).
- `orbit auto-task add --dedupe skip_if_open` → error, possible values `skip-if-open, always`; the file and JSON then store `skip_if_open`; `orbit auto-task show` prints `dedupe: SkipIfOpen` (Rust variant name). Pick the kebab or snake form for the CLI and the wire, and print the same token in `show`.

## What to change

1. Decide `unassessed`: add to the `TaskComplexity` enum, every schema that enumerates it, `orbit task add/update --complexity`, and the crew-pool selection (`workflow.*_complexity_crews`: treat as medium, or skip pools) — **or** make auto-task templates carry `complexity` with a default. Document the choice in `references/setup/auto-tasks.md`.
2. `--dedupe` accepts both `skip-if-open` and `skip_if_open` (clap alias), serializes as one canonical form, and `auto-task show` prints that form via the serde name, not `{:?}`.
3. Round-trip tests: mint → task.update(no-op) succeeds; add → show → file agree on the dedupe token.

### Acceptance Criteria

- A minted task's `complexity` is a value `task.update` accepts, or `unassessed` is added to every complexity enum/schema/CLI parser and documented
- `auto-task add --dedupe` accepts both spellings; file, JSON and `show` print one canonical token
- Round-trip tests exist for both

## Execution Summary

<details>
<summary>Click to expand</summary>

## Findings

Half of AC1 was already resolved by ORB-12116 (landed before this task started): `TaskComplexity::Unassessed` already exists as a full enum/serde value (`crates/orbit-types/src/task/model.rs`), is what auto-task mint stamps on every minted task, round-trips through every store and `task.show`/`task.list`, and is deliberately rejected only when a caller *explicitly* passes `complexity: "unassessed"` to `task.add`/`task.update` (so an agent can't clear an assessment). `ComplexityCrewPools` (`crates/orbit-config/src/crew_pools.rs`) already has no pool for `Unassessed`, so a minted task always falls through to the default crew. None of this was documented in `references/setup/auto-tasks.md`, and there was no test proving the exact scenario in the bug report — a no-op `task.update` (not touching `complexity`) on a minted task — actually succeeds (it does, since `complexity` is patched only when the caller supplies it).

`DedupePolicy` (`crates/orbit-types/src/workflow/auto_task.rs`) had a real bug: CLI `--dedupe` only accepted the clap-default kebab-case spelling (`skip-if-open`), the file/JSON canonical form was snake_case (`skip_if_open`, via `#[serde(rename_all = "snake_case")]`), and `auto-task show` printed the raw Rust variant name via `{:?}` (`SkipIfOpen`) — three different spellings.

## Changes

1. `crates/orbit-types/src/workflow/auto_task.rs`: added `#[value(alias = "skip_if_open")]` to `DedupePolicy::SkipIfOpen` so `--dedupe` accepts both `skip-if-open` and `skip_if_open`; added `as_str()`/`Display` returning the canonical snake_case token (matching the existing serde/file form, and the established `TaskStatus::InProgress` kebab-CLI/snake-wire pattern in this codebase).
2. `crates/orbit-cli/src/command/auto_task/show.rs`: `dedupe` line now prints via `Display` instead of `{:?}`, so `show` matches the file and JSON.
3. `crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md` and its mirror `plugin/skills/orbit/references/setup/auto-tasks.md` (kept byte-identical per the `sync-plugin-skills` guardrail): documented the `--dedupe` alias/canonical-token behavior, and added a new "Minted tasks carry `complexity: \"unassessed\"`" section documenting the ORB-12116 decision (assessed-only `task.add`/`task.update`, no-op updates unaffected) and the crew-pool fallback-to-default behavior.

## Round-trip tests (AC3)

- `crates/orbit-types/src/workflow/tests/auto_task.rs`: `dedupe_policy_display_matches_its_serialized_wire_token` — `Display`/`as_str`/serde all agree on `skip_if_open`/`always`.
- `crates/orbit-cli/src/command/tests/auto_task.rs`: `dedupe_accepts_both_spellings_and_agrees_across_file_json_and_show` — parses `--dedupe skip-if-open` and `--dedupe skip_if_open`, then asserts the definition file, the JSON document, and `show`'s text all read `skip_if_open`.
- `crates/orbit-core/src/adapter/tool_host/tests/auto_task_tools.rs`: `minted_tasks_unassessed_complexity_survives_a_later_no_op_update` — mints a task (`complexity: "unassessed"`), then calls `orbit.task.update` with an unrelated field only (the no-op the bug report described), and asserts it succeeds and `complexity` stays `"unassessed"` through `task.show`.

## Criteria → results

1. "A minted task's `complexity` is a value `task.update` accepts, or `unassessed` is added to every complexity enum/schema/CLI parser and documented" — the second branch: already true in code (from ORB-12116), now documented in both `auto-tasks.md` copies, with a test proving the actual no-op-update scenario succeeds.
2. "`auto-task add --dedupe` accepts both spellings; file, JSON and `show` print one canonical token" — done; canonical token is `skip_if_open`/`always` (snake_case, matching the pre-existing file/JSON form).
3. "Round-trip tests exist for both" — done (3 new tests, listed above).

## Validation

- `make ci-fast`: passed.
- `make ci-lint` (workspace clippy, warnings denied): passed.
- `make goldens`: passed (no golden files needed regeneration — no Clap `///` help text or MCP tool description changed).
- `cargo test -p orbit-types workflow::tests::auto_task`: 2 passed.
- `cargo test -p orbit-cli --bin orbit dedupe_accepts`: 1 passed.
- `cargo test -p orbit-core auto_task_tools`: 7 passed (including the new round-trip test).
- `cargo fmt` applied (two test files needed formatting after initial edits).
- `git status --short` / `git diff --check`: clean, only the 7 tracked files listed above changed; no untracked files.

No blockers or deviations. Scope was extended beyond the originally declared `context_files` to `crates/orbit-types/src/workflow/auto_task.rs` (owns `DedupePolicy`, not covered by any declared dir) and to the sibling test files for `orbit-types`, `orbit-cli`, and `orbit-core` (test-layout convention puts them outside the declared source dirs) and to the `plugin/` doc mirror (kept in sync with the declared doc to satisfy the `sync-plugin-skills` guardrail); recorded via `orbit.task.update` with rationale in a task comment before editing.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12253-6aa4d9e0`
- Behind base: 0
- Ahead of base: 1