### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design-patterns/command.md
+++ b/docs/design-patterns/command.md
@@ -1,11 +1,11 @@
 ---
 type: pattern
 summary: "Command Pattern"
-last_validated: 2026-08-22
+last_validated: 2026-09-12
 ---
 # Command Pattern
 
-In this codebase, Command = the `Tool` trait at `crates/orbit-tools/src/lib.rs:246`:
+In this codebase, Command = the `Tool` trait at `crates/orbit-tools/src/lib.rs:286`:
 
 ```rust
 pub trait Tool: Send + Sync {
@@ -14,15 +14,15 @@ pub trait Tool: Send + Sync {
 }
 ```
 
-The registry at `crates/orbit-tools/src/registry.rs:31` stores `Arc<dyn Tool>` keyed by `ToolSchema::name`. Adding a tool means: writing a struct, `impl Tool`, registering in `builtin::register_builtins`. The dispatcher never changes.
+The registry at `crates/orbit-tools/src/registry.rs:32` stores `Arc<dyn Tool>` keyed by `ToolSchema::name`. Adding a tool means: writing a struct, `impl Tool`, registering in `builtin::register_builtins`. The dispatcher never changes.
 
 ## Destructive CLI confirmation
 
-CLI commands never prompt or read stdin. An irreversible single action exposes
+Destructive CLI commands never prompt or read stdin. An irreversible single action exposes
 `--confirm` and refuses before mutation when it is absent. A migration or bulk
 cleanup command is non-destructive by default (report/dry-run) and uses
 `--confirm` to apply. Existing spellings may remain as compatibility aliases
-(`--yes` for worktree GC and `--delete` for learning prune), but new commands
+(`--yes` for worktree GC), but new commands
 must not introduce another confirmation spelling. Reversible mutations should
 instead document and test their recovery command.
 
@@ -44,12 +44,12 @@ impl Tool for OrbitPipelineInvokeTool {
 }
 ```
 
-`execute_host_action` (`orbit/mod.rs:251`) resolves the caller's identity, requires a host on the context, and forwards `(action, input, agent, model, reservation_owner)` into the runtime.
+`execute_host_action` (`orbit/mod.rs:273`) resolves the caller's identity, requires a host on the context, and forwards the action, input, identity, and reservation metadata into the runtime.
 
 Patterns to copy:
 
 - **A new tool of this kind lands in three places.** New struct in `orbit/<area>/<verb>.rs`, new variant in `OrbitBuiltinAction`, new match arm in the host's `execute()`. The dispatcher and registry are untouched.
-- **Schema in `orbit-tools`; logic in `orbit-core`.** This is the rule that keeps `orbit-tools` free of runtime / store dependencies per the architecture diagram in `CLAUDE.md`. If your tool needs the task store, the activity-job engine, or sandboxed exec, it must dispatch through the host — don't pull those deps into `orbit-tools`.
+- **Schema in `orbit-tools`; logic in `orbit-core`.** This is the rule that keeps `orbit-tools` free of runtime / store dependencies per the architecture diagram in `ARCHITECTURE.md`. If your tool needs the task store, the activity-job engine, or sandboxed exec, it must dispatch through the host — don't pull those deps into `orbit-tools`.
 - **MCP-only adapters stay in `orbit-mcp`.** Global host/workspace discovery is not a generic `ToolRegistry` command. Its schema and projection live beside MCP framing and are composed with the caller-supplied host; adding one does not add an `OrbitBuiltinAction` or Core `run_tool` arm.
 
 ---

--- a/docs/design/user-interface/3_vision.md
+++ b/docs/design/user-interface/3_vision.md
@@ -4,7 +4,7 @@ type: design
 title: "User Interface — Vision"
 owner: gemini
 last_updated: 2026-04-30
-last_validated: 2026-08-17
+last_validated: 2026-09-12
 status: Draft
 feature: user-interface
 doc_role: vision

--- a/docs/design/user-interface/4_decisions.md
+++ b/docs/design/user-interface/4_decisions.md
@@ -3,8 +3,8 @@ summary: "User Interface — Decisions"
 type: design
 title: "User Interface — Decisions"
 owner: gemini
-last_updated: 2026-08-11
-last_validated: 2026-08-17
+last_updated: 2026-09-12
+last_validated: 2026-09-12
 status: Draft
 feature: user-interface
 doc_role: decisions
@@ -66,6 +66,9 @@ Render companion metrics as compact pairs: `tokens` is `total/output`, `tool fai
 
 **Recorded:** 2026-05-11 02:06:39.449202Z · [T20260430-29]
 
