### PR TITLE
`orbit tool run orbit.task.add/update` return thin projections while MCP returns the full task; unknown input keys are silently dropped

### DIFF
--- a/crates/orbit-cli/src/command/tool/run.rs
+++ b/crates/orbit-cli/src/command/tool/run.rs
@@ -33,10 +33,13 @@ pub struct ToolRunArgs {
     /// Comma-separated top-level fields to keep from object output. For an
     /// envelope-shaped result (e.g. `orbit.task.list`'s `{tasks, total,
     /// truncated}`), fields project each record inside the envelope's
-    /// record array instead of the envelope's own top-level keys.
+    /// record array instead of the envelope's own top-level keys. Task
+    /// add/update/approve/start default to the full record; pass this to
+    /// opt into a compact projection.
     #[arg(long, value_delimiter = ',', conflicts_with = "full")]
     pub fields: Vec<String>,
-    /// Return the tool's full unfiltered JSON output
+    /// Return the tool's full unfiltered JSON output. Task add/update/approve/start
+    /// already default to the full record; this still expands compact list output.
     #[arg(long)]
     pub full: bool,
     /// Compatibility alias for pretty-printing JSON error output
@@ -236,14 +239,7 @@ pub(super) fn shape_tool_output(
 }
 
 fn should_project_minimal_task_output(tool_name: &str) -> bool {
-    if !matches!(
-        tool_name,
-        "orbit.task.list" | "orbit.task.add" | "orbit.task.artifact.put" | "orbit.task.update"
-    ) {
-        return false;
-    }
-
-    true
+    matches!(tool_name, "orbit.task.list" | "orbit.task.artifact.put")
 }
 
 /// Projects `--fields` (or the default minimal set) inside the `tasks` array

--- a/crates/orbit-cli/src/command/tool/tests/run.rs
+++ b/crates/orbit-cli/src/command/tool/tests/run.rs
@@ -126,6 +126,65 @@ fn list_output_projects_explicit_fields_inside_envelope() {
 }
 
 #[test]
+fn add_update_approve_start_preserve_full_task_by_default() {
+    let output = json!({
+        "id": "T20260422-0001",
+        "title": "Full record",
+        "status": "backlog",
+        "priority": "medium",
+        "type": "feature",
+        "complexity": "low",
+        "tags": ["qa"],
+        "context_files": ["file:src/lib.rs"],
+        "created_by": "codex",
+        "crew": "grok",
+        "orchestrator": null,
+        "plan": "keep the full envelope",
+        "comments": [],
+        "history": [],
+        "redactions": [],
+        "redactions_applied": false,
+        "created_at": "2026-04-22T00:00:00Z",
+        "updated_at": "2026-04-22T00:00:00Z"
+    });
+
+    for tool in [
+        "orbit.task.add",
+        "orbit.task.update",
+        "orbit.task.approve",
+        "orbit.task.start",
+    ] {
+        assert_eq!(
+            shape_tool_output(tool, output.clone(), false, &[]),
+            output,
+            "{tool} must default to the full task record"
+        );
+    }
+}
+
+#[test]
+fn add_output_still_projects_explicit_fields() {
+    let shaped = shape_tool_output(
+        "orbit.task.add",
+        json!({
+            "id": "T20260422-0001",
+            "title": "Full record",
+            "status": "proposed",
+            "complexity": "low"
+        }),
+        false,
+        &["id".to_string(), "title".to_string()],
+    );
+    assert_eq!(
+        shaped,
+        json!({
+            "id": "T20260422-0001",
+            "title": "Full record"
+        })
+    );
+}
+
+#[test]
 fn show_output_preserves_task_details_by_default() {
     let output = json!({
         "id": "T20260422-0001",

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -633,7 +633,7 @@
   {
     "description": "Create an Orbit task and return the created task JSON",
     "inputSchema": {
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "acceptance_criteria": {
           "anyOf": [
@@ -765,7 +765,7 @@
   {
     "description": "Approve an Orbit task and return the updated task JSON",
     "inputSchema": {
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "agent": {
           "description": "Deprecated compatibility field. Prefer `model` with the agent family (`codex`, `claude`, `gemini`, or `grok`).",
@@ -1029,7 +1029,7 @@
   {
     "description": "Start work on an Orbit task and return the updated task JSON",
     "inputSchema": {
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "comment": {
           "description": "Optional task comment to append",
@@ -1072,7 +1072,7 @@
   {
     "description": "Update an Orbit task and return the fresh task JSON",
     "inputSchema": {
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "acceptance_criteria": {
           "anyOf": [

--- a/crates/orbit-common/src/protocol/tests/mod.rs
+++ b/crates/orbit-common/src/protocol/tests/mod.rs
@@ -1,2 +1,4 @@
 mod toml;
+mod tool_input;
+mod tool_schema;
 mod yaml;

--- a/crates/orbit-common/src/protocol/tests/tool_input.rs
+++ b/crates/orbit-common/src/protocol/tests/tool_input.rs
@@ -1,0 +1,68 @@
+use serde_json::json;
+
+use crate::protocol::tool_input::{
+    reject_retired_task_add_input_fields, reject_unknown_tool_fields,
+};
+
+#[test]
+fn reject_unknown_tool_fields_suggests_comment_for_note() {
+    let error = reject_unknown_tool_fields(
+        &json!({ "id": "ORB-1", "note": "should be comment" }),
+        &["id", "comment", "status"],
+    )
+    .expect_err("unknown field must fail");
+
+    let message = error.to_string();
+    assert!(message.contains("unknown field 'note'"), "{message}");
+    assert!(message.contains("did you mean 'comment'"), "{message}");
+    assert_eq!(
+        error.did_you_mean().map(|names| names.to_vec()),
+        Some(vec!["comment".to_string()])
+    );
+}
+
+#[test]
+fn reject_unknown_tool_fields_normalizes_camel_case() {
+    let error = reject_unknown_tool_fields(
+        &json!({ "acceptanceCriteria": ["one"] }),
+        &["acceptance_criteria", "title"],
+    )
+    .expect_err("camelCase alias must fail with a canonical hint");
+
+    assert!(
+        error
+            .to_string()
+            .contains("did you mean 'acceptance_criteria'"),
+        "{}",
+        error
+    );
+}
+
+#[test]
+fn reject_unknown_tool_fields_allows_transport_wrappers() {
+    reject_unknown_tool_fields(
+        &json!({
+            "id": "ORB-1",
+            "workspace": "ws_orbit",
+            "_meta": { "orbit": { "workspace": "ws_orbit" } }
+        }),
+        &["id"],
+    )
+    .expect("transport wrappers are not tool arguments");
+}
+
+#[test]
+fn reject_retired_task_add_fields_points_at_update() {
+    let error = reject_retired_task_add_input_fields(&json!({
+        "title": "x",
+        "dependencies": ["ORB-1"],
+    }))
+    .expect_err("retired add fields must fail");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("unknown field 'dependencies'"),
+        "{message}"
+    );
+    assert!(message.contains("orbit.task.update"), "{message}");
+}

--- a/crates/orbit-common/src/protocol/tests/tool_schema.rs
+++ b/crates/orbit-common/src/protocol/tests/tool_schema.rs
@@ -1,0 +1,51 @@
+use orbit_types::tool::ToolParam;
+
+use crate::protocol::tool_schema::{
+    tool_arguments_allow_additional_properties, tool_input_schema_for,
+};
+
+fn param(name: &str) -> ToolParam {
+    ToolParam {
+        name: name.to_string(),
+        description: String::new(),
+        param_type: "string".to_string(),
+        required: false,
+    }
+}
+
+#[test]
+fn task_mutation_argument_schemas_forbid_additional_properties() {
+    for tool_name in [
+        "orbit.task.add",
+        "orbit.task.update",
+        "orbit.task.approve",
+        "orbit.task.start",
+    ] {
+        assert!(
+            !tool_arguments_allow_additional_properties(tool_name),
+            "{tool_name} arguments must be closed"
+        );
+        let schema = tool_input_schema_for(tool_name, &[param("id")]);
+        assert_eq!(
+            schema
+                .get("additionalProperties")
+                .and_then(|value| value.as_bool()),
+            Some(false),
+            "{tool_name}"
+        );
+    }
+}
+
+#[test]
+fn other_tool_argument_schemas_still_allow_additional_properties() {
+    assert!(tool_arguments_allow_additional_properties(
+        "orbit.task.show"
+    ));
+    let schema = tool_input_schema_for("orbit.task.list", &[param("status")]);
+    assert_eq!(
+        schema
+            .get("additionalProperties")
+            .and_then(|value| value.as_bool()),
+        Some(true)
+    );
+}

--- a/crates/orbit-common/src/protocol/tool_input.rs
+++ b/crates/orbit-common/src/protocol/tool_input.rs
@@ -13,18 +13,149 @@ pub const RETIRED_TASK_ADD_INPUT_FIELDS: &[&str] = &[
     "dependencies",
 ];
 
-pub fn strip_retired_task_add_input_fields(input: &mut Value) -> Vec<&'static str> {
-    let Some(object) = input.as_object_mut() else {
-        return Vec::new();
+/// Top-level keys that are transport/session wrappers, not tool arguments.
+///
+/// MCP `_meta` and the workspace routing selector may appear beside the
+/// advertised parameters. They stay allowed even when the tool's JSON Schema
+/// sets `additionalProperties: false` on the argument object.
+pub const TOOL_INPUT_TRANSPORT_WRAPPER_KEYS: &[&str] = &["_meta", "workspace"];
+
+/// Refuse unknown top-level tool-argument keys with a did-you-mean hint.
+///
+/// Transport wrappers in [`TOOL_INPUT_TRANSPORT_WRAPPER_KEYS`] are ignored.
+/// The first unknown key is reported; a close match against `allowed` is
+/// included in the message and on [`OrbitError::did_you_mean`].
+pub fn reject_unknown_tool_fields(input: &Value, allowed: &[&str]) -> Result<(), OrbitError> {
+    let Some(object) = input.as_object() else {
+        return Ok(());
     };
 
-    let mut ignored = Vec::new();
+    let unknown = object
+        .keys()
+        .filter(|key| {
+            let key = key.as_str();
+            !TOOL_INPUT_TRANSPORT_WRAPPER_KEYS.contains(&key) && !allowed.contains(&key)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    if unknown.is_empty() {
+        return Ok(());
+    }
+
+    let first = &unknown[0];
+    let suggestion = suggest_tool_field(first, allowed);
+    let message = unknown_tool_field_message(&unknown, suggestion);
+    Err(OrbitError::invalid_input_with_suggestions(
+        message,
+        suggestion
+            .map(|name| vec![name.to_string()])
+            .unwrap_or_default(),
+    ))
+}
+
+/// Refuse retired `orbit.task.add` fields that used to be stripped silently.
+///
+/// These names are not misspellings of add parameters; they belong on
+/// `orbit.task.update` (or a later follow-up). The error names the field and
+/// the tool that accepts it.
+pub fn reject_retired_task_add_input_fields(input: &Value) -> Result<(), OrbitError> {
+    let Some(object) = input.as_object() else {
+        return Ok(());
+    };
+
     for field in RETIRED_TASK_ADD_INPUT_FIELDS {
-        if object.remove(*field).is_some() {
-            ignored.push(*field);
+        if object.contains_key(*field) {
+            return Err(OrbitError::InvalidInput(format!(
+                "unknown field '{field}' (orbit.task.add does not accept '{field}'; \
+                 set it with orbit.task.update)"
+            )));
         }
     }
-    ignored
+    Ok(())
+}
+
+fn unknown_tool_field_message(unknown: &[String], suggestion: Option<&str>) -> String {
+    let hint = suggestion
+        .map(|name| format!(" (did you mean '{name}'?)"))
+        .unwrap_or_default();
+    if unknown.len() == 1 {
+        format!("unknown field '{}'{}", unknown[0], hint)
+    } else {
+        format!("unknown fields '{}'{}", unknown.join("', '"), hint)
+    }
+}
+
+fn suggest_tool_field<'a>(unknown: &str, allowed: &[&'a str]) -> Option<&'a str> {
+    let normalized = normalize_tool_field_name(unknown);
+    if let Some(name) = allowed.iter().find(|name| **name == normalized) {
+        return Some(*name);
+    }
+    if let Some(canonical) = synonym_tool_field(unknown).or_else(|| synonym_tool_field(&normalized))
+        && allowed.contains(&canonical)
+    {
+        return Some(canonical);
+    }
+
+    let mut best: Option<(&'a str, usize)> = None;
+    for name in allowed {
+        let distance = levenshtein(unknown, name).min(levenshtein(&normalized, name));
+        if best.is_none_or(|(_, best_distance)| distance < best_distance) {
+            best = Some((*name, distance));
+        }
+    }
+    best.and_then(|(name, distance)| {
+        let threshold = unknown.len().max(name.len()).div_ceil(3).max(1);
+        (distance <= threshold).then_some(name)
+    })
+}
+
+fn synonym_tool_field(unknown: &str) -> Option<&'static str> {
+    match unknown {
+        "note" | "notes" | "message" | "msg" => Some("comment"),
+        "deps" | "depends_on" | "depends-on" => Some("dependencies"),
+        "acceptancecriteria" => Some("acceptance_criteria"),
+        "contextfiles" => Some("context_files"),
+        "requiredtools" => Some("required_tools"),
+        _ => None,
+    }
+}
+
+fn normalize_tool_field_name(raw: &str) -> String {
+    let mut normalized = String::with_capacity(raw.len() + 4);
+    for (index, ch) in raw.chars().enumerate() {
+        if ch == '-' {
+            if !normalized.ends_with('_') {
+                normalized.push('_');
+            }
+            continue;
+        }
+        if ch.is_ascii_uppercase() {
+            if index > 0 && !normalized.ends_with('_') {
+                normalized.push('_');
+            }
+            normalized.push(ch.to_ascii_lowercase());
+            continue;
+        }
+        normalized.push(ch);
+    }
+    normalized
+}
+
+fn levenshtein(left: &str, right: &str) -> usize {
+    let right_chars = right.chars().collect::<Vec<_>>();
+    let mut previous = (0..=right_chars.len()).collect::<Vec<_>>();
+    let mut current = vec![0; right_chars.len() + 1];
+    for (i, left_ch) in left.chars().enumerate() {
+        current[0] = i + 1;
+        for (j, right_ch) in right_chars.iter().enumerate() {
+            let cost = usize::from(left_ch != *right_ch);
+            current[j + 1] = (previous[j + 1] + 1)
+                .min(current[j] + 1)
+                .min(previous[j] + cost);
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+    previous[right_chars.len()]
 }
 
 pub fn required_string(

--- a/crates/orbit-common/src/protocol/tool_schema.rs
+++ b/crates/orbit-common/src/protocol/tool_schema.rs
@@ -51,8 +51,24 @@ pub fn tool_input_schema_for(tool_name: &str, params: &[ToolParam]) -> Map<Strin
     if !required.is_empty() {
         schema.insert("required".to_string(), Value::Array(required));
     }
-    schema.insert("additionalProperties".to_string(), Value::Bool(true));
+    schema.insert(
+        "additionalProperties".to_string(),
+        Value::Bool(tool_arguments_allow_additional_properties(tool_name)),
+    );
     schema
+}
+
+/// Whether the advertised argument object accepts undeclared keys.
+///
+/// Registered task mutation tools refuse extras at runtime; their schemas
+/// match that contract. Other tools keep `additionalProperties: true` until
+/// they grow the same check. Transport wrappers (`_meta`, `workspace`) are
+/// not modeled as additional argument properties.
+pub fn tool_arguments_allow_additional_properties(tool_name: &str) -> bool {
+    !matches!(
+        tool_name,
+        "orbit.task.add" | "orbit.task.update" | "orbit.task.approve" | "orbit.task.start"
+    )
 }
 
 /// Build the canonical JSON-Schema fragment for one tool parameter.

--- a/crates/orbit-core/src/adapter/tool_host/tests/mod.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/mod.rs
@@ -2,5 +2,6 @@ mod auto_task_tools;
 mod command_tools;
 mod friction_tools;
 mod state_tools;
+mod task_envelope;
 mod task_tools;
 mod workflow_tools;

--- a/crates/orbit-core/src/adapter/tool_host/tests/task_envelope.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/task_envelope.rs
@@ -1,0 +1,169 @@
+use serde_json::{Map, Value, json};
+
+use super::super::test_support::{create_task, test_runtime};
+use crate::adapter::command::ToolEntryPoint;
+use orbit_types::task::TaskStatus;
+
+const ENVELOPE_EXTRAS: &[&str] = &["warnings", "redactions", "redactions_applied"];
+
+fn execute_as(
+    runtime: &crate::OrbitRuntime,
+    name: &str,
+    input: Value,
+    entry: ToolEntryPoint,
+) -> Value {
+    runtime
+        .execute_tool_command_dispatch(
+            name,
+            input,
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+            entry,
+        )
+        .unwrap_or_else(|error| panic!("{name} via {entry:?} failed: {error}"))
+        .value
+}
+
+fn execute(runtime: &crate::OrbitRuntime, name: &str, input: Value) -> Value {
+    execute_as(runtime, name, input, ToolEntryPoint::Cli)
+}
+
+fn task_record_view(value: &Value) -> Map<String, Value> {
+    let mut object = value
+        .as_object()
+        .unwrap_or_else(|| panic!("task envelope must be an object: {value}"))
+        .clone();
+    for extra in ENVELOPE_EXTRAS {
+        object.remove(*extra);
+    }
+    object
+}
+
+fn envelope_keys(value: &Value) -> Vec<String> {
+    let mut keys = value
+        .as_object()
+        .unwrap_or_else(|| panic!("task envelope must be an object: {value}"))
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    keys.sort();
+    keys
+}
+
+fn assert_same_task_record(left_label: &str, left: &Value, right_label: &str, right: &Value) {
+    assert_eq!(
+        task_record_view(left),
+        task_record_view(right),
+        "{left_label} and {right_label} must match field-for-field\n{left_label}: {left}\n{right_label}: {right}"
+    );
+}
+
+#[test]
+fn task_add_update_approve_start_match_show_and_cli_mcp_envelopes() {
+    let (_root, runtime, repo_root) = test_runtime();
+
+    let added_cli = execute_as(
+        &runtime,
+        "orbit.task.add",
+        json!({
+            "title": "Envelope parity CLI",
+            "description": "Compare mutating tool output with task.show.",
+            "complexity": "medium",
+            "workspace": ".",
+            "tags": ["envelope", "qa"],
+        }),
+        ToolEntryPoint::Cli,
+    );
+    let added_mcp = execute_as(
+        &runtime,
+        "orbit.task.add",
+        json!({
+            "title": "Envelope parity MCP",
+            "description": "Compare mutating tool output with task.show.",
+            "complexity": "medium",
+            "workspace": ".",
+            "tags": ["envelope", "qa"],
+        }),
+        ToolEntryPoint::Mcp,
+    );
+    assert_eq!(
+        envelope_keys(&added_cli),
+        envelope_keys(&added_mcp),
+        "CLI and MCP add envelopes must advertise the same keys"
+    );
+
+    let added_id = added_cli["id"].as_str().expect("added id").to_string();
+    let shown_cli = execute_as(
+        &runtime,
+        "orbit.task.show",
+        json!({ "id": added_id }),
+        ToolEntryPoint::Cli,
+    );
+    let shown_mcp = execute_as(
+        &runtime,
+        "orbit.task.show",
+        json!({ "id": added_id }),
+        ToolEntryPoint::Mcp,
+    );
+    assert_eq!(shown_cli, shown_mcp, "CLI and MCP show must be identical");
+    assert_same_task_record("orbit.task.add", &added_cli, "orbit.task.show", &shown_cli);
+
+    let updated = execute(
+        &runtime,
+        "orbit.task.update",
+        json!({
+            "id": added_id,
+            "plan": "Keep the full record on every transport.",
+            "comment": "envelope check",
+        }),
+    );
+    let shown_after_update = execute(&runtime, "orbit.task.show", json!({ "id": added_id }));
+    assert_same_task_record(
+        "orbit.task.update",
+        &updated,
+        "orbit.task.show",
+        &shown_after_update,
+    );
+
+    let proposed = create_task(
+        &runtime,
+        &repo_root,
+        "Approve envelope",
+        "Approve returns the full task.",
+        TaskStatus::Proposed,
+        &[],
+    );
+    let approved = execute(
+        &runtime,
+        "orbit.task.approve",
+        json!({ "id": proposed.id, "note": "ready" }),
+    );
+    let shown_after_approve = execute(&runtime, "orbit.task.show", json!({ "id": proposed.id }));
+    assert_same_task_record(
+        "orbit.task.approve",
+        &approved,
+        "orbit.task.show",
+        &shown_after_approve,
+    );
+
+    let ready = create_task(
+        &runtime,
+        &repo_root,
+        "Start envelope",
+        "Start returns the full task.",
+        TaskStatus::Backlog,
+        &[],
+    );
+    let started = execute(
+        &runtime,
+        "orbit.task.start",
+        json!({ "id": ready.id, "note": "picking up" }),
+    );
+    let shown_after_start = execute(&runtime, "orbit.task.show", json!({ "id": ready.id }));
+    assert_same_task_record(
+        "orbit.task.start",
+        &started,
+        "orbit.task.show",
+        &shown_after_start,
+    );
+}

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -13,8 +13,9 @@ pub mod workflow;
 pub mod workspace_claim;
 
 use orbit_common::OrbitError;
+use orbit_common::protocol::tool_input::reject_unknown_tool_fields;
 use orbit_types::identity::{normalize_agent_family_for_model, require_canonical_agent_family};
-use orbit_types::tool::{McpToolScope, ToolParam};
+use orbit_types::tool::{McpToolScope, ToolParam, ToolSchema};
 use serde_json::Value;
 
 use crate::{OrbitBuiltinAction, OrbitTaskScope, ToolContext, ToolRegistry};
@@ -221,6 +222,18 @@ pub(super) fn reject_agent_field(input: &Value, tool_name: &str) -> Result<(), O
         )));
     }
     Ok(())
+}
+
+pub(super) fn reject_unknown_tool_arguments(
+    input: &Value,
+    schema: &ToolSchema,
+) -> Result<(), OrbitError> {
+    let allowed = schema
+        .parameters
+        .iter()
+        .map(|param| param.name.as_str())
+        .collect::<Vec<_>>();
+    reject_unknown_tool_fields(input, &allowed)
 }
 
 pub(super) fn scored_identity_params() -> Vec<ToolParam> {

--- a/crates/orbit-tools/src/builtin/orbit/task/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add.rs
@@ -1,7 +1,7 @@
 use orbit_common::OrbitError;
-use orbit_common::protocol::tool_input::{required_string, strip_retired_task_add_input_fields};
+use orbit_common::protocol::tool_input::{reject_retired_task_add_input_fields, required_string};
 use orbit_types::tool::{ToolParam, ToolSchema};
-use serde_json::{Value, json};
+use serde_json::Value;
 
 use crate::{OrbitBuiltinAction, Tool, ToolContext};
 
@@ -121,32 +121,14 @@ impl Tool for OrbitTaskAddTool {
 
     fn execute(&self, ctx: &ToolContext, mut input: Value) -> Result<Value, OrbitError> {
         super::super::reject_agent_field(&input, "orbit.task.add")?;
+        reject_retired_task_add_input_fields(&input)?;
+        super::super::reject_unknown_tool_arguments(&input, &self.schema())?;
         required_string(&input, &["title"], "title")?;
         required_string(&input, &["description"], "description")?;
         required_string(&input, &["complexity"], "complexity")?;
         super::super::resolve_workspace_argument(ctx, &mut input, "orbit.task.add")?;
         super::super::apply_session_orchestrator_default(ctx, &mut input);
 
-        let ignored_fields = strip_retired_task_add_input_fields(&mut input);
-        if !ignored_fields.is_empty() {
-            tracing::warn!(
-                target: "orbit.tools.task.add",
-                ignored_fields = ?ignored_fields,
-                "ignored retired orbit.task.add fields"
-            );
-        }
-
-        let mut response =
-            super::super::execute_host_action(ctx, input, OrbitBuiltinAction::TaskAdd)?;
-        if !ignored_fields.is_empty() {
-            let response_object = response.as_object_mut().ok_or_else(|| {
-                OrbitError::Execution(
-                    "orbit.task.add host returned a non-object response".to_string(),
-                )
-            })?;
-            response_object.insert("ignored_fields".to_string(), json!(ignored_fields));
-        }
-
-        Ok(response)
+        super::super::execute_host_action(ctx, input, OrbitBuiltinAction::TaskAdd)
     }
 }

--- a/crates/orbit-tools/src/builtin/orbit/task/approve.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/approve.rs
@@ -34,6 +34,7 @@ impl Tool for OrbitTaskApproveTool {
     }
 
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        super::super::reject_unknown_tool_arguments(&input, &self.schema())?;
         super::super::execute_host_action(ctx, input, OrbitBuiltinAction::TaskApprove)
     }
 }

--- a/crates/orbit-tools/src/builtin/orbit/task/start.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/start.rs
@@ -41,6 +41,7 @@ impl Tool for OrbitTaskStartTool {
 
     fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
         super::super::reject_agent_field(&input, "orbit.task.start")?;
+        super::super::reject_unknown_tool_arguments(&input, &self.schema())?;
         super::super::execute_host_action(ctx, input, OrbitBuiltinAction::TaskStart)
     }
 }

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
@@ -58,51 +58,6 @@ fn mk_ctx(host: RecordingHost) -> ToolContext {
     }
 }
 
-fn capture_warnings<F, T>(f: F) -> (T, String)
-where
-    F: FnOnce() -> T,
-{
-    use std::io::{self, Write};
-    use tracing_subscriber::filter::LevelFilter;
-    use tracing_subscriber::fmt::MakeWriter;
-
-    #[derive(Clone)]
-    struct CaptureMakeWriter(Arc<Mutex<Vec<u8>>>);
-    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
-
-    impl<'a> MakeWriter<'a> for CaptureMakeWriter {
-        type Writer = CaptureWriter;
-
-        fn make_writer(&'a self) -> Self::Writer {
-            CaptureWriter(Arc::clone(&self.0))
-        }
-    }
-
-    impl Write for CaptureWriter {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.0.lock().expect("capture lock").extend_from_slice(buf);
-            Ok(buf.len())
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-    }
-
-    let buffer = Arc::new(Mutex::new(Vec::new()));
-    let subscriber = tracing_subscriber::fmt()
-        .with_writer(CaptureMakeWriter(Arc::clone(&buffer)))
-        .with_max_level(LevelFilter::WARN)
-        .with_target(true)
-        .with_ansi(false)
-        .without_time()
-        .finish();
-    let result = tracing::subscriber::with_default(subscriber, f);
-    let logs =
-        String::from_utf8(buffer.lock().expect("capture buffer lock").clone()).expect("utf8 logs");
-    (result, logs)
-}
-
 fn capture_info<F, T>(f: F) -> (T, String)
 where
     F: FnOnce() -> T,
@@ -233,16 +188,47 @@ fn schema_exposes_only_trimmed_create_task_fields() {
 }
 
 #[test]
-fn add_call_with_retired_fields_reports_and_ignores_them() {
+fn add_call_rejects_retired_fields() {
+    for field in RETIRED_TASK_ADD_INPUT_FIELDS {
+        let host = RecordingHost::default();
+        let ctx = mk_ctx(host.clone());
+        let mut input = json!({
+            "title": "Retired field must fail",
+            "description": "orbit.task.add no longer strips extras",
+            "workspace": "/tmp/test-ws",
+            "complexity": "low",
+            "model": "grok",
+        });
+        input
+            .as_object_mut()
+            .expect("object")
+            .insert((*field).to_string(), json!("ignored"));
+
+        let error = OrbitTaskAddTool
+            .execute(&ctx, input)
+            .expect_err("retired add fields must be refused");
+        let message = error.to_string();
+        assert!(
+            message.contains(&format!("unknown field '{field}'")),
+            "{field}: {message}"
+        );
+        assert!(message.contains("orbit.task.update"), "{field}: {message}");
+        assert!(
+            host.call.lock().expect("lock").is_none(),
+            "host must not run when {field} is present"
+        );
+    }
+}
+
+#[test]
+fn add_call_forwards_supported_fields() {
     let host = RecordingHost::default();
     let ctx = mk_ctx(host.clone());
-    let tool = OrbitTaskAddTool;
-
     let input = json!({
-        "title": "Trimmed add fields test",
-        "description": "Compatibility coverage for ORB-00255",
+        "title": "Supported add fields",
+        "description": "Canonical create payload",
         "workspace": "/tmp/test-ws",
-        "acceptance_criteria": ["MCP schema is trimmed", "retired fields are ignored"],
+        "acceptance_criteria": ["MCP schema is trimmed"],
         "tags": ["mcp", "schema"],
         "context_files": ["file:crates/orbit-tools/src/builtin/orbit/task/add.rs"],
         "priority": "medium",
@@ -250,32 +236,14 @@ fn add_call_with_retired_fields_reports_and_ignores_them() {
         "type": "chore",
         "relations": [{"type": "related_to", "target": "ORB-00002"}],
         "model": "grok",
-        "plan": "ignored plan",
-        "status": "done",
         "crew": "release-crew",
-        "parent_id": "ORB-00003",
-        "source_task_id": "ORB-00004",
-        "external_refs": [{"system": "ENG", "id": "123"}],
-        "context": "file:legacy-alias.rs",
-        "comment": "ignored comment",
-        "dependencies": ["ORB-00001"]
     });
 
-    let (res, logs) = capture_warnings(|| tool.execute(&ctx, input).expect("execute succeeds"));
+    let res = OrbitTaskAddTool
+        .execute(&ctx, input)
+        .expect("supported add fields succeed");
     assert_eq!(res["id"], "ORB-TEST");
-    assert_eq!(res["ignored_fields"], json!(RETIRED_TASK_ADD_INPUT_FIELDS));
-    assert_eq!(
-        logs.matches("ignored retired orbit.task.add fields")
-            .count(),
-        1,
-        "compatibility warning must fire once per execute call: {logs}"
-    );
-    for removed in RETIRED_TASK_ADD_INPUT_FIELDS {
-        assert!(
-            logs.contains(*removed),
-            "compatibility warning must name retired field {removed}: {logs}"
-        );
-    }
+    assert!(res.get("ignored_fields").is_none());
 
     let recorded = host
         .call
@@ -284,42 +252,10 @@ fn add_call_with_retired_fields_reports_and_ignores_them() {
         .take()
         .expect("host was called");
     assert_eq!(recorded.action, OrbitBuiltinAction::TaskAdd);
-    assert_eq!(recorded.agent.as_deref(), None);
     assert_eq!(recorded.model.as_deref(), Some("grok"));
-
-    let rec_input = recorded.input;
-    for removed in RETIRED_TASK_ADD_INPUT_FIELDS {
-        assert!(
-            rec_input.get(*removed).is_none(),
-            "retired field {removed} must be stripped before host execution"
-        );
-    }
-    for kept in [
-        "title",
-        "description",
-        "workspace",
-        "acceptance_criteria",
-        "tags",
-        "context_files",
-        "priority",
-        "complexity",
-        "type",
-        "relations",
-        "crew",
-        "model",
-    ] {
-        assert!(
-            rec_input.get(kept).is_some(),
-            "kept field {kept} must survive host execution"
-        );
-    }
-    assert_eq!(rec_input["complexity"], "medium");
+    assert_eq!(recorded.input["crew"], "release-crew");
     assert_eq!(
-        rec_input["crew"], "release-crew",
-        "crew must survive host execution and reach the create path"
-    );
-    assert_eq!(
-        rec_input["context_files"][0],
+        recorded.input["context_files"][0],
         "file:crates/orbit-tools/src/builtin/orbit/task/add.rs"
     );
 }

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/mod.rs
@@ -3,4 +3,5 @@
 mod add;
 mod artifact_put;
 mod list;
+mod strict_input;
 mod update;

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/strict_input.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/strict_input.rs
@@ -1,0 +1,173 @@
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+
+use orbit_common::OrbitError;
+
+use super::super::add::OrbitTaskAddTool;
+use super::super::approve::OrbitTaskApproveTool;
+use super::super::start::OrbitTaskStartTool;
+use super::super::update::OrbitTaskUpdateTool;
+use crate::{OrbitBuiltinAction, OrbitTaskScope, OrbitToolHost, Tool, ToolContext};
+
+struct RecordingHost;
+
+impl OrbitToolHost for RecordingHost {
+    fn execute(
+        &self,
+        _action: OrbitBuiltinAction,
+        _input: Value,
+        _agent: Option<String>,
+        _model: Option<String>,
+        _reservation_owner: Option<crate::ReservationOwnerContext>,
+    ) -> Result<Value, OrbitError> {
+        panic!("host must not run when input is invalid");
+    }
+
+    fn task_scope(&self) -> OrbitTaskScope {
+        OrbitTaskScope::default()
+    }
+}
+
+fn ctx() -> ToolContext {
+    ToolContext {
+        orbit_host: Some(Arc::new(RecordingHost)),
+        ..ToolContext::default()
+    }
+}
+
+fn assert_unknown_field(error: OrbitError, field: &str, hint: Option<&str>) {
+    let message = error.to_string();
+    assert!(
+        message.contains(&format!("unknown field '{field}'")),
+        "{message}"
+    );
+    if let Some(hint) = hint {
+        assert!(
+            message.contains(&format!("did you mean '{hint}'")),
+            "{message}"
+        );
+        assert!(
+            error
+                .did_you_mean()
+                .is_some_and(|names| names.iter().any(|name| name == hint)),
+            "{error:?}"
+        );
+    }
+}
+
+#[test]
+fn update_rejects_note_with_comment_hint() {
+    let error = OrbitTaskUpdateTool
+        .execute(
+            &ctx(),
+            json!({
+                "id": "ORB-00001",
+                "status": "rejected",
+                "note": "should be comment",
+                "model": "codex",
+            }),
+        )
+        .expect_err("note is not an update argument");
+    assert_unknown_field(error, "note", Some("comment"));
+}
+
+#[test]
+fn update_rejects_bogus_key() {
+    let error = OrbitTaskUpdateTool
+        .execute(
+            &ctx(),
+            json!({
+                "id": "ORB-00001",
+                "bogus_key": 1,
+                "model": "codex",
+            }),
+        )
+        .expect_err("undeclared update keys must fail");
+    assert_unknown_field(error, "bogus_key", None);
+}
+
+#[test]
+fn add_rejects_unknown_key() {
+    let error = OrbitTaskAddTool
+        .execute(
+            &ctx(),
+            json!({
+                "title": "Unknown key",
+                "description": "must fail",
+                "complexity": "low",
+                "workspace": "/tmp/test-ws",
+                "bogus_key": true,
+            }),
+        )
+        .expect_err("undeclared add keys must fail");
+    assert_unknown_field(error, "bogus_key", None);
+}
+
+#[test]
+fn approve_rejects_unknown_key() {
+    let error = OrbitTaskApproveTool
+        .execute(
+            &ctx(),
+            json!({
+                "id": "ORB-00001",
+                "bogus_key": 1,
+            }),
+        )
+        .expect_err("undeclared approve keys must fail");
+    assert_unknown_field(error, "bogus_key", None);
+}
+
+#[test]
+fn start_rejects_unknown_key() {
+    let error = OrbitTaskStartTool
+        .execute(
+            &ctx(),
+            json!({
+                "id": "ORB-00001",
+                "bogus_key": 1,
+                "model": "codex",
+            }),
+        )
+        .expect_err("undeclared start keys must fail");
+    assert_unknown_field(error, "bogus_key", None);
+}
+
+#[test]
+fn update_allows_workspace_and_meta_wrappers() {
+    struct OkHost;
+    impl OrbitToolHost for OkHost {
+        fn execute(
+            &self,
+            action: OrbitBuiltinAction,
+            input: Value,
+            _agent: Option<String>,
+            _model: Option<String>,
+            _reservation_owner: Option<crate::ReservationOwnerContext>,
+        ) -> Result<Value, OrbitError> {
+            assert_eq!(action, OrbitBuiltinAction::TaskUpdate);
+            assert_eq!(input["id"], "ORB-00001");
+            Ok(json!({ "id": "ORB-00001" }))
+        }
+
+        fn task_scope(&self) -> OrbitTaskScope {
+            OrbitTaskScope::default()
+        }
+    }
+
+    let ctx = ToolContext {
+        orbit_host: Some(Arc::new(OkHost)),
+        ..ToolContext::default()
+    };
+    OrbitTaskUpdateTool
+        .execute(
+            &ctx,
+            json!({
+                "id": "ORB-00001",
+                "workspace": "ws_orbit",
+                "_meta": { "orbit": { "workspace": "ws_orbit" } },
+                "model": "codex",
+            }),
+        )
+        .expect("transport wrappers must not fail closed tools");
+}

--- a/crates/orbit-tools/src/builtin/orbit/task/update.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/update.rs
@@ -190,6 +190,7 @@ impl Tool for OrbitTaskUpdateTool {
                     .to_string(),
             ));
         }
+        super::super::reject_unknown_tool_arguments(&input, &self.schema())?;
         super::super::execute_host_action(ctx, input, OrbitBuiltinAction::TaskUpdate)
     }
 }

--- a/crates/orbit-web/src/api/tasks.rs
+++ b/crates/orbit-web/src/api/tasks.rs
@@ -164,9 +164,9 @@ pub(super) struct CreateTaskBody {
     /// Retired create input, declared so it stays *knowingly* tolerated rather
     /// than falling into [`CreateTaskBody::unsupported`]. `comment` is one of
     /// [`RETIRED_TASK_ADD_INPUT_FIELDS`](orbit_common::protocol::tool_input::RETIRED_TASK_ADD_INPUT_FIELDS):
-    /// the native `orbit.task.add` tool strips it with a warning instead of
-    /// failing, and this endpoint keeps that contract. Comment on a task with
-    /// `POST /tasks/:id/comments`.
+    /// the native `orbit.task.add` tool now rejects it with `invalid_input`.
+    /// This HTTP body still accepts the key so existing dashboard clients are
+    /// not broken; comment on a task with `POST /tasks/:id/comments`.
     #[serde(default)]
     comment: Option<String>,
     /// Trap field (ORB-10648): attribution was consolidated to `model`-only, so


### PR DESCRIPTION
## Task

[ORB-12252](https://orbit-cli.com/tasks/ORB-12252) — `orbit tool run orbit.task.add/update` return thin projections while MCP returns the full task; unknown input keys are silently dropped

### Description

Same tool, two envelopes (0.21.0):

- `orbit tool run orbit.task.add --input …` returns a record where `complexity`, `tags`, `context_files`, `created_by`, `crew`, `orchestrator` are absent/null even though `task.show` immediately afterwards has them (DANI-10327). MCP `orbit_task_add` returns the full task plus `warnings`, `redactions`, `redactions_applied`.
- `orbit tool run orbit.task.update` returns a 10-key projection (`created_at, dependencies, id, implemented_by, priority, resolved_dependencies, status, title, type, updated_at`) — no `history`, `comments`, `tags`, `context_files`, `plan`. Description says "return the fresh task JSON".
- Unknown input keys are accepted and ignored: `orbit.task.update {"id":…, "status":"rejected", "bogus_key":1, "note":"…"}` → 200 with `note` dropped (the parameter is `comment`); `orbit.task.add {… "dependencies":[…]}` is known to drop `dependencies` silently (the add schema has no such field). An agent that misspells a field gets a success and a half-recorded task.

## What to change

1. One task envelope. `task.add`, `task.update`, `task.approve`, `task.start` return the same full record as `task.show` on every transport (CLI tool run, MCP direct, federated). If the CLI projection was a size optimisation, expose it as an explicit `fields` projection like `task.show` has, defaulting to full.
2. Strict input on the registered task tools: unknown top-level keys → `invalid_input: unknown field 'note' (did you mean 'comment'?)`. Keep `additionalProperties: true` only for the documented `_meta`/transport wrappers, not for tool arguments. If some client relies on passing extras, add a `warnings` entry listing dropped keys as an interim step and log at WARN — but do not stay silent.
3. Tests: CLI-vs-MCP envelope equality for add/update/approve/start; unknown-key rejection with did-you-mean.

### Acceptance Criteria

- `orbit tool run orbit.task.add/update/approve/start` return the same full task record as MCP and as `task.show`
- Unknown top-level input keys on the registered task tools are refused with `invalid_input` and a did-you-mean hint (or, at minimum, surfaced in `warnings` and logged)
- Tests compare the CLI and MCP envelopes field-for-field

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- CLI `orbit tool run` no longer post-filters `orbit.task.add` / `orbit.task.update` to the 10-key minimal projection. Those tools, plus already-full `approve`/`start`, default to the same `serialize_task` record MCP and `task.show` return. `--fields` remains the explicit compact projection; `orbit.task.list` and `orbit.task.artifact.put` stay compact by default.
- Registered `orbit.task.add`/`update`/`approve`/`start` refuse unknown top-level argument keys with `invalid_input` and a did-you-mean hint (e.g. `note` → `comment`). Transport wrappers `_meta` and `workspace` remain allowed. Advertised MCP argument schemas for those four tools now set `additionalProperties: false`.
- Retired `orbit.task.add` fields (`dependencies`, `plan`, `status`, …) are `invalid_input` pointing at `orbit.task.update`, instead of silent `ignored_fields`.

Assessment: host serialization was already full; the CLI default projection was the split. Strict input lives at the registered-tool boundary so CLI tool-run and MCP share one rule.

Criteria:
1. Full record on add/update/approve/start across CLI tool-run, MCP, and task.show — met. CLI shape defaults to identity for those tools; core test compares each mutating envelope to `task.show` field-for-field (minus `warnings`/`redactions`/`redactions_applied`) and CLI vs MCP add key sets.
2. Unknown keys refused with did-you-mean — met. `note` on update yields `unknown field 'note' (did you mean 'comment'?)`. Retired add fields fail closed rather than warn-and-ignore.
3. CLI vs MCP envelope tests field-for-field — met in `adapter::tool_host::tests::task_envelope` (same host dispatch, Cli vs Mcp entry points) plus CLI `shape_tool_output` identity tests.

Validation:
- `cargo test -p orbit-common --lib -- protocol::tests::tool_input protocol::tests::tool_schema` — passed (6 tests)
- `cargo test -p orbit-tools --lib -- builtin::orbit::task::tests` — passed (36 tests)
- `cargo test -p orbit-cli --bin orbit -- command::tool::tests::run` — passed (9 tests)
- `cargo test -p orbit-core --lib -- adapter::tool_host::tests::task_envelope` — passed (1 test)
- `make ci-fast` — passed
- `make ci-lint` — passed
- `make goldens` — failed once on MCP tools/list snapshot; `make goldens UPDATE=1` regenerated `crates/orbit-cli/tests/snapshots/mcp_tools_list.json` (only `orbit_task_add`/`approve`/`start`/`update` flipped `additionalProperties` true→false), then passed
- `git diff --check` — passed

Deviations: HTTP `POST /tasks` still tolerates retired `comment` for dashboard clients (comment updated). `orbit.task.list` / `artifact.put` remain compact by default (out of the add/update/approve/start criterion). Host camelCase aliases on these four tools are now rejected with a snake_case hint rather than silently accepted.

Risks: tightening `additionalProperties` and refusing retired add fields is a breaking input contract for callers who passed extras; the MCP snapshot test flags schema changes as breaking. Compact `--fields` is CLI-only; MCP callers who want a projection still use `orbit.task.show` `fields`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12252-6aa4d870`
- Behind base: 0
- Ahead of base: 1