### PR TITLE
`orbit.task.update` accepts any `status` value with no lifecycle guard: `proposed → done` and `done → proposed` both succeed

### DIFF
--- a/crates/orbit-cli/src/command/task/archive.rs
+++ b/crates/orbit-cli/src/command/task/archive.rs
@@ -6,7 +6,9 @@ use crate::command::{CommandOut, Execute, Payload};
 use super::output::task_to_json_for_runtime;
 
 #[derive(Args)]
-#[command(after_help = "Restore an archived task by updating it to any other status.")]
+#[command(
+    after_help = "Archived is terminal: restore a task with `task update <id> --status <status> --force`."
+)]
 pub struct TaskArchiveArgs {
     /// Task ID
     pub id: String,

--- a/crates/orbit-cli/src/command/task/update.rs
+++ b/crates/orbit-cli/src/command/task/update.rs
@@ -87,6 +87,11 @@ pub struct TaskUpdateArgs {
     /// Note recorded on the approval's status history entry (with `--approve`)
     #[arg(long, requires = "approve")]
     pub note: Option<String>,
+    /// Apply `--status` even when the task lifecycle refuses the transition
+    /// (for example reopening a done task). Human-operator override: the
+    /// change is recorded in task history as `forced`.
+    #[arg(long, requires = "status")]
+    pub force: bool,
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
@@ -98,7 +103,8 @@ pub struct TaskUpdateArgs {
 /// same invocation, and `--status` would be a direct contradiction of the
 /// transition being requested. Rejecting the combination in the parser keeps
 /// approval one write with one history entry.
-const APPROVE_CONFLICTS: [&str; 19] = [
+const APPROVE_CONFLICTS: [&str; 20] = [
+    "force",
     "title",
     "description",
     "acceptance_criteria",
@@ -148,6 +154,7 @@ impl Execute for TaskUpdateArgs {
             model,
             approve,
             note,
+            force,
             json: _,
         } = self;
 
@@ -213,34 +220,34 @@ impl Execute for TaskUpdateArgs {
         }
         let (agent, model) = super::mutation_identity(model);
 
-        let task = runtime.update_task_with_identity(
-            &id,
-            TaskUpdateParams {
-                title,
-                description,
-                acceptance_criteria,
-                dependencies,
-                tags,
-                plan,
-                execution_summary,
-                comment,
-                status: status.map(Into::into),
-                task_type,
-                priority,
-                complexity,
-                planned_by,
-                implemented_by,
-                pr_status,
-                job_run_id,
-                crew,
-                orchestrator,
-                context_files,
-                upsert_artifacts,
-                ..Default::default()
-            },
-            agent,
-            model,
-        )?;
+        let params = TaskUpdateParams {
+            title,
+            description,
+            acceptance_criteria,
+            dependencies,
+            tags,
+            plan,
+            execution_summary,
+            comment,
+            status: status.map(Into::into),
+            task_type,
+            priority,
+            complexity,
+            planned_by,
+            implemented_by,
+            pr_status,
+            job_run_id,
+            crew,
+            orchestrator,
+            context_files,
+            upsert_artifacts,
+            ..Default::default()
+        };
+        let task = if force {
+            runtime.force_update_task_with_identity(&id, params, agent, model)?
+        } else {
+            runtime.update_task_with_identity(&id, params, agent, model)?
+        };
 
         Ok(Payload::detail(
             task_to_json_for_runtime(runtime, &task)?,

--- a/crates/orbit-cli/tests/task_list.rs
+++ b/crates/orbit-cli/tests/task_list.rs
@@ -77,9 +77,14 @@ impl TestWorkspace {
         val["id"].as_str().expect("task id").to_string()
     }
 
+    /// Park a fixture task in an arbitrary status. `--force` is the human
+    /// override for the lifecycle table (ORB-12245); listing behaviour, not
+    /// the route a task took to its status, is what these tests measure.
     fn update_status(&self, id: &str, status: &str) {
         self.run(
-            &["task", "update", id, "--status", status, "--json"],
+            &[
+                "task", "update", id, "--status", status, "--force", "--json",
+            ],
             "update task status",
         );
     }

--- a/crates/orbit-cli/tests/task_trimmed_surface.rs
+++ b/crates/orbit-cli/tests/task_trimmed_surface.rs
@@ -16,40 +16,113 @@ use orbit_common::test_env;
 use serde_json::{Value, json};
 use tempfile::{TempDir, tempdir};
 
+/// [ORB-12245] `done` and `archived` are terminal on the governed surface.
+/// A human on the bare CLI can still override the table with `--force`, and
+/// the override is named in the task's history.
 #[test]
-fn update_status_restores_archived_task_directly_to_any_status() {
+fn update_status_reopens_terminal_tasks_only_with_an_explicit_force() {
+    let workspace = TestWorkspace::new();
+    let id = workspace.add_task("Terminal task");
+    workspace.drive_to_done(&id);
+
+    let refused = workspace.run_raw(&["task", "update", &id, "--status", "rejected"]);
+    assert!(!refused.status.success(), "done must not reopen silently");
+    let refusal = String::from_utf8_lossy(&refused.stderr).to_string();
+    assert!(
+        refusal.contains("cannot move from 'done' to 'rejected'"),
+        "the refusal must name the pair: {refusal}"
+    );
+
+    let reopened = workspace.task_json(&[
+        "task", "update", &id, "--status", "rejected", "--force", "--json",
+    ]);
+    assert_eq!(reopened["status"], json!("rejected"));
+    assert!(!reopened["execution_summary"].as_str().unwrap().is_empty());
+
+    let forced = reopened["history"]
+        .as_array()
+        .expect("task history")
+        .last()
+        .expect("forced event")
+        .clone();
+    assert_eq!(forced["event"], json!("forced"));
+    assert_eq!(forced["from_status"], json!("done"));
+    assert_eq!(forced["to_status"], json!("rejected"));
+
+    // Reconsidering a rejection needs no override.
+    let reconsidered =
+        workspace.task_json(&["task", "update", &id, "--status", "backlog", "--json"]);
+    assert_eq!(reconsidered["status"], json!("backlog"));
+}
+
+/// `orbit task archive` shelves a task from any status; restoring it is the
+/// same human override as reopening a completed one.
+#[test]
+fn update_status_restores_an_archived_task_with_force() {
     let workspace = TestWorkspace::new();
     let id = workspace.add_task("Restore me");
     workspace.run(&["task", "update", &id, "--status", "backlog"], "approve");
     workspace.run(&["task", "archive", &id], "archive");
 
-    let restored =
-        workspace.task_json(&["task", "update", &id, "--status", "in-progress", "--json"]);
-    assert_eq!(restored["status"], json!("in-progress"));
+    let refused = workspace.run_raw(&["task", "update", &id, "--status", "backlog"]);
+    assert!(
+        !refused.status.success(),
+        "archived must not restore silently"
+    );
+
+    let restored = workspace.task_json(&[
+        "task", "update", &id, "--status", "backlog", "--force", "--json",
+    ]);
+    assert_eq!(restored["status"], json!("backlog"));
 }
 
+/// Completion evidence is required wherever the status is set: the CLI is no
+/// more able to mint a `done` task out of a proposal than an agent is.
 #[test]
-fn update_status_reopens_done_directly_and_accepts_accompanying_edits() {
+fn update_status_refuses_completion_without_review_and_evidence() {
     let workspace = TestWorkspace::new();
-    let id = workspace.add_task("Terminal task");
-    workspace.drive_to_done(&id);
+    let id = workspace.add_task("Fabricated completion");
 
-    let reopened = workspace.task_json(&[
+    let skipped = workspace.run_raw(&["task", "update", &id, "--status", "done"]);
+    assert!(!skipped.status.success());
+    assert!(
+        String::from_utf8_lossy(&skipped.stderr).contains("reachable only from 'review'"),
+        "completion must not skip review"
+    );
+
+    workspace.run(&["task", "update", &id, "--status", "backlog"], "approve");
+    workspace.run(
+        &[
+            "task",
+            "update",
+            &id,
+            "--plan",
+            "1) do it",
+            "--status",
+            "in-progress",
+        ],
+        "start",
+    );
+    workspace.run(&["task", "update", &id, "--status", "review"], "to review");
+
+    let unproven = workspace.run_raw(&["task", "update", &id, "--status", "done"]);
+    assert!(!unproven.status.success());
+    assert!(
+        String::from_utf8_lossy(&unproven.stderr).contains("execution summary"),
+        "completion must name its missing evidence"
+    );
+
+    let done = workspace.task_json(&[
         "task",
         "update",
         &id,
+        "--execution-summary",
+        "did it",
         "--status",
-        "rejected",
-        "--title",
-        "Reclassified task",
+        "done",
         "--json",
     ]);
-    assert_eq!(reopened["status"], json!("rejected"));
-    assert_eq!(reopened["title"], json!("Reclassified task"));
-    assert!(!reopened["execution_summary"].as_str().unwrap().is_empty());
-
-    let archived = workspace.task_json(&["task", "update", &id, "--status", "archived", "--json"]);
-    assert_eq!(archived["status"], json!("archived"));
+    assert_eq!(done["status"], json!("done"));
 }
 
 #[test]

--- a/crates/orbit-core/assets/skills/orbit/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit/SKILL.md
@@ -46,19 +46,32 @@ If an activity already injected a task snapshot, use that envelope first.
 proposed → backlog → in-progress → review → done
          ↘ rejected
 
-someday → in-progress
-blocked → in-progress
-
-review      → rejected
-rejected    → backlog | in-progress  (reconsider)
+someday  → backlog | in-progress
+blocked  → backlog | in-progress
+review   → backlog | in-progress | rejected
+rejected → backlog | in-progress   (reconsider)
+any open status → blocked | archived
 ```
 
+Every status change goes through this table, whether you send it as
+`orbit.task.update` or as `task.start`/`task.approve`. Two rules are enforced
+and cannot be worked around from a tool call:
+
+- **`in-progress` needs a plan.** Starting from `proposed`, `someday`, or
+  `blocked` requires a non-empty execution plan; send it on the same call.
+- **`done` is reachable only from `review`,** and needs completion evidence:
+  a non-empty `execution_summary`, or a `job_run_id` whose run succeeded.
+
+`done` and `archived` are terminal, and a `rejected` task may only be
+reconsidered back to `backlog` or `in-progress`. A regression in delivered work
+is a *new* task with a `regression_from` relation — not a reopened one.
+
 Creating a task does not authorize dispatch or completion. Follow the user's
-approval and repository delivery policy. The diagram summarizes common paths;
-`task.start` also supports authorized pickup from `proposed` with a real plan.
-Use `blocked` when execution cannot safely continue. Provenance follows the
-surface: `orbit tool run ...` is agent-driven, bare `orbit task ...` is
-human-driven.
+approval and repository delivery policy. Use `blocked` when execution cannot
+safely continue. Provenance follows the surface: `orbit tool run ...` is
+agent-driven, bare `orbit task ...` is human-driven — and only a human on the
+bare CLI can override the table, with `orbit task update <id> --status <status>
+--force`, which records the override in task history.
 
 ## Common Mistakes — DO NOT
 

--- a/crates/orbit-core/src/adapter/tool_host/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/task_tools.rs
@@ -308,6 +308,12 @@ pub(super) fn update(
                 .to_string(),
         ));
     }
+    if input.get("force").is_some() {
+        return Err(OrbitError::InvalidInput(
+            "orbit.task.update does not accept `force`; lifecycle transitions are enforced for agents, and the override is a human CLI action"
+                .to_string(),
+        ));
+    }
     let id = required_string(&input, &["id"], "id")?;
     let context_files = optional_csv_or_string_list_alias(&input, &["context_files", "context"])?;
     if !allows_missing_context(&input)?

--- a/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
@@ -456,6 +456,54 @@ fn friction_stats_does_not_write_state_scoreboard_file() {
     );
 }
 
+/// [ORB-12245] The agent-facing update surface is governed by the same
+/// lifecycle table the CLI and dashboard use, and it has no override: `force`
+/// is refused outright, so an agent cannot grant itself one.
+#[test]
+fn task_update_tool_enforces_the_lifecycle_and_refuses_force() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task = create_task(
+        &runtime,
+        &repo_root,
+        "Fabricated completion",
+        "An agent must not mark unstarted work done.",
+        TaskStatus::Proposed,
+        &[],
+    );
+    let agent = Some("codex".to_string());
+    let model = Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string());
+
+    let message = invalid_input_message(runtime.execute_tool_command(
+        "orbit.task.update",
+        json!({ "id": task.id.clone(), "status": "done" }),
+        agent.clone(),
+        model.clone(),
+    ));
+    assert_eq!(
+        message,
+        format!(
+            "task '{}' cannot move from 'proposed' to 'done': 'done' is reachable only from 'review'",
+            task.id
+        )
+    );
+    assert_eq!(
+        runtime.get_task(&task.id).expect("reread task").status,
+        TaskStatus::Proposed
+    );
+
+    let message = invalid_input_message(runtime.execute_tool_command(
+        "orbit.task.update",
+        json!({ "id": task.id.clone(), "status": "done", "force": true }),
+        agent,
+        model,
+    ));
+    assert!(message.contains("does not accept `force`"), "{message}");
+    assert_eq!(
+        runtime.get_task(&task.id).expect("reread task").status,
+        TaskStatus::Proposed
+    );
+}
+
 #[test]
 fn task_delete_tool_rejects_unforced_protected_statuses() {
     let (_root, runtime, repo_root) = test_runtime();

--- a/crates/orbit-core/src/application/task/lifecycle.rs
+++ b/crates/orbit-core/src/application/task/lifecycle.rs
@@ -1,0 +1,178 @@
+//! The task lifecycle: which status changes are legal, and what each one
+//! requires before it may be written.
+//!
+//! [ORB-12245] `orbit.task.update` used to be a free status setter. Any agent
+//! could move a `proposed` task straight to `done` — no plan, no run, no
+//! review — and move it back again, while `task.start` and the delivery
+//! pipeline enforced real rules on the paths Orbit itself drives. The rules
+//! now live here, and every attributed surface (the CLI `task update`, the
+//! dashboard, and the registered `orbit.task.update` tool) routes its status
+//! changes through them.
+
+use orbit_common::OrbitError;
+use orbit_types::task::{Task, TaskStatus};
+use orbit_types::workflow::JobRunState;
+
+use crate::OrbitRuntime;
+
+use super::params::TaskUpdateParams;
+
+const UNAUTHORED_TASK_PLAN_PLACEHOLDER: &str = "To be authored by executing agent at start time.";
+
+/// Status event recorded when a human overrides the lifecycle table on the
+/// bare CLI, so an audit can tell a governed transition from an override.
+pub(crate) const FORCED_STATUS_EVENT: &str = "forced";
+
+/// Whether `from -> to` is a legal lifecycle edge.
+///
+/// The shape mirrors the diagram agents are given in the `orbit` skill:
+///
+/// ```text
+/// proposed → backlog → in-progress → review → done
+///          ↘ rejected
+/// someday  → in-progress ; blocked → backlog | in-progress
+/// review   → backlog | in-progress | rejected
+/// rejected → backlog | in-progress   (reconsider)
+/// *        → blocked | archived      (from any open status)
+/// ```
+///
+/// Two rules carry the governance weight. `done` is reachable only from
+/// `review`, so completion always follows work that was offered for review;
+/// and `done`/`archived` are terminal, so delivered or shelved work is not
+/// quietly reopened — a regression gets a new task with a `regression_from`
+/// relation. Reconsidering a rejection is the single exception, because a
+/// rejection closes a proposal rather than recording delivery.
+pub(crate) fn task_status_transition_allowed(from: TaskStatus, to: TaskStatus) -> bool {
+    use TaskStatus::{
+        Archived, Backlog, Blocked, Done, InProgress, Proposed, Rejected, Review, Someday,
+    };
+
+    if from == to {
+        return true;
+    }
+
+    match (from, to) {
+        (Done | Archived, _) => false,
+        (Rejected, target) => matches!(target, Backlog | InProgress),
+        // An executor must be able to block from anywhere it can still run,
+        // and any open task can be shelved.
+        (_, Blocked | Archived) => true,
+        (Blocked, target) => matches!(target, Backlog | InProgress),
+        (Proposed, target) => matches!(target, Backlog | Someday | InProgress | Rejected),
+        (Backlog, target) => matches!(target, Proposed | Someday | InProgress | Rejected),
+        (Someday, target) => matches!(target, Backlog | InProgress | Rejected),
+        (InProgress, target) => matches!(target, Backlog | Someday | Review | Rejected),
+        (Review, target) => matches!(target, Backlog | InProgress | Done | Rejected),
+    }
+}
+
+/// Refuse a status change the lifecycle does not allow, or one whose
+/// preconditions the task does not yet meet.
+///
+/// `params` is the same write that carries the status, so a caller may supply
+/// the missing plan or execution summary in the call that transitions — the
+/// precondition is read from the task the write would produce, not from the
+/// one it started with.
+pub(crate) fn ensure_status_change_allowed(
+    runtime: &OrbitRuntime,
+    task: &Task,
+    params: &TaskUpdateParams,
+    target: TaskStatus,
+) -> Result<(), OrbitError> {
+    let from = task.status;
+    if from == target {
+        return Ok(());
+    }
+    if !task_status_transition_allowed(from, target) {
+        return Err(refused(
+            &task.id,
+            from,
+            target,
+            unreachable_reason(from, target),
+        ));
+    }
+
+    match target {
+        TaskStatus::InProgress if in_progress_transition_requires_plan(from) => {
+            let plan = params.plan.as_deref().unwrap_or(task.plan.as_str());
+            ensure_task_has_execution_plan(&task.id, plan)
+        }
+        TaskStatus::Done if !completion_evidence_present(runtime, task, params)? => Err(refused(
+            &task.id,
+            from,
+            target,
+            "completion requires a non-empty execution summary, or a job run ID whose run \
+             finished successfully",
+        )),
+        _ => Ok(()),
+    }
+}
+
+/// The precondition a refused edge is missing, in the terms of the pair that
+/// was asked for rather than of the table that refused it.
+fn unreachable_reason(from: TaskStatus, to: TaskStatus) -> &'static str {
+    match (from, to) {
+        (_, TaskStatus::Done) => "'done' is reachable only from 'review'",
+        (TaskStatus::Done | TaskStatus::Archived, _) => {
+            "delivered and archived work does not reopen; file a new task with a \
+             'regression_from' relation instead"
+        }
+        (TaskStatus::Rejected, _) => {
+            "a rejection is only reconsidered back to 'backlog' or 'in-progress'"
+        }
+        _ => "the lifecycle has no edge between these statuses",
+    }
+}
+
+fn refused(id: &str, from: TaskStatus, to: TaskStatus, reason: &str) -> OrbitError {
+    OrbitError::InvalidInput(format!(
+        "task '{id}' cannot move from '{from}' to '{to}': {reason}"
+    ))
+}
+
+/// Whether the task carries evidence that the work it claims to complete was
+/// actually performed: an execution summary someone wrote, or a job run that
+/// finished successfully.
+fn completion_evidence_present(
+    runtime: &OrbitRuntime,
+    task: &Task,
+    params: &TaskUpdateParams,
+) -> Result<bool, OrbitError> {
+    let summary = params
+        .execution_summary
+        .as_deref()
+        .unwrap_or(task.execution_summary.as_str());
+    if !summary.trim().is_empty() {
+        return Ok(true);
+    }
+
+    let job_run_id = match &params.job_run_id {
+        Some(replacement) => replacement.as_deref(),
+        None => task.job_run_id.as_deref(),
+    };
+    let Some(job_run_id) = job_run_id.map(str::trim).filter(|id| !id.is_empty()) else {
+        return Ok(false);
+    };
+
+    Ok(runtime
+        .get_job_run_backend(job_run_id)?
+        .is_some_and(|run| run.state == JobRunState::Success))
+}
+
+pub(crate) fn ensure_task_has_execution_plan(id: &str, plan: &str) -> Result<(), OrbitError> {
+    let normalized = plan.trim();
+    if normalized.is_empty() || normalized == UNAUTHORED_TASK_PLAN_PLACEHOLDER {
+        return Err(OrbitError::InvalidInput(format!(
+            "task '{id}' requires a non-empty execution plan before transitioning to in-progress"
+        )));
+    }
+    Ok(())
+}
+
+/// `backlog` and `in-progress` are the statuses a managed run picks work up
+/// from, where the plan is authored by the executing agent at start time.
+/// Every other source is a human or agent starting work directly, which must
+/// bring a plan with it.
+pub(crate) fn in_progress_transition_requires_plan(from_status: TaskStatus) -> bool {
+    !matches!(from_status, TaskStatus::Backlog | TaskStatus::InProgress)
+}

--- a/crates/orbit-core/src/application/task/mod.rs
+++ b/crates/orbit-core/src/application/task/mod.rs
@@ -3,6 +3,7 @@
 mod add;
 pub(crate) mod contention;
 mod helpers;
+mod lifecycle;
 mod lint;
 mod listing;
 mod params;
@@ -19,11 +20,9 @@ pub(crate) use params::TaskRecordUpdateParams;
 pub use params::{TaskAddParams, TaskUpdateParams};
 
 pub(crate) use helpers::{SYSTEM_ACTOR_LABEL, TaskAttributionInput, assemble_task_attribution};
+pub(crate) use lifecycle::{ensure_task_has_execution_plan, in_progress_transition_requires_plan};
 pub(crate) use paths::{
     canonicalize_context_files_for_read, compute_task_add_warnings, context_workspace_root,
-};
-pub(crate) use transitions::{
-    ensure_task_has_execution_plan, in_progress_transition_requires_plan,
 };
 
 #[cfg(test)]

--- a/crates/orbit-core/src/application/task/tests/lifecycle.rs
+++ b/crates/orbit-core/src/application/task/tests/lifecycle.rs
@@ -1,0 +1,363 @@
+//! The lifecycle table every attributed status change is checked against
+//! [ORB-12245].
+
+use chrono::Utc;
+use orbit_common::OrbitError;
+use orbit_types::task::{Task, TaskStatus};
+use orbit_types::workflow::JobRunState;
+
+use super::super::lifecycle::task_status_transition_allowed;
+use super::test_runtime;
+use crate::OrbitRuntime;
+use crate::application::task::{TaskAddParams, TaskUpdateParams};
+
+const ALL_STATUSES: [TaskStatus; 9] = [
+    TaskStatus::Proposed,
+    TaskStatus::Backlog,
+    TaskStatus::Someday,
+    TaskStatus::InProgress,
+    TaskStatus::Review,
+    TaskStatus::Done,
+    TaskStatus::Blocked,
+    TaskStatus::Archived,
+    TaskStatus::Rejected,
+];
+
+/// A task that already carries both completion preconditions, so a matrix
+/// walk measures the transition table alone.
+fn add_task_with_evidence(runtime: &OrbitRuntime, title: &str) -> Task {
+    runtime
+        .add_task(TaskAddParams {
+            title: title.to_string(),
+            description: "Exercise the lifecycle table.".to_string(),
+            acceptance_criteria: vec!["Only legal transitions are written.".to_string()],
+            plan: "1) do the thing 2) verify".to_string(),
+            ..Default::default()
+        })
+        .expect("add task")
+}
+
+/// Put a fixture task into `status` without consulting the table: seeding is
+/// an in-crate concern, and the guarded surface is what the tests measure.
+fn seed_status(runtime: &OrbitRuntime, id: &str, status: TaskStatus) {
+    runtime
+        .update_task(
+            id,
+            TaskUpdateParams {
+                status: Some(status),
+                execution_summary: Some("did the thing; verified".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("seed fixture status");
+}
+
+/// The guarded surface: exactly what `orbit.task.update`, the dashboard, and
+/// the CLI `task update` reach.
+fn guarded_update(
+    runtime: &OrbitRuntime,
+    id: &str,
+    params: TaskUpdateParams,
+) -> Result<Task, OrbitError> {
+    runtime.update_task_with_identity(id, params, None, None)
+}
+
+fn guarded_status(
+    runtime: &OrbitRuntime,
+    id: &str,
+    status: TaskStatus,
+) -> Result<Task, OrbitError> {
+    guarded_update(
+        runtime,
+        id,
+        TaskUpdateParams {
+            status: Some(status),
+            ..Default::default()
+        },
+    )
+}
+
+#[test]
+fn guarded_update_writes_every_legal_edge_and_refuses_every_other_one() {
+    let (_root, runtime) = test_runtime();
+
+    for from in ALL_STATUSES {
+        for to in ALL_STATUSES {
+            let task = add_task_with_evidence(&runtime, &format!("Matrix {from} to {to}"));
+            seed_status(&runtime, &task.id, from);
+
+            match guarded_status(&runtime, &task.id, to) {
+                Ok(updated) => {
+                    assert!(
+                        task_status_transition_allowed(from, to),
+                        "{from} -> {to} was written but the table refuses it"
+                    );
+                    assert_eq!(updated.status, to);
+                }
+                Err(error) => {
+                    assert!(
+                        !task_status_transition_allowed(from, to),
+                        "{from} -> {to} is a legal edge but was refused: {error}"
+                    );
+                    assert!(
+                        matches!(error, OrbitError::InvalidInput(_)),
+                        "{from} -> {to} must be invalid_input, got {error}"
+                    );
+                    let message = error.to_string();
+                    assert!(
+                        message.contains(&format!("from '{from}' to '{to}'")),
+                        "{from} -> {to} must name the pair: {message}"
+                    );
+                    assert_eq!(
+                        runtime.get_task(&task.id).expect("reread task").status,
+                        from,
+                        "a refused transition must not be written"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn done_is_unreachable_from_proposed_and_backlog() {
+    let (_root, runtime) = test_runtime();
+
+    for from in [TaskStatus::Proposed, TaskStatus::Backlog] {
+        let task = add_task_with_evidence(&runtime, &format!("Complete from {from}"));
+        seed_status(&runtime, &task.id, from);
+
+        let error = guarded_status(&runtime, &task.id, TaskStatus::Done)
+            .expect_err("completion must not skip review");
+        let message = error.to_string();
+        assert!(
+            message.contains("'done' is reachable only from 'review'"),
+            "{from}: {message}"
+        );
+    }
+}
+
+#[test]
+fn in_progress_requires_a_plan_exactly_like_task_start() {
+    let (_root, runtime) = test_runtime();
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Unplanned work".to_string(),
+            description: "Starting without a plan is refused on every surface.".to_string(),
+            ..Default::default()
+        })
+        .expect("add unplanned task");
+
+    let refused = guarded_status(&runtime, &task.id, TaskStatus::InProgress)
+        .expect_err("an unplanned start is refused");
+    let started = runtime
+        .start_task(&task.id, None, None)
+        .expect_err("task.start refuses the same task");
+    assert_eq!(refused.to_string(), started.to_string());
+    assert_eq!(
+        runtime.get_task(&task.id).expect("reread task").status,
+        TaskStatus::Proposed
+    );
+
+    // The plan may arrive on the write that transitions.
+    let planned = guarded_update(
+        &runtime,
+        &task.id,
+        TaskUpdateParams {
+            plan: Some("1) reproduce 2) fix".to_string()),
+            status: Some(TaskStatus::InProgress),
+            ..Default::default()
+        },
+    )
+    .expect("a planned start is accepted");
+    assert_eq!(planned.status, TaskStatus::InProgress);
+}
+
+#[test]
+fn completion_requires_a_summary_or_a_successful_run() {
+    let (_root, runtime) = test_runtime();
+    let task = add_task_with_evidence(&runtime, "Evidence for completion");
+    runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Review),
+                ..Default::default()
+            },
+        )
+        .expect("seed a reviewed task without evidence");
+
+    let error = guarded_status(&runtime, &task.id, TaskStatus::Done)
+        .expect_err("completion without evidence is refused");
+    assert!(error.to_string().contains("execution summary"), "{error}");
+
+    // A failed run is not evidence of completion.
+    let failed_run = finished_run(&runtime, "failed-delivery", JobRunState::Failed);
+    let error = guarded_update(
+        &runtime,
+        &task.id,
+        TaskUpdateParams {
+            job_run_id: Some(Some(failed_run)),
+            status: Some(TaskStatus::Done),
+            ..Default::default()
+        },
+    )
+    .expect_err("a failed run does not complete a task");
+    assert!(
+        error.to_string().contains("finished successfully"),
+        "{error}"
+    );
+
+    let succeeded_run = finished_run(&runtime, "successful-delivery", JobRunState::Success);
+    let completed = guarded_update(
+        &runtime,
+        &task.id,
+        TaskUpdateParams {
+            job_run_id: Some(Some(succeeded_run)),
+            status: Some(TaskStatus::Done),
+            ..Default::default()
+        },
+    )
+    .expect("a successful run completes the task");
+    assert_eq!(completed.status, TaskStatus::Done);
+}
+
+#[test]
+fn completion_accepts_a_summary_written_by_the_same_update() {
+    let (_root, runtime) = test_runtime();
+    let task = add_task_with_evidence(&runtime, "Summary with the transition");
+    runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Review),
+                ..Default::default()
+            },
+        )
+        .expect("seed a reviewed task without evidence");
+
+    let completed = guarded_update(
+        &runtime,
+        &task.id,
+        TaskUpdateParams {
+            execution_summary: Some("delivered and verified".to_string()),
+            status: Some(TaskStatus::Done),
+            ..Default::default()
+        },
+    )
+    .expect("the summary on this write satisfies completion");
+    assert_eq!(completed.status, TaskStatus::Done);
+}
+
+#[test]
+fn terminal_statuses_stay_closed_while_a_rejection_can_be_reconsidered() {
+    let (_root, runtime) = test_runtime();
+
+    for target in [
+        TaskStatus::Proposed,
+        TaskStatus::Backlog,
+        TaskStatus::InProgress,
+    ] {
+        let task = add_task_with_evidence(&runtime, &format!("Reopen done to {target}"));
+        seed_status(&runtime, &task.id, TaskStatus::Done);
+        let error =
+            guarded_status(&runtime, &task.id, target).expect_err("done work does not reopen");
+        assert!(
+            error.to_string().contains("regression_from"),
+            "{target}: {error}"
+        );
+    }
+
+    for target in [TaskStatus::Backlog, TaskStatus::InProgress] {
+        let task = add_task_with_evidence(&runtime, &format!("Reconsider rejection as {target}"));
+        seed_status(&runtime, &task.id, TaskStatus::Rejected);
+        let reconsidered = guarded_status(&runtime, &task.id, target)
+            .unwrap_or_else(|error| panic!("rejected -> {target} must stay open: {error}"));
+        assert_eq!(reconsidered.status, target);
+    }
+}
+
+#[test]
+fn forcing_a_refused_transition_records_the_override_in_history() {
+    let (_root, runtime) = test_runtime();
+    let task = add_task_with_evidence(&runtime, "Forced reopen");
+    seed_status(&runtime, &task.id, TaskStatus::Done);
+    guarded_status(&runtime, &task.id, TaskStatus::Backlog).expect_err("guarded reopen is refused");
+
+    let reopened = runtime
+        .force_update_task_with_identity(
+            &task.id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Backlog),
+                ..Default::default()
+            },
+            None,
+            None,
+        )
+        .expect("a human may override the table");
+    assert_eq!(reopened.status, TaskStatus::Backlog);
+    // The override preserves the delivered work's evidence.
+    assert_eq!(reopened.execution_summary, "did the thing; verified");
+
+    let history = runtime.get_task_history(&task.id).expect("task history");
+    let forced = history.last().expect("forced event");
+    assert_eq!(forced.event, "forced");
+    assert_eq!(forced.from_status, Some(TaskStatus::Done));
+    assert_eq!(forced.to_status, Some(TaskStatus::Backlog));
+}
+
+#[test]
+fn forcing_a_legal_transition_still_records_it_as_an_override() {
+    let (_root, runtime) = test_runtime();
+    let task = add_task_with_evidence(&runtime, "Forced but legal");
+
+    runtime
+        .force_update_task_with_identity(
+            &task.id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Backlog),
+                ..Default::default()
+            },
+            None,
+            None,
+        )
+        .expect("force applies a legal transition too");
+
+    let history = runtime.get_task_history(&task.id).expect("task history");
+    assert_eq!(history.last().expect("forced event").event, "forced");
+}
+
+/// `archive_task` and the delivery pipeline's activities are in-crate callers
+/// that own their own transition rules, so the table does not second-guess
+/// them — archiving delivered work stays a one-step operator action.
+#[test]
+fn internal_callers_keep_transitions_the_table_refuses() {
+    let (_root, runtime) = test_runtime();
+    let task = add_task_with_evidence(&runtime, "Archive delivered work");
+    seed_status(&runtime, &task.id, TaskStatus::Done);
+
+    runtime.archive_task(&task.id).expect("archive done task");
+    assert_eq!(
+        runtime.get_task(&task.id).expect("reread task").status,
+        TaskStatus::Archived
+    );
+}
+
+fn finished_run(runtime: &OrbitRuntime, job_id: &str, state: JobRunState) -> String {
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run(job_id, 1, Utc::now(), None, None)
+        .expect("insert run");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, Utc::now(), std::process::id())
+        .expect("start run");
+    runtime
+        .stores()
+        .jobs()
+        .finalize_job_run(&run.run_id, state, Utc::now(), Some(1))
+        .expect("finalize run");
+    run.run_id.to_string()
+}

--- a/crates/orbit-core/src/application/task/tests/mod.rs
+++ b/crates/orbit-core/src/application/task/tests/mod.rs
@@ -2,6 +2,7 @@
 
 mod add;
 mod contention;
+mod lifecycle;
 mod params;
 mod paths;
 mod records;

--- a/crates/orbit-core/src/application/task/tests/update.rs
+++ b/crates/orbit-core/src/application/task/tests/update.rs
@@ -1,4 +1,6 @@
-//! Explicit status classification through the owning `update_task` layer.
+//! Status classification and field edits through the owning `update_task`
+//! layer. The lifecycle table each attributed status change is checked
+//! against is covered in [`super::lifecycle`].
 
 use orbit_engine::TaskActivityUpdate;
 use orbit_types::task::{Task, TaskArtifact, TaskStatus};
@@ -32,51 +34,6 @@ fn update_status(
     )
 }
 
-const ALL_STATUSES: [TaskStatus; 9] = [
-    TaskStatus::Proposed,
-    TaskStatus::Backlog,
-    TaskStatus::InProgress,
-    TaskStatus::Review,
-    TaskStatus::Done,
-    TaskStatus::Blocked,
-    TaskStatus::Archived,
-    TaskStatus::Rejected,
-    TaskStatus::Someday,
-];
-
-#[test]
-fn explicit_update_allows_the_complete_status_transition_matrix() {
-    let (_root, runtime) = test_runtime();
-
-    for source in ALL_STATUSES {
-        for target in ALL_STATUSES {
-            let task = add_proposed_task(&runtime, &format!("Matrix {source} to {target}"));
-            update_status(&runtime, &task.id, source).expect("establish matrix source");
-            let history_before = runtime
-                .get_task_history(&task.id)
-                .expect("history before transition");
-
-            let updated = update_status(&runtime, &task.id, target)
-                .unwrap_or_else(|error| panic!("{source} -> {target} failed: {error}"));
-
-            assert_eq!(updated.id, task.id);
-            assert_eq!(updated.status, target);
-            let history_after = runtime
-                .get_task_history(&task.id)
-                .expect("history after transition");
-            if source == target {
-                assert_eq!(history_after, history_before, "{source} same-status edit");
-            } else {
-                let event = history_after.last().expect("status transition event");
-                assert_eq!(event.from_status, Some(source));
-                assert_eq!(event.to_status, Some(target));
-                assert!(!event.by.trim().is_empty());
-                assert!(event.at >= task.created_at);
-            }
-        }
-    }
-}
-
 #[test]
 fn update_status_covers_approve_transitions() {
     let (_root, runtime) = test_runtime();
@@ -90,10 +47,21 @@ fn update_status_covers_approve_transitions() {
     // review -> done (the former review approval).
     let done = drive_to_done(&runtime, &task.id);
     assert_eq!(done.status, TaskStatus::Done);
+    let approval = runtime
+        .get_task_history(&task.id)
+        .expect("task history")
+        .last()
+        .cloned()
+        .expect("completion event");
+    assert_eq!(approval.from_status, Some(TaskStatus::Review));
+    assert_eq!(approval.to_status, Some(TaskStatus::Done));
 }
 
+/// Reopening delivered work is a human override (`orbit task update --force`),
+/// not an ordinary edit — but when an operator takes it, the task's evidence
+/// must survive intact.
 #[test]
-fn reopening_done_preserves_identity_history_artifacts_and_execution_evidence() {
+fn forced_reopen_preserves_identity_history_artifacts_and_execution_evidence() {
     let (_root, runtime) = test_runtime();
     let task = add_proposed_task(&runtime, "Preserve reopen evidence");
     runtime
@@ -112,15 +80,17 @@ fn reopening_done_preserves_identity_history_artifacts_and_execution_evidence() 
         .expect("done artifacts");
 
     let reopened = runtime
-        .update_task(
+        .force_update_task_with_identity(
             &task.id,
             TaskUpdateParams {
                 status: Some(TaskStatus::Proposed),
                 title: Some("Reclassified without replacing evidence".to_string()),
                 ..Default::default()
             },
+            None,
+            None,
         )
-        .expect("reopen done task directly");
+        .expect("a human may reopen a done task");
 
     assert_eq!(reopened.id, done.id);
     assert_eq!(reopened.execution_summary, done.execution_summary);
@@ -144,10 +114,12 @@ fn reopening_done_preserves_identity_history_artifacts_and_execution_evidence() 
 fn manual_status_edits_do_not_require_execution_fields_or_fabricate_attribution() {
     let (_root, runtime) = test_runtime();
     let task = add_proposed_task(&runtime, "Classification is not execution");
+    update_status(&runtime, &task.id, TaskStatus::Backlog).expect("approve the proposal");
+    update_status(&runtime, &task.id, TaskStatus::InProgress).expect("pick the task up");
 
-    let in_progress = update_status(&runtime, &task.id, TaskStatus::InProgress)
-        .expect("manual in-progress status needs no plan");
-    assert!(in_progress.plan.is_empty());
+    // Only completion demands execution evidence: offering work for review is
+    // a classification, and classifying does not make this runtime the
+    // implementer.
     let review = update_status(&runtime, &task.id, TaskStatus::Review)
         .expect("manual review status needs no summary");
     assert!(review.execution_summary.is_empty());
@@ -164,7 +136,7 @@ fn invalid_accompanying_edit_does_not_partially_apply_status() {
             &task.id,
             TaskUpdateParams {
                 title: Some("   ".to_string()),
-                status: Some(TaskStatus::Done),
+                status: Some(TaskStatus::Backlog),
                 ..Default::default()
             },
         )

--- a/crates/orbit-core/src/application/task/transitions.rs
+++ b/crates/orbit-core/src/application/task/transitions.rs
@@ -13,12 +13,12 @@ use crate::OrbitRuntime;
 use super::helpers::{
     SYSTEM_ACTOR_LABEL, build_task_comments, effective_actor_label, implementation_label,
 };
+use super::lifecycle::{ensure_task_has_execution_plan, in_progress_transition_requires_plan};
 use super::params::TaskUpdateParams;
 
 #[cfg(test)]
 use std::sync::Mutex;
 
-const UNAUTHORED_TASK_PLAN_PLACEHOLDER: &str = "To be authored by executing agent at start time.";
 const RELATION_RESOLVES: &str = "resolves";
 /// [ORB-10470] Status event recorded when a resumed run restores its own
 /// lineage's coupling to a task (re-admission and/or batch re-claim).
@@ -828,18 +828,4 @@ fn ensure_task_delete_allowed(id: &str, status: TaskStatus, force: bool) -> Resu
     Err(OrbitError::InvalidInput(format!(
         "task '{id}' is in status '{status}'; use --force to delete tasks not in proposed or rejected status"
     )))
-}
-
-pub(crate) fn ensure_task_has_execution_plan(id: &str, plan: &str) -> Result<(), OrbitError> {
-    let normalized = plan.trim();
-    if normalized.is_empty() || normalized == UNAUTHORED_TASK_PLAN_PLACEHOLDER {
-        return Err(OrbitError::InvalidInput(format!(
-            "task '{id}' requires a non-empty execution plan before transitioning to in-progress"
-        )));
-    }
-    Ok(())
-}
-
-pub(crate) fn in_progress_transition_requires_plan(from_status: TaskStatus) -> bool {
-    !matches!(from_status, TaskStatus::Backlog | TaskStatus::InProgress)
 }

--- a/crates/orbit-core/src/application/task/update.rs
+++ b/crates/orbit-core/src/application/task/update.rs
@@ -14,11 +14,30 @@ use super::helpers::{
     SYSTEM_ACTOR_LABEL, TaskAttributionInput, assemble_task_attribution, build_task_comments,
     describe_optional_field_value,
 };
+use super::lifecycle::{FORCED_STATUS_EVENT, ensure_status_change_allowed};
 use super::params::TaskUpdateParams;
 use super::paths::{
     canonicalize_context_files_for_read, context_files_pruned_history_entry,
     context_workspace_root, normalize_context_files_for_write,
 };
+
+/// Which lifecycle rules a status change on this write must satisfy
+/// [ORB-12245].
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+enum StatusAuthority {
+    /// In-process callers that own their own transition rules: the delivery
+    /// pipeline's activities, which compare-and-set against the status they
+    /// observed, and Core use cases such as [`OrbitRuntime::archive_task`].
+    #[default]
+    Internal,
+    /// Attributed operator and agent surfaces — the CLI `task update`, the
+    /// dashboard, and the registered `orbit.task.update` tool. The lifecycle
+    /// table decides.
+    Lifecycle,
+    /// A human overriding the table on the bare CLI, recorded in task history
+    /// as [`FORCED_STATUS_EVENT`].
+    Forced,
+}
 
 #[derive(Default)]
 struct TaskUpdateContext {
@@ -27,11 +46,21 @@ struct TaskUpdateContext {
     model: Option<String>,
     artifact_owner: Option<String>,
     expected_status: Option<TaskStatus>,
+    status_authority: StatusAuthority,
 }
 
 impl OrbitRuntime {
-    pub fn update_task(&self, id: &str, params: TaskUpdateParams) -> Result<Task, OrbitError> {
-        self.update_task_with_identity(id, params, None, None)
+    /// The in-crate task setter. Status changes are *not* checked against the
+    /// lifecycle table here: callers are Core's own use cases, which either
+    /// change no status or own the transition themselves. Everything outside
+    /// this crate goes through a guarded entry point below.
+    pub(crate) fn update_task(
+        &self,
+        id: &str,
+        params: TaskUpdateParams,
+    ) -> Result<Task, OrbitError> {
+        self.ensure_coordination_task_write_permitted()?;
+        self.update_task_with_context(id, params, TaskUpdateContext::default())
     }
 
     pub fn update_task_with_identity(
@@ -48,6 +77,34 @@ impl OrbitRuntime {
             TaskUpdateContext {
                 agent,
                 model,
+                status_authority: StatusAuthority::Lifecycle,
+                ..Default::default()
+            },
+        )
+    }
+
+    /// The human escape hatch behind `orbit task update --force`: apply the
+    /// update even when the lifecycle table refuses the status change, and
+    /// record the override in task history.
+    ///
+    /// Only the bare CLI reaches this. The registered `orbit.task.update` tool
+    /// refuses a `force` argument outright, so no agent can grant itself the
+    /// override.
+    pub fn force_update_task_with_identity(
+        &self,
+        id: &str,
+        params: TaskUpdateParams,
+        agent: Option<String>,
+        model: Option<String>,
+    ) -> Result<Task, OrbitError> {
+        self.ensure_coordination_task_write_permitted()?;
+        self.update_task_with_context(
+            id,
+            params,
+            TaskUpdateContext {
+                agent,
+                model,
+                status_authority: StatusAuthority::Forced,
                 ..Default::default()
             },
         )
@@ -69,6 +126,7 @@ impl OrbitRuntime {
                 agent,
                 model,
                 artifact_owner: owner,
+                status_authority: StatusAuthority::Lifecycle,
                 ..Default::default()
             },
         )
@@ -158,6 +216,7 @@ impl OrbitRuntime {
             model,
             artifact_owner,
             expected_status,
+            status_authority,
         } = context;
         let (canonical_agent, canonical_model) =
             self.try_canonical_agent_model_identity(agent.as_deref(), model.as_deref())?;
@@ -169,6 +228,12 @@ impl OrbitRuntime {
                 "task '{id}' status changed to '{}' before this activity write; expected '{expected_status}'",
                 task.status
             )));
+        }
+        let requested_status = params.status.filter(|status| *status != task.status);
+        if let Some(target) = requested_status
+            && status_authority == StatusAuthority::Lifecycle
+        {
+            ensure_status_change_allowed(self, &task, &params, target)?;
         }
         let prune_root = context_workspace_root(&self.paths().repo_root, None);
 
@@ -279,6 +344,11 @@ impl OrbitRuntime {
                 to_status: None,
             });
         }
+        // A forced transition is still a transition: naming it in history is
+        // what separates a human override from a governed lifecycle move.
+        let status_event = (status_authority == StatusAuthority::Forced
+            && requested_status.is_some())
+        .then(|| FORCED_STATUS_EVENT.to_string());
         let previous_status = task.status;
         let updated = self.with_mutation(|| {
             let updated = self.stores().task_records().update(
@@ -288,6 +358,7 @@ impl OrbitRuntime {
                     actor: effective_label.clone(),
                     planned_by: attribution.planned_by.clone(),
                     implemented_by: attribution.implemented_by.clone(),
+                    status_event: status_event.clone(),
                     status_note,
                     append_comments: append_comments.clone(),
                     append_history: append_history.clone(),

--- a/crates/orbit-core/tests/relation_auto_close.rs
+++ b/crates/orbit-core/tests/relation_auto_close.rs
@@ -153,6 +153,7 @@ fn task_update_to_done_resolves_related_friction() {
     let (_root, runtime, repo_root) = test_runtime();
     let friction_id = add_test_friction(&runtime);
     let task_id = add_task_with_resolves(&runtime, &repo_root, &friction_id, "backlog");
+    move_backlog_task_to_review(&runtime, &task_id);
 
     let updated = runtime
         .run_tool(
@@ -336,6 +337,7 @@ fn cross_workspace_resolves_update_to_done_is_rejected() {
     let friction_id = add_test_friction(&runtime_a);
     let owner = runtime_a.workspace_id().expect("workspace a id");
     let task_id = add_task_with_resolves(&runtime_b, &repo_b, &friction_id, "backlog");
+    move_backlog_task_to_review(&runtime_b, &task_id);
 
     let error = runtime_b
         .run_tool(
@@ -351,7 +353,7 @@ fn cross_workspace_resolves_update_to_done_is_rejected() {
     assert_friction_still_open(&runtime_a, &friction_id);
     assert_eq!(
         runtime_b.get_task(&task_id).expect("get task").status,
-        TaskStatus::Backlog
+        TaskStatus::Review
     );
 }
 
@@ -409,6 +411,7 @@ fn same_workspace_resolves_still_wins_when_another_workspace_shares_the_id() {
     assert_eq!(foreign_id, local_id);
 
     let task_id = add_task_with_resolves(&runtime_b, &repo_b, &local_id, "backlog");
+    move_backlog_task_to_review(&runtime_b, &task_id);
     runtime_b
         .run_tool(
             "orbit.task.update",

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/update.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/update.rs
@@ -191,6 +191,36 @@ fn schema_and_handler_exclude_inline_artifacts() {
     assert!(error.to_string().contains("orbit.task.artifact.put"));
 }
 
+/// [ORB-12245] The lifecycle override is a human CLI action. The agent-facing
+/// schema does not advertise it, and the handler refuses it rather than
+/// silently ignoring it.
+#[test]
+fn schema_omits_and_handler_rejects_force() {
+    let schema = OrbitTaskUpdateTool.schema();
+    assert!(
+        schema
+            .parameters
+            .iter()
+            .all(|parameter| parameter.name != "force")
+    );
+
+    let error = OrbitTaskUpdateTool
+        .execute(
+            &update_tool_context(Arc::new(FakeTaskHost::seeded(None))),
+            json!({
+                "id": "ORB-00001",
+                "model": "codex",
+                "status": "done",
+                "force": true,
+            }),
+        )
+        .expect_err("agents cannot override the task lifecycle");
+    assert!(
+        error.to_string().contains("does not accept `force`"),
+        "{error}"
+    );
+}
+
 #[test]
 fn update_handler_persists_source_task_id() {
     let host = Arc::new(FakeTaskHost::seeded(None));

--- a/crates/orbit-tools/src/builtin/orbit/task/update.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/update.rs
@@ -184,6 +184,12 @@ impl Tool for OrbitTaskUpdateTool {
                     .to_string(),
             ));
         }
+        if input.get("force").is_some() {
+            return Err(OrbitError::InvalidInput(
+                "orbit.task.update does not accept `force`; lifecycle transitions are enforced for agents, and the override is a human CLI action"
+                    .to_string(),
+            ));
+        }
         if input.get("artifacts").is_some() {
             return Err(OrbitError::InvalidInput(
                 "orbit.task.update does not accept inline artifacts; use orbit.task.artifact.put"

--- a/crates/orbit-web/src/api/tests/auto_tasks.rs
+++ b/crates/orbit-web/src/api/tests/auto_tasks.rs
@@ -858,12 +858,14 @@ async fn list_reports_no_open_duplicate_when_only_instance_is_someday() {
     // Mint an instance and park it in Someday.
     let task = runtime.auto_task_mint("parked-chore").expect("mint");
     runtime
-        .update_task(
+        .update_task_with_identity(
             &task.id,
             TaskUpdateParams {
                 status: Some(TaskStatus::Someday),
                 ..Default::default()
             },
+            None,
+            None,
         )
         .expect("park task");
 
@@ -890,12 +892,14 @@ async fn list_reports_no_open_duplicate_when_only_instance_is_someday() {
 
     // Once an active instance exists, the same query marks open_duplicate as true.
     runtime
-        .update_task(
+        .update_task_with_identity(
             &task.id,
             TaskUpdateParams {
                 status: Some(TaskStatus::Backlog),
                 ..Default::default()
             },
+            None,
+            None,
         )
         .expect("activate task");
 

--- a/crates/orbit-web/src/api/tests/task_listing.rs
+++ b/crates/orbit-web/src/api/tests/task_listing.rs
@@ -196,12 +196,14 @@ async fn list_and_detail_reuse_bundle_sidecars_with_response_parity() {
     let runtime = Arc::new(OrbitRuntime::in_memory().unwrap());
     let task = seed_task_with_artifact(&runtime);
     runtime
-        .update_task(
+        .update_task_with_identity(
             &task.id,
             TaskUpdateParams {
                 comment: Some("Nonempty review evidence".to_string()),
                 ..Default::default()
             },
+            None,
+            None,
         )
         .unwrap();
     let statuses = runtime.task_status_index().unwrap();

--- a/crates/orbit-web/src/api/tests/tasks.rs
+++ b/crates/orbit-web/src/api/tests/tasks.rs
@@ -1583,45 +1583,56 @@ async fn post_task(runtime: Arc<OrbitRuntime>, body: Value) -> Response {
         .expect("response")
 }
 
+/// [ORB-12245] The dashboard is an attributed operator surface, so its status
+/// edits obey the same lifecycle table as every other one: delivered work is
+/// not reopened from a PATCH, and completion still comes from `review`.
 #[tokio::test]
-async fn update_task_reopens_done_and_restores_archived_without_intermediate_statuses() {
+async fn update_task_refuses_to_fabricate_or_reopen_a_completion() {
     let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
-    let task = seed_backlog_task(&runtime, "Flexible API status");
+    let task = seed_backlog_task(&runtime, "Dashboard status governance");
 
-    let done = patch_task(runtime.clone(), &task.id, json!({ "status": "done" })).await;
-    assert_eq!(done.status(), StatusCode::OK);
-    assert_eq!(body_json(done).await["status"], json!("done"));
+    let skipped = patch_task(runtime.clone(), &task.id, json!({ "status": "done" })).await;
+    assert_eq!(skipped.status(), StatusCode::BAD_REQUEST);
+    assert!(
+        body_json(skipped).await["error"]
+            .as_str()
+            .expect("error message")
+            .contains("'done' is reachable only from 'review'")
+    );
 
-    let archived = patch_task(
-        runtime.clone(),
-        &task.id,
-        json!({ "status": "archived", "title": "Archived through PATCH" }),
-    )
-    .await;
-    assert_eq!(archived.status(), StatusCode::OK);
-    let archived = body_json(archived).await;
-    assert_eq!(archived["status"], json!("archived"));
-    assert_eq!(archived["title"], json!("Archived through PATCH"));
+    for (status, body) in [
+        (
+            "in-progress",
+            json!({ "status": "in-progress", "plan": "1) do it" }),
+        ),
+        (
+            "review",
+            json!({ "status": "review", "execution_summary": "did it" }),
+        ),
+        ("done", json!({ "status": "done" })),
+    ] {
+        let response = patch_task(runtime.clone(), &task.id, body).await;
+        assert_eq!(response.status(), StatusCode::OK, "{status}");
+        assert_eq!(body_json(response).await["status"], json!(status));
+    }
 
-    let restored = patch_task(
-        runtime.clone(),
-        &task.id,
-        json!({ "status": "in-progress" }),
-    )
-    .await;
-    assert_eq!(restored.status(), StatusCode::OK);
-    assert_eq!(body_json(restored).await["status"], json!("in-progress"));
+    let reopened = patch_task(runtime.clone(), &task.id, json!({ "status": "backlog" })).await;
+    assert_eq!(reopened.status(), StatusCode::BAD_REQUEST);
+    assert!(
+        body_json(reopened).await["error"]
+            .as_str()
+            .expect("error message")
+            .contains("regression_from")
+    );
 
     let fetched = body_json(request_shared(runtime, &format!("/tasks/{}", task.id)).await).await;
+    assert_eq!(fetched["status"], json!("done"));
     let history = fetched["history"].as_array().expect("history array");
     assert!(
         history
             .iter()
-            .any(|entry| { entry["from_status"] == "done" && entry["to_status"] == "archived" })
+            .any(|entry| { entry["from_status"] == "review" && entry["to_status"] == "done" })
     );
-    assert!(history.iter().any(|entry| {
-        entry["from_status"] == "archived" && entry["to_status"] == "in_progress"
-    }));
 }
 
 /// ORB-10648: `priority` is now a declared update field. It was undeclared

--- a/plugin/skills/orbit/SKILL.md
+++ b/plugin/skills/orbit/SKILL.md
@@ -46,19 +46,32 @@ If an activity already injected a task snapshot, use that envelope first.
 proposed → backlog → in-progress → review → done
          ↘ rejected
 
-someday → in-progress
-blocked → in-progress
-
-review      → rejected
-rejected    → backlog | in-progress  (reconsider)
+someday  → backlog | in-progress
+blocked  → backlog | in-progress
+review   → backlog | in-progress | rejected
+rejected → backlog | in-progress   (reconsider)
+any open status → blocked | archived
 ```
 
+Every status change goes through this table, whether you send it as
+`orbit.task.update` or as `task.start`/`task.approve`. Two rules are enforced
+and cannot be worked around from a tool call:
+
+- **`in-progress` needs a plan.** Starting from `proposed`, `someday`, or
+  `blocked` requires a non-empty execution plan; send it on the same call.
+- **`done` is reachable only from `review`,** and needs completion evidence:
+  a non-empty `execution_summary`, or a `job_run_id` whose run succeeded.
+
+`done` and `archived` are terminal, and a `rejected` task may only be
+reconsidered back to `backlog` or `in-progress`. A regression in delivered work
+is a *new* task with a `regression_from` relation — not a reopened one.
+
 Creating a task does not authorize dispatch or completion. Follow the user's
-approval and repository delivery policy. The diagram summarizes common paths;
-`task.start` also supports authorized pickup from `proposed` with a real plan.
-Use `blocked` when execution cannot safely continue. Provenance follows the
-surface: `orbit tool run ...` is agent-driven, bare `orbit task ...` is
-human-driven.
+approval and repository delivery policy. Use `blocked` when execution cannot
+safely continue. Provenance follows the surface: `orbit tool run ...` is
+agent-driven, bare `orbit task ...` is human-driven — and only a human on the
+bare CLI can override the table, with `orbit task update <id> --status <status>
+--force`, which records the override in task history.
 
 ## Common Mistakes — DO NOT
 

--- a/website/src/content/docs/concepts/tasks.md
+++ b/website/src/content/docs/concepts/tasks.md
@@ -62,21 +62,45 @@ defining one.
 | `backlog`     | Approved and queued for work. |
 | `someday`     | Future-scoped — wanted but not yet actionable. Agents skip `someday` tasks. |
 | `in-progress` | Actively being worked on. |
-| `review`      | Implementation complete; awaiting review/merge. Requires an `execution_summary`. |
-| `done`        | Accepted and closed. **Terminal** — no further transitions. |
+| `review`      | Implementation complete; awaiting review/merge. Completion out of `review` requires an `execution_summary` or a successful run. |
+| `done`        | Accepted and closed. **Terminal** — reopening needs an explicit human override. |
 | `blocked`     | Temporarily paused (waiting on a dependency or decision). |
-| `archived`    | Soft-deleted via the dedicated `orbit task archive` command. Restorable to `backlog` with `orbit task update <id> --status backlog`. |
+| `archived`    | Soft-deleted, with `orbit task archive` or a `--status archived` update. **Terminal** — restore it with `orbit task update <id> --status backlog --force`. |
 | `rejected`    | Declined. Can be re-opened to `backlog` or `in-progress`. |
 
 ### Transition rules
 
-Transitions are permissive by default — any move is allowed unless it violates one of these invariants:
+Every status change — `orbit task update`, the dashboard, and the
+`orbit.task.update` tool alike — is checked against one lifecycle table:
 
-1. **Done is terminal.** No transitions out of `done`.
-2. **Archived requires `orbit task archive`.** A bare `--status archived` update is rejected.
-3. **`in-progress → review` requires an `execution_summary`.**
+```text
+proposed → backlog → in-progress → review → done
+         ↘ rejected
+
+someday  → backlog | in-progress
+blocked  → backlog | in-progress
+review   → backlog | in-progress | rejected
+rejected → backlog | in-progress   (reconsider)
+any open status → blocked | archived
+```
+
+1. **Done is reachable only from `review`,** and needs completion evidence: a
+   non-empty `execution_summary`, or a `job_run_id` whose run succeeded. An
+   agent cannot mark unstarted work done.
+2. **`done` and `archived` are terminal.** A regression in delivered work is a
+   *new* task with a `regression_from` relation, not a reopened one. Only a
+   rejection may be reconsidered, back to `backlog` or `in-progress`.
+3. **`in-progress` requires a plan** when it is entered from `proposed`,
+   `someday`, or `blocked` — the same rule `orbit task start` enforces. Send
+   `--plan` on the same command.
 4. **Required tools freeze at execution admission.** They may be edited only
    before the task enters `in-progress`.
+
+A refused transition is an `invalid_input` error naming the from/to pair and
+the missing precondition. A human on the bare CLI can override the table with
+`orbit task update <id> --status <status> --force`, which records the change in
+the task's history as a `forced` event; the tool and MCP surfaces refuse a
+`force` argument outright.
 
 Friction reports use their own `orbit friction` surface and are not task
 statuses.

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -56,10 +56,10 @@ See [Delivery Workflows](../../getting-started/workflows/).
 | Command | Purpose |
 |---|---|
 | `orbit task add` | Create a task. `--title` and `--complexity` are required. |
-| `orbit task update <id>` | Update fields. `--approve` takes the next approval step (`proposed → backlog`, `review → done`). |
+| `orbit task update <id>` | Update fields. `--approve` takes the next approval step (`proposed → backlog`, `review → done`); `--status` follows the [lifecycle table](../../concepts/tasks/#transition-rules), and `--force` overrides it. |
 | `orbit task list` | List tasks. Status-neutral by default; filter with `--status`, `--tag`, `--path`, `--ready`, `--ref`. |
 | `orbit task show <id>` | Show one task, found by ID across registered workspaces. `--fields` projects specific fields. |
-| `orbit task archive <id>` | Archive a task. A bare `--status archived` update is refused. |
+| `orbit task archive <id>` | Archive a task from any status. Archived is terminal: restore with `task update <id> --status backlog --force`. |
 | `orbit task artifact` | Manage task artifact files. |
 | `orbit task lint` | Flag stale paths and vague acceptance criteria. |
 | `orbit task flow` | Filed-vs-closed rates over time — is the backlog draining? |


### PR DESCRIPTION
## Task

[ORB-12245](https://orbit-cli.com/tasks/ORB-12245) — `orbit.task.update` accepts any `status` value with no lifecycle guard: `proposed → done` and `done → proposed` both succeed

### Description

Reproduced over the Claude Desktop MCP connection and the CLI tool surface on 0.21.0 (ws_nebula, DANI-10330):

    orbit_task_update {workspace:"ws_nebula", id:"DANI-10330", status:"done", model:"claude"}
    → 200, history gains {event:"status_changed", from:"proposed", to:"done"}; plan "", execution_summary "", job_run_id null
    orbit_task_update {…, status:"proposed"}
    → 200, history gains {from:"done", to:"proposed"}

By contrast `orbit.task.start` on the same task correctly refused: `task 'DANI-10330' requires a non-empty execution plan before transitioning to in-progress`. And the pipeline's `task_complete`/`pr_complete` activities describe a *guarded* `review -> done` transition. So the guard exists for the paths Orbit itself uses, but the general-purpose `update` is a free setter that lets any agent (or a stray prompt) mark work done without a run, a summary, or a review.

The skill's lifecycle diagram (`references/orbit` SKILL.md) is:

    proposed → backlog → in-progress → review → done ; ↘ rejected
    someday → in-progress ; blocked → in-progress ; review → rejected ; rejected → backlog | in-progress

## What to change

In `crates/orbit-core/src/application/task/transitions.rs` (or wherever `task.start`'s plan guard lives) make `orbit.task.update` route `status` changes through the same transition table:

- Allowed edges as in the diagram, plus `* → blocked` (an executor must be able to block from anywhere) and `blocked → backlog`.
- `→ in-progress` requires a non-empty plan (same rule as `task.start`).
- `→ done` is only reachable from `review`, and requires a non-empty `execution_summary` **or** a `job_run_id` whose run is terminal-success. Human operators keep an escape hatch: `orbit task update <id> --status done --force` (bare CLI only, recorded in history as `forced`), never the registered tool.
- `done/rejected/archived → anything` is refused except `rejected → backlog|in-progress` (reconsider) — reopening a done task means filing a new one with a `regression_from` relation.
- Refusals are `invalid_input` with the from/to pair and the missing precondition in the message.
- `proposal_approved` (`task.approve`) is unchanged.

Update `crates/orbit-core/assets/skills/orbit/SKILL.md` lifecycle text if any edge above differs from what it shows. Existing pipelines must not regress: run the workflow integration tests that drive `pr_promote`, `pr_complete`, `task_complete`, triage re-backlog and the auto-drain.

### Acceptance Criteria

- `orbit.task.update` with `status:"done"` on a `proposed` or `backlog` task is refused with `invalid_input` naming the missing precondition
- `orbit.task.update` with `status:"in-progress"` and an empty plan is refused exactly like `task.start`
- `done → proposed/backlog/in-progress` via `task.update` is refused; `rejected → backlog|in-progress` still works
- Bare-CLI `--force` path exists for done, is refused over the registered tool/MCP, and records `forced` in history
- Workflow integration tests for promote/complete/triage/auto-drain pass unchanged; new unit tests cover every refused edge

## Execution Summary

<details>
<summary>Click to expand</summary>

Lifecycle guard for every attributed status change.

WHAT CHANGED
- New `crates/orbit-core/src/application/task/lifecycle.rs` owns the transition table (`task_status_transition_allowed`), the completion-evidence rule, the plan precondition, and the `forced` status event. `ensure_task_has_execution_plan` / `in_progress_transition_requires_plan` moved here from `transitions.rs` (which was already ~845 lines), so `task.start`, the automation host, and `task.update` share one spelling of the rules.
- `application/task/update.rs` carries a `StatusAuthority` on the update context: `Lifecycle` for `update_task_with_identity` (CLI, dashboard) and `update_task_with_owner` (registered tool / MCP); `Forced` for the new `force_update_task_with_identity`; `Internal` for `update_task`, which is now `pub(crate)` so no crate outside Core can set a status without passing the table. Internal callers keep their own transitions: `archive_task`, the review gate, and the pipeline's `update_task_from_activity` / `apply_task_automation_update` (both already compare-and-set on the status they observed).
- Table: `proposed → backlog|someday|in-progress|rejected`; `backlog → proposed|someday|in-progress|rejected`; `someday → backlog|in-progress|rejected`; `in-progress → backlog|someday|review|rejected`; `review → backlog|in-progress|done|rejected`; `blocked → backlog|in-progress`; `rejected → backlog|in-progress`; any open status → `blocked` or `archived`; `done`/`archived` terminal. `→ in-progress` requires a plan exactly as `task.start` does (same helper, identical message, same backlog/in-progress exemption). `→ done` additionally requires a non-empty execution summary or a `job_run_id` whose run is `Success`; both may arrive on the same write. Refusals are `invalid_input` naming the from/to pair and the missing precondition.
- `orbit task update --force` (requires `--status`, conflicts with `--approve`) applies a refused transition and records history event `forced` with from/to. Both agent surfaces — the `orbit.task.update` tool schema handler and the tool host — reject a `force` argument with an explicit message; the schema never advertises it.
- Docs updated with the behaviour: skill `SKILL.md` lifecycle section (+ its `plugin/skills/orbit` mirror, regenerated with `scripts/sync-plugin-skills.sh`), `website/.../concepts/tasks.md` (its "transitions are permissive" rules section described guards that did not exist), `website/.../reference/cli.md`, and `task archive`'s after-help (restore is now `--force`).

CRITERIA
1. done from proposed/backlog — refused, `task '<id>' cannot move from 'proposed' to 'done': 'done' is reachable only from 'review'` (tests: `lifecycle::done_is_unreachable_from_proposed_and_backlog`, tool-host `task_update_tool_enforces_the_lifecycle_and_refuses_force`, dashboard `update_task_refuses_to_fabricate_or_reopen_a_completion`, CLI `update_status_refuses_completion_without_review_and_evidence`).
2. in-progress with an empty plan — refused; the test asserts the message is byte-identical to `task.start`'s (`lifecycle::in_progress_requires_a_plan_exactly_like_task_start`).
3. done → proposed/backlog/in-progress refused with the `regression_from` guidance; rejected → backlog|in-progress still works (`lifecycle::terminal_statuses_stay_closed_while_a_rejection_can_be_reconsidered`, CLI `update_status_reopens_terminal_tasks_only_with_an_explicit_force`).
4. `--force` exists on the bare CLI, is refused over tool and MCP, and records `forced` (`lifecycle::forcing_a_refused_transition_records_the_override_in_history`, `forcing_a_legal_transition_still_records_it_as_an_override`, orbit-tools `schema_omits_and_handler_rejects_force`, tool-host test above, CLI force tests).
5. Full matrix test asserts write-iff-allowed over all 9x9 pairs on the guarded surface, checks invalid_input, the named pair, and that a refused edge is not written. Workflow suites unchanged and green: orbit-engine (693+8, incl. pr_promote/pr_complete/task_complete), orbit-core job/operation/triage/workspace-auto (auto-drain) suites.

VALIDATION (run in this worktree)
- PASSED `make ci-fast`, `make ci-lint`, `make goldens` (help/output/MCP snapshots unchanged — task help is not a golden).
- PASSED `cargo test -p orbit-engine` (693/6/1/1), `cargo test -p orbit-cli` (all targets), `cargo test -p orbit-core --test relation_auto_close` (10/10).
- PASSED with pre-existing failures only: `cargo test -p orbit-core --lib` 1481 passed / 6 failed; `-p orbit-web` 381/6; `-p orbit-tools --lib` 140/1. Every one of those 13 failures was reproduced on a pristine HEAD (36a8a30f7) tree extracted with `git archive` and is unrelated to this change: strict `orbit.task.add` unknown-field rejection and agent/model canonicalization (`task_add_tool_ignores_retired_*`, `task_update_tool_rejects_unresolved_source_task_id_atomically`, `activity_update_comment_records_comment_as_system`, `update_task_automation_records_status_history_as_system`, `artifact_put_reads_relative_source_and_delegates_to_task_update`, the six orbit-web comment/model-provenance tests).
- NOT RUN: full `make ci` (workspace policy: CI is the merge gate); website build (no source changed beyond Markdown copy).

TESTS ADJUSTED (they asserted the removed free-setter behaviour, or seeded through it)
- `application/task/tests/update.rs`: dropped `explicit_update_allows_the_complete_status_transition_matrix` (replaced by the guarded matrix in `tests/lifecycle.rs`); the reopen-evidence test now exercises `--force`; the manual-edit test now drives a legal path.
- orbit-web `update_task_reopens_done_and_restores_archived_without_intermediate_statuses` → `update_task_refuses_to_fabricate_or_reopen_a_completion` (the dashboard is a governed surface and has no override).
- CLI `task_trimmed_surface` reopen/restore tests now assert refusal + forced override; `task_list`'s status-seeding helper passes `--force`; `relation_auto_close` fixtures move backlog → review before completing (their subject is friction auto-resolve, not the lifecycle).

SCOPE ADDITIONS (appended to context_files, with reasons)
- `lifecycle.rs` + `tests/lifecycle.rs` — new files (required declaration).
- `application/task/update.rs` — the enforcement point; the guard cannot live in `transitions.rs` alone because `update` is the write path.
- `cli/command/task/archive.rs`, `website/.../concepts/tasks.md`, `website/.../reference/cli.md`, `plugin/skills/orbit/SKILL.md` — consumer docs that described the old (or aspirational) rules and would otherwise be stale.

DEVIATION / RISK
- The description asked for `blocked → backlog` and `* → blocked`; the table also allows `any open status → archived` so the dashboard's status dropdown and `task update --status archived` keep working alongside `orbit task archive`. Two website statements claiming a bare `--status archived` was already refused were corrected rather than implemented, since refusing it would break the dashboard control.
- `archived` is terminal per the description, so restoring one now needs `--force` on the bare CLI; the `task archive` after-help and website docs say so. The dashboard cannot restore an archived task or reopen a done one — that is the intended governance outcome (file a new task with `regression_from`).
- `update_task` became `pub(crate)`; three orbit-web tests that used it now call `update_task_with_identity`. No production code outside Core called it.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12245-6aa4e0d7`
- Behind base: 0
- Ahead of base: 1