### PR TITLE
[ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
@@ -894,8 +894,8 @@ fn apply_task_automation_update_under_lock(
     if update.status == Some(TaskStatus::Done) && existing_task.status != TaskStatus::Done {
         runtime.ensure_resolves_are_workspace_local(&existing_task)?;
     }
-    let (agent, model) = runtime
-        .try_canonical_agent_model_identity(update.agent.as_deref(), update.model.as_deref())?;
+    let (agent, model) =
+        crate::context::trusted_write_identity(update.agent.as_deref(), update.model.as_deref());
     let runtime_model_identity = <OrbitRuntime as RuntimeHost>::actor_model_identity(runtime);
     let attribution = assemble_task_attribution(
         &existing_task,

--- a/crates/orbit-core/src/adapter/tool_execution.rs
+++ b/crates/orbit-core/src/adapter/tool_execution.rs
@@ -13,6 +13,21 @@ impl OrbitRuntime {
         self.run_tool_with_role(name, input, Role::Admin)
     }
 
+    /// Run a registered tool for a human-operated in-process adapter.
+    /// The trusted label lives in `ToolContext`, never in agent-controlled
+    /// input, so the ordinary public tool path remains family-validated.
+    pub fn run_tool_as_human(&self, name: &str, input: Value) -> Result<Value, OrbitError> {
+        self.run_tool_with_context_and_role(
+            name,
+            input,
+            Role::Admin,
+            ToolContext {
+                trusted_actor_label: Some("human".to_string()),
+                ..Default::default()
+            },
+        )
+    }
+
     pub(crate) fn run_tool_with_role(
         &self,
         name: &str,

--- a/crates/orbit-core/src/adapter/tool_host/host.rs
+++ b/crates/orbit-core/src/adapter/tool_host/host.rs
@@ -69,6 +69,27 @@ impl OrbitToolHost for RuntimeOrbitToolHost {
     fn task_scope(&self) -> OrbitTaskScope {
         self.task_scope.clone()
     }
+
+    fn execute_with_trusted_actor(
+        &self,
+        action: OrbitBuiltinAction,
+        input: Value,
+        actor_label: String,
+        reservation_owner: Option<ReservationOwnerContext>,
+    ) -> Result<Value, OrbitError> {
+        super::dispatch::execute(
+            &self.runtime,
+            &self.task_scope,
+            super::dispatch::ToolCaller {
+                session_context: &self.session_context,
+                agent: None,
+                model: Some(actor_label),
+                reservation_owner,
+            },
+            action,
+            input,
+        )
+    }
 }
 
 fn trusted_env_run_id() -> Option<String> {

--- a/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
@@ -337,7 +337,7 @@ fn mcp_task_add_uses_session_workspace_from_worktree_cwd() {
 }
 
 #[test]
-fn task_add_tool_rejects_dropped_task_types_and_ignores_retired_status() {
+fn task_add_tool_rejects_dropped_task_types_and_retired_status() {
     let (_root, runtime, _repo_root) = test_runtime();
 
     for dropped_type in ["task", "epic", "issue", "friction"] {
@@ -360,26 +360,20 @@ fn task_add_tool_rejects_dropped_task_types_and_ignores_retired_status() {
         );
     }
 
-    // ORB-00255 retired `status` from the `orbit.task.add` schema; an input
-    // value is silently stripped and the task lands as `proposed`.
-    let output = runtime
-        .execute_tool_command(
-            "orbit.task.add",
-            json!({
-                "title": "Retired task-add status",
-                "description": "Should ignore retired task-add status.",
-                "complexity": "low",
-                "workspace": ".",
-                "status": "done",
-            }),
-            Some("codex".to_string()),
-            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
-        )
-        .expect("retired status field is ignored");
-    assert_eq!(
-        output.get("status").and_then(Value::as_str),
-        Some("proposed")
-    );
+    let message = invalid_input_message(runtime.execute_tool_command(
+        "orbit.task.add",
+        json!({
+            "title": "Retired task-add status",
+            "description": "Should ignore retired task-add status.",
+            "complexity": "low",
+            "workspace": ".",
+            "status": "done",
+        }),
+        Some("codex".to_string()),
+        Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+    ));
+    assert!(message.contains("status"), "{message}");
+    assert!(message.contains("orbit.task.update"), "{message}");
 }
 
 #[test]
@@ -594,9 +588,7 @@ fn task_delete_tool_allows_forced_protected_statuses() {
 }
 
 #[test]
-fn task_add_tool_ignores_retired_dependencies() {
-    // ORB-00255 retired `dependencies` from the `orbit.task.add` schema; any
-    // value supplied is silently stripped before persistence.
+fn task_add_tool_rejects_retired_dependencies() {
     let (_root, runtime, repo_root) = test_runtime();
     let dependency = create_task(
         &runtime,
@@ -607,22 +599,20 @@ fn task_add_tool_ignores_retired_dependencies() {
         &[],
     );
 
-    let output = runtime
-        .execute_tool_command(
-            "orbit.task.add",
-            json!({
-                "title": "Dependent task from tool",
-                "description": "Exercise dependency input on the agent-facing task creation path.",
-                "complexity": "low",
-                "workspace": ".",
-                "dependencies": [dependency.id.clone()],
-            }),
-            Some("codex".to_string()),
-            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
-        )
-        .expect("task add tool succeeds");
-
-    assert_eq!(output.get("dependencies"), Some(&json!([])));
+    let message = invalid_input_message(runtime.execute_tool_command(
+        "orbit.task.add",
+        json!({
+            "title": "Dependent task from tool",
+            "description": "Exercise dependency input on the agent-facing task creation path.",
+            "complexity": "low",
+            "workspace": ".",
+            "dependencies": [dependency.id.clone()],
+        }),
+        Some("codex".to_string()),
+        Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+    ));
+    assert!(message.contains("dependencies"), "{message}");
+    assert!(message.contains("orbit.task.update"), "{message}");
 }
 
 #[test]
@@ -1393,30 +1383,26 @@ fn task_add_tool_normalizes_tags_at_write_time() {
 }
 
 #[test]
-fn task_add_tool_ignores_retired_external_refs() {
-    // ORB-00255 retired `external_refs` from the `orbit.task.add` schema; any
-    // value supplied is silently stripped before persistence.
+fn task_add_tool_rejects_retired_external_refs() {
     let (_root, runtime, _repo_root) = test_runtime();
 
-    let output = runtime
-        .execute_tool_command(
-            "orbit.task.add",
-            json!({
-                "title": "External ref task",
-                "description": "Exercise external ref input on the agent-facing task creation path.",
-                "complexity": "low",
-                "workspace": ".",
-                "external_refs": [
-                    {"system": "jira", "id": "ENG-1234", "url": "https://example.com/browse/ENG-1234"},
-                    {"system": "linear", "id": "LIN-567"}
-                ],
-            }),
-            Some("codex".to_string()),
-            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
-        )
-        .expect("task add tool succeeds");
-
-    assert_eq!(output.get("external_refs"), Some(&json!([])));
+    let message = invalid_input_message(runtime.execute_tool_command(
+        "orbit.task.add",
+        json!({
+            "title": "External ref task",
+            "description": "Exercise external ref input on the agent-facing task creation path.",
+            "complexity": "low",
+            "workspace": ".",
+            "external_refs": [
+                {"system": "jira", "id": "ENG-1234", "url": "https://example.com/browse/ENG-1234"},
+                {"system": "linear", "id": "LIN-567"}
+            ],
+        }),
+        Some("codex".to_string()),
+        Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+    ));
+    assert!(message.contains("external_refs"), "{message}");
+    assert!(message.contains("orbit.task.update"), "{message}");
 }
 
 #[test]
@@ -1936,8 +1922,7 @@ fn task_update_tool_clears_source_task_id_with_empty_string() {
 
 #[test]
 fn task_update_tool_rejects_unresolved_source_task_id_atomically() {
-    // ORB-00255 retired `source_task_id` from the `orbit.task.add` schema,
-    // so an unresolved ID must travel via `orbit.task.update`.
+    // `source_task_id` is update-only; seed the update target without it.
     let (_root, runtime, _repo_root) = test_runtime();
     let unresolved_from_update = "ORB-99999";
 
@@ -1946,21 +1931,15 @@ fn task_update_tool_rejects_unresolved_source_task_id_atomically() {
             "orbit.task.add",
             json!({
                 "title": "Bug without resolved source",
-                "description": "A bug whose retired add-side source ID should be ignored.",
+                "description": "A bug whose unresolved source ID should be rejected atomically.",
                 "complexity": "low",
                 "workspace": ".",
                 "type": "bug",
-                "source_task_id": "ORB-99998",
             }),
             Some("codex".to_string()),
             Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
         )
         .expect("task add tool succeeds");
-    assert_eq!(
-        update_target.get("source_task_id"),
-        Some(&Value::Null),
-        "retired add-side source_task_id must be ignored"
-    );
     let error = runtime
         .execute_tool_command(
             "orbit.task.update",

--- a/crates/orbit-core/src/application/task/helpers.rs
+++ b/crates/orbit-core/src/application/task/helpers.rs
@@ -21,6 +21,7 @@ pub(crate) struct TaskAttributionInput<'a> {
 
 pub(crate) struct TaskAttribution {
     pub(crate) actor: String,
+    pub(crate) authored_role_label: String,
     pub(crate) planned_by: Option<Option<String>>,
     pub(crate) implemented_by: Option<Option<String>>,
 }
@@ -62,6 +63,7 @@ pub(crate) fn assemble_task_attribution(
 
     Ok(TaskAttribution {
         actor,
+        authored_role_label,
         planned_by,
         implemented_by,
     })

--- a/crates/orbit-core/src/application/task/update.rs
+++ b/crates/orbit-core/src/application/task/update.rs
@@ -42,6 +42,7 @@ enum StatusAuthority {
 #[derive(Default)]
 struct TaskUpdateContext {
     status_note: Option<String>,
+    actor_override: Option<String>,
     agent: Option<String>,
     model: Option<String>,
     artifact_owner: Option<String>,
@@ -77,6 +78,27 @@ impl OrbitRuntime {
             TaskUpdateContext {
                 agent,
                 model,
+                status_authority: StatusAuthority::Lifecycle,
+                ..Default::default()
+            },
+        )
+    }
+
+    /// Apply a dashboard-authored mutation under an explicit human label.
+    /// Agent-facing callers use `update_task_with_identity`, whose provenance
+    /// is validated as a canonical agent family.
+    pub fn update_task_as_human(
+        &self,
+        id: &str,
+        params: TaskUpdateParams,
+        actor_label: String,
+    ) -> Result<Task, OrbitError> {
+        self.ensure_coordination_task_write_permitted()?;
+        self.update_task_with_context(
+            id,
+            params,
+            TaskUpdateContext {
+                actor_override: Some(actor_label),
                 status_authority: StatusAuthority::Lifecycle,
                 ..Default::default()
             },
@@ -156,7 +178,8 @@ impl OrbitRuntime {
             },
             TaskUpdateContext {
                 status_note: note,
-                agent: agent.or_else(|| model.is_none().then(|| SYSTEM_ACTOR_LABEL.to_string())),
+                actor_override: Some(SYSTEM_ACTOR_LABEL.to_string()),
+                agent,
                 model,
                 expected_status: Some(expected_status),
                 ..Default::default()
@@ -212,14 +235,17 @@ impl OrbitRuntime {
     ) -> Result<Task, OrbitError> {
         let TaskUpdateContext {
             status_note,
+            actor_override,
             agent,
             model,
             artifact_owner,
             expected_status,
             status_authority,
         } = context;
-        let (canonical_agent, canonical_model) =
-            self.try_canonical_agent_model_identity(agent.as_deref(), model.as_deref())?;
+        let (canonical_agent, canonical_model) = match actor_override.as_ref() {
+            Some(_) => crate::context::trusted_write_identity(agent.as_deref(), model.as_deref()),
+            None => self.try_canonical_agent_model_identity(agent.as_deref(), model.as_deref())?,
+        };
         let task = self.get_task(id)?;
         if let Some(expected_status) = expected_status
             && task.status != expected_status
@@ -287,7 +313,7 @@ impl OrbitRuntime {
             &task,
             TaskAttributionInput {
                 default_actor_label: &actor.label,
-                actor_override: None,
+                actor_override: actor_override.as_deref(),
                 agent: canonical_agent.as_deref(),
                 model: canonical_model.as_deref(),
                 runtime_model_identity: None,
@@ -303,14 +329,16 @@ impl OrbitRuntime {
                 explicit_implemented_by: params.implemented_by.as_ref(),
             },
         )?;
-        let effective_label = attribution.actor;
+        let effective_label = attribution.actor.clone();
         let status_note = status_note
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(ToOwned::to_owned);
-        let append_comments =
-            build_task_comments(params.comment.clone(), effective_label.as_str())?;
+        let append_comments = build_task_comments(
+            params.comment.clone(),
+            attribution.authored_role_label.as_str(),
+        )?;
         // ORB-10311: a persisted task comment no longer emits a bare `commented`
         // history stub; the comment itself (append_comments) is the record.
         let source_task_id_replacement = params

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -158,6 +158,21 @@ pub(crate) fn resolve_write_actor_label(
     }
 }
 
+/// Preserve attribution supplied by a trusted in-process workflow boundary.
+/// Public agent surfaces must use [`resolve_write_actor_label`] instead.
+pub(crate) fn trusted_write_identity(
+    agent: Option<&str>,
+    model: Option<&str>,
+) -> (Option<String>, Option<String>) {
+    let trim = |value: Option<&str>| {
+        value
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    };
+    (trim(agent), trim(model))
+}
+
 fn os_user_name() -> Option<String> {
     OS_USER_ENV.iter().find_map(|key| {
         std::env::var(key).ok().and_then(|value| {

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -147,6 +147,14 @@ pub(super) fn resolve_identity(
     ctx: &ToolContext,
     input: &Value,
 ) -> Result<OrbitIdentity, OrbitError> {
+    if let Some(actor_label) = trimmed_optional(ctx.trusted_actor_label.clone()) {
+        return Ok(OrbitIdentity {
+            agent: None,
+            model: Some(actor_label.clone()),
+            actor_label: Some(actor_label),
+        });
+    }
+
     let input_agent = optional_string_alias(input, &["agent"])?;
     let input_model = optional_string_alias(input, &["model"])?;
     let context_agent = trimmed_optional(ctx.agent_name.clone());
@@ -173,9 +181,14 @@ pub(super) fn resolve_identity(
         (None, None)
     };
     let family = require_canonical_agent_family(agent.as_deref(), model.as_deref())?;
+    let model = if context_has_identity {
+        family.clone()
+    } else {
+        model.or_else(|| family.clone())
+    };
     Ok(OrbitIdentity {
         agent: family.clone(),
-        model: family.clone(),
+        model,
         actor_label: family,
     })
 }
@@ -263,13 +276,22 @@ pub(super) fn execute_host_action(
     action: OrbitBuiltinAction,
 ) -> Result<Value, OrbitError> {
     let identity = resolve_identity(ctx, &input)?;
-    require_orbit_host(ctx)?.execute(
-        action,
-        input,
-        identity.agent,
-        identity.model,
-        ctx.reservation_owner.clone(),
-    )
+    let host = require_orbit_host(ctx)?;
+    match ctx.trusted_actor_label.as_deref() {
+        Some(actor_label) => host.execute_with_trusted_actor(
+            action,
+            input,
+            actor_label.to_string(),
+            ctx.reservation_owner.clone(),
+        ),
+        None => host.execute(
+            action,
+            input,
+            identity.agent,
+            identity.model,
+            ctx.reservation_owner.clone(),
+        ),
+    }
 }
 
 pub(super) fn resolve_workspace_argument(

--- a/crates/orbit-tools/src/builtin/orbit/tests/identity.rs
+++ b/crates/orbit-tools/src/builtin/orbit/tests/identity.rs
@@ -18,7 +18,7 @@ fn runtime_identity_overwrites_self_reported_model_at_tool_boundary() {
 }
 
 #[test]
-fn input_model_normalizes_full_strings_and_refuses_unrecognized_families() {
+fn input_model_preserves_full_strings_and_refuses_unrecognized_families() {
     let ctx = ToolContext {
         cwd: None,
         session_context: Default::default(),
@@ -26,6 +26,7 @@ fn input_model_normalizes_full_strings_and_refuses_unrecognized_families() {
         workspace_root: None,
         agent_name: None,
         model_name: None,
+        trusted_actor_label: None,
         proc_allowed_programs: Vec::new(),
         proc_spawn_environment: None,
         proc_spawn_activity_scoped: false,
@@ -38,7 +39,7 @@ fn input_model_normalizes_full_strings_and_refuses_unrecognized_families() {
 
     let identity = resolve_identity(&ctx, &json!({ "model": "gpt-5.5" })).expect("normalize");
     assert_eq!(identity.agent.as_deref(), Some("codex"));
-    assert_eq!(identity.model.as_deref(), Some("codex"));
+    assert_eq!(identity.model.as_deref(), Some("gpt-5.5"));
     assert_eq!(identity.actor_label.as_deref(), Some("codex"));
 
     let error = resolve_identity(&ctx, &json!({ "model": "llama" })).expect_err("llama refused");
@@ -54,6 +55,7 @@ fn tool_context(agent: &str, model: &str) -> ToolContext {
         workspace_root: None,
         agent_name: Some(agent.to_string()),
         model_name: Some(model.to_string()),
+        trusted_actor_label: None,
         proc_allowed_programs: Vec::new(),
         proc_spawn_environment: None,
         proc_spawn_activity_scoped: false,

--- a/crates/orbit-tools/src/lib.rs
+++ b/crates/orbit-tools/src/lib.rs
@@ -163,6 +163,18 @@ pub trait OrbitToolHost: Send + Sync {
         reservation_owner: Option<ReservationOwnerContext>,
     ) -> Result<Value, OrbitError>;
 
+    /// Execute with an actor asserted by the in-process host rather than tool
+    /// input. Implementations that do not distinguish trust reuse `execute`.
+    fn execute_with_trusted_actor(
+        &self,
+        action: OrbitBuiltinAction,
+        input: Value,
+        actor_label: String,
+        reservation_owner: Option<ReservationOwnerContext>,
+    ) -> Result<Value, OrbitError> {
+        self.execute(action, input, None, Some(actor_label), reservation_owner)
+    }
+
     fn task_scope(&self) -> OrbitTaskScope;
 }
 
@@ -209,6 +221,10 @@ pub struct ToolContext {
     /// Resolved model identifier (e.g. `"opus-4.6"`). Used alongside `agent_name`
     /// for the attribution footer.
     pub model_name: Option<String>,
+    /// Trusted actor supplied by an in-process host adapter. This is separate
+    /// from agent-controlled tool input so human and system writes do not
+    /// weaken canonical agent-family validation at the public tool boundary.
+    pub trusted_actor_label: Option<String>,
     /// Program allowlist for `proc.spawn`. When `proc_spawn_activity_scoped`
     /// is `true`, an empty list denies every program (fail-closed). When
     /// `proc_spawn_activity_scoped` is `false`, an empty list preserves the
@@ -249,6 +265,7 @@ impl std::fmt::Debug for ToolContext {
             .field("workspace_root", &self.workspace_root)
             .field("agent_name", &self.agent_name)
             .field("model_name", &self.model_name)
+            .field("trusted_actor_label", &self.trusted_actor_label)
             .field("proc_allowed_programs", &self.proc_allowed_programs)
             .field(
                 "has_proc_spawn_environment",

--- a/crates/orbit-web/src/api/frictions.rs
+++ b/crates/orbit-web/src/api/frictions.rs
@@ -85,7 +85,11 @@ async fn run_friction(
 ) -> Result<Value, Box<Response>> {
     blocking("friction tool", move || {
         let (tool, input) = call.into_tool_call();
-        runtime.run_tool(&tool, input)
+        if input.get("model").and_then(Value::as_str) == Some(HUMAN_ACTOR_LABEL) {
+            runtime.run_tool_as_human(&tool, input)
+        } else {
+            runtime.run_tool(&tool, input)
+        }
     })
     .await
 }

--- a/crates/orbit-web/src/api/tasks.rs
+++ b/crates/orbit-web/src/api/tasks.rs
@@ -677,7 +677,7 @@ pub(super) async fn add_task_comment_action(
     };
     let id = id.to_string();
     task_mutation_response(runtime, "task comment", move |runtime| {
-        runtime.update_task_with_identity(&id, params, Some(author), None)
+        runtime.update_task_as_human(&id, params, author)
     })
     .await
 }


### PR DESCRIPTION
## Task

[ORB-12280](https://orbit-cli.com/tasks/ORB-12280) — [ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `CI`
- Failing job: `Check / Clippy / Test`
- Failing step: `Run CI guardrails`
- Commit the runner actually checked out: `a084776b18bd1afe430892f84f400788e82dcdda`
- Normalized error signature (the dedupe identity, not a quote): `fail [ <n>.<n>s] (<n>/<n>) orbit-tools builtin::orbit::task::tests::artifact_put::artifact_put_reads_relative_source_and_delegates_to_task_update`
- Repository: `constellation-works/orbit`
- Release branch as GitHub reports it: `agent-main`
- Evidence collected at: 2026-09-12T06:05:37.320104992+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/constellation-works/orbit/actions/runs/34676055259 run `34676055259` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `a084776b18bd1afe430892f84f400788e82dcdda`
  - current head of that ref: `b30ef98f7c9620453fd649c7baa3a14d76dcdc60`
  - commit actually checked out: `a084776b18bd1afe430892f84f400788e82dcdda`
  - checkout evidence: `* branch            a084776b18bd1afe430892f84f400788e82dcdda -> FETCH_HEAD`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/usr/bin/git checkout --progress --force a084776b18bd1afe430892f84f400788e82dcdda`
  - failed job `Check / Clippy / Test` (id `103506006009`): https://github.com/constellation-works/orbit/actions/runs/34676055259/job/103506006009
  - failing step(s): `Run CI guardrails`

## Failed-step log excerpt

_Failure regions from a completely scanned command; the full command was not retained. 1227822 of 1272291 source bytes omitted, including 0 assertion payload bytes. All 63 recognized failure anchors and bounded context are retained (64 KiB selection limit)._

```
2026-09-12T05:43:09.9236295Z ##[group]Run ./scripts/ci-guardrails.sh
[... 604604 command bytes omitted ...]
2026-09-12T05:47:19.0535537Z [31;1m        FAIL[0m [   0.005s] (2742/5692) [35;1morbit-tools[0m [36mbuiltin::orbit::task::tests::artifact_put[0m[36m::[0m[34;1martifact_put_reads_relative_source_and_delegates_to_task_update[0m
2026-09-12T05:47:19.0540440Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T05:47:19.0540709Z 
2026-09-12T05:47:19.0540829Z     running 1 test
2026-09-12T05:47:19.0541473Z     test builtin::orbit::task::tests::artifact_put::artifact_put_reads_relative_source_and_delegates_to_task_update ... FAILED
2026-09-12T05:47:19.0542028Z 
2026-09-12T05:47:19.0542141Z     failures:
2026-09-12T05:47:19.0542296Z 
2026-09-12T05:47:19.0542397Z     failures:
2026-09-12T05:47:19.0542937Z         builtin::orbit::task::tests::artifact_put::artifact_put_reads_relative_source_and_delegates_to_task_update
2026-09-12T05:47:19.0543439Z 
2026-09-12T05:47:19.0543784Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 140 filtered out; finished in 0.00s
2026-09-12T05:47:19.0544371Z     [0m
2026-09-12T05:47:19.0544687Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T05:47:19.0544920Z 
2026-09-12T05:47:19.0545973Z     [0m[31;1mthread 'builtin::orbit::task::tests::artifact_put::artifact_put_reads_relative_source_and_delegates_to_task_update' (69741) panicked at crates/orbit-tools/src/builtin/orbit/task/tests/artifact_put.rs:96:5:[0m
2026-09-12T05:47:19.0548157Z     [31;1massertion `left == right` failed[0m
2026-09-12T05:47:19.0548629Z       left: Some("codex")
2026-09-12T05:47:19.0549162Z      right: Some("gpt-5")
2026-09-12T05:47:19.0549716Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T05:47:19.0550126Z 
2026-09-12T05:47:19.0597141Z [32;1m        PASS[0m [   0.006s] (2743/5692) [35;1morbit-tools[0m [36mbuiltin::orbit::task::tests::artifact_put[0m[36m::[0m[34;1martifact_put_rejects_agent_identity_field[0m
2026-09-12T05:47:19.0649775Z [32;1m        PASS[0m [   0.006s] (2744/5692) [35;1morbit-tools[0m [36mbuiltin::orbit::task::tests::artifact_put[0m[36m::[0m[34;1martifact_put_rejects_source_outside_workspace_root[0m
2026-09-12T05:47:19.0691761Z [32;1m        PASS[0m [   0.004s] (2745/5692) [35;1morbit-tools[0m [36mbuiltin::orbit::task::tests::artifact_put[0m[36m::[0m[34;1martifact_put_rejects_symlink_inside_workspace_pointing_outside[0m
2026-09-12T05:47:19.0760037Z [32;1m        PASS[0m [   0.007s] (2746/5692) [35;1morbit-tools[0m [36mbuiltin::orbit::task::tests::artifact_put[0m[36m::[0m[34;1martifact_put_size_failure_never_calls_host[0m
2026-09-12T05:47:19.0798952Z [32;1m        PASS[0m [   0.004s] (2747/5692) [35;1morbit-tools[0m [36mbuiltin::orbit::task::tests::artifact_put[0m[36m::[0m[34;1mpreloaded_artifact_payload_is_private_to_authenticated_ssh_mcp[0m
2026-09-12T05:47:19.0840284Z [32;1m        PASS[0m [   0.004s] (2748/5692) [35;1morbit-tools[0m [36mbuiltin::orbit::task::tests::artifact_put[0m[36m::[0m[34;1mremote_agent_session_cannot_attach_mcp_ssh_acceptance_secret[0m
2026-09-12T05:47:19.0876599Z [32;1m        PASS[0m [   0.004s] (2749/5692) [35;1morbit-tools[0m [36mbuiltin::orbit::task::tests::list[0m[36m::[0m[34;1mschema_exposes_multi_status_filter[0m
[... 78773 command bytes omitted ...]
2026-09-12T05:47:27.0083843Z [31;1m        FAIL[0m [   1.318s] (3124/5692) [35;1morbit-web[0m [36mapi::tests::frictions[0m[36m::[0m[34;1mcreate_forwards_explicit_model_attribution[0m
2026-09-12T05:47:27.0085207Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T05:47:27.0085584Z 
2026-09-12T05:47:27.0085756Z     running 1 test
2026-09-12T05:47:27.0088513Z     test api::tests::frictions::create_forwards_explicit_model_attribution ... FAILED
2026-09-12T05:47:27.0089347Z 
2026-09-12T05:47:27.0089549Z     failures:
2026-09-12T05:47:27.0089797Z 
2026-09-12T05:47:27.0089990Z     failures:
2026-09-12T05:47:27.0090474Z         api::tests::frictions::create_forwards_explicit_model_attribution
2026-09-12T05:47:27.0090922Z 
2026-09-12T05:47:27.0091371Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 387 filtered out; finished in 1.31s
2026-09-12T05:47:27.0092107Z     [0m
2026-09-12T05:47:27.0092589Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T05:47:27.0092920Z 
2026-09-12T05:47:27.0093836Z     [0m[31;1mthread 'api::tests::frictions::create_forwards_explicit_model_attribution' (78005) panicked at crates/orbit-web/src/api/tests/frictions.rs:189:5:[0m
2026-09-12T05:47:27.0095133Z     [31;1massertion `left == right` failed: caller-supplied `model` is forwarded to the tool host unchanged[0m
2026-09-12T05:47:27.0095815Z       left: String("codex")
2026-09-12T05:47:27.0096432Z      right: "gpt-5.5"
2026-09-12T05:47:27.0097688Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T05:47:27.0098176Z 
2026-09-12T05:47:27.0268600Z [32;1m        PASS[0m [   1.346s] (3125/5692) [35;1morbit-web[0m [36mapi::tests::diagnostics[0m[36m::[0m[34;1mimplement_one_duration_is_faceted_by_complexity[0m
2026-09-12T05:47:27.2379925Z [32;1m        PASS[0m [   0.228s] (3126/5692) [35;1morbit-web[0m [36mapi::tests::frictions[0m[36m::[0m[34;1mcreate_requires_localhost_origin[0m
2026-09-12T05:47:27.3102735Z [32;1m        PASS[0m [   0.318s] (3127/5692) [35;1morbit-web[0m [36mapi::tests::frictions[0m[36m::[0m[34;1mcreate_persists_and_echoes_fields[0m
2026-09-12T05:47:27.3170699Z [32;1m        PASS[0m [   0.007s] (3128/5692) [35;1morbit-web[0m [36mapi::tests::frictions[0m[36m::[0m[34;1mdashboard_friction_parameters_are_declared_by_the_registry[0m
2026-09-12T05:47:27.3451657Z [32;1m        PASS[0m [   0.318s] (3129/5692) [35;1morbit-web[0m [36mapi::tests::frictions[0m[36m::[0m[34;1mcreate_round_trips_tags_and_during_task[0m
2026-09-12T05:47:27.5398857Z [31;1m        FAIL[0m [   0.302s] (3130/5692) [35;1morbit-web[0m [36mapi::tests::frictions[0m[36m::[0m[34;1mcreate_without_attribution_defaults_model_to_human[0m
2026-09-12T05:47:27.5418060Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T05:47:27.5437535Z 
2026-09-12T05:47:27.5437753Z     running 1 test
2026-09-12T05:47:27.5438304Z     test api::tests::frictions::create_without_attribution_defaults_model_to_human ... FAILED
2026-09-12T05:47:27.5438753Z 
2026-09-12T05:47:27.5438869Z     failures:
2026-09-12T05:47:27.5439034Z 
2026-09-12T05:47:27.5439176Z     failures:
2026-09-12T05:47:27.5439606Z         api::tests::frictions::create_without_attribution_defaults_model_to_human
2026-09-12T05:47:27.5439984Z 
2026-09-12T05:47:27.5440392Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 387 filtered out; finished in 0.30s
2026-09-12T05:47:27.5447943Z     [0m
2026-09-12T05:47:27.5477991Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T05:47:27.5478313Z 
2026-09-12T05:47:27.5538566Z     [0m[31;1mthread 'api::tests::frictions::create_without_attribution_defaults_model_to_human' (80099) panicked at crates/orbit-web/src/api/tests/frictions.rs:163:5:[0m
2026-09-12T05:47:27.5567771Z     [31;1massertion `left == right` failed[0m
2026-09-12T05:47:27.5586784Z       left: 400
2026-09-12T05:47:27.5597892Z      right: 200
2026-09-12T05:47:27.5598739Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T05:47:27.5600176Z 
2026-09-12T05:47:27.6330225Z [32;1m        PASS[0m [   0.315s] (3131/5692) [35;1morbit-web[0m [36mapi::tests::frictions[0m[36m::[0m[34;1mlist_forwards_empty_multi_word_query_notes[0m
2026-09-12T05:47:27.6643017Z [32;1m        PASS[0m [   0.319s] (3132/5692) [35;1morbit-web[0m [36mapi::tests::frictions[0m[36m::[0m[34;1mpatch_requires_localhost_origin[0m
2026-09-12T05:47:27.8675877Z [32;1m        PASS[0m [   0.329s] (3133/5692) [35;1morbit-web[0m [36mapi::tests::frictions[0m[36m::[0m[34;1mpatch_round_trip_updates_status_and_tags[0m
2026-09-12T05:47:27.9340988Z [32;1m        PASS[0m [   0.301s] (3134/5692) [35;1morbit-web[0m [36mapi::tests::frictions[0m[36m::[0m[34;1mpath_traversal_id_is_rejected[0m
2026-09-12T05:47:27.9790104Z [32;1m        PASS[0m [   0.315s] (3135/5692) [35;1morbit-web[0m [36mapi::tests::frictions[0m[36m::[0m[34;1mresolve_requires_localhost_origin[0m
2026-09-12T05:47:28.1669926Z [32;1m        PASS[0m [   0.231s] (3136/5692) [35;1morbit-web[0m [36mapi::tests::handlers[0m[36m::[0m[34;1mcrews_endpoint_returns_sorted_runtime_registry[0m
2026-09-12T05:47:28.1999693Z [32;1m        PASS[0m [   0.332s] (3137/5692) [35;1morbit-web[0m [36mapi::tests::frictions[0m[36m::[0m[34;1mstats_shape_exposes_triage_counts[0m
[... 29804 command bytes omitted ...]
2026-09-12T05:47:47.8489073Z [31;1m        FAIL[0m [   0.321s] (3285/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mhistorical_review_record_renders_as_an_opaque_task_comment[0m
2026-09-12T05:47:47.8518138Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T05:47:47.8547630Z 
2026-09-12T05:47:47.8548220Z     running 1 test
2026-09-12T05:47:47.8574148Z     test api::tests::tasks::historical_review_record_renders_as_an_opaque_task_comment ... FAILED
2026-09-12T05:47:47.8574623Z 
2026-09-12T05:47:47.8574737Z     failures:
2026-09-12T05:47:47.8574906Z 
2026-09-12T05:47:47.8575010Z     failures:
2026-09-12T05:47:47.8575440Z         api::tests::tasks::historical_review_record_renders_as_an_opaque_task_comment
2026-09-12T05:47:47.8575871Z 
2026-09-12T05:47:47.8576226Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 387 filtered out; finished in 0.31s
2026-09-12T05:47:47.8576887Z     [0m
2026-09-12T05:47:47.8577371Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T05:47:47.8577615Z 
2026-09-12T05:47:47.8578385Z     [0m[31;1mthread 'api::tests::tasks::historical_review_record_renders_as_an_opaque_task_comment' (96346) panicked at crates/orbit-web/src/api/tests/tasks.rs:1488:5:[0m
2026-09-12T05:47:47.8579199Z     [31;1massertion `left == right` failed[0m
2026-09-12T05:47:47.8579536Z       left: 400
2026-09-12T05:47:47.8579827Z      right: 200
2026-09-12T05:47:47.8580360Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T05:47:47.8580760Z 
2026-09-12T05:47:48.2837209Z [32;1m        PASS[0m [   0.437s] (3286/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mlist_tasks_honors_status_type_and_limit_filters[0m
2026-09-12T05:47:48.6049411Z [32;1m        PASS[0m [   0.321s] (3287/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mlist_tasks_ignores_empty_values_and_the_workspace_selector[0m
2026-09-12T05:47:48.9609075Z [32;1m        PASS[0m [   0.353s] (3288/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mlist_tasks_includes_complexity_when_set[0m
2026-09-12T05:47:49.0608831Z [32;1m        PASS[0m [  11.655s] (3289/5692) [35;1morbit-web[0m [36mapi::tests::runs[0m[36m::[0m[34;1mlist_run_events_returns_payload_too_large_when_scan_budget_exceeded[0m
2026-09-12T05:47:49.1492035Z [32;1m        PASS[0m [   1.340s] (3290/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mlist_tasks_filters_before_limit[0m
2026-09-12T05:47:49.2323225Z [32;1m        PASS[0m [   1.447s] (3291/5692) [35;1morbit-cli::mcp_roundtrip[0m [34;1mtask_read_surfaces_tolerate_a_crew_this_host_does_not_define[0m
2026-09-12T05:47:49.3248497Z [32;1m        PASS[0m [   0.366s] (3292/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mlist_tasks_includes_done_and_archived_statuses_newest_first[0m
[... 1603 command bytes omitted ...]
2026-09-12T05:47:50.6500726Z [31;1m        FAIL[0m [   0.292s] (3301/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mtask_comment_author_is_human_not_the_ambient_model[0m
2026-09-12T05:47:50.6508333Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T05:47:50.6509059Z 
2026-09-12T05:47:50.6509350Z     running 1 test
2026-09-12T05:47:50.6510030Z     test api::tests::tasks::task_comment_author_is_human_not_the_ambient_model ... FAILED
2026-09-12T05:47:50.6510592Z 
2026-09-12T05:47:50.6510803Z     failures:
2026-09-12T05:47:50.6511078Z 
2026-09-12T05:47:50.6511284Z     failures:
2026-09-12T05:47:50.6511766Z         api::tests::tasks::task_comment_author_is_human_not_the_ambient_model
2026-09-12T05:47:50.6513581Z 
2026-09-12T05:47:50.6514066Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 387 filtered out; finished in 0.29s
2026-09-12T05:47:50.6514930Z     [0m
2026-09-12T05:47:50.6515433Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T05:47:50.6515785Z 
2026-09-12T05:47:50.6516691Z     [0m[31;1mthread 'api::tests::tasks::task_comment_author_is_human_not_the_ambient_model' (96488) panicked at crates/orbit-web/src/api/tests/tasks.rs:1522:5:[0m
2026-09-12T05:47:50.6517830Z     [31;1massertion `left == right` failed[0m
2026-09-12T05:47:50.6518530Z       left: 400
2026-09-12T05:47:50.6518885Z      right: 200
2026-09-12T05:47:50.6519516Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T05:47:50.6520019Z 
2026-09-12T05:47:50.6738705Z [31;1m        FAIL[0m [   0.291s] (3302/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mtask_comment_author_rejects_model_constants_but_keeps_human_names[0m
2026-09-12T05:47:50.6771134Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T05:47:50.6771642Z 
2026-09-12T05:47:50.6797954Z     running 1 test
2026-09-12T05:47:50.6828166Z     test api::tests::tasks::task_comment_author_rejects_model_constants_but_keeps_human_names ... FAILED
2026-09-12T05:47:50.6857480Z 
2026-09-12T05:47:50.6857906Z     failures:
2026-09-12T05:47:50.6887587Z 
2026-09-12T05:47:50.6917778Z     failures:
2026-09-12T05:47:50.6918478Z         api::tests::tasks::task_comment_author_rejects_model_constants_but_keeps_human_names
2026-09-12T05:47:50.6947681Z 
2026-09-12T05:47:50.6978033Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 387 filtered out; finished in 0.28s
2026-09-12T05:47:50.7007866Z     [0m
2026-09-12T05:47:50.7008466Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T05:47:50.7037666Z 
2026-09-12T05:47:50.7061315Z     [0m[31;1mthread 'api::tests::tasks::task_comment_author_rejects_model_constants_but_keeps_human_names' (96494) panicked at crates/orbit-web/src/api/tests/tasks.rs:1550:9:[0m
2026-09-12T05:47:50.7088332Z     [31;1massertion `left == right` failed[0m
2026-09-12T05:47:50.7127725Z       left: 400
2026-09-12T05:47:50.7140674Z      right: 200
2026-09-12T05:47:50.7142341Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T05:47:50.7143326Z 
2026-09-12T05:47:50.7384521Z [32;1m        PASS[0m [   0.301s] (3303/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mtask_comment_endpoint_rejects_blank_messages[0m
2026-09-12T05:47:50.9808517Z [32;1m        PASS[0m [   0.309s] (3304/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mupdate_task_allow_missing_context_permits_a_dead_selector[0m
2026-09-12T05:47:51.0050295Z [32;1m        PASS[0m [   0.355s] (3305/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mtask_locks_endpoint_matches_cli_json_contract[0m
2026-09-12T05:47:51.0478398Z [31;1m        FAIL[0m [   0.309s] (3306/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mupdate_task_applies_model_provenance[0m
2026-09-12T05:47:51.0498931Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T05:47:51.0527567Z 
2026-09-12T05:47:51.0536272Z     running 1 test
2026-09-12T05:47:51.0537125Z     test api::tests::tasks::update_task_applies_model_provenance ... FAILED
2026-09-12T05:47:51.0537756Z 
2026-09-12T05:47:51.0537969Z     failures:
2026-09-12T05:47:51.0538221Z 
2026-09-12T05:47:51.0538423Z     failures:
2026-09-12T05:47:51.0538866Z         api::tests::tasks::update_task_applies_model_provenance
2026-09-12T05:47:51.0539293Z 
2026-09-12T05:47:51.0539722Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 387 filtered out; finished in 0.30s
2026-09-12T05:47:51.0540433Z     [0m
2026-09-12T05:47:51.0540895Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T05:47:51.0542349Z 
2026-09-12T05:47:51.0543083Z     [0m[31;1mthread 'api::tests::tasks::update_task_applies_model_provenance' (96532) panicked at crates/orbit-web/src/api/tests/tasks.rs:2036:5:[0m
2026-09-12T05:47:51.0543974Z     [31;1msupplied model must author the write, got `codex`[0m
2026-09-12T05:47:51.0544610Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T05:47:51.0545002Z 
2026-09-12T05:47:51.1254007Z [32;1m        PASS[0m [   1.893s] (3307/5692) [35;1morbit-cli::mcp_roundtrip[0m [34;1mtask_show_is_global_by_default_across_tool_run_and_mcp[0m
2026-09-12T05:47:51.2936845Z [32;1m        PASS[0m [   0.313s] (3308/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mupdate_task_applies_priority_and_reads_it_back[0m
2026-09-12T05:47:51.3266192Z [32;1m        PASS[0m [   0.321s] (3309/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mupdate_task_clears_relations_with_empty_array[0m
2026-09-12T05:47:51.3543448Z [32;1m        PASS[0m [   0.306s] (3310/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mupdate_task_rejects_a_dead_context_selector[0m
2026-09-12T05:47:51.5780414Z [32;1m        PASS[0m [   0.284s] (3311/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mupdate_task_rejects_an_undeclared_body_field_without_partial_application[0m
2026-09-12T05:47:51.6238893Z [32;1m        PASS[0m [   0.297s] (3312/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mupdate_task_rejects_required_tools_as_creation_only[0m
2026-09-12T05:47:51.6716219Z [32;1m        PASS[0m [   0.317s] (3313/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mupdate_task_reopens_done_and_restores_archived_without_intermediate_statuses[0m
2026-09-12T05:47:51.9047025Z [32;1m        PASS[0m [   0.779s] (3314/5692) [35;1morbit-cli::mcp_roundtrip[0m [34;1mthe_callers_file_never_raises_a_session_above_its_request[0m
[... 186270 command bytes omitted ...]
2026-09-12T05:50:41.3797175Z [31;1m        FAIL[0m [   0.246s] (4199/5692) [35;1morbit-core[0m [36madapter::engine_host::tests::runtime_host[0m[36m::[0m[34;1mactivity_update_comment_records_comment_as_system[0m
2026-09-12T05:50:41.3798124Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T05:50:41.3798317Z 
2026-09-12T05:50:41.3798396Z     running 1 test
2026-09-12T05:50:41.3798787Z     test adapter::engine_host::tests::runtime_host::activity_update_comment_records_comment_as_system ... FAILED
2026-09-12T05:50:41.3799159Z 
2026-09-12T05:50:41.3799246Z     failures:
2026-09-12T05:50:41.3799357Z 
2026-09-12T05:50:41.3799429Z     failures:
2026-09-12T05:50:41.3799754Z         adapter::engine_host::tests::runtime_host::activity_update_comment_records_comment_as_system
2026-09-12T05:50:41.3800046Z 
2026-09-12T05:50:41.3800483Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1479 filtered out; finished in 0.24s
2026-09-12T05:50:41.3800887Z     [0m
2026-09-12T05:50:41.3801130Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T05:50:41.3801311Z 
2026-09-12T05:50:41.3802024Z     [0m[31;1mthread 'adapter::engine_host::tests::runtime_host::activity_update_comment_records_comment_as_system' (104332) panicked at crates/orbit-core/src/adapter/engine_host/tests/runtime_host.rs:757:10:[0m
2026-09-12T05:50:41.3803045Z     [31;1mactivity update: InvalidInput("`model` 'system' is not a canonical agent family (codex, claude, gemini, grok) or a recognized full model string")[0m
2026-09-12T05:50:41.3803699Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T05:50:41.3803954Z 
2026-09-12T05:50:41.7669819Z [32;1m        PASS[0m [   0.387s] (4200/5692) [35;1morbit-core[0m [36madapter::engine_host::tests::runtime_host[0m[36m::[0m[34;1mapply_task_automation_update_does_not_touch_context_files_when_unset[0m
2026-09-12T05:50:42.1319180Z [32;1m        PASS[0m [   0.365s] (4201/5692) [35;1morbit-core[0m [36madapter::engine_host::tests::runtime_host[0m[36m::[0m[34;1mapply_task_automation_update_keeps_external_refs_written_after_locked_read[0m
2026-09-12T05:50:42.3559461Z [32;1m        PASS[0m [   0.224s] (4202/5692) [35;1morbit-core[0m [36madapter::engine_host::tests::runtime_host[0m[36m::[0m[34;1mapply_task_automation_update_refuses_done_when_status_changes_after_locked_read[0m
2026-09-12T05:50:42.5881936Z [32;1m        PASS[0m [   0.232s] (4203/5692) [35;1morbit-core[0m [36madapter::engine_host::tests::runtime_host[0m[36m::[0m[34;1mapply_task_automation_update_replaces_context_files_when_set[0m
2026-09-12T05:50:42.8052053Z [32;1m        PASS[0m [   0.217s] (4204/5692) [35;1morbit-core[0m [36madapter::engine_host::tests::runtime_host[0m[36m::[0m[34;1mautomation_can_restamp_in_progress_task_without_plan[0m
2026-09-12T05:50:43.0399211Z [32;1m        PASS[0m [   0.235s] (4205/5692) [35;1morbit-core[0m [36madapter::engine_host::tests::runtime_host[0m[36m::[0m[34;1mautomation_review_done_transitions_preserve_existing_implemented_by_without_model[0m
2026-09-12T05:50:43.2710295Z [32;1m        PASS[0m [   0.231s] (4206/5692) [35;1morbit-core[0m [36madapter::engine_host::tests::runtime_host[0m[36m::[0m[34;1mautomation_update_under_agent_runtime_uses_model_identity_for_attribution[0m
2026-09-12T05:50:43.5001879Z [32;1m        PASS[0m [   0.229s] (4207/5692) [35;1morbit-core[0m [36madapter::engine_host::tests::runtime_host[0m[36m::[0m[34;1mautomation_update_without_agent_runtime_falls_back_to_system_attribution[0m
[... 2583 command bytes omitted ...]
2026-09-12T05:50:46.0941427Z [31;1m        FAIL[0m [   0.221s] (4219/5692) [35;1morbit-core[0m [36madapter::engine_host::tests::runtime_host[0m[36m::[0m[34;1mupdate_task_automation_records_status_history_as_system[0m
2026-09-12T05:50:46.0942357Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T05:50:46.0942610Z 
2026-09-12T05:50:46.0942716Z     running 1 test
2026-09-12T05:50:46.0943330Z     test adapter::engine_host::tests::runtime_host::update_task_automation_records_status_history_as_system ... FAILED
2026-09-12T05:50:46.0943862Z 
2026-09-12T05:50:46.0943968Z     failures:
2026-09-12T05:50:46.0944106Z 
2026-09-12T05:50:46.0944185Z     failures:
2026-09-12T05:50:46.0944505Z         adapter::engine_host::tests::runtime_host::update_task_automation_records_status_history_as_system
2026-09-12T05:50:46.0944814Z 
2026-09-12T05:50:46.0945036Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1479 filtered out; finished in 0.22s
2026-09-12T05:50:46.0945407Z     [0m
2026-09-12T05:50:46.0945638Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T05:50:46.0945801Z 
2026-09-12T05:50:46.0946453Z     [0m[31;1mthread 'adapter::engine_host::tests::runtime_host::update_task_automation_records_status_history_as_system' (104374) panicked at crates/orbit-core/src/adapter/engine_host/tests/runtime_host.rs:572:6:[0m
2026-09-12T05:50:46.0947718Z     [31;1mrun update_task automation: InvalidInput("`model` 'system' is not a canonical agent family (codex, claude, gemini, grok) or a recognized full model string")[0m
2026-09-12T05:50:46.0948405Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T05:50:46.0948660Z 
2026-09-12T05:50:46.3553468Z [32;1m        PASS[0m [   0.261s] (4220/5692) [35;1morbit-core[0m [36madapter::engine_host::tests::runtime_host[0m[36m::[0m[34;1mv2_update_task_activity_preserves_existing_implemented_by[0m
2026-09-12T05:50:46.6114876Z [32;1m        PASS[0m [   0.256s] (4221/5692) [35;1morbit-core[0m [36madapter::engine_host::tests::runtime_host[0m[36m::[0m[34;1mv2_update_task_activity_uses_resolved_crew_identity[0m
2026-09-12T05:50:46.9635140Z [32;1m        PASS[0m [   0.352s] (4222/5692) [35;1morbit-core[0m [36madapter::engine_host::tests::runtime_host[0m[36m::[0m[34;1mworktree_setup_admits_backlog_and_refuses_withdrawn_statuses[0m
2026-09-12T05:50:47.2069708Z [32;1m        PASS[0m [   0.243s] (4223/5692) [35;1morbit-core[0m [36madapter::engine_host::tests::runtime_host[0m[36m::[0m[34;1mworktree_setup_materializes_no_orbit_targets_from_context_files[0m
2026-09-12T05:50:48.6915489Z [32;1m        PASS[0m [   1.484s] (4224/5692) [35;1morbit-core[0m [36madapter::engine_host::v2_host::ci_failure_tasks::repair_assessment::tests[0m[36m::[0m[34;1mcontradictory_observations_and_foreign_validation_owners_are_rejected[0m
2026-09-12T05:50:49.6465826Z [32;1m        PASS[0m [   0.955s] (4225/5692) [35;1morbit-core[0m [36madapter::engine_host::v2_host::ci_failure_tasks::repair_assessment::tests[0m[36m::[0m[34;1mdelivery_must_be_authoritative_and_bound_to_owner_and_revision[0m
2026-09-12T05:50:50.1197690Z [32;1m        PASS[0m [   0.473s] (4226/5692) [35;1morbit-core[0m [36madapter::engine_host::v2_host::ci_failure_tasks::repair_assessment::tests[0m[36m::[0m[34;1minsufficient_historical_state_stays_unresolved_until_reassessment_then_files_no_owner[0m
2026-09-12T05:50:54.7100619Z [32;1m        PASS[0m [   4.590s] (4227/5692) [35;1morbit-core[0m [36madapter::engine_host::v2_host::ci_failure_tasks::repair_assessment::tests[0m[36m::[0m[34;1mmismatched_assessment_and_validation_references_never_cover[0m
[... 112199 command bytes omitted ...]
2026-09-12T05:52:56.7044267Z [31;1m        FAIL[0m [   0.209s] (4692/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_add_tool_ignores_retired_dependencies[0m
2026-09-12T05:52:56.7045107Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T05:52:56.7045342Z 
2026-09-12T05:52:56.7045451Z     running 1 test
2026-09-12T05:52:56.7045917Z     test adapter::tool_host::tests::task_tools::task_add_tool_ignores_retired_dependencies ... FAILED
2026-09-12T05:52:56.7046361Z 
2026-09-12T05:52:56.7046460Z     failures:
2026-09-12T05:52:56.7046623Z 
2026-09-12T05:52:56.7046702Z     failures:
2026-09-12T05:52:56.7046985Z         adapter::tool_host::tests::task_tools::task_add_tool_ignores_retired_dependencies
2026-09-12T05:52:56.7047379Z 
2026-09-12T05:52:56.7047645Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1479 filtered out; finished in 0.20s
2026-09-12T05:52:56.7048021Z     [0m
2026-09-12T05:52:56.7048256Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T05:52:56.7048411Z 
2026-09-12T05:52:56.7049016Z     [0m[31;1mthread 'adapter::tool_host::tests::task_tools::task_add_tool_ignores_retired_dependencies' (107901) panicked at crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs:575:10:[0m
2026-09-12T05:52:56.7049973Z     [31;1mtask add tool succeeds: InvalidInput("unknown field 'dependencies' (orbit.task.add does not accept 'dependencies'; set it with orbit.task.update)")[0m
2026-09-12T05:52:56.7050638Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T05:52:56.7051079Z 
2026-09-12T05:52:56.9094181Z [31;1m        FAIL[0m [   0.205s] (4693/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_add_tool_ignores_retired_external_refs[0m
2026-09-12T05:52:56.9094837Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T05:52:56.9095013Z 
2026-09-12T05:52:56.9095100Z     running 1 test
2026-09-12T05:52:56.9095440Z     test adapter::tool_host::tests::task_tools::task_add_tool_ignores_retired_external_refs ... FAILED
2026-09-12T05:52:56.9095732Z 
2026-09-12T05:52:56.9095809Z     failures:
2026-09-12T05:52:56.9095958Z 
2026-09-12T05:52:56.9096040Z     failures:
2026-09-12T05:52:56.9096323Z         adapter::tool_host::tests::task_tools::task_add_tool_ignores_retired_external_refs
2026-09-12T05:52:56.9096575Z 
2026-09-12T05:52:56.9096808Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1479 filtered out; finished in 0.20s
2026-09-12T05:52:56.9097190Z     [0m
2026-09-12T05:52:56.9097617Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T05:52:56.9097775Z 
2026-09-12T05:52:56.9098575Z     [0m[31;1mthread 'adapter::tool_host::tests::task_tools::task_add_tool_ignores_retired_external_refs' (107908) panicked at crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs:1369:10:[0m
2026-09-12T05:52:56.9099530Z     [31;1mtask add tool succeeds: InvalidInput("unknown field 'external_refs' (orbit.task.add does not accept 'external_refs'; set it with orbit.task.update)")[0m
2026-09-12T05:52:56.9100199Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T05:52:56.9100444Z 
2026-09-12T05:52:57.1245118Z [32;1m        PASS[0m [   0.215s] (4694/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_add_tool_infers_agent_from_model_only_input[0m
2026-09-12T05:52:57.3428038Z [32;1m        PASS[0m [   0.218s] (4695/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_add_tool_keeps_scalar_acceptance_criteria_as_one_value[0m
2026-09-12T05:52:57.5566456Z [32;1m        PASS[0m [   0.214s] (4696/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_add_tool_normalizes_tags_at_write_time[0m
2026-09-12T05:52:57.7715908Z [32;1m        PASS[0m [   0.215s] (4697/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_add_tool_preserves_commas_in_acceptance_criteria_array[0m
2026-09-12T05:52:57.9917702Z [32;1m        PASS[0m [   0.220s] (4698/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_add_tool_recovers_mcp_encoded_acceptance_and_context_arrays[0m
2026-09-12T05:52:58.1926362Z [32;1m        PASS[0m [   0.201s] (4699/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_add_tool_refuses_unrecognized_model[0m
2026-09-12T05:52:58.4148783Z [31;1m        FAIL[0m [   0.222s] (4700/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_add_tool_rejects_dropped_task_types_and_ignores_retired_status[0m
2026-09-12T05:52:58.4149558Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T05:52:58.4149857Z 
2026-09-12T05:52:58.4149995Z     running 1 test
2026-09-12T05:52:58.4150535Z     test adapter::tool_host::tests::task_tools::task_add_tool_rejects_dropped_task_types_and_ignores_retired_status ... FAILED
2026-09-12T05:52:58.4150881Z 
2026-09-12T05:52:58.4150957Z     failures:
2026-09-12T05:52:58.4151066Z 
2026-09-12T05:52:58.4151140Z     failures:
2026-09-12T05:52:58.4151480Z         adapter::tool_host::tests::task_tools::task_add_tool_rejects_dropped_task_types_and_ignores_retired_status
2026-09-12T05:52:58.4151782Z 
2026-09-12T05:52:58.4152006Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1479 filtered out; finished in 0.22s
2026-09-12T05:52:58.4152375Z     [0m
2026-09-12T05:52:58.4152611Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T05:52:58.4152964Z 
2026-09-12T05:52:58.4153647Z     [0m[31;1mthread 'adapter::tool_host::tests::task_tools::task_add_tool_rejects_dropped_task_types_and_ignores_retired_status' (107946) panicked at crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs:378:10:[0m
2026-09-12T05:52:58.4154667Z     [31;1mretired status field is ignored: InvalidInput("unknown field 'status' (orbit.task.add does not accept 'status'; set it with orbit.task.update)")[0m
2026-09-12T05:52:58.4155329Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T05:52:58.4155574Z 
2026-09-12T05:52:58.6226176Z [32;1m        PASS[0m [   0.208s] (4701/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_add_tool_rejects_unknown_crew[0m
2026-09-12T05:52:58.8334525Z [32;1m        PASS[0m [   0.211s] (4702/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_add_tool_rejects_unknown_required_tools_with_suggestions[0m
2026-09-12T05:52:59.0618191Z [32;1m        PASS[0m [   0.228s] (4703/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_add_tool_validates_context_selectors_against_repo_root_not_workspace_subdir[0m
2026-09-12T05:52:59.3062137Z [32;1m        PASS[0m [   0.244s] (4704/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_delete_tool_allows_forced_protected_statuses[0m
2026-09-12T05:52:59.4823426Z [32;1m        PASS[0m [   0.176s] (4705/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_delete_tool_allows_unforced_proposed_and_rejected_tasks[0m
2026-09-12T05:52:59.7494544Z [32;1m        PASS[0m [   0.267s] (4706/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_delete_tool_rejects_unforced_protected_statuses[0m
2026-09-12T05:53:00.0434807Z [32;1m        PASS[0m [   0.294s] (4707/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_list_and_search_tools_filter_by_tags_with_and_semantics[0m
2026-09-12T05:53:00.2537822Z [32;1m        PASS[0m [   0.210s] (4708/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_list_tool_accepts_comma_delimited_and_array_status_filters[0m
[... 6880 command bytes omitted ...]
2026-09-12T05:53:07.8837766Z [31;1m        FAIL[0m [   0.198s] (4740/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_update_tool_rejects_unresolved_source_task_id_atomically[0m
2026-09-12T05:53:07.8838793Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T05:53:07.8839034Z 
2026-09-12T05:53:07.8839161Z     running 1 test
2026-09-12T05:53:07.8839810Z     test adapter::tool_host::tests::task_tools::task_update_tool_rejects_unresolved_source_task_id_atomically ... FAILED
2026-09-12T05:53:07.8840341Z 
2026-09-12T05:53:07.8840454Z     failures:
2026-09-12T05:53:07.8840596Z 
2026-09-12T05:53:07.8840699Z     failures:
2026-09-12T05:53:07.8841206Z         adapter::tool_host::tests::task_tools::task_update_tool_rejects_unresolved_source_task_id_atomically
2026-09-12T05:53:07.8841686Z 
2026-09-12T05:53:07.8842046Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1479 filtered out; finished in 0.19s
2026-09-12T05:53:07.8842671Z     [0m
2026-09-12T05:53:07.8843012Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T05:53:07.8843269Z 
2026-09-12T05:53:07.8844312Z     [0m[31;1mthread 'adapter::tool_host::tests::task_tools::task_update_tool_rejects_unresolved_source_task_id_atomically' (108381) panicked at crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs:1910:10:[0m
2026-09-12T05:53:07.8845969Z     [31;1mtask add tool succeeds: InvalidInput("unknown field 'source_task_id' (orbit.task.add does not accept 'source_task_id'; set it with orbit.task.update)")[0m
2026-09-12T05:53:07.8847050Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T05:53:07.8847611Z 
2026-09-12T05:53:08.1215556Z [32;1m        PASS[0m [   0.238s] (4741/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_update_tool_replaces_context_files_and_keeps_future_paths[0m
2026-09-12T05:53:08.3269159Z [32;1m        PASS[0m [   0.205s] (4742/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_update_tool_replaces_dependencies[0m
2026-09-12T05:53:08.5558462Z [32;1m        PASS[0m [   0.229s] (4743/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_update_tool_replaces_tags[0m
2026-09-12T05:53:08.7848152Z [32;1m        PASS[0m [   0.229s] (4744/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mthe_session_orchestrator_never_backfills_an_existing_task[0m
2026-09-12T05:53:09.0317768Z [32;1m        PASS[0m [   0.247s] (4745/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mthe_session_orchestrator_respects_the_lifecycle_restriction[0m
2026-09-12T05:53:09.2386543Z [32;1m        PASS[0m [   0.207s] (4746/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::workflow_tools[0m[36m::[0m[34;1mmanaged_run_environment_denies_ship_and_resume_end_to_end[0m
2026-09-12T05:53:09.4105868Z [32;1m        PASS[0m [   0.172s] (4747/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::workflow_tools[0m[36m::[0m[34;1mmanaged_run_environment_still_permits_run_observation[0m
2026-09-12T05:53:09.5983509Z [32;1m        PASS[0m [   0.188s] (4748/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::workflow_tools[0m[36m::[0m[34;1mmcp_run_list_keeps_per_run_recovery_attribution_with_uneven_histories[0m
[... 63544 command bytes omitted ...]
2026-09-12T05:53:52.7703683Z [31;1m        FAIL[0m [   0.303s] (5033/5692) [35;1morbit-core[0m [36mapplication::job::tests::exec[0m[36m::[0m[34;1mepic_pipeline_completes_an_untagged_no_diff_root_when_authorized[0m
2026-09-12T05:53:52.7704679Z [31;1m [0m [31;1mstdout[0m [31;1m───[0m
2026-09-12T05:53:52.7704908Z 
2026-09-12T05:53:52.7705021Z     running 1 test
2026-09-12T05:53:52.7705502Z     test application::job::tests::exec::epic_pipeline_completes_an_untagged_no_diff_root_when_authorized ... FAILED
2026-09-12T05:53:52.7705873Z 
2026-09-12T05:53:52.7705956Z     failures:
2026-09-12T05:53:52.7706055Z 
2026-09-12T05:53:52.7706131Z     failures:
2026-09-12T05:53:52.7706470Z         application::job::tests::exec::epic_pipeline_completes_an_untagged_no_diff_root_when_authorized
2026-09-12T05:53:52.7706762Z 
2026-09-12T05:53:52.7706991Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1479 filtered out; finished in 0.30s
2026-09-12T05:53:52.7707529Z     [0m
2026-09-12T05:53:52.7707761Z [31;1m [0m [31;1mstderr[0m [31;1m───[0m
2026-09-12T05:53:52.7707925Z 
2026-09-12T05:53:52.7708544Z     [0m[31;1mthread 'application::job::tests::exec::epic_pipeline_completes_an_untagged_no_diff_root_when_authorized' (109837) panicked at crates/orbit-core/src/application/job/tests/exec.rs:1494:6:[0m
2026-09-12T05:53:52.7710009Z     [31;1man untagged no-diff epic root must complete under authorization, not demand the no-diff-expected tag pr_complete requires: DeterministicActionFailed { action: "task_complete", message: "invalid input: `model` 'human:runner' is not a canonical agent family (codex, claude, gemini, grok) or a recognized full model string" }[0m
2026-09-12T05:53:52.7711270Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
2026-09-12T05:53:52.7711527Z 
2026-09-12T05:53:53.0089515Z [32;1m        PASS[0m [   0.238s] (5034/5692) [35;1morbit-core[0m [36mapplication::job::tests::exec[0m[36m::[0m[34;1mepic_pipeline_dispatches_three_children_serially_without_push_or_pr_inputs[0m
2026-09-12T05:53:53.2950912Z [32;1m        PASS[0m [   0.286s] (5035/5692) [35;1morbit-core[0m [36mapplication::job::tests::exec[0m[36m::[0m[34;1mepic_pipeline_fails_closed_when_descendants_remain_and_names_them[0m
2026-09-12T05:53:53.5441106Z [32;1m        PASS[0m [   0.249s] (5036/5692) [35;1morbit-core[0m [36mapplication::job::tests::exec[0m[36m::[0m[34;1mepic_pipeline_local_mode_merges_once_into_the_workspace_base[0m
2026-09-12T05:53:53.7881282Z [32;1m        PASS[0m [   0.244s] (5037/5692) [35;1morbit-core[0m [36mapplication::job::tests::exec[0m[36m::[0m[34;1mepic_pipeline_no_diff_skips_empty_pr_and_promotes_the_root[0m
2026-09-12T05:53:54.0361095Z [32;1m        PASS[0m [   0.248s] (5038/5692) [35;1morbit-core[0m [36mapplication::job::tests::exec[0m[36m::[0m[34;1mepic_pipeline_pr_mode_delivers_one_pr_against_the_workspace_base[0m
2026-09-12T05:53:54.2769283Z [32;1m        PASS[0m [   0.241s] (5039/5692) [35;1morbit-core[0m [36mapplication::job::tests::exec[0m[36m::[0m[34;1mepic_pipeline_reenters_drain_when_finisher_authors_a_child[0m
2026-09-12T05:53:54.5287380Z [32;1m        PASS[0m [   0.252s] (5040/5692) [35;1morbit-core[0m [36mapplication::job::tests::exec[0m[36m::[0m[34;1mepic_pipeline_with_no_children_runs_finisher_and_keeps_its_commits[0m
2026-09-12T05:53:54.7619775Z [32;1m        PASS[0m [   0.233s] (5041/5692) [35;1morbit-core[0m [36mapplication::job::tests::exec[0m[36m::[0m[34;1mepic_pipeline_with_no_children_runs_no_child_pipeline[0m
[... 141562 command bytes omitted ...]
2026-09-12T05:56:02.0631410Z [31;1m     Summary[0m [ 608.727s] [1m5692[0m tests run: [1m5678[0m [32;1mpassed[0m, [1m14[0m [31;1mfailed[0m, [1m20[0m [33;1mskipped[0m
2026-09-12T05:56:02.0632929Z [31;1m        FAIL[0m [   0.005s] (2742/5692) [35;1morbit-tools[0m [36mbuiltin::orbit::task::tests::artifact_put[0m[36m::[0m[34;1martifact_put_reads_relative_source_and_delegates_to_task_update[0m
2026-09-12T05:56:02.0634430Z [31;1m        FAIL[0m [   1.318s] (3124/5692) [35;1morbit-web[0m [36mapi::tests::frictions[0m[36m::[0m[34;1mcreate_forwards_explicit_model_attribution[0m
2026-09-12T05:56:02.0635601Z [31;1m        FAIL[0m [   0.302s] (3130/5692) [35;1morbit-web[0m [36mapi::tests::frictions[0m[36m::[0m[34;1mcreate_without_attribution_defaults_model_to_human[0m
2026-09-12T05:56:02.0636766Z [31;1m        FAIL[0m [   0.321s] (3285/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mhistorical_review_record_renders_as_an_opaque_task_comment[0m
2026-09-12T05:56:02.0638052Z [31;1m        FAIL[0m [   0.292s] (3301/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mtask_comment_author_is_human_not_the_ambient_model[0m
2026-09-12T05:56:02.0639198Z [31;1m        FAIL[0m [   0.291s] (3302/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mtask_comment_author_rejects_model_constants_but_keeps_human_names[0m
2026-09-12T05:56:02.0640138Z [31;1m        FAIL[0m [   0.309s] (3306/5692) [35;1morbit-web[0m [36mapi::tests::tasks[0m[36m::[0m[34;1mupdate_task_applies_model_provenance[0m
2026-09-12T05:56:02.0640981Z [31;1m        FAIL[0m [   0.246s] (4199/5692) [35;1morbit-core[0m [36madapter::engine_host::tests::runtime_host[0m[36m::[0m[34;1mactivity_update_comment_records_comment_as_system[0m
2026-09-12T05:56:02.0641939Z [31;1m        FAIL[0m [   0.221s] (4219/5692) [35;1morbit-core[0m [36madapter::engine_host::tests::runtime_host[0m[36m::[0m[34;1mupdate_task_automation_records_status_history_as_system[0m
2026-09-12T05:56:02.0642855Z [31;1m        FAIL[0m [   0.209s] (4692/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_add_tool_ignores_retired_dependencies[0m
2026-09-12T05:56:02.0643779Z [31;1m        FAIL[0m [   0.205s] (4693/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_add_tool_ignores_retired_external_refs[0m
2026-09-12T05:56:02.0644713Z [31;1m        FAIL[0m [   0.222s] (4700/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_add_tool_rejects_dropped_task_types_and_ignores_retired_status[0m
2026-09-12T05:56:02.0645689Z [31;1m        FAIL[0m [   0.198s] (4740/5692) [35;1morbit-core[0m [36madapter::tool_host::tests::task_tools[0m[36m::[0m[34;1mtask_update_tool_rejects_unresolved_source_task_id_atomically[0m
2026-09-12T05:56:02.0646645Z [31;1m        FAIL[0m [   0.303s] (5033/5692) [35;1morbit-core[0m [36mapplication::job::tests::exec[0m[36m::[0m[34;1mepic_pipeline_completes_an_untagged_no_diff_root_when_authorized[0m
2026-09-12T05:56:02.0660667Z [31;1merror[0m: test run failed
2026-09-12T05:56:02.0684767Z ##[error]Process completed with exit code 100.

```

_The collection display was truncated. Selected evidence is used for diagnosis; its retention limits are independent of that display._

_The run-scoped failed-step log came back empty, so this excerpt is the evidence from job `Check / Clippy / Test` (id `103506006009`), read from the job log API._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `CI` run https://github.com/constellation-works/orbit/actions/runs/34675646390 — superseded_by_newer_workflow_run: newer relevant run 34676055259 at 2026-09-12T05:37:24Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34675350107 — superseded_by_newer_workflow_run: newer relevant run 34676055259 at 2026-09-12T05:37:24Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34675261078 — superseded_by_newer_workflow_run: newer relevant run 34676055259 at 2026-09-12T05:37:24Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34674932395 — superseded_by_newer_workflow_run: newer relevant run 34676055259 at 2026-09-12T05:37:24Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34674836117 — superseded_by_newer_workflow_run: newer relevant run 34676055259 at 2026-09-12T05:37:24Z is completed with conclusion failure
- `CI` run https://github.com/constellation-works/orbit/actions/runs/34674724739 — superseded_by_newer_workflow_run: newer relevant run 34676055259 at 2026-09-12T05:37:24Z is completed with conclusion failure

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 3,
  "current_failures_discovered": 5,
  "current_failures_investigated": 3,
  "current_failures_investigation_attempted": 5,
  "inconclusive": 0,
  "investigation_cursor": 496998,
  "job_log_reads": 5,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_job_log_reads": 6,
  "max_pull_requests": 10,
  "max_retired_ref_probes": 20,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely"
  ],
  "pull_requests_scanned": 0,
  "refs_scanned": 1,
  "retired_refs": [
    "orbit/ORB-12244-6aa4d8ad",
    "orbit/ORB-12245-6aa4e0d7",
    "orbit/ORB-12250-6aa4d39f",
    "orbit/ORB-12252-6aa4d870",
    "orbit/ORB-12253-6aa4d9e0",
    "orbit/ORB-12255-6aa4d0d0",
    "orbit/ORB-12258-6aa4d3fc",
    "orbit/ORB-12260-6aa4e0d7",
    "orbit/ORB-12263-6aa4d9e6",
    "orbit/ORB-12265-6aa4d871",
    "orbit/ORB-12267-6aa4d9e5",
    "orbit/ORB-12272-6aa4df44"
  ],
  "runs_listed": 100,
  "unverified_refs": []
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


## On-call consolidation 2026-09-12
This task owns the overlapping ORB-12279 coverage and ORB-12281 Linux-sandbox failure cluster. Latest current landed candidate b30ef98f7c9620453fd649c7baa3a14d76dcdc60 has Linux failure https://github.com/constellation-works/orbit/actions/runs/34676891983/job/103508222967 (artifact_put_reads_relative_source_and_delegates_to_task_update: actual codex vs expected gpt-5) and coverage failure https://github.com/constellation-works/orbit/actions/runs/34676891983/job/103508222964 (trusted system and human:runner actors rejected plus four task-add tests expecting retired fields ignored).
Read-only triage identifies ORB-12250 / 18c465a8f / PR #2020 resolve_identity change to require_canonical_agent_family with family copied to all actor/model fields. Preserve public canonical agent-family validation while restoring legitimate trusted internal system and human web actor paths. Do not simply weaken assertions to hide production attribution failures. Distinguish intended canonical model storage from actual identity regression. Four retired-field assertions require alignment with intentional ORB-11698 / 6acf7875b / PR #1584 rejection of dependencies, external_refs, status, source_task_id in task.add. Verify all claims against source and tests before changing.
ORB-12273 missing-provider fixture failure was already fixed by ORB-12272 / 9b46fd717 / PR #2027; do not undo that fix. Other operator is implementing ORB-12237 clock consolidation; avoid unrelated scheduling changes. Task is stepped up to sol/hard because identity validation crosses public/trusted boundaries and needs careful regression coverage.

### Acceptance Criteria

- The root cause of the `CI` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Execution summary derived by Orbit for ORB-12280 from the change delivered by run jrun-20260912-0623-c2; no execution summary was persisted by the implementing agent.

Changed files (12):
- modified: crates/orbit-core/src/adapter/engine_host/runtime_host.rs
- modified: crates/orbit-core/src/adapter/tool_execution.rs
- modified: crates/orbit-core/src/adapter/tool_host/host.rs
- modified: crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
- modified: crates/orbit-core/src/application/task/helpers.rs
- modified: crates/orbit-core/src/application/task/update.rs
- modified: crates/orbit-core/src/context.rs
- modified: crates/orbit-tools/src/builtin/orbit/mod.rs
- modified: crates/orbit-tools/src/builtin/orbit/tests/identity.rs
- modified: crates/orbit-tools/src/lib.rs
- modified: crates/orbit-web/src/api/frictions.rs
- modified: crates/orbit-web/src/api/tasks.rs

This restates the worktree change the delivery commit contains and asserts nothing beyond it. Re-check it with `git show --stat` on the delivery commit.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12280-6aa4efcc`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra