### PR TITLE
CLI polish from the 0.21.0 sweep: `job show` prints Rust Debug for fan-in, stale `if_revision` returns `internal_error`, `doctor` gives three different remediations for stale auto-tasks, `tool scaffold qa.echo` registers `qa`

### DIFF
--- a/crates/orbit-cli/src/command/job/support.rs
+++ b/crates/orbit-cli/src/command/job/support.rs
@@ -1,6 +1,9 @@
 use orbit_core::JobRun;
 use orbit_core::application::job::{JobCatalogEntry, JobCatalogFilter};
-use orbit_types::workflow::{ActivityV2Spec, JobKind, JobV2Step, JobV2StepBody};
+use orbit_types::workflow::{
+    ActivityV2Spec, BackoffStrategy, FanInSpec, JobKind, JobV2Step, JobV2StepBody, JoinMode,
+    RetrySpec,
+};
 use serde_json::{Value, json};
 
 pub(super) fn format_last_run(last_run: Option<&JobRun>) -> String {
@@ -130,7 +133,7 @@ pub(super) fn write_v2_step(step: &JobV2Step, indent: usize, out: &mut String) {
         let _ = writeln!(out, "{pad}{} {}", bold("When:"), when);
     }
     if let Some(retry) = &step.retry {
-        let _ = writeln!(out, "{pad}{} {:?}", bold("Retry:"), retry);
+        let _ = writeln!(out, "{pad}{} {}", bold("Retry:"), format_retry(retry));
     }
     match &step.body {
         JobV2StepBody::TargetRef(target) => {
@@ -176,7 +179,12 @@ pub(super) fn write_v2_step(step: &JobV2Step, indent: usize, out: &mut String) {
         }
         JobV2StepBody::Parallel { parallel } => {
             let _ = writeln!(out, "{pad}{} parallel", bold("Body:"));
-            let _ = writeln!(out, "{pad}{} {:?}", bold("Join:"), parallel.join);
+            let _ = writeln!(
+                out,
+                "{pad}{} {}",
+                bold("Join:"),
+                format_join_mode(&parallel.join)
+            );
             let _ = writeln!(
                 out,
                 "{pad}{} {}",
@@ -191,7 +199,7 @@ pub(super) fn write_v2_step(step: &JobV2Step, indent: usize, out: &mut String) {
             let _ = writeln!(out, "{pad}{} fan_out", bold("Body:"));
             let _ = writeln!(out, "{pad}{} {}", bold("Items:"), fan_out.items.as_str());
             let _ = writeln!(out, "{pad}{} {}", bold("Max Workers:"), fan_out.max_workers);
-            let _ = writeln!(out, "{pad}{} {:?}", bold("Fan In:"), fan_in);
+            let _ = writeln!(out, "{pad}{} {}", bold("Fan In:"), format_fan_in(fan_in));
             write_v2_step(&fan_out.worker, indent + 2, out);
         }
         JobV2StepBody::Loop { loop_ } => {
@@ -230,4 +238,32 @@ fn v2_step_target_summary(step: &JobV2Step) -> (String, String) {
         JobV2StepBody::FanOut { .. } => ("fan_out".to_string(), step.id.clone()),
         JobV2StepBody::Loop { .. } => ("loop".to_string(), step.id.clone()),
     }
+}
+
+pub(super) fn format_join_mode(mode: &JoinMode) -> String {
+    match mode {
+        JoinMode::All => "all".to_string(),
+        JoinMode::Any => "any".to_string(),
+        JoinMode::Quorum { n } => format!("quorum({n})"),
+    }
+}
+
+pub(super) fn format_fan_in(fan_in: &FanInSpec) -> String {
+    let join = format_join_mode(&fan_in.join);
+    if let Some(collect) = &fan_in.collect {
+        format!("join={join} collect={collect}")
+    } else {
+        format!("join={join}")
+    }
+}
+
+pub(super) fn format_retry(retry: &RetrySpec) -> String {
+    let strategy = match retry.backoff_strategy {
+        BackoffStrategy::Exponential => "exponential",
+        BackoffStrategy::Linear => "linear",
+    };
+    format!(
+        "max_attempts={} initial_backoff_ms={} backoff_cap_ms={} strategy={strategy}",
+        retry.max_attempts, retry.initial_backoff_ms, retry.backoff_cap_ms
+    )
 }

--- a/crates/orbit-cli/src/command/job/tests/command.rs
+++ b/crates/orbit-cli/src/command/job/tests/command.rs
@@ -38,3 +38,85 @@ fn parses_job_replay_subcommand() {
 fn parses_job_resume_subcommand() {
     assert!(Cli::try_parse_from(["orbit", "job", "resume", "jrun-1", "--json"]).is_ok());
 }
+
+#[test]
+fn write_v2_step_has_no_debug_output_for_fan_in_and_retry() {
+    use crate::command::job::support::{
+        format_fan_in, format_join_mode, format_retry, write_v2_step,
+    };
+    use orbit_types::workflow::{
+        BackoffStrategy, FanInSpec, FanOutBlock, JobV2Step, JobV2StepBody, JoinMode, ParallelBlock,
+        RetrySpec,
+    };
+
+    let fan_in = FanInSpec {
+        join: JoinMode::Any,
+        collect: Some("pilot_results".to_string()),
+    };
+    assert_eq!(format_fan_in(&fan_in), "join=any collect=pilot_results");
+
+    let retry = RetrySpec {
+        max_attempts: 3,
+        initial_backoff_ms: 1000,
+        backoff_cap_ms: 30000,
+        backoff_strategy: BackoffStrategy::Exponential,
+    };
+    assert_eq!(
+        format_retry(&retry),
+        "max_attempts=3 initial_backoff_ms=1000 backoff_cap_ms=30000 strategy=exponential"
+    );
+
+    assert_eq!(format_join_mode(&JoinMode::All), "all");
+    assert_eq!(format_join_mode(&JoinMode::Quorum { n: 2 }), "quorum(2)");
+
+    let step = JobV2Step {
+        id: "fan_out_step".to_string(),
+        when: None,
+        retry: Some(retry),
+        recovery_activity: None,
+        resolved_recovery_activity: None,
+        body: JobV2StepBody::FanOut {
+            fan_out: FanOutBlock {
+                items: "items".to_string(),
+                max_workers: 4,
+                worker: Box::new(JobV2Step {
+                    id: "worker_step".to_string(),
+                    when: None,
+                    retry: None,
+                    recovery_activity: None,
+                    resolved_recovery_activity: None,
+                    body: JobV2StepBody::Parallel {
+                        parallel: ParallelBlock {
+                            join: JoinMode::All,
+                            branches: vec![],
+                        },
+                    },
+                }),
+            },
+            fan_in,
+        },
+    };
+
+    let mut out = String::new();
+    write_v2_step(&step, 0, &mut out);
+    assert!(
+        !out.contains("{:?}"),
+        "output should not contain {{:?}} placeholder: {out}"
+    );
+    assert!(
+        !out.contains("FanInSpec {"),
+        "output should not contain debug FanInSpec: {out}"
+    );
+    assert!(
+        !out.contains("RetrySpec {"),
+        "output should not contain debug RetrySpec: {out}"
+    );
+    assert!(
+        out.contains("join=any collect=pilot_results"),
+        "output should contain formatted fan-in: {out}"
+    );
+    assert!(
+        out.contains("all\n"),
+        "output should contain formatted join: {out}"
+    );
+}

--- a/crates/orbit-cli/src/command/tool/manifest.rs
+++ b/crates/orbit-cli/src/command/tool/manifest.rs
@@ -39,24 +39,36 @@ fn manifest_candidates(tool_path: &Path) -> Vec<PathBuf> {
     ]
 }
 
+const KNOWN_SCRIPT_EXTENSIONS: &[&str] =
+    &["sh", "bash", "zsh", "py", "js", "mjs", "cjs", "ts", "rb"];
+
+pub(super) fn tool_file_stem(tool_path: &Path) -> &str {
+    let file_name = tool_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("external-tool");
+    if let Some((stem, ext)) = file_name.rsplit_once('.')
+        && KNOWN_SCRIPT_EXTENSIONS
+            .iter()
+            .any(|known| known.eq_ignore_ascii_case(ext))
+    {
+        return stem;
+    }
+    file_name
+}
+
 pub(super) fn sidecar_manifest_path(tool_path: &Path) -> PathBuf {
     sidecar_manifest_path_with_extension(tool_path, "yaml")
 }
 
 fn sidecar_manifest_path_with_extension(tool_path: &Path, extension: &str) -> PathBuf {
     let parent = tool_path.parent().unwrap_or_else(|| Path::new("."));
-    let stem = tool_path
-        .file_stem()
-        .and_then(|value| value.to_str())
-        .unwrap_or("external-tool");
+    let stem = tool_file_stem(tool_path);
     parent.join(format!("{stem}.orbit-tool.{extension}"))
 }
 
 pub(super) fn infer_tool_name(path: &Path) -> String {
-    path.file_stem()
-        .and_then(|value| value.to_str())
-        .unwrap_or("external-tool")
-        .to_string()
+    tool_file_stem(path).to_string()
 }
 
 pub(super) fn load_external_tool_manifest(path: &Path) -> Result<ExternalToolManifest, OrbitError> {

--- a/crates/orbit-cli/src/command/tool/tests/run.rs
+++ b/crates/orbit-cli/src/command/tool/tests/run.rs
@@ -275,3 +275,84 @@ fn local_machine_identity_prefers_persisted_host_identity() {
         ("hm_cli".to_string(), Some("cli-host".to_string()))
     );
 }
+
+#[test]
+fn infer_tool_name_preserves_dotted_names_without_known_script_extension() {
+    use super::super::manifest::infer_tool_name;
+    use std::path::Path;
+
+    assert_eq!(infer_tool_name(Path::new("qa.echo")), "qa.echo");
+    assert_eq!(
+        infer_tool_name(Path::new("my.nested.tool.name")),
+        "my.nested.tool.name"
+    );
+    assert_eq!(infer_tool_name(Path::new("/path/to/qa.echo")), "qa.echo");
+}
+
+#[test]
+fn infer_tool_name_strips_known_script_extensions() {
+    use super::super::manifest::infer_tool_name;
+    use std::path::Path;
+
+    assert_eq!(infer_tool_name(Path::new("qa.echo.py")), "qa.echo");
+    assert_eq!(infer_tool_name(Path::new("qa.echo.sh")), "qa.echo");
+    assert_eq!(infer_tool_name(Path::new("qa.echo.js")), "qa.echo");
+    assert_eq!(infer_tool_name(Path::new("echo.py")), "echo");
+    assert_eq!(infer_tool_name(Path::new("echo.sh")), "echo");
+}
+
+#[test]
+fn sidecar_manifest_path_preserves_dotted_names() {
+    use super::super::manifest::sidecar_manifest_path;
+    use std::path::Path;
+
+    assert_eq!(
+        sidecar_manifest_path(Path::new("qa.echo")),
+        Path::new("qa.echo.orbit-tool.yaml")
+    );
+    assert_eq!(
+        sidecar_manifest_path(Path::new("/tools/qa.echo")),
+        Path::new("/tools/qa.echo.orbit-tool.yaml")
+    );
+    assert_eq!(
+        sidecar_manifest_path(Path::new("qa.echo.py")),
+        Path::new("qa.echo.orbit-tool.yaml")
+    );
+    assert_eq!(
+        sidecar_manifest_path(Path::new("echo.py")),
+        Path::new("echo.orbit-tool.yaml")
+    );
+}
+
+#[test]
+fn tool_scaffold_registers_full_dotted_name_in_manifest() {
+    use crate::command::Execute;
+    use crate::command::tool::manifest::load_external_tool_manifest;
+    use crate::command::tool::scaffold::ToolScaffoldArgs;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let script_path = dir.path().join("qa.echo");
+
+    let args = ToolScaffoldArgs {
+        path: script_path.display().to_string(),
+        name: None,
+        description: "Test description".to_string(),
+        force: false,
+    };
+
+    let runtime = orbit_core::OrbitRuntime::from_roots(dir.path(), dir.path()).expect("runtime");
+    args.execute(&runtime).expect("scaffold succeeds");
+
+    assert!(script_path.exists(), "script was created");
+    let manifest_path = dir.path().join("qa.echo.orbit-tool.yaml");
+    assert!(
+        manifest_path.exists(),
+        "manifest with full dotted name was created"
+    );
+
+    let manifest = load_external_tool_manifest(&manifest_path).expect("load manifest");
+    assert_eq!(
+        manifest.name, "qa.echo",
+        "registered name must be full name"
+    );
+}

--- a/crates/orbit-cli/src/output/json.rs
+++ b/crates/orbit-cli/src/output/json.rs
@@ -90,6 +90,7 @@ fn error_code(error: &OrbitError) -> &str {
         OrbitError::TaskStatusTransition(_) => "task_status_transition",
         OrbitError::JobRunStateTransition(_) => "job_run_state_transition",
         OrbitError::JobRunStartConflict(_) => "job_run_start_conflict",
+        OrbitError::JobRunControlConflict(_) => "conflict",
         OrbitError::WorkspaceError(_) => "workspace_error",
         OrbitError::Io(_) => "io_error",
         OrbitError::AdrInvalidTransition(_) => "adr_invalid_transition",

--- a/crates/orbit-common/src/error.rs
+++ b/crates/orbit-common/src/error.rs
@@ -294,12 +294,12 @@ pub enum OrbitError {
     /// without matching on message text.
     #[error("job run start conflict: {0}")]
     JobRunStartConflict(String),
-    /// [ORB-11253] A run-control update lost a compare-and-set to a concurrent
-    /// update of the same control. Distinct from
+    /// [ORB-11253, ORB-12260] A control update lost a compare-and-set to a
+    /// concurrent update of the same control. Distinct from
     /// [`OrbitError::JobValidation`] on purpose: nothing is wrong with the
     /// request, it was simply superseded, so the caller re-reads the current
     /// value and decides again rather than correcting anything.
-    #[error("job run control conflict: {0}")]
+    #[error("{0}")]
     JobRunControlConflict(String),
     #[error("workspace error: {0}")]
     WorkspaceError(String),

--- a/crates/orbit-core/src/application/artifact_health.rs
+++ b/crates/orbit-core/src/application/artifact_health.rs
@@ -121,7 +121,7 @@ impl ArtifactKind {
 fn init_command(kind: ArtifactKind) -> &'static str {
     match kind {
         ArtifactKind::Skill | ArtifactKind::Job | ArtifactKind::Activity => "orbit init",
-        ArtifactKind::AutoTask | ArtifactKind::Routine => "orbit workspace init",
+        ArtifactKind::AutoTask | ArtifactKind::Routine => "orbit workspace sync",
     }
 }
 

--- a/crates/orbit-core/src/application/tests/managed_assets.rs
+++ b/crates/orbit-core/src/application/tests/managed_assets.rs
@@ -815,7 +815,7 @@ mod artifacts {
         assert_eq!(finding.condition, ArtifactCondition::Stale);
         assert_eq!(finding.provenance, ArtifactProvenance::OrbitWritten);
         assert!(
-            finding.remediation.contains("orbit workspace init"),
+            finding.remediation.contains("orbit workspace sync"),
             "{}",
             finding.remediation
         );

--- a/crates/orbit-mcp/src/error.rs
+++ b/crates/orbit-mcp/src/error.rs
@@ -94,6 +94,9 @@ fn error_code(err: &OrbitError) -> &str {
         // incumbent owner is an expected race, and the caller yields rather
         // than treating its own request as malformed.
         OrbitError::JobRunStartConflict(_) => "job_run_start_conflict",
+        // [ORB-11253, ORB-12260] A compare-and-set revision conflict on a
+        // run-control update or operation grant transition.
+        OrbitError::JobRunControlConflict(_) => "conflict",
         OrbitError::DependencyNotDelivered { .. } => "dependency_not_delivered",
         OrbitError::ShipRunInFlight { .. } => "ship_run_in_flight",
         OrbitError::WorkspaceClaimHeld(_) => "workspace_claim_held",

--- a/crates/orbit-mcp/src/tests/error.rs
+++ b/crates/orbit-mcp/src/tests/error.rs
@@ -180,3 +180,39 @@ fn friction_not_local_has_a_stable_code_and_names_owners() {
             && message.contains("ws_friction")
     }));
 }
+
+#[test]
+fn control_conflict_has_stable_conflict_code_and_names_object() {
+    for (error, expected_object, expected_hint) in [
+        (
+            OrbitError::JobRunControlConflict(
+                "operation grant 'ogrant-123' is at revision 2, not the expected 1; reread and retry"
+                    .to_string(),
+            ),
+            "operation grant 'ogrant-123'",
+            "reread and retry",
+        ),
+        (
+            OrbitError::JobRunControlConflict(
+                "worker ceiling of job run 'jrun-456' is at revision 2, not 1; re-read it and decide again"
+                    .to_string(),
+            ),
+            "worker ceiling of job run 'jrun-456'",
+            "re-read it and decide again",
+        ),
+    ] {
+        let payload = error_payload(&error);
+        assert_eq!(payload["code"], "conflict");
+        let message = payload["message"].as_str().expect("error message");
+        assert!(!message.starts_with("job run control conflict:"));
+        assert!(message.contains(expected_object), "missing object in message: {message}");
+        assert!(message.contains(expected_hint), "missing hint in message: {message}");
+
+        let result = tool_error_result(&error);
+        assert_eq!(result.is_error, Some(true));
+        assert_eq!(
+            result.structured_content.expect("structured error payload")["code"],
+            "conflict"
+        );
+    }
+}


### PR DESCRIPTION
## Task

[ORB-12260](https://orbit-cli.com/tasks/ORB-12260) — CLI polish from the 0.21.0 sweep: `job show` prints Rust Debug for fan-in, stale `if_revision` returns `internal_error`, `doctor` gives three different remediations for stale auto-tasks, `tool scaffold qa.echo` registers `qa`

### Description

Four small, unrelated sharp edges found on 0.21.0; each is a few lines.

1. **`orbit job show task_pilot_pipeline`** prints `Fan In: FanInSpec { join: Any, collect: Some("pilot_results") }` — `crates/orbit-cli/src/command/job/support.rs:194` uses `{:?}`. Print `join=any collect=pilot_results` (and the same for any other `{:?}` in that renderer).
2. **`orbit_operation_revoke {if_revision: 1}` when the grant is at revision 2** returns `{"code":"internal_error","message":"job run control conflict: operation grant 'ogrant-…' is at revision 2, not the expected 1; reread and retry"}`. It is not internal and it is not a job run: return `code: "conflict"` (or `revision_conflict`) with a message that names the grant; keep the `reread and retry` hint. Same for `operation stop` and `workflow.run.workers if_revision`.
3. **`orbit doctor`** `artifacts-auto-tasks` warning says `Action: Run \`orbit workspace init\``; `orbit workspace sync --check` says `run \`orbit workspace sync\``; `doctor --fix-stale-artifacts` also exists and retires stale copies. Pick one remediation (sync is the documented converge command; `--fix-stale-artifacts` is the destructive retire) and make doctor say it, with `--fix-stale-artifacts` mentioned only for the "retire" case.
4. **`orbit tool scaffold qa.echo`** writes `qa.echo` (the script) and `qa.orbit-tool.yaml` with `name: qa` — the positional is a path and `.echo` is treated as an extension. Either error when the stem differs from the requested name and `--name` was not given, or take the full basename as the name unless it has a known script extension (`.sh`, `.py`, `.js`). The printed next steps (`orbit tool add qa.echo`, `orbit tool show qa`) already disagree with each other.

### Acceptance Criteria

- `job show` has no `{:?}` output for fan-in/fan-out specs
- Stale `if_revision` on operation stop/revoke and run workers returns a conflict error code, not `internal_error`, and the message names the right object
- `doctor` names exactly one remediation for stale shipped artifacts, consistent with `workspace sync --check`
- `tool scaffold <name.with.dots>` either refuses or registers the full name; the printed next steps agree with the registered name

## Execution Summary

<details>
<summary>Click to expand</summary>

### Acceptance Criteria Results
- `job show` has no `{:?}` output for fan-in/fan-out specs: Passed. Added explicit formatters for `FanInSpec`, `JoinMode`, and `RetrySpec` in `crates/orbit-cli/src/command/job/support.rs` (printing `join=any collect=pilot_results`), removing all `{:?}` in `write_v2_step`. Verified by `write_v2_step_has_no_debug_output_for_fan_in_and_retry`.
- Stale `if_revision` on operation stop/revoke and run workers returns a conflict error code, not `internal_error`, and the message names the right object: Passed. Removed the static "job run control conflict:" prefix from `JobRunControlConflict` in `crates/orbit-common/src/error.rs` so messages directly name the target object (`operation grant ...` or `worker ceiling of job run ...`) and preserve the re-read/retry hint; mapped `JobRunControlConflict` to error code `conflict` in `crates/orbit-cli/src/output/json.rs` and `crates/orbit-mcp/src/error.rs`. Verified by `control_conflict_has_stable_conflict_code_and_names_object` in `orbit-mcp`.
- `doctor` names exactly one remediation for stale shipped artifacts, consistent with `workspace sync --check`: Passed. Updated `init_command` in `crates/orbit-core/src/application/artifact_health.rs` to recommend `orbit workspace sync` for auto-tasks and routines, matching `workspace sync --check` convergence while leaving `--fix-stale-artifacts` solely for retiring deprecated definitions. Verified by `drifted_orbit_written_default_is_stale_and_not_removed_by_the_fix_flag`.
- `tool scaffold <name.with.dots>` either refuses or registers the full name; the printed next steps agree with the registered name: Passed. Updated `tool_file_stem`, `infer_tool_name`, and `sidecar_manifest_path_with_extension` in `crates/orbit-cli/src/command/tool/manifest.rs` to preserve dotted tool names (e.g. `qa.echo`) unless ending in known script extensions (`.sh`, `.py`, `.js`, etc.), aligning the scaffolded script, manifest name, sidecar file path, and next steps. Verified by new unit tests in `command::tool::tests::run`.

### Validation Commands
- `cargo test --bin orbit command::job::tests`: passed
- `cargo test -p orbit-mcp`: passed
- `cargo test -p orbit-core application::tests::managed_assets`: passed
- `cargo test --bin orbit command::tool::tests::run`: passed
- `make ci-fast`: passed
- `make ci-lint`: passed
- `make goldens`: passed
- `git diff --check`: passed
- `git status --short`: passed

### Remaining Risks or Deviations
None. Changes are minimal and targeted to the 4 reported sharp edges.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12260-6aa4e0d7`
- Behind base: 0
- Ahead of base: 1