+This layout was superseded by the Tasks side dock: Status and Log now share the
+right column, and `#log-panel` fills the dock when Log is selected.
+
 ### Context
 The Tasks view keeps `orbit.log` visible beside the task list, but the log panel could grow taller than short viewports and push footer controls below the screen.
 
@@ -116,6 +119,9 @@ Render the dashboard scoreboard as focused sections: Delivery, Review, Knowledge
 
 **Recorded:** 2026-05-18 06:55:55.249402Z · [ORB-00146]
 
+The extracted crate is now named `orbit-web`; it still owns the HTTP API and
+embedded dashboard assets while `orbit-cli` remains the thin entry point.
+
 ### Context
 The Orbit web dashboard lived inside orbit-cli even though its HTML, JavaScript, read-only axum API handlers, and embedded assets formed a distinct internal surface. The only local coupling was the CLI Execute trait; keeping the dashboard in orbit-cli forced unrelated CLI edits to rebuild the heavier web tree and mixed dashboard tests into the CLI target.
 
@@ -150,6 +156,10 @@ Render canonical scoreboard metrics as one metric-major Unified Leaderboard Matr
 ## Global, Multi-Workspace Dashboard
 
 **Recorded:** 2026-07-26 21:51:44.038593Z · [ORB-00030], [ORB-10458]
+
+The single-workspace serving branch described below has since been retired.
+`orbit web serve` now always enumerates the selected registry; `--global` is an
+accepted compatibility no-op, and `--workspace` selects the initial workspace.
 
 ### Context
 

--- a/docs/design/user-interface/specs/theme.md
+++ b/docs/design/user-interface/specs/theme.md
@@ -2,7 +2,7 @@
 type: design
 summary: "Spec: Canon Refined Theme"
 tags: ["user-interface"]
-last_validated: 2026-08-17
+last_validated: 2026-09-12
 ---
 
 # Spec: Canon Refined Theme
@@ -23,7 +23,8 @@ The theme uses a layered dark mode, relying on subtle lightness shifts rather th
 
 ### Borders
 Borders delineate structure without heavy contrast.
-- `--border`: `#333333` (Standard dividers)
+- `--border`: `#2a2a2e` (Panel and control edges)
+- `--hair`: `#17171a` (Dividers inside panels and controls)
 - Focused inputs use the `--accent` border; there is no dedicated `--border-strong` token.
 
 ### Typography

--- a/docs/design/worktree-artifacts/1_overview.md
+++ b/docs/design/worktree-artifacts/1_overview.md
@@ -4,7 +4,7 @@ type: design
 title: "Worktree Artifacts - Overview"
 owner: codex
 last_updated: 2026-08-15
-last_validated: 2026-08-17
+last_validated: 2026-09-12
 status: Accepted
 feature: worktree-artifacts
 doc_role: overview

--- a/docs/design/worktree-artifacts/2_design.md
+++ b/docs/design/worktree-artifacts/2_design.md
@@ -4,7 +4,7 @@ type: design
 title: "Worktree Artifacts - Design"
 owner: codex
 last_updated: 2026-08-15
-last_validated: 2026-08-17
+last_validated: 2026-09-12
 status: Accepted
 feature: worktree-artifacts
 doc_role: design
@@ -25,7 +25,7 @@ related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10272", "ORB-102
 > into feature decision docs; [ORB-10805] removed the redundant tracked store and
 > its IDs.
 
-The historical implementation treated decision and learning bodies as branch-local files with workspace-local IDs ([Workspace-scoped knowledge keys, no global knowledge IDs](../host-registry/4_decisions.md#workspace-scoped-knowledge-keys-no-global-knowledge-ids)). The root split remains relevant to task execution, while the artifact-specific mechanisms below document retired behavior.
+The historical implementation treated decision and learning bodies as branch-local files with workspace-local IDs (the workspace-scoped knowledge-key model from [ORB-10725]). The root split remains relevant to task execution, while the artifact-specific mechanisms below document retired behavior.
 
 ## 1. Runtime Roots
 
@@ -36,7 +36,7 @@ Explicit `--root` and `ORBIT_ROOT` overrides pin both roots to preserve the old 
 ## 2. Allocation Metadata
 
 In the retired standalone/worktree implementation, `id_allocations` lived in
-`shared_root/.orbit/state/semantic.db`. The allocator serializes ID creation with a
+`shared_root/state/semantic.db`. The allocator serializes ID creation with a
 shared lock, then body writes update the row with:
 
 - `worktree_root`: the recorded worktree root for the body.
@@ -45,8 +45,8 @@ shared lock, then body writes update the row with:
 
 Backfilled shared-root artifacts received `body_path` during allocator initialization so old ADRs and migrated learnings remained readable from any worktree. ORB-10736 removed this allocator and the native learning projections; current store migrations explicitly drop `id_allocations`, while any old `.orbit/learnings/` files remain inert historical data.
 
-The retired design had one allocator, and every create path used it. [Workspace-scoped knowledge keys, no global knowledge IDs](../host-registry/4_decisions.md#workspace-scoped-knowledge-keys-no-global-knowledge-ids) keyed
-knowledge `(workspace_id, artifact_key)`, so an ID was unique within its workspace
+The retired design had one allocator, and every create path used it. Under [ORB-10725],
+knowledge used `(workspace_id, artifact_key)` as its key, so an ID was unique within its workspace
 and made no claim outside it; [ORB-10725] deleted the hub-global sequence that
 §2.1 and §2.2 once described.
 
@@ -59,10 +59,10 @@ marker. [ORB-10330] added the owner-side `finalize_preallocated` paths and the
 gated broker composition that paired one hub allocation with one owner-checkout
 finalization, correlated by `mcp_call_id`.
 
-**Both are removed** ([ORB-10725], [Workspace-scoped knowledge keys, no global knowledge IDs](../host-registry/4_decisions.md#workspace-scoped-knowledge-keys-no-global-knowledge-ids)). Public issuance never activated, so
+**Both are removed** ([ORB-10725]). Public issuance never activated, so
 no ID was ever drawn from the sequence and nothing had to be renumbered; what the
 substrate encoded was a superseded model, which is why it was deleted rather than
-parked alongside the registry tables that [Defer fleet registration and execution placement to v2](../host-registry/4_decisions.md#defer-fleet-registration-and-execution-placement-to-v2) keeps dormant for v2. Remote
+parked alongside the registry tables that [V1 has no fleet control plane](../host-registry/4_decisions.md#v1-has-no-fleet-control-plane) keeps dormant for v2. Remote
 feature v2 keeps its ledger slot — feature-migration names are immutable, so a
 database that recorded it must still find it — but the slot is a no-op, and Remote
 feature v3 drops the tables `IF EXISTS` so a database that applied the original v2
@@ -198,7 +198,7 @@ The retired `worktree_root` column preserved historical rows from earlier phases
 - [ORB-10330] added the owner-side preallocated finalizers (`finalize_preallocated`
   on the ADR and learning stores) and the gated broker composition. Removed by
   [ORB-10725]: with no allocation step there is no preallocated ID to finalize.
-- [ORB-10725] deleted both substrates under [Workspace-scoped knowledge keys, no global knowledge IDs](../host-registry/4_decisions.md#workspace-scoped-knowledge-keys-no-global-knowledge-ids), turned Remote feature v2
+- [ORB-10725] deleted both substrates under the workspace-scoped knowledge-key model, turned Remote feature v2
   into a no-op slot, and added Remote feature v3 to drop its tables from databases
   that had applied it.
 - [ORB-10545] added exact-bundle reconciliation and made superseded ADR bodies


### PR DESCRIPTION
## Task

[ORB-12285](https://orbit-cli.com/tasks/ORB-12285) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Batch selection:
- At starting HEAD b416d058e2ee50501122048addac31d501c0d6df, an in-scope Markdown scan excluding docs/changelogs/** and docs/design/_archive/** found no document missing last_validated. The five paths dated 2026-08-17 were docs/design/user-interface/3_vision.md, docs/design/user-interface/4_decisions.md, docs/design/user-interface/specs/theme.md, docs/design/worktree-artifacts/1_overview.md, and docs/design/worktree-artifacts/2_design.md. The sixth was docs/design-patterns/command.md, the path-first member of the next-oldest 2026-08-22 group. Exactly these six files were worked.
- All six already had schema-compatible frontmatter. No frontmatter-less document was selected, so no metadata migration or inferred type/summary was needed.

Changes and verification:
- docs/design-patterns/command.md: updated Tool/registry/host-dispatch line anchors, narrowed the stdin statement to destructive CLI commands because orbit init is interactive, removed the retired learning-prune --delete alias, and pointed the architecture statement to ARCHITECTURE.md. Verified with rg over crates/orbit-tools, crates/orbit-agent, crates/orbit-core, and crates/orbit-cli plus direct reads of lib.rs, registry.rs, builtin/orbit/mod.rs, pipeline/invoke.rs, runtime/factory.rs, command/mod.rs, and init/agent_prompt.rs.
- docs/design/user-interface/3_vision.md: no prose change; the current dashboard surfaces named by the vision were verified in crates/orbit-web assets and routes, and the local theme link resolves. The external benchmark judgments about k9s, htop, Bloomberg Terminal, Linear, and Vercel are not repository-observable; they were left unchanged as non-implementation comparison points.
- docs/design/user-interface/4_decisions.md: added current-state notes for the Tasks Status/Log side dock, the orbit-web crate name, and always-global registry-backed serving; updated existing last_updated. Historical decisions were traced with git log --all --grep for their recorded task markers. Current behavior was verified in crates/orbit-web/src/{lib.rs,state.rs,api/**}, crates/orbit-web/assets/dashboard/**, crates/orbit-core/src/metrics/reliability.rs, crates/orbit-types/src/workflow/activity_job/activity_roles.rs, and crates/orbit-store/src/driver/sqlite/reliability_store.rs. The historical 30-day measurement of roughly one recovery invocation per 3.6 implementation attempts cannot be reproduced from repository contents alone; it was left unchanged and is explicitly the one unverified claim in this stamped document.
- docs/design/user-interface/specs/theme.md: corrected --border from #333333 to #2a2a2e and documented the live #17171a --hair divider token. Verified all listed colors, fonts, sizing, animation, expanded-row styling, caret rotation, and layout against crates/orbit-web/assets/dashboard/dashboard.css.
- docs/design/worktree-artifacts/1_overview.md: no prose change. Verified current shared/local root behavior in crates/orbit-core/src/runtime/resolve.rs and current retirement state through the absence of public ADR/learning tools plus the id_allocations drop migration. Historical locations and behavior were checked in the recorded ORB task commits with git log, git ls-tree, git cat-file, and git grep.
- docs/design/worktree-artifacts/2_design.md: corrected the retired database path to shared_root/state/semantic.db and repaired obsolete host-registry links without adding a section. Verified current root precedence in crates/orbit-core/src/runtime/resolve.rs, the id_allocations removal in crates/orbit-store/src/driver/sqlite/migration/mod.rs, retired tool absence in crates/orbit-tools/tests/public_tool_surface.rs, and historical artifact code at the recorded task commits with git log, git ls-tree, git cat-file, and git grep.

Acceptance criteria:
- Exactly the missing-then-oldest stable-path batch was selected from the starting revision and all six, but no others, were validated and stamped 2026-09-12.
- Each stamp is backed by the per-document source/history evidence above. One non-reproducible historical metric and the vision comparison judgments were left textually unchanged and are disclosed above.
- No selected document had uncertain classification. No frontmatter was created, no new metadata field or marker system was introduced, and no document or section was authored.
- Formatting-only work was limited to repairing obsolete relative decision links; existing prose was not reflowed or rewrapped.
- git diff --name-only contains only the six authorized docs. No .orbit/adrs/**, CHANGELOG.md, docs/changelogs/**, docs/design/_archive/**, generated state, or asset file changed.

Validation:
- PASSED: make ci-fast (rerun after the final edits; exit 0). Its compiler-cache namespace subcheck reported the expected environment skip because unprivileged mount namespaces are unavailable; the gate itself passed.
- PASSED: make ci-lint (workspace/all-target clippy with warnings denied; exit 0).
- PASSED: make goldens (exit 0; no golden changes).
- PASSED: git diff --check.
- PASSED: excluded-path diff-name check returned no matches.
- PASSED: GIT_OPTIONAL_LOCKS=0 git status --short showed exactly six expected modified docs and no untracked files.

Assessment: The batch is complete, bounded, source-backed, and ready for pipeline handoff. No remaining implementation risk or deviation from the plan was found.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12285-6aa50ba3`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra