### PR TITLE
[code-review] Authorization audit rows record the OS username in `role`, so denial-by-role aggregation fragments per account

### DIFF
--- a/crates/orbit-core/src/runtime/authorization.rs
+++ b/crates/orbit-core/src/runtime/authorization.rs
@@ -343,7 +343,9 @@ impl OrbitRuntime {
             tool_name,
             target_type: Some("operation".to_string()),
             target_id: Some(operation_id.to_string()),
-            role: self.actor_label().to_string(),
+            // Coarse actor kind (`human` / `operator` / family), not the
+            // `human:<os-user>` attribution label [ORB-12274].
+            role: self.actor().audit_role().to_string(),
             status,
             exit_code: i32::from(status != AuditEventStatus::Success),
             duration_ms: 1,

--- a/crates/orbit-core/src/runtime/tests/authorization.rs
+++ b/crates/orbit-core/src/runtime/tests/authorization.rs
@@ -11,15 +11,16 @@
 use std::collections::BTreeSet;
 
 use orbit_common::OrbitError;
+use orbit_common::test_env::{self, AGENT_IDENTITY_ENV};
 use orbit_store::contracts::TaskCreateParams;
 use orbit_tools::ToolContext;
 use orbit_types::policy::Role;
 use orbit_types::task::{TaskPriority, TaskStatus, TaskType};
-use orbit_types::telemetry::AuditEventStatus;
+use orbit_types::telemetry::{AuditEvent, AuditEventStatus};
 use orbit_types::tool::{McpCapability, ToolSessionContext};
 use serde_json::json;
 
-use crate::OrbitRuntime;
+use crate::{ActorIdentity, OrbitRuntime};
 
 fn context_with(capabilities: [McpCapability; 1]) -> ToolContext {
     ToolContext {
@@ -299,4 +300,117 @@ fn audit_stats_denials_break_down_by_operation() {
             .map(|(_, count)| *count),
         Some(2)
     );
+}
+
+/// [ORB-12274]: a bare CLI caller with `USER` set must record audit `role`
+/// as the actor kind (`human`), never `human:<os-user>`. The same identity
+/// must not fragment `audit_denials_by_role`.
+#[test]
+fn authorization_row_role_for_bare_cli_is_human_not_os_user() {
+    let os_user = "qa-operator";
+    let _env = test_env::scoped(AGENT_IDENTITY_ENV.iter().map(|name| (*name, None)).chain([
+        ("ORBIT_OPERATOR", None),
+        ("USER", Some(os_user)),
+        ("USERNAME", None),
+        ("LOGNAME", None),
+    ]));
+
+    let actor = ActorIdentity::from_env();
+    assert_eq!(actor.label, format!("human:{os_user}"));
+
+    let runtime = deny_governed_tool_as(actor);
+    let record = authorization_record(&runtime, AuditEventStatus::Denied);
+
+    assert_eq!(record.role, "human");
+    assert!(
+        !record.role.contains(os_user),
+        "authorization role must not carry the OS account name: {}",
+        record.role
+    );
+
+    let buckets = runtime
+        .audit_denials_by_role(None)
+        .expect("denials by role");
+    assert!(
+        buckets.iter().any(|(role, _)| role == "human"),
+        "expected a human denial bucket, got {buckets:?}"
+    );
+    assert!(
+        buckets
+            .iter()
+            .all(|(role, _)| !role.contains(os_user) && !role.starts_with("human:")),
+        "denial-by-role buckets must be actor kinds, not OS accounts: {buckets:?}"
+    );
+}
+
+/// [ORB-12274]: when the operator override is the resolved identity, the
+/// authorization row records `operator`, not a named human or OS account.
+#[test]
+fn authorization_row_role_for_operator_override_identity_is_operator() {
+    let _env = test_env::scoped(AGENT_IDENTITY_ENV.iter().map(|name| (*name, None)).chain([
+        ("ORBIT_OPERATOR", Some("1")),
+        ("USER", Some("qa-operator")),
+        ("USERNAME", None),
+        ("LOGNAME", None),
+    ]));
+
+    let actor = ActorIdentity::from_env();
+    assert_eq!(actor.label, "operator");
+
+    let runtime = deny_governed_tool_as(actor);
+    let record = authorization_record(&runtime, AuditEventStatus::Denied);
+    assert_eq!(record.role, "operator");
+}
+
+/// [ORB-12274]: an agent envelope still records the canonical family as
+/// authorization `role`.
+#[test]
+fn authorization_row_role_for_agent_envelope_is_canonical_family() {
+    let _env = test_env::scoped(
+        AGENT_IDENTITY_ENV
+            .iter()
+            .filter(|name| **name != "ORBIT_AGENT_MODEL")
+            .map(|name| (*name, None))
+            .chain([
+                ("ORBIT_AGENT_MODEL", Some("grok")),
+                ("ORBIT_OPERATOR", None),
+                ("USER", Some("qa-operator")),
+            ]),
+    );
+
+    let actor = ActorIdentity::from_env();
+    assert_eq!(actor.label, "grok");
+
+    let runtime = deny_governed_tool_as(actor);
+    let record = authorization_record(&runtime, AuditEventStatus::Denied);
+    assert_eq!(record.role, "grok");
+}
+
+fn deny_governed_tool_as(actor: ActorIdentity) -> OrbitRuntime {
+    let runtime = OrbitRuntime::in_memory()
+        .expect("build runtime")
+        .with_actor(actor);
+    let task_id = seed_task(&runtime);
+    let error = runtime
+        .run_tool_with_context_and_role(
+            "orbit.task.delete",
+            json!({ "id": task_id, "force": true }),
+            Role::Admin,
+            context_with([McpCapability::Agent]),
+        )
+        .expect_err("agent capability must not reach task deletion");
+    assert!(
+        matches!(error, OrbitError::CapabilityDenied(_)),
+        "expected a capability denial, got: {error}"
+    );
+    runtime
+}
+
+fn authorization_record(runtime: &OrbitRuntime, status: AuditEventStatus) -> AuditEvent {
+    runtime
+        .list_audit_events(None, None, Some(status), None, 50)
+        .expect("list audit events")
+        .into_iter()
+        .find(|event| event.command == "authorization")
+        .expect("the decision persists its own audit row")
 }


### PR DESCRIPTION
## Task

[ORB-12274](https://orbit-cli.com/tasks/ORB-12274) — [code-review] Authorization audit rows record the OS username in `role`, so denial-by-role aggregation fragments per account

### Description

Found reviewing `adb260750..f2c64100e` as a whole; this is an interaction between two changes that merged in the same window, so neither PR review could see it.

## What happens

`OrbitRuntime::record_authorization_event` writes the audit row's `role` from the *actor label*:

- `crates/orbit-core/src/runtime/authorization.rs:346` — `role: self.actor_label().to_string()`
- `actor_label()` is `self.context.actor().label` (`crates/orbit-core/src/runtime/mod.rs:612-614`)

ORB-12250 (`18c465a8f`) then changed what that label is for a bare-CLI caller. `ActorIdentity::from_env` now falls through to the OS account name:

- `crates/orbit-core/src/context.rs:108-110` — `if let Some(user) = os_user_name() { return Self::human(format!("human:{user}")); }`
- `os_user_name()` reads `USER` / `USERNAME` / `LOGNAME` (`crates/orbit-core/src/context.rs:25`, `:140-148`)

The same commit added the accessor that exists precisely to keep the audit dimension coarse:

- `crates/orbit-core/src/context.rs:120-132` — `ActorIdentity::audit_role()`, documented "Audit `role` for this process actor … Bare CLI records `human`"
- its own unit test is named `audit_role_is_kind_not_os_user_label` (`crates/orbit-core/src/context.rs:557-566`)

`audit_role()` is wired into exactly one call site — the CLI guard row at `crates/orbit-cli/src/command/operation.rs:162` (`meta.role = actor.audit_role().to_string()`). The authorization row was not updated.

## Why it matters

1. **Role aggregation fragments.** `get_audit_denials_by_role` is `SELECT role, COUNT(*) … GROUP BY role` (`crates/orbit-store/src/driver/sqlite/audit_event_store/mod.rs:496-510`). Every distinct OS account becomes its own bucket instead of the `human` / `operator` / `<agent family>` set the column is meant to hold.
2. **The same denial reports two different roles.** A `CliCommand`-surface governed denial writes the CLI guard row with `role = "human"` and the authorization row with `role = "human:<user>"`.
3. **The OS account name is persisted into the audit store.** The repo redacts `$HOME` from log and config output for this class of leak (`redact_home_dir`), but the username lands verbatim in `audit_events.role`.
4. ORB-12257 (`b0d91903f`) landed in this same window and made these authorization rows first-class in `orbit audit stats` (`audit_denials_by_operation`, `crates/orbit-cli/src/command/audit/stats.rs:25-28`), so the fidelity of these rows now matters more than it did before.

This is an unmet acceptance item of ORB-12250 itself, whose description says: *"5. Audit `role` for bare CLI becomes `human` (or `operator` when `ORBIT_OPERATOR=1`)."*

## Scope note

Only the audit `role` column is wrong. The other `actor_label()` readers (`crates/orbit-core/src/application/job/agent_invoke.rs:172`, `crates/orbit-core/src/adapter/tool_host/workflow_tools.rs:268`, `pipeline_tools.rs:34,116`, `command_tools.rs:22`) populate *actor attribution* fields, where `human:<user>` is the intended new behavior. Do not change those.

## Fix

Use `self.actor().audit_role()` for the `role` field in `record_authorization_event`. Existing rows are not retroactively affected.

## Confirmation basis

Confirmed by reading the live code at `f2c64100e`; no live interleaving was constructed. The existing test at `crates/orbit-core/src/runtime/tests/authorization.rs:249` asserts only `!record.role.is_empty()`, which is why the change passed.

### Acceptance Criteria

- A governed-operation denial raised from a bare CLI caller with `USER` set in the environment writes an `audit_events` row whose `role` is `human`, not `human:<username>`, and `operator` when the operator override is the resolved identity.
- An agent-envelope caller (`ORBIT_AGENT_MODEL` naming a canonical family) still records that family as `role` on the authorization row.
- A test asserts the exact `role` value on the authorization row for the bare-CLI case, and fails if the row carries the OS account name.
- `orbit audit stats` denial-by-role buckets are the actor-kind set (`human` / `operator` / agent family / `unknown`), with no per-OS-account bucket.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `record_authorization_event` now writes `role` from `self.actor().audit_role()` instead of `actor_label()`, so a bare CLI process with `USER` set records `human` (and `operator` when that is the resolved identity) rather than `human:<os-user>`.
- Authorization tests assert the exact role for bare-CLI, operator-override, and agent-envelope identities, and that `audit_denials_by_role` has a `human` bucket with no OS-account key.
- Other `actor_label()` readers (attribution fields) were left unchanged. No new files.

Assessment: The one-line writer change matches the existing `audit_role()` contract already used by the CLI guard row. Tests isolate env, inject the resolved actor via `with_actor`, and deny through a session Agent grant so the denial path stays deterministic.

Criteria:
1. Bare CLI + `USER` → authorization row `role == "human"`; operator-override identity → `role == "operator"`: met (`authorization_row_role_for_bare_cli_is_human_not_os_user`, `authorization_row_role_for_operator_override_identity_is_operator`).
2. Agent envelope (`ORBIT_AGENT_MODEL=grok`) → authorization row `role == "grok"`: met (`authorization_row_role_for_agent_envelope_is_canonical_family`).
3. Bare-CLI test asserts exact `role` and fails if the OS account name is present: met.
4. Denial-by-role buckets are actor-kind values with no per-OS-account key: met via `audit_denials_by_role` on the same bare-CLI fixture (`get_audit_denials_by_role` is `GROUP BY role`; `orbit audit stats` does not print a by-role section — it consumes the same `role` column through that store query / scoreboard).

Validation:
- `cargo test -p orbit-core --lib runtime::tests::authorization`: passed (11 tests).
- `cargo clippy -p orbit-core --lib --tests -- -D warnings`: passed.
- `make ci-fast`: passed.
- `git diff --check`: passed.
- `make ci-lint`: not run (focused clippy on the owning crate passed; workspace-wide clippy left to CI).
- `make goldens`: not run (no CLI help / MCP surface change).

Deviations: none.
Remaining risks: historical `audit_events` rows still carry `human:<user>` if written before this change; no backfill, as specified. `audit_denials_by_role` also counts the tool-dispatch entry-point row, which may add a separate kind bucket (`agent`) alongside `human`; that is existing dual-row behavior, not a new per-account split.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12274-6aa5016e`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra