### PR TITLE
[friction-curation] Attribute retired config warnings to the layer that contains the key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,6 +2226,7 @@ dependencies = [
  "toml",
  "toml_edit",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/orbit-config/Cargo.toml
+++ b/crates/orbit-config/Cargo.toml
@@ -23,3 +23,4 @@ tracing.workspace = true
 [dev-dependencies]
 orbit-common = { path = "../orbit-common", features = ["test-util"] }
 tempfile.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/orbit-config/src/layering.rs
+++ b/crates/orbit-config/src/layering.rs
@@ -29,7 +29,7 @@ use crate::operation::{
 };
 use crate::persistence::PersistenceConfig;
 use crate::registry::CONFIG_KEY_REGISTRY;
-use crate::resolved::ResolvedConfig;
+use crate::resolved::{ResolvedConfig, warn_compatibility_keys};
 
 /// Security-sensitive settings that a workspace file must restate to keep.
 /// Inheriting a machine-global sandbox, approval, or environment allowlist
@@ -219,7 +219,10 @@ pub(crate) fn load_layered_resolved(
             redact_home_dir(&config_path.display().to_string())
         ))
     })?;
-    let mut resolved = ResolvedConfig::from_raw_str(&merged_raw, config_path, persistence)?;
+    let mut resolved = ResolvedConfig::from_layered_raw_str(&merged_raw, config_path, persistence)?;
+    for document in [global.as_ref(), workspace.as_ref()].into_iter().flatten() {
+        warn_compatibility_keys(&document.value, &document.path);
+    }
     resolved.operation = resolve_operation_layers(global.as_ref(), workspace.as_ref())?;
     Ok(LoadedResolvedConfig {
         resolved,

--- a/crates/orbit-config/src/resolved.rs
+++ b/crates/orbit-config/src/resolved.rs
@@ -143,6 +143,25 @@ impl ResolvedConfig {
         config_path: &Path,
         persistence: PersistenceConfig,
     ) -> Result<Self, OrbitError> {
+        Self::from_raw_str_with_warnings(raw, config_path, persistence, true)
+    }
+
+    /// Parse a merged layered document while leaving compatibility warnings
+    /// to the loader, which still has each source document and its path.
+    pub(crate) fn from_layered_raw_str(
+        raw: &str,
+        config_path: &Path,
+        persistence: PersistenceConfig,
+    ) -> Result<Self, OrbitError> {
+        Self::from_raw_str_with_warnings(raw, config_path, persistence, false)
+    }
+
+    fn from_raw_str_with_warnings(
+        raw: &str,
+        config_path: &Path,
+        persistence: PersistenceConfig,
+        emit_compatibility_warnings: bool,
+    ) -> Result<Self, OrbitError> {
         let parsed = toml::from_str::<RawRuntimeConfig>(raw).map_err(|err| {
             OrbitError::InvalidInput(format!(
                 "invalid runtime config '{}': {err}",
@@ -183,19 +202,17 @@ impl ResolvedConfig {
             snapshot.workflow_default_crew.as_deref(),
         );
 
-        if parsed
-            .knowledge
-            .as_ref()
-            .and_then(|section| section.task_id_pattern.as_ref())
-            .is_some()
-        {
-            warn_deprecated_task_id_pattern(config_path);
-        }
-        if parsed.duel.is_some() {
-            warn_retired_duel_config(config_path);
-        }
-        if parsed.routines.is_some() {
-            warn_retired_routines_config(config_path);
+        let compatibility_keys = CompatibilityKeys {
+            deprecated_task_id_pattern: parsed
+                .knowledge
+                .as_ref()
+                .and_then(|section| section.task_id_pattern.as_ref())
+                .is_some(),
+            retired_duel: parsed.duel.is_some(),
+            retired_routines: parsed.routines.is_some(),
+        };
+        if emit_compatibility_warnings {
+            compatibility_keys.warn(config_path);
         }
 
         Ok(Self {
@@ -495,6 +512,35 @@ fn warn_deprecated_task_id_pattern(config_path: &Path) {
         config = %path,
         "knowledge.task_id_pattern is deprecated and ignored",
     );
+}
+
+struct CompatibilityKeys {
+    deprecated_task_id_pattern: bool,
+    retired_duel: bool,
+    retired_routines: bool,
+}
+
+impl CompatibilityKeys {
+    fn warn(&self, config_path: &Path) {
+        if self.deprecated_task_id_pattern {
+            warn_deprecated_task_id_pattern(config_path);
+        }
+        if self.retired_duel {
+            warn_retired_duel_config(config_path);
+        }
+        if self.retired_routines {
+            warn_retired_routines_config(config_path);
+        }
+    }
+}
+
+pub(crate) fn warn_compatibility_keys(document: &toml::Value, config_path: &Path) {
+    CompatibilityKeys {
+        deprecated_task_id_pattern: value_at_path(document, "knowledge.task_id_pattern").is_some(),
+        retired_duel: value_at_path(document, "duel").is_some(),
+        retired_routines: value_at_path(document, "routines").is_some(),
+    }
+    .warn(config_path);
 }
 
 pub(crate) const RETIRED_DUEL_CONFIG_WARNING: &str =

--- a/crates/orbit-config/src/tests/layering.rs
+++ b/crates/orbit-config/src/tests/layering.rs
@@ -1,12 +1,136 @@
 //! Global-over-workspace layering and source provenance.
 
 use std::collections::BTreeMap;
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
 
 use tempfile::tempdir;
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::fmt::MakeWriter;
 
 use super::{roots, write_config};
 use crate::load_effective_config;
+use crate::resolved::RETIRED_ROUTINES_CONFIG_WARNING;
 use crate::{ConfigRoots, ConfigSnapshot, ConfigValueSourceKind, ResolvedConfig};
+
+#[derive(Clone)]
+struct CaptureMakeWriter(Arc<Mutex<Vec<u8>>>);
+
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl<'writer> MakeWriter<'writer> for CaptureMakeWriter {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'writer self) -> Self::Writer {
+        CaptureWriter(Arc::clone(&self.0))
+    }
+}
+
+impl Write for CaptureWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.0
+            .lock()
+            .expect("capture lock")
+            .extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn capture_warnings<T>(action: impl FnOnce() -> T) -> (T, Vec<serde_json::Value>) {
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(CaptureMakeWriter(Arc::clone(&buffer)))
+        .with_max_level(LevelFilter::WARN)
+        .with_target(false)
+        .without_time()
+        .finish();
+    let result = tracing::subscriber::with_default(subscriber, action);
+    let output = String::from_utf8(buffer.lock().expect("capture buffer lock").clone())
+        .expect("warning output is UTF-8");
+    let warnings = output
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("warning is JSON"))
+        .collect();
+    (result, warnings)
+}
+
+fn routines_warning_paths(warnings: &[serde_json::Value]) -> Vec<&str> {
+    warnings
+        .iter()
+        .filter_map(|warning| {
+            let fields = warning.get("fields")?;
+            if fields.get("RETIRED_ROUTINES_CONFIG_WARNING")?.as_str()?
+                != RETIRED_ROUTINES_CONFIG_WARNING
+            {
+                return None;
+            }
+            fields.get("config")?.as_str()
+        })
+        .collect()
+}
+
+#[test]
+fn global_only_retired_routines_warning_names_global_config() {
+    let global = tempdir().expect("global tempdir");
+    let workspace = tempdir().expect("workspace tempdir");
+    write_config(global.path(), "[routines]\nrole = \"source\"\n");
+    write_config(workspace.path(), "[scoring]\nenabled = false\n");
+
+    let (result, warnings) =
+        capture_warnings(|| ResolvedConfig::load(&roots(global.path(), workspace.path())));
+
+    result.expect("layered config loads");
+    let global_path = global.path().join("config.toml");
+    assert_eq!(
+        routines_warning_paths(&warnings),
+        vec![global_path.to_str().expect("UTF-8 path")]
+    );
+}
+
+#[test]
+fn workspace_only_retired_routines_warning_names_workspace_config() {
+    let global = tempdir().expect("global tempdir");
+    let workspace = tempdir().expect("workspace tempdir");
+    write_config(global.path(), "[scoring]\nenabled = false\n");
+    write_config(workspace.path(), "[routines]\nrole = \"source\"\n");
+
+    let (result, warnings) =
+        capture_warnings(|| ResolvedConfig::load(&roots(global.path(), workspace.path())));
+
+    result.expect("layered config loads");
+    let workspace_path = workspace.path().join("config.toml");
+    assert_eq!(
+        routines_warning_paths(&warnings),
+        vec![workspace_path.to_str().expect("UTF-8 path")]
+    );
+}
+
+#[test]
+fn retired_routines_warning_names_each_layer_that_requires_cleanup_once() {
+    let global = tempdir().expect("global tempdir");
+    let workspace = tempdir().expect("workspace tempdir");
+    write_config(global.path(), "[routines]\nrole = \"source\"\n");
+    write_config(workspace.path(), "[routines]\nrole = \"source\"\n");
+
+    let (result, warnings) =
+        capture_warnings(|| ResolvedConfig::load(&roots(global.path(), workspace.path())));
+
+    result.expect("layered config loads");
+    let global_path = global.path().join("config.toml");
+    let workspace_path = workspace.path().join("config.toml");
+    assert_eq!(
+        routines_warning_paths(&warnings),
+        vec![
+            global_path.to_str().expect("UTF-8 path"),
+            workspace_path.to_str().expect("UTF-8 path"),
+        ]
+    );
+}
 
 #[test]
 fn workspace_single_key_inherits_other_global_keys_then_built_in_defaults() {


### PR DESCRIPTION
## Task

[ORB-12294](https://orbit-cli.com/tasks/ORB-12294) — [friction-curation] Attribute retired config warnings to the layer that contains the key

### Description

## Problem
Layered config loading reports a retired key against the highest-precedence config file, even when the key exists only in another layer. On the current managed host, `~/.orbit/config.toml` contains `[routines]` while the Orbit workspace `.orbit/config.toml` does not, yet every registered tool invocation and `orbit run readiness --json` warns with `config=~/workspace/constellation/codebases/orbit/.orbit/config.toml`. Operators are therefore instructed to edit a file that cannot contain the offending section.

## Reproduction and source evidence
- Installed Orbit 0.21.0 (binary mtime 2026-09-12 07:34:53 UTC; deployed source identified by on-call as `34555aa5ca64`) emits `RETIRED_ROUTINES_CONFIG_WARNING` with the workspace path during registered tool calls and a managed `proc.spawn` readiness invocation.
- `rg '^\\[routines\\]'` finds the section at `~/.orbit/config.toml:65` and no match in `~/workspace/constellation/codebases/orbit/.orbit/config.toml`.
- `crates/orbit-config/src/layering.rs` merges the global and workspace documents, then passes one `config_path` chosen as workspace-first to `ResolvedConfig::from_raw_str`.
- `crates/orbit-config/src/resolved.rs` detects `parsed.routines.is_some()` from that merged document and logs the supplied single path, losing the originating layer.
- Historical search found only ORB-12236, the completed change that intentionally introduced the compatibility warning; it does not cover accurate layer attribution.

## Required behavior
Emit each retired/deprecated config warning with the path of the document that actually contains its triggering key. Preserve layered value resolution, acceptance-and-ignore compatibility, error attribution, precedence, and warning text. A key present in both layers should have deterministic, non-misleading behavior without duplicate noise unless both files genuinely require an operator action.

## Constraints
Keep the fix inside orbit-config's authoritative layered loading/validation boundary. Do not remove the compatibility warning early, change config precedence, modify operator configuration, or broaden accepted config syntax.

### Acceptance Criteria

- A layered-config regression test with `[routines]` only in the global file captures `RETIRED_ROUTINES_CONFIG_WARNING` and proves its `config` field names the global config path, not the existing workspace config path.
- Equivalent coverage for a retired/deprecated key present only in the workspace layer attributes the warning to the workspace config path.
- Behavior when the triggering key is present in both layers is explicit and tested: every file that requires operator cleanup is identifiable, without accidental duplicate warnings for one file.
- Existing config layering, validation/error attribution, compatibility acceptance-and-ignore behavior, and precedence tests remain green.
- `make ci-fast`, `make ci-lint`, and `make goldens` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Layered loading now suppresses merged-document compatibility warnings and emits the unchanged retired/deprecated warnings once per source document using that document's actual path.
- Single-document parsing and ConfigStore validation retain their existing compatibility-warning behavior.
- Added structured tracing regression coverage for global-only, workspace-only, and both-layer [routines] configurations; added tracing-subscriber as a test-only dependency.

Acceptance criteria:
1. Global-only [routines]: passed; regression test asserts the sole RETIRED_ROUTINES_CONFIG_WARNING config field equals the global config path while a workspace config exists.
2. Workspace-only [routines]: passed; regression test asserts the warning names the workspace config path.
3. Both layers: passed; regression test asserts deterministic global-then-workspace warnings, exactly once for each affected file.
4. Layering, validation/error attribution, compatibility acceptance-and-ignore, and precedence: passed; the full orbit-config suite completed 122 tests successfully.
5. Required gates: passed.

Validation:
- cargo fmt --all -- --check: passed.
- cargo test -p orbit-config: passed (122 unit tests; 0 doc tests).
- make ci-fast: passed; its compiler-cache namespace probe reported the documented environment skip because unprivileged user namespaces are unavailable, while the gate exited 0.
- make ci-lint: passed.
- make goldens: passed.
- git diff --check: passed.
- git status --short: passed; only the five intended scoped files are modified.

Assessment: The warning provenance rule now lives at the layered boundary that retains source documents, while resolved parsing keeps one canonical compatibility-warning implementation and preserves the existing warning text and resolution behavior.
Remaining risks or deviations: None. The environment-limited ci-fast sub-probe is informational and did not weaken or fail the required gate.
Friction checkpoint: No qualifying friction found.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12294-6aa50710`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra