### PR TITLE
[ci-failure-sweep] Fix red CI: CI / Coverage (informational) / Collect workspace coverage

### DIFF
--- a/crates/orbit-config/src/tests/store.rs
+++ b/crates/orbit-config/src/tests/store.rs
@@ -665,7 +665,7 @@ fn exists_on_disk_and_explicit_value_for_missing_and_present_keys() {
     let present_path = config_path(present_dir.path());
     fs::write(
         &present_path,
-        "[scoring]\nenabled = false\n\n[crews.sol]\nmodel = \"gpt-5.6-sol\"\n",
+        "[workflow]\ndefault_crew = \"sol\"\n\n[scoring]\nenabled = false\n\n[crews.sol]\nmodel = \"gpt-5.6-sol\"\nprovider = \"codex\"\n",
     )
     .expect("write config");
 


### PR DESCRIPTION
## Task

[ORB-12272](https://orbit-cli.com/tasks/ORB-12272) — [ci-failure-sweep] Fix red CI: CI / Coverage (informational) / Collect workspace coverage

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `CI`
- Failing job: `Coverage (informational)`
- Failing step: `Collect workspace coverage`
- Commit the runner actually checked out: `1df36e3201b1a1ff3c01be408ee7b61352ac1449`
- Normalized error signature (the dedupe identity, not a quote): `test tests::store::exists_on_disk_and_explicit_value_for_missing_and_present_keys ... failed`
- Repository: `constellation-works/orbit`
- Release branch as GitHub reports it: `agent-main`
- Evidence collected at: 2026-09-12T05:09:40.543549546+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/constellation-works/orbit/actions/runs/34673579462 run `34673579462` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `1df36e3201b1a1ff3c01be408ee7b61352ac1449`
  - current head of that ref: `fd2e593783d4a0f0afa67d7ee5fed437f85dbef5`
  - commit actually checked out: `1df36e3201b1a1ff3c01be408ee7b61352ac1449`
  - checkout evidence: `* branch            1df36e3201b1a1ff3c01be408ee7b61352ac1449 -> FETCH_HEAD`
  - checkout evidence: `1df36e3201b1a1ff3c01be408ee7b61352ac1449`
  - checkout evidence: `##[group]Checking out the ref`
  - failed job `Coverage (informational)` (id `103499346462`): https://github.com/constellation-works/orbit/actions/runs/34673579462/job/103499346462
  - failing step(s): `Collect workspace coverage`

## Failed-step log excerpt

_Failure regions from a completely scanned command; the full command was not retained. 344694 of 348655 source bytes omitted, including 0 assertion payload bytes. All 4 recognized failure anchors and bounded context are retained (64 KiB selection limit)._

```
Coverage (informational)	Collect workspace coverage	﻿2026-09-12T04:57:50.6391379Z ##[group]Run cargo llvm-cov --workspace --locked --no-report
Coverage (informational)	Collect workspace coverage	[... 341708 command bytes omitted ...]
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1629516Z test tests::store::exists_on_disk_and_explicit_value_for_missing_and_present_keys ... FAILED
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1630465Z test tests::store::get_rejects_unknown_key ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1631219Z test tests::store::get_crew_effort_is_null_when_omitted_and_does_not_invent_a_default ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1631978Z test tests::store::get_returns_configured_value ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1634847Z test tests::store::get_returns_default_when_key_absent ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1641743Z test tests::store::get_returns_configured_log_rotation_values ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1642557Z test tests::store::get_returns_default_log_rotation_values_when_absent ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1643518Z test tests::store::keys_registry_lists_all_runtime_log_keys ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1644268Z test tests::store::open_for_workspace_set_fails_closed_without_flag ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1645141Z test tests::store::hand_authored_crew_effort_is_readable_without_config_set ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1647719Z test tests::store::open_for_workspace_set_fresh_starts_empty ... ok
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1653681Z test tests::store::set_crew_effort_rejects_invalid_value_and_leaves_file_byte_identical ... ok
Coverage (informational)	Collect workspace coverage	[... 2986 command bytes omitted ...]
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1759536Z thread 'tests::store::exists_on_disk_and_explicit_value_for_missing_and_present_keys' (80201) panicked at crates/orbit-config/src/tests/store.rs:679:14:
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1760441Z query set: InvalidInput("[crews.sol].provider must not be empty")
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1761069Z note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1761468Z 
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1761472Z 
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1761564Z failures:
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1761897Z     tests::store::exists_on_disk_and_explicit_value_for_missing_and_present_keys
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1762134Z 
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1762455Z test result: FAILED. 118 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1762806Z 
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1763120Z [1m[91merror[0m: test failed, to rerun pass `-p orbit-config --lib`
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1792757Z error: process didn't exit successfully: `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo test --tests --manifest-path /home/runner/work/orbit/orbit/Cargo.toml --target-dir /home/runner/work/orbit/orbit/target/llvm-cov-target --workspace --locked` (exit status: 101)
Coverage (informational)	Collect workspace coverage	2026-09-12T05:04:14.1809816Z ##[error]Process completed with exit code 101.

```

_The collection display was truncated. Selected evidence is used for diagnosis; its retention limits are independent of that display._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `CI` run https://github.com/constellation-works/orbit/actions/runs/34673721759 — ref_no_longer_exists: branch 'orbit/ORB-12255-6aa4d0d0' has no head on origin: its pull request was merged or the branch was deleted, so this run describes code that is either already landed — where the landing branch's own runs are the current evidence — or abandoned
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34673576158 — ref_no_longer_exists: branch 'orbit/ORB-12258-6aa4d3fc' has no head on origin: its pull request was merged or the branch was deleted, so this run describes code that is either already landed — where the landing branch's own runs are the current evidence — or abandoned

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 3,
  "current_failures_discovered": 4,
  "current_failures_investigated": 2,
  "current_failures_investigation_attempted": 6,
  "inconclusive": 0,
  "investigation_cursor": 496997,
  "job_log_reads": 4,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_job_log_reads": 6,
  "max_pull_requests": 10,
  "max_retired_ref_probes": 20,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely",
    "6 of 12 current or mixed-state runs were listed but not investigated (max_investigated_runs=6); their run URLs are still present, and the rotating slot reaches a different overflow candidate on the next sweep"
  ],
  "pull_requests_scanned": 0,
  "refs_scanned": 1,
  "retired_refs": [
    "orbit/ORB-12236-6aa4b992",
    "orbit/ORB-12255-6aa4d0d0",
    "orbit/ORB-12258-6aa4d3fc"
  ],
  "runs_listed": 100,
  "unverified_refs": []
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `CI` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Fixed the invalid present-config fixture in `crates/orbit-config/src/tests/store.rs` by adding the required `[workflow].default_crew = "sol"` and `provider = "codex"` fields.
- The production validation and assertion logic were not weakened or disabled.

Acceptance criteria:
1. Repository-owned root cause fixed: the fixture now satisfies the current crew schema, so the reported `[crews.sol].provider must not be empty` failure is resolved.
2. Reproduction: the runner-equivalent command `cargo test --tests --manifest-path Cargo.toml --target-dir target/llvm-cov-target --workspace --locked` reproduced the reported store-test failure before the edit. After the edit, the narrowest faithful equivalent `cargo test -p orbit-config --lib tests::store::exists_on_disk_and_explicit_value_for_missing_and_present_keys --locked` passed, as did all 28 `tests::store` tests.
3. Documented pre-handoff gates: `make ci-fast`, `make ci-lint`, and `make goldens` all exited 0. `make ci-fast` reported the compiler-cache namespace subcheck as skipped because this environment cannot create a bubblewrap mount namespace; the gate itself completed successfully.
4. Infrastructure condition not applicable: the failure was reproduced locally with the same repository-owned validation fixture and corrected.

Validation:
- PASSED `cargo test -p orbit-config --lib tests::store::exists_on_disk_and_explicit_value_for_missing_and_present_keys --locked`
- PASSED `cargo test -p orbit-config --lib tests::store --locked` (28 passed)
- PASSED `make ci-fast`
- PASSED `make ci-lint`
- PASSED `make goldens`
- PASSED `git diff --check`
- PASSED `GIT_OPTIONAL_LOCKS=0 git status --short` (only the scoped test file is modified)
- FAILED post-fix full workspace command `cargo test --tests --manifest-path Cargo.toml --target-dir target/llvm-cov-target --workspace --locked` due two separate orbit-core tests rejecting the existing `model: "system"` attribution; those failures are outside this task's scoped fixture and were not changed.

Assessment: Minimal, schema-correct test-fixture repair. Remaining risk is limited to the unrelated orbit-core failures surfaced by the full workspace run.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12272-6aa4df44`
- Behind base: 0
- Ahead of base: 1