### PR TITLE
[code-scanning-sweep] Fix rust/path-injection in crates/orbit-registry/src/workspace_registry/io.rs

### DIFF
--- a/crates/orbit-registry/src/tests/workspace_registry.rs
+++ b/crates/orbit-registry/src/tests/workspace_registry.rs
@@ -754,14 +754,15 @@ fn registry_io_rejects_a_symlinked_registry_file() {
 }
 
 #[test]
-fn registry_lock_creates_a_missing_parent_directory() {
+fn registry_lock_rejects_a_missing_parent_without_creating_it() {
     let root = tempdir().expect("tempdir");
     let registry_dir = root.path().join("custom-orbit");
     let path = registry_dir.join("workspaces.json");
 
-    with_registry_lock(&path, || Ok(())).expect("lock registry in a new root");
+    let error = with_registry_lock(&path, || Ok(())).expect_err("missing root must fail");
 
-    assert!(registry_dir.is_dir());
+    assert!(error.to_string().contains("canonicalize"), "{error}");
+    assert!(!registry_dir.exists());
 }
 
 #[test]

--- a/crates/orbit-registry/src/workspace_registry/io.rs
+++ b/crates/orbit-registry/src/workspace_registry/io.rs
@@ -39,19 +39,13 @@ pub fn load_registry() -> Result<WorkspaceRegistry, OrbitError> {
 /// but a caller that loads, edits, and saves is not: two such callers (the
 /// scheduled sweep validating checkouts, `orbit workspace init` registering a
 /// new one) interleave, and the second save silently drops the first one's
-/// edit. Wrap the whole read-modify-write in this.
+/// edit. Wrap the whole read-modify-write in this. The owning runtime must
+/// initialize the selected global root before taking this lock; lock acquisition
+/// never creates a directory from its path argument.
 pub fn with_registry_lock<T>(
     path: &Path,
     op: impl FnOnce() -> Result<T, OrbitError>,
 ) -> Result<T, OrbitError> {
-    let parent = registry_parent(path)?;
-    std::fs::create_dir_all(parent).map_err(|error| {
-        OrbitError::Io(format!(
-            "create workspace registry directory {}: {error}",
-            parent.display()
-        ))
-    })?;
-
     let path = validated_registry_path(path)?;
     with_exclusive_file_lock(&path, "workspace registry", op)
 }


### PR DESCRIPTION
## Task

[ORB-12284](https://orbit-cli.com/tasks/ORB-12284) — [code-scanning-sweep] Fix rust/path-injection in crates/orbit-registry/src/workspace_registry/io.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#427`
- Rule: `rust/path-injection` (rust/path-injection)
- Security severity: `high`
- Tool: `CodeQL` (version `2.27.0`, guid `unknown`)
- Message: This path depends on a user-provided value. This path depends on a user-provided value. This path depends on a user-provided value.
- Ref: `refs/heads/agent-main`
- Commit: `b30ef98f7c9620453fd649c7baa3a14d76dcdc60`
- Location: `crates/orbit-registry/src/workspace_registry/io.rs` line 41
- Created: `2026-09-12T04:33:29Z`
- Updated: `2026-09-12T04:33:29Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/427

## Per-alert disposition

Record one outcome for every alert listed above before handoff:

- `fixed` — this task changed the source and the rule no longer reports at that location.
- `already-covered` — the repair already landed. Name the covering commit, show it is an ancestor of the HEAD you validated, and cite the current source that carries it. Do not present another task's commit as this task's own change, and do not manufacture an empty or unrelated commit to satisfy delivery.
- `not-reproducible-in-source` — the reported location does not match the current source (a stale path, line, or message). Record what that location holds today.

Source-side coverage and hosted alert closure are separate outcomes: do not record a hosted alert as closed without a hosted rescan.

## Collection bounds

```json
{
  "alerts_at_cap": false,
  "alerts_limit": 100,
  "notes": []
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/path-injection` at `crates/orbit-registry/src/workspace_registry/io.rs` line 41 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Record one disposition for every alert listed in the task description: `fixed`, `already-covered`, or `not-reproducible-in-source`. An `already-covered` disposition must name the covering commit, show that commit is an ancestor of the HEAD you validated, and cite the current source carrying the repair; never present another task's commit as this task's own change.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected locations. Report source-side coverage and hosted alert closure separately: do not record a hosted alert as closed without a hosted rescan.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Removed `create_dir_all(parent)` from `with_registry_lock`, eliminating the alert #427 user-derived directory-creation sink before registry-path validation. The lock boundary now validates the fixed `workspaces.json` path and requires the owning runtime to initialize its selected global root.
- Replaced the old missing-parent creation test with a regression proving lock acquisition rejects a missing root and leaves the path untouched. Existing `workspace init --root` coverage confirms legitimate missing custom roots are still initialized at the owning CLI boundary.

Acceptance criteria:
1. Alert #427 disposition: `fixed`. The task changes `crates/orbit-registry/src/workspace_registry/io.rs`; current lines 45-50 contain validation followed by lock acquisition and no directory-creation sink. No suppression, dismissal, path exclusion, or CodeQL model change was added.
2. Intended behavior is preserved: initialized roots still lock normally, and `workspace_init_with_root_override_uses_custom_registry` proves a missing operator-selected custom root is created and receives its registry. Only the unsafe side effect in the lower-level lock helper was removed.
3. The sole listed alert (#427, `rust/path-injection`, reported at b30ef98 line 41) is `fixed` by this task.
4. Source-side security coverage passed: the affected file contains no `create_dir_all`, registry regression tests pass, the repository CodeQL extension schema checks pass, and existing HTTP boundary tests prove an unknown query selector creates nothing and a stray body `workspace` field is rejected. The CodeQL CLI is not installed in this executor, so the full query pack was not run locally. No hosted rescan was available or performed; alert #427 must remain recorded as open until CI/GitHub rescans the delivered commit.

Validation:
- PASSED: `cargo test -p orbit-registry` (63 unit tests, 1 dependency-boundary test).
- PASSED: `cargo test -p orbit-cli workspace_init_with_root_override_uses_custom_registry -- --nocapture`.
- PASSED: `cargo test -p orbit-web create_task_rejects_stray_workspace_body_key -- --nocapture` and `cargo test -p orbit-web create_task_with_unknown_workspace_is_404_and_creates_nothing -- --nocapture`.
- PASSED: `make ci-fast` (its compiler-cache namespace probe reported the documented environment skip because unprivileged user namespaces are unavailable; all enforced checks passed).
- PASSED: `make ci-lint`.
- PASSED: `make goldens`.
- PASSED: `./scripts/test-codeql-extension-schema.py`, `./scripts/check-codeql-extension-schema.py`, and source assertion that `create_dir_all` is absent from the affected file.
- PASSED: `git diff --check`.
- NOT RUN: local CodeQL `rust/path-injection` query and hosted rescan; `codeql` is unavailable and this activity has no GitHub security authority.

Assessment: Small boundary correction with direct regression coverage. No remaining source-side path-creation flow exists at the reported location. Hosted alert closure is the only deferred external confirmation.
Deviations from original plan: No new web test source was needed because the requested selector/body redirect cases already have focused tests; those existing tests were executed instead.
Friction checkpoint: no qualifying friction.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12284-6aa50592`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*

Orchestrated-By: astra