### PR TITLE
Land on-call review settings and strengthen the preparation crew

### DIFF
--- a/.orbit/auto_tasks/delivery-code-review.yaml
+++ b/.orbit/auto_tasks/delivery-code-review.yaml
@@ -6,7 +6,7 @@ schedule:
   deliveries_landed:
     owner_machine: hm_9ca6004473492f06
     branch: agent-main
-    threshold: 10
+    threshold: 3
     max_wait_minutes: 360
     coverage: landed_code_review_v1
     max_items: 20

--- a/.orbit/auto_tasks/delivery-qa.yaml
+++ b/.orbit/auto_tasks/delivery-qa.yaml
@@ -6,7 +6,7 @@ schedule:
   deliveries_landed:
     owner_machine: hm_9ca6004473492f06
     branch: agent-main
-    threshold: 15
+    threshold: 10
     max_wait_minutes: 360
     coverage: integrated_qa_v1
     max_items: 20
@@ -31,7 +31,7 @@ template:
   - delivery-qa
   - no-diff-expected
   priority: medium
-  crew: luna
+  crew: grok
   status: backlog
 dedupe: skip_if_open
 created_by: system

--- a/.orbit/config.toml
+++ b/.orbit/config.toml
@@ -15,7 +15,7 @@ sandbox = "danger-full-access"
 auto_ship = true
 base_branch = "agent-main"
 default_crew = "luna"
-system_crew = "luna"
+system_crew = "sol"
 
 [crews.opus]
 backend = "cli"
@@ -73,4 +73,4 @@ roots = ["docs/"]
 
 [operation]
 review_crew = "opus"
-review_policy = "none"
+review_policy = "after-landing"

--- a/.orbit/routines/ci_failure_sweep.yaml
+++ b/.orbit/routines/ci_failure_sweep.yaml
@@ -33,7 +33,7 @@ enabled: true
 hosts:
   - dk-server-1
 trigger:
-  cron: "*/30 * * * *"
+  cron: "5 * * * *"
   missed_run: skip
 target: job:ci_failure_sweep_pipeline
 policy:


### PR DESCRIPTION
## Task

[ORB-12286](https://orbit-cli.com/tasks/ORB-12286) — Land on-call review settings and strengthen the preparation crew

### Description

During authorized 2026-09-12 on-call deployment preflight, primary agent-main contains existing unpushed f09be87a6777a97c671a56e644fa3bac4deed850 based on b30ef98. It contains intended on-call settings that must be preserved and landed via PR rather than discarded or pushed directly. Apply these exact settings to the assigned worktree based on current remote agent-main:
- .orbit/auto_tasks/delivery-code-review.yaml schedule.deliveries_landed.threshold = 3 (was 10 remotely)
- .orbit/auto_tasks/delivery-qa.yaml threshold = 10 (was 15 remotely) and template.crew = grok (was luna remotely)
- .orbit/config.toml operation.review_policy = after-landing (was none remotely), preserving review_crew opus
- .orbit/routines/ci_failure_sweep.yaml trigger.cron = '5 * * * *' (was every30min remotely).
Also set workflow.system_crew = sol in workspace .orbit/config.toml (currently luna), so substantive preparation uses a stronger crew under Daniel's instruction reserving luna for very easy tasks. Do not change default_crew or unrelated enabled/paused settings. This task itself is a trivial explicit configuration edit suitable for luna. Record previous values for end-of-shift restoration consideration.

No code/runtime redesign, release changes or direct primary checkout writes. Do not touch or rebase primary f09be87a; root will reconcile its now-covered patch after this delivery. Validate config/YAML parsing and repository gates. Current installed registry bug ORB-12283 may still deny task bookkeeping; root supplies plan and owns lifecycle persistence. If that known write is denied, report exact failure and continue authorized file work using injected task snapshot, without sandbox bypass or fallback store, and return full validation in result envelope.

### Acceptance Criteria

- Four existing local settings edits are preserved in the delivered PR with the exact target values listed.
- workflow.system_crew resolves to sol while default_crew and unrelated controls are unchanged; old system_crew luna is recorded for handoff.
- Config and YAML parse correctly; make ci-fast, make ci-lint, make goldens and git diff --check pass.
- No primary-checkout mutation or release action; envelope reports validation and any known bookkeeping denial.

## Execution Summary

<details>
<summary>Click to expand</summary>

Execution summary derived by Orbit for ORB-12286 from the change delivered by run jrun-20260912-0710-c2; no execution summary was persisted by the implementing agent.

Changed files (4):
- modified: .orbit/auto_tasks/delivery-code-review.yaml
- modified: .orbit/auto_tasks/delivery-qa.yaml
- modified: .orbit/config.toml
- modified: .orbit/routines/ci_failure_sweep.yaml

This restates the worktree change the delivery commit contains and asserts nothing beyond it. Re-check it with `git show --stat` on the delivery commit.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12286-6aa4fadf`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra