### PR TITLE
Restore managed workspace resolution with a read-only global registry

### DIFF
--- a/crates/orbit-cmd/src/registry_runtime.rs
+++ b/crates/orbit-cmd/src/registry_runtime.rs
@@ -199,13 +199,7 @@ impl RegisteredRuntimeFactory {
         selector: &str,
     ) -> Result<ResolvedWorkspaceSelection, OrbitError> {
         let registry_path = workspace_registry::registry_path_for(global_root);
-        let registry = workspace_registry::with_registry_lock(&registry_path, || {
-            let mut registry = workspace_registry::load_registry_from(&registry_path)?;
-            if workspace_registry::validate_workspaces(&mut registry) {
-                let _ = workspace_registry::save_registry_to(&registry, &registry_path);
-            }
-            Ok(registry)
-        })?;
+        let registry = load_registry_for_selector_resolution(&registry_path)?;
         let (workspace, checkout) = resolve_cli_workspace_binding(&registry, selector)?;
         if workspace.status != WorkspaceStatus::Active {
             return Err(inactive_cli_workspace(workspace, checkout));
@@ -343,13 +337,7 @@ impl RegisteredRuntimeFactory {
         };
         let global_root = runtime.global_root();
         let registry_path = workspace_registry::registry_path_for(&global_root);
-        let registry = workspace_registry::with_registry_lock(&registry_path, || {
-            let mut registry = workspace_registry::load_registry_from(&registry_path)?;
-            if workspace_registry::validate_workspaces(&mut registry) {
-                let _ = workspace_registry::save_registry_to(&registry, &registry_path);
-            }
-            Ok(registry)
-        })?;
+        let registry = load_registry_for_selector_resolution(&registry_path)?;
         match resolve_cli_workspace_target(&registry, runtime, &selector)? {
             CliWorkspaceTarget::CurrentRuntime => Ok(None),
             CliWorkspaceTarget::Checkout {
@@ -370,6 +358,28 @@ impl RegisteredRuntimeFactory {
             }
         }
     }
+}
+
+/// Read the common no-maintenance case without taking a write lock. If the
+/// snapshot needs migration or checkout validation, re-read it under the lock
+/// so a concurrent registration cannot be overwritten by the maintenance save.
+fn load_registry_for_selector_resolution(
+    registry_path: &Path,
+) -> Result<WorkspaceRegistry, OrbitError> {
+    let loaded = workspace_registry::load_registry_from_read_only(registry_path)?;
+    let mut registry = loaded.registry;
+    let validation_required = workspace_registry::validate_workspaces(&mut registry);
+    if !loaded.migration_required && !validation_required {
+        return Ok(registry);
+    }
+
+    workspace_registry::with_registry_lock(registry_path, || {
+        let mut registry = workspace_registry::load_registry_from(registry_path)?;
+        if workspace_registry::validate_workspaces(&mut registry) {
+            let _ = workspace_registry::save_registry_to(&registry, registry_path);
+        }
+        Ok(registry)
+    })
 }
 
 /// The host data directory a registry lookup reads: the `--root` override when

--- a/crates/orbit-cmd/src/tests/registry_runtime.rs
+++ b/crates/orbit-cmd/src/tests/registry_runtime.rs
@@ -507,6 +507,209 @@ fn workspace_registered_during_selector_resolution_survives_validation_save() {
     );
 }
 
+/// Managed MCP calls and registered CLI tools both enter through these two
+/// resolver seams. Run them as an unprivileged child so directory modes enforce
+/// the same no-lock-file boundary as a read-only registry mount; the parent test
+/// process may be root and would otherwise bypass ordinary permission bits.
+#[cfg(unix)]
+#[test]
+fn read_only_global_registry_supports_mcp_and_cli_workspace_bindings() {
+    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::process::CommandExt;
+
+    const CHILD_MARKER: &str = "ORBIT_TEST_READ_ONLY_SELECTOR_CHILD";
+    const GLOBAL_ROOT: &str = "ORBIT_TEST_READ_ONLY_SELECTOR_GLOBAL";
+    const ROOT: &str = "ORBIT_TEST_READ_ONLY_SELECTOR_ROOT";
+    const TASK_ID: &str = "ORBIT_TEST_READ_ONLY_SELECTOR_TASK";
+
+    if std::env::var_os(CHILD_MARKER).is_some() {
+        let root = PathBuf::from(std::env::var(ROOT).expect("fixture root"));
+        let global = PathBuf::from(std::env::var(GLOBAL_ROOT).expect("global root"));
+        let task_id = std::env::var(TASK_ID).expect("task id");
+        let lock_path = global.join(".workspaces.json.lock");
+        let lock_error = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .expect_err("read-only registry root must reject the original lock open");
+        assert!(
+            matches!(
+                lock_error.kind(),
+                std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::ReadOnlyFilesystem
+            ),
+            "unexpected lock error: {lock_error}"
+        );
+
+        let selected = RegisteredRuntimeFactory::resolve_workspace_selector(&global, "ws_beta")
+            .expect("explicit MCP selector must be observational");
+        let beta = RegisteredRuntimeFactory::open_registered_checkout(
+            &global,
+            &selected.workspace,
+            &selected.checkout,
+        )
+        .expect("open MCP-selected workspace");
+        run_tool(
+            &beta,
+            "orbit.task.update",
+            json!({
+                "id": task_id,
+                "workspace": selected.checkout.repo_root,
+                "plan": "Updated after explicit MCP workspace resolution."
+            }),
+        )
+        .expect("MCP-selected runtime must reach writable assigned task state");
+
+        let alpha =
+            RegisteredRuntimeFactory::initialize_with_overrides(Some(&global), Some("ws_alpha"))
+                .expect("open initial CLI runtime");
+        execute_cli_tool(
+            &alpha,
+            "orbit.task.update",
+            json!({
+                "id": task_id,
+                "workspace": "ws_beta",
+                "plan": "Updated after registered CLI workspace binding."
+            }),
+        )
+        .expect("CLI-bound runtime must reach writable assigned task state");
+
+        for selector in ["ws_inactive", "ws_unknown"] {
+            let error = RegisteredRuntimeFactory::resolve_workspace_selector(&global, selector)
+                .expect_err("inactive and unknown MCP selectors must fail closed");
+            assert!(
+                error.to_string().contains(selector),
+                "selector must be named: {error}"
+            );
+
+            let mut input = json!({"workspace": selector});
+            let error = match RegisteredRuntimeFactory::bind_cli_tool_workspace(&alpha, &mut input)
+            {
+                Ok(_) => panic!("inactive and unknown CLI selectors must fail closed"),
+                Err(error) => error,
+            };
+            assert!(
+                error.to_string().contains(selector),
+                "selector must be named: {error}"
+            );
+        }
+
+        assert!(
+            !lock_path.exists(),
+            "unchanged-registry resolution must not create the global lock file"
+        );
+        assert!(root.join("beta/.orbit").is_dir());
+        return;
+    }
+
+    let root = tempfile::tempdir().expect("root");
+    let global = root.path().join("global");
+    std::fs::create_dir_all(&global).expect("global root");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_read_only\"\nhost_id = \"read-only\"\ntask_prefix = \"ORB\"\n",
+    )
+    .expect("host identity");
+
+    let (alpha_workspace, alpha_checkout) =
+        registered_workspace(root.path(), "ws_alpha", "alpha", "hm_read_only");
+    let (beta_workspace, beta_checkout) =
+        registered_workspace(root.path(), "ws_beta", "beta", "hm_read_only");
+    let (mut inactive_workspace, inactive_checkout) =
+        registered_workspace(root.path(), "ws_inactive", "inactive", "hm_read_only");
+    inactive_workspace.status = WorkspaceStatus::Invalid;
+    save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![
+                alpha_workspace.clone(),
+                beta_workspace.clone(),
+                inactive_workspace,
+            ],
+            checkouts: vec![
+                alpha_checkout.clone(),
+                beta_checkout.clone(),
+                inactive_checkout,
+            ],
+            ..Default::default()
+        },
+        &registry_path_for(&global),
+    )
+    .expect("workspace registry");
+
+    let beta = RegisteredRuntimeFactory::open_registered_checkout(
+        &global,
+        &beta_workspace,
+        &beta_checkout,
+    )
+    .expect("seed beta runtime");
+    let created = run_tool(
+        &beta,
+        "orbit.task.add",
+        json!({
+            "title": "Read-only registry routing task",
+            "description": "The assigned task state remains writable.",
+            "complexity": "low",
+            "workspace": beta_checkout.repo_root
+        }),
+    )
+    .expect("seed assigned task");
+    let task_id = created["id"].as_str().expect("created task id");
+
+    fn make_writable(path: &Path) {
+        let metadata = std::fs::metadata(path).expect("fixture metadata");
+        let mode = if metadata.is_dir() { 0o777 } else { 0o666 };
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+            .expect("make assigned state writable");
+        if metadata.is_dir() {
+            for entry in std::fs::read_dir(path).expect("fixture directory") {
+                make_writable(&entry.expect("fixture entry").path());
+            }
+        }
+    }
+
+    make_writable(&global.join("tasks"));
+    for checkout in [&alpha_checkout, &beta_checkout] {
+        make_writable(&checkout.repo_root);
+    }
+    std::fs::set_permissions(root.path(), std::fs::Permissions::from_mode(0o755))
+        .expect("make fixture root traversable");
+    std::fs::set_permissions(
+        global.join("workspaces.json"),
+        std::fs::Permissions::from_mode(0o444),
+    )
+    .expect("make registry file read-only");
+    std::fs::set_permissions(
+        global.join("host.toml"),
+        std::fs::Permissions::from_mode(0o444),
+    )
+    .expect("make host identity read-only");
+    std::fs::set_permissions(&global, std::fs::Permissions::from_mode(0o555))
+        .expect("make registry root read-only");
+
+    let mut command = std::process::Command::new(std::env::current_exe().expect("test binary"));
+    orbit_common::test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
+    command
+        .arg("read_only_global_registry_supports_mcp_and_cli_workspace_bindings")
+        .arg("--exact")
+        .env(CHILD_MARKER, "1")
+        .env(ROOT, root.path())
+        .env(GLOBAL_ROOT, &global)
+        .env(TASK_ID, task_id);
+    // SAFETY: `geteuid` reads process credentials and has no preconditions.
+    if unsafe { libc::geteuid() } == 0 {
+        command.gid(65_534).uid(65_534);
+    }
+    let output = command.output().expect("run unprivileged selector test");
+    assert!(
+        output.status.success(),
+        "read-only selector child failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[test]
 fn bootstrap_hint_stays_within_its_registered_git_repository() {
     let root = tempfile::tempdir().expect("root");

--- a/crates/orbit-registry/src/tests/workspace_registry.rs
+++ b/crates/orbit-registry/src/tests/workspace_registry.rs
@@ -12,9 +12,10 @@ use tempfile::tempdir;
 
 use crate::workspace_registry::{
     assign_checkout_role, find_checkout_by_path, find_workspace, find_workspace_by_id,
-    find_workspace_by_path, load_registry_from, load_registry_from_with_writer, register_checkout,
-    remove_workspace, rename_local_owner_host_id, resolve_logical_workspace, save_registry_to,
-    set_path_override, validate_workspaces, with_registry_lock,
+    find_workspace_by_path, load_registry_from, load_registry_from_read_only,
+    load_registry_from_with_writer, register_checkout, remove_workspace,
+    rename_local_owner_host_id, resolve_logical_workspace, save_registry_to, set_path_override,
+    validate_workspaces, with_registry_lock,
 };
 
 fn timestamp() -> chrono::DateTime<Utc> {
@@ -124,6 +125,50 @@ fn legacy_registry_migrates_to_path_free_catalog_and_is_byte_stable() {
     let second = load_registry_from(&path).expect("load migrated registry again");
     assert_eq!(second, migrated);
     assert_eq!(fs::read(&path).expect("read second migration"), first_bytes);
+}
+
+#[test]
+fn read_only_load_reports_legacy_migration_without_writing() {
+    let root = tempdir().expect("tempdir");
+    let path = root.path().join("workspaces.json");
+    let original = write_json(
+        &path,
+        &json!({
+            "workspaces": [{
+                "id": "ws_orbit",
+                "name": "orbit",
+                "root": "/repos/orbit",
+                "orbit_dir": "/repos/orbit/.orbit",
+                "git_remote": null,
+                "base_branch": "main",
+                "status": "active",
+                "created_at": "2026-07-18T01:02:03Z",
+                "updated_at": "2026-07-18T01:02:03Z"
+            }],
+            "path_overrides": {}
+        }),
+    );
+
+    let loaded = load_registry_from_read_only(&path).expect("inspect legacy registry");
+
+    assert!(loaded.migration_required);
+    assert_eq!(loaded.registry.workspaces[0].id, "ws_orbit");
+    assert_eq!(loaded.registry.checkouts[0].workspace_id, "ws_orbit");
+    assert_eq!(fs::read(&path).expect("read unchanged registry"), original);
+}
+
+#[test]
+fn read_only_load_reports_current_registry_without_maintenance() {
+    let root = tempdir().expect("tempdir");
+    let path = root.path().join("workspaces.json");
+    save_registry_to(&WorkspaceRegistry::default(), &path).expect("write current registry");
+    let original = fs::read(&path).expect("snapshot current registry");
+
+    let loaded = load_registry_from_read_only(&path).expect("inspect current registry");
+
+    assert!(!loaded.migration_required);
+    assert_eq!(loaded.registry, WorkspaceRegistry::default());
+    assert_eq!(fs::read(&path).expect("read unchanged registry"), original);
 }
 
 #[test]

--- a/crates/orbit-registry/src/workspace_registry/io.rs
+++ b/crates/orbit-registry/src/workspace_registry/io.rs
@@ -11,6 +11,13 @@ use crate::{HostIdentityState, inspect_host_identity};
 
 const REGISTRY_FILE_NAME: &str = "workspaces.json";
 
+/// A validated registry snapshot that has not performed any maintenance write.
+#[derive(Debug)]
+pub struct ReadOnlyRegistryLoad {
+    pub registry: WorkspaceRegistry,
+    pub migration_required: bool,
+}
+
 /// Return the path to the machine-global workspace registry.
 pub fn registry_path() -> Result<PathBuf, OrbitError> {
     Ok(registry_path_for(&global_orbit_dir()?))
@@ -54,22 +61,39 @@ pub fn load_registry_from(path: &Path) -> Result<WorkspaceRegistry, OrbitError> 
     load_registry_from_with_writer(path, write_registry)
 }
 
+/// Load and validate a registry without creating a lock or persisting migrations.
+///
+/// Callers that only inspect current registry data can use the returned snapshot
+/// directly. A caller that sees `migration_required` must re-read and migrate
+/// while holding [`with_registry_lock`] before it performs maintenance.
+pub fn load_registry_from_read_only(path: &Path) -> Result<ReadOnlyRegistryLoad, OrbitError> {
+    let path = validated_registry_path(path)?;
+    if !path.exists() {
+        return Ok(ReadOnlyRegistryLoad {
+            registry: WorkspaceRegistry::default(),
+            migration_required: false,
+        });
+    }
+    let content =
+        std::fs::read_to_string(&path).map_err(|error| OrbitError::Io(error.to_string()))?;
+    let context = registry_host_context(&path)?;
+    let (registry, migration_required) = parse_workspace_registry(&content, &context)?;
+    Ok(ReadOnlyRegistryLoad {
+        registry,
+        migration_required,
+    })
+}
+
 pub(crate) fn load_registry_from_with_writer(
     path: &Path,
     writer: impl FnOnce(&WorkspaceRegistry, &Path) -> Result<(), OrbitError>,
 ) -> Result<WorkspaceRegistry, OrbitError> {
     let path = validated_registry_path(path)?;
-    if !path.exists() {
-        return Ok(WorkspaceRegistry::default());
+    let loaded = load_registry_from_read_only(&path)?;
+    if loaded.migration_required {
+        writer(&loaded.registry, &path)?;
     }
-    let content =
-        std::fs::read_to_string(&path).map_err(|error| OrbitError::Io(error.to_string()))?;
-    let context = registry_host_context(&path)?;
-    let (registry, migrated) = parse_workspace_registry(&content, &context)?;
-    if migrated {
-        writer(&registry, &path)?;
-    }
-    Ok(registry)
+    Ok(loaded.registry)
 }
 
 /// Save the machine-global workspace registry atomically.

--- a/crates/orbit-registry/src/workspace_registry/mod.rs
+++ b/crates/orbit-registry/src/workspace_registry/mod.rs
@@ -13,8 +13,9 @@ pub use catalog::{
     validate_workspace_registry, validate_workspaces,
 };
 pub use io::{
-    global_orbit_dir, load_registry, load_registry_from, registry_path, registry_path_for,
-    save_registry, save_registry_to, with_registry_lock,
+    ReadOnlyRegistryLoad, global_orbit_dir, load_registry, load_registry_from,
+    load_registry_from_read_only, registry_path, registry_path_for, save_registry,
+    save_registry_to, with_registry_lock,
 };
 pub use publication::{
     bind_publication, bind_publication_by_id, find_publication_binding,


### PR DESCRIPTION
## Task

[ORB-12283](https://orbit-cli.com/tasks/ORB-12283) — Restore managed workspace resolution with a read-only global registry

### Description

ORB-12237 failed before implementation in ws_orbit/jrun-20260912-0612-c2 at 2026-09-12T06:13:47Z: explicit ws_orbit MCP task.update/friction.add and registered CLI fallback could not open ~/.orbit/.workspaces.json.lock (EROFS). No-selector task.show and workspace.list succeeded. Installed orbit 0.21.0, mtime 06:01:13 UTC; exact installed source unverified.

Verified source: ORB-12240 / PR #2012 / 0e157a4ae introduced unconditional with_registry_lock around RegisteredRuntimeFactory::resolve_workspace_selector and bind_cli_tool_workspace (crates/orbit-cmd/src/registry_runtime.rs:202,346), before loading/validating unchanged registry. MCP explicit selection calls this from crates/orbit-cli/src/command/mcp/server.rs:366. Managed workers correctly mount global registry read-only. Restore read-only unchanged-registry resolution while preserving synchronized real maintenance/migrations, fail-closed active-workspace routing and concurrent registration preservation. Do not widen sandbox, grant registry writes, remove locking around actual writes, use fallback stores or weaken ORB-12240's concurrency test. Cover relevant converted entry points.

Bootstrap: root orchestrator will prefill plan using authoritative MCP. Worker uses injected task snapshot and assigned worktree; if its durable bookkeeping fails with this known bug, report denial and continue already-authorized implementation without bypassing permissions. Host pipeline/orchestrator owns lifecycle writes; return complete implementation and test evidence in result envelope. No nested dispatch.

Operator handoff: install during safe quiescence and verify real managed explicit ws_orbit bookkeeping before retrying ORB-12237. Leaf owns isolated tests, not production deploy.

### Acceptance Criteria

- Both explicit MCP and registered CLI tool binding resolve an active registered workspace with read-only global registry and reach writable assigned task state without unnecessary global write locks.
- Isolated regression tests exercise actual read-only filesystem constraints and detect the original EROFS in both paths.
- Actual maintenance remains atomic, preserves concurrent registrations, and passes the existing ORB-12240 concurrency regression.
- Inactive and unknown selectors fail closed; no sandbox widening or fallback store.
- Focused tests and make ci-fast, make ci-lint, make goldens pass; precise managed-canary/deployment handoff recorded.

## Execution Summary

<details>
<summary>Click to expand</summary>

Execution summary derived by Orbit for ORB-12283 from the change delivered by run jrun-20260912-0630-c2; no execution summary was persisted by the implementing agent.

Changed files (5):
- modified: crates/orbit-cmd/src/registry_runtime.rs
- modified: crates/orbit-cmd/src/tests/registry_runtime.rs
- modified: crates/orbit-registry/src/tests/workspace_registry.rs
- modified: crates/orbit-registry/src/workspace_registry/io.rs
- modified: crates/orbit-registry/src/workspace_registry/mod.rs

This restates the worktree change the delivery commit contains and asserts nothing beyond it. Re-check it with `git show --stat` on the delivery commit.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12283-6aa4f16c`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra