### PR TITLE
[BLOCKED] [code-review] `neutralize_inner_sandbox`'s doc comment was orphaned onto `apply_trusted_host_provider_sandbox`, describing the opposite behavior

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/argv.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/argv.rs
@@ -71,10 +71,6 @@ pub(super) fn try_audit_argv_for_dispatch(
     }
 }
 
-/// Pin codex's `--sandbox` to `danger-full-access`, drop gemini's `-s` /
-/// `--sandbox` toggle, and drop grok's `--sandbox <profile>` value so the
-/// inner CLI sandbox does not double-encode the outer orbit-exec sandbox.
-/// Claude has no native sandbox flag — nothing to neutralize.
 /// Apply a trusted-host `provider_sandbox` label to the provider CLI config.
 ///
 /// Codex is the only provider whose inner sandbox is a dynamic `--sandbox`
@@ -96,6 +92,10 @@ pub(super) fn apply_trusted_host_provider_sandbox(
     }
 }
 
+/// Pin codex's `--sandbox` to `danger-full-access`, drop gemini's `-s` /
+/// `--sandbox` toggle, and drop grok's `--sandbox <profile>` value so the
+/// inner CLI sandbox does not double-encode the outer orbit-exec sandbox.
+/// Claude has no native sandbox flag — nothing to neutralize.
 pub(super) fn neutralize_inner_sandbox(
     provider: &str,
     provider_config: &mut HashMap<String, String>,


### PR DESCRIPTION
## Delivery failure handoff

Orbit preserved and pushed this task's candidate after the shipment pipeline failed. This PR is intentionally blocked; inspect the recorded failure before retrying delivery.

- Task: `ORB-12277`
- Run: `jrun-20260912-0614-c2`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `b30ef98f7c9620453fd649c7baa3a14d76dcdc60`
- Target base: `b30ef98f7c9620453fd649c7baa3a14d76dcdc60`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess reported declared envelope status="failed" despite exit 0: error.code=orbit_task_update_unavailable; error.message=Required execution summary could not be persisted because /home/daniel/.orbit/.workspaces.json.lock is on a read-only filesystem.
```