### PR TITLE
[code-review] `triage_failed_runs`' only authorized transition (blocked → done) is now refused by the task lifecycle table

### DIFF
--- a/.orbit/resources/activities/triage_failed_runs.yaml
+++ b/.orbit/resources/activities/triage_failed_runs.yaml
@@ -16,9 +16,8 @@ spec:
     the agent reads the failure evidence, classifies the cause
     (environmental / task_defect / code_defect / unknown), applies bounded
     read-mostly mitigation, and returns per-task dispositions as data. Its
-    one permitted lifecycle write is the evidence-gated blocked → done
-    reconciliation of externally-completed work; every other transition
-    belongs to the deterministic `apply_triage_dispositions` step, and the
+    dispositions are advisory data; every lifecycle transition belongs to
+    the deterministic `apply_triage_dispositions` step or a human, and the
     tool allowlist makes code edits, commits, pushes, merges, PR approvals,
     and pipeline invocations structurally impossible (`on_denial: terminate`).
   input_schema_json:
@@ -115,22 +114,19 @@ spec:
        are already reconciled deterministically before you run — do not
        reimplement that. Record what you did in `mitigation`.
     4. Decide the disposition:
-       - **work already landed → reconcile to done yourself.** If the
+       - **work already landed → leave blocked for human reconciliation.** If the
          evidence is conclusive that the task's deliverable already landed
          despite the failed run — e.g. the run failed at `pr_promote` /
          `pr_open` but the task's own PR is recorded as merged to the
          landing branch (task history/comments, run logs, `.orbit/state/`,
-         or the repo's git refs via the provider-native file-read tool) — set the task to `done`
-         via `orbit.task.update` with `status: "done"`, attaching a comment
-         that cites the exact evidence (PR number, merge commit, where you
-         saw it). Then return
-         `stay_blocked` as the disposition: the apply step sees the task
-         has left `blocked` and skips it. Never `rebacklog` landed work —
-         a rerun redoes merged work and risks duplicate PRs. This is the
-         ONLY lifecycle transition you may perform, and only on a
-         candidate you were given; if the evidence is anything short of
-         conclusive, do not touch the task and fall through to the rules
-         below.
+         or the repo's git refs via the provider-native file-read tool) —
+         return `stay_blocked` and cite the exact evidence in `diagnosis`
+         (PR number, merge commit, where you saw it). The deterministic apply
+         step records that diagnosis while leaving the task blocked for a
+         human to reconcile through a lifecycle-legal path. Never `rebacklog`
+         landed work — a rerun redoes merged work and risks duplicate PRs.
+         If the evidence is anything short of conclusive, fall through to
+         the rules below.
        - `environmental` and mitigated (or transient and now clear) →
          `rebacklog`. The deterministic apply step returns the task to the
          backlog and the normal ship sweep picks it up — never re-run a
@@ -141,10 +137,8 @@ spec:
     Hard bounds (violations terminate the run):
     - Never edit code, commit, push, merge, or approve a PR.
     - Never invoke a pipeline or job run.
-    - The only lifecycle transition you may perform yourself is the
-      evidence-gated blocked → done reconciliation in step 4, on a listed
-      candidate. Never make any other status change — return dispositions
-      as data; the deterministic step is the only other writer.
+    - Never change task status. Return dispositions as data; the deterministic
+      apply step is the only lifecycle writer in this activity.
     - Only reason about the candidates you were given.
 
     Return exactly one JSON object:
@@ -155,7 +149,6 @@ spec:
   tools:
     - orbit.task.show
     - orbit.task.list
-    - orbit.task.update
     - orbit.friction.add
     - orbit.search
     - proc.spawn

--- a/crates/orbit-core/assets/activities/triage_failed_runs.yaml
+++ b/crates/orbit-core/assets/activities/triage_failed_runs.yaml
@@ -16,9 +16,8 @@ spec:
     the agent reads the failure evidence, classifies the cause
     (environmental / task_defect / code_defect / unknown), applies bounded
     read-mostly mitigation, and returns per-task dispositions as data. Its
-    one permitted lifecycle write is the evidence-gated blocked → done
-    reconciliation of externally-completed work; every other transition
-    belongs to the deterministic `apply_triage_dispositions` step, and the
+    dispositions are advisory data; every lifecycle transition belongs to
+    the deterministic `apply_triage_dispositions` step or a human, and the
     tool allowlist makes code edits, commits, pushes, merges, PR approvals,
     and pipeline invocations structurally impossible (`on_denial: terminate`).
   input_schema_json:
@@ -115,22 +114,19 @@ spec:
        are already reconciled deterministically before you run — do not
        reimplement that. Record what you did in `mitigation`.
     4. Decide the disposition:
-       - **work already landed → reconcile to done yourself.** If the
+       - **work already landed → leave blocked for human reconciliation.** If the
          evidence is conclusive that the task's deliverable already landed
          despite the failed run — e.g. the run failed at `pr_promote` /
          `pr_open` but the task's own PR is recorded as merged to the
          landing branch (task history/comments, run logs, `.orbit/state/`,
-         or the repo's git refs via the provider-native file-read tool) — set the task to `done`
-         via `orbit.task.update` with `status: "done"`, attaching a comment
-         that cites the exact evidence (PR number, merge commit, where you
-         saw it). Then return
-         `stay_blocked` as the disposition: the apply step sees the task
-         has left `blocked` and skips it. Never `rebacklog` landed work —
-         a rerun redoes merged work and risks duplicate PRs. This is the
-         ONLY lifecycle transition you may perform, and only on a
-         candidate you were given; if the evidence is anything short of
-         conclusive, do not touch the task and fall through to the rules
-         below.
+         or the repo's git refs via the provider-native file-read tool) —
+         return `stay_blocked` and cite the exact evidence in `diagnosis`
+         (PR number, merge commit, where you saw it). The deterministic apply
+         step records that diagnosis while leaving the task blocked for a
+         human to reconcile through a lifecycle-legal path. Never `rebacklog`
+         landed work — a rerun redoes merged work and risks duplicate PRs.
+         If the evidence is anything short of conclusive, fall through to
+         the rules below.
        - `environmental` and mitigated (or transient and now clear) →
          `rebacklog`. The deterministic apply step returns the task to the
          backlog and the normal ship sweep picks it up — never re-run a
@@ -141,10 +137,8 @@ spec:
     Hard bounds (violations terminate the run):
     - Never edit code, commit, push, merge, or approve a PR.
     - Never invoke a pipeline or job run.
-    - The only lifecycle transition you may perform yourself is the
-      evidence-gated blocked → done reconciliation in step 4, on a listed
-      candidate. Never make any other status change — return dispositions
-      as data; the deterministic step is the only other writer.
+    - Never change task status. Return dispositions as data; the deterministic
+      apply step is the only lifecycle writer in this activity.
     - Only reason about the candidates you were given.
 
     Return exactly one JSON object:
@@ -155,7 +149,6 @@ spec:
   tools:
     - orbit.task.show
     - orbit.task.list
-    - orbit.task.update
     - orbit.friction.add
     - orbit.search
     - proc.spawn

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/triage.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/triage.rs
@@ -409,28 +409,11 @@ fn diagnosed_run_is_suppressed_until_new_failure_or_explicit_request() {
 }
 
 #[test]
-fn agent_completed_task_makes_apply_step_a_clean_skip() {
+fn landed_work_stays_blocked_with_diagnosis_for_human_reconciliation() {
     let (_root, runtime, repo_root) = test_runtime();
-    let task_id = create_backlog_task(&runtime, &repo_root, "completed-externally");
+    let task_id = create_backlog_task(&runtime, &repo_root, "landed-externally");
     fail_pipeline_run_for_task(&runtime, &task_id);
     let listing = list_candidates(&runtime, json!({}));
-
-    runtime
-        .apply_task_automation_update(
-            &task_id,
-            TaskAutomationUpdate {
-                status: Some(TaskStatus::Done),
-                status_note: Some(
-                    "triage reconciled externally-completed work: PR #619 merged".to_string(),
-                ),
-                ..TaskAutomationUpdate::default()
-            },
-        )
-        .expect("triage agent reconciles task to done");
-    let history_len_before_apply = runtime
-        .get_task_history(&task_id)
-        .expect("history before apply")
-        .len();
 
     let applied = apply_dispositions(
         &runtime,
@@ -439,28 +422,28 @@ fn agent_completed_task_makes_apply_step_a_clean_skip() {
                 "task_id": task_id,
                 "classification": "unknown",
                 "disposition": "stay_blocked",
-                "diagnosis": "work already landed",
+                "diagnosis": "work already landed: PR #619 merged as abc123 on agent-main",
             }],
             "candidates": listing["candidates"],
         }),
     );
-    assert_eq!(applied["skipped_count"], json!(1));
-    assert_eq!(applied["diagnosed_count"], json!(0));
-    assert_eq!(
-        applied["results"][0]["reason"],
-        json!("task is no longer blocked (status: done)")
-    );
+    assert_eq!(applied["diagnosed_count"], json!(1));
+    assert_eq!(applied["skipped_count"], json!(0));
     assert_eq!(
         runtime.get_task(&task_id).expect("task after apply").status,
-        TaskStatus::Done
+        TaskStatus::Blocked,
+        "landed work awaits lifecycle-legal human reconciliation"
     );
-    assert_eq!(
-        runtime
-            .get_task_history(&task_id)
-            .expect("history after apply")
-            .len(),
-        history_len_before_apply,
-        "the deterministic apply step must not double-write after reconciliation"
+    let history = runtime.get_task_history(&task_id).expect("history");
+    let note = history
+        .iter()
+        .rev()
+        .find(|entry| entry.event == TRIAGE_DIAGNOSIS_EVENT)
+        .and_then(|entry| entry.note.as_deref())
+        .expect("triage diagnosis recorded");
+    assert!(
+        note.contains("PR #619 merged as abc123 on agent-main"),
+        "the durable diagnosis must preserve the exact landing evidence: {note}"
     );
 }
 

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/triage.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/triage.rs
@@ -9,9 +9,8 @@
 //! bounds: only listed candidates may be touched, only `environmental`
 //! classifications may re-backlog, and a durable per-task re-backlog budget
 //! (counted from `triage_rebacklogged` history events) stops the
-//! blocked → backlog → blocked ping-pong. The agent's one direct lifecycle
-//! write is an evidence-gated blocked → done reconciliation; every other
-//! transition remains bounded here.
+//! blocked → backlog → blocked ping-pong. Agent dispositions are advisory;
+//! lifecycle transitions remain bounded here or require human action.
 
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/crates/orbit-core/src/bootstrap/activity.rs
+++ b/crates/orbit-core/src/bootstrap/activity.rs
@@ -563,8 +563,8 @@ backend = "cli"
                     // pipeline / job dispatch
                     "orbit.pipeline.invoke",
                     "orbit.pipeline.wait",
-                    // task lifecycle writes other than the activity's one
-                    // evidence-gated blocked -> done reconciliation
+                    // task lifecycle writes
+                    "orbit.task.update",
                     "orbit.task.start",
                     "orbit.task.approve",
                     "orbit.task.reject",
@@ -578,12 +578,7 @@ backend = "cli"
                         "triage agent must not be able to call `{denied}`"
                     );
                 }
-                for allowed in [
-                    "orbit.task.show",
-                    "orbit.task.update",
-                    "orbit.friction.add",
-                    "proc.spawn",
-                ] {
+                for allowed in ["orbit.task.show", "orbit.friction.add", "proc.spawn"] {
                     assert!(
                         tool_allowed(allowed, &spec.tools),
                         "triage agent should be able to call `{allowed}`"


### PR DESCRIPTION
## Task

[ORB-12297](https://orbit-cli.com/tasks/ORB-12297) — [code-review] `triage_failed_runs`' only authorized transition (blocked → done) is now refused by the task lifecycle table

### Description

## Problem

ORB-12245 (`b30ef98f7`) added an enforced task lifecycle table and routed every attributed surface — including the registered `orbit.task.update` tool — through it. The shipped `triage_failed_runs` activity still instructs its agent to perform a `blocked → done` reconciliation through that exact tool, which the table refuses.

- `crates/orbit-core/assets/activities/triage_failed_runs.yaml:118-133`: "**work already landed → reconcile to done yourself** … set the task to `done` via `orbit.task.update` with `status: \"done\"` … This is the ONLY lifecycle transition you may perform". The activity's `tools:` list (`:155-162`) grants `orbit.task.update`, and the candidates it is given are `blocked` tasks.
- `crates/orbit-core/src/application/task/lifecycle.rs:60`: `(Blocked, target) => matches!(target, Backlog | InProgress)` — `Done` is not reachable from `Blocked`. The refusal message is `'done' is reachable only from 'review'` (`lifecycle.rs:115`).
- The tool path is the guarded one: `crates/orbit-tools/src/builtin/orbit/task/update.rs:199-200` → `crates/orbit-core/src/adapter/tool_host/task_tools.rs:324` (`update_task_with_owner`) → `crates/orbit-core/src/application/task/update.rs:135-152`, which sets `StatusAuthority::Lifecycle`, so `ensure_status_change_allowed` runs (`update.rs:232-237`).
- The human escape hatch does not help an agent: `orbit.task.update` rejects a `force` argument outright (`crates/orbit-tools/src/builtin/orbit/task/update.rs:187-192`, mirrored in `task_tools.rs:311-316`), and `force_update_task_with_identity` is reachable only from the bare CLI `orbit task update --force`.

Even if the transition were reachable, the `done` precondition would also apply: `completion_evidence_present` requires a non-empty `execution_summary` or a successfully finished job run (`lifecycle.rs:133-158`), and the failed run the triage is reconciling is by definition not successful.

## Impact

The documented self-heal for "the PR merged but the run died at `pr_promote`/`pr_open`" cannot execute. The triage agent receives an `invalid_input` error mid-run for the one write it is authorized to make, so landed work stays `blocked` until a human runs `orbit task update <id> --status done --force`. The agent's documented alternative is the disposition it is explicitly warned against (`rebacklog` of landed work re-runs a merged pipeline and risks duplicate PRs).

## Fix direction

Pick one authoritative answer and make the other side agree: either give the reconciliation a lifecycle-legal path (for example route it through the deterministic apply step / an internal-authority activity, which already bypasses the table via `update_task_from_activity`), or rewrite the activity's step-4 instruction and hard bounds so they no longer advertise a transition the domain refuses. Do not weaken the lifecycle table for agents as a workaround.

### Acceptance Criteria

- The `blocked -> done` reconciliation described in `triage_failed_runs` either succeeds end to end through a lifecycle-legal path, or the activity text no longer instructs a transition the lifecycle table refuses.
- A test exercises the reconciliation on a `blocked` candidate and asserts the resulting task status, so the activity instruction and the enforced table cannot drift apart again.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Rewrote both mirrored triage_failed_runs activity assets so already-landed work returns stay_blocked with exact merge evidence for human reconciliation instead of attempting the lifecycle-illegal blocked -> done transition.
- Removed orbit.task.update from the triage agent allowlist and strengthened the bootstrap structural test to deny all task lifecycle writes.
- Replaced the internal-authority done simulation with an end-to-end blocked-candidate disposition test that asserts the task remains blocked and the landing evidence is durably recorded.
- Updated triage module documentation to match the advisory-agent/deterministic-writer boundary.

Acceptance criteria:
1. The activity no longer instructs blocked -> done. It explicitly keeps landed work blocked for human reconciliation through a lifecycle-legal path, and its tool allowlist no longer grants orbit.task.update.
2. landed_work_stays_blocked_with_diagnosis_for_human_reconciliation creates a blocked failed-run candidate, applies the prescribed stay_blocked disposition, asserts TaskStatus::Blocked, and verifies the durable diagnosis contains the exact landing evidence. The bootstrap allowlist test also asserts orbit.task.update is structurally denied.

Validation:
- cargo test -p orbit-core landed_work_stays_blocked_with_diagnosis_for_human_reconciliation: passed.
- cargo test -p orbit-core triage_agent_allowlist_makes_write_surfaces_structurally_impossible: passed.
- cargo test -p orbit-core adapter::engine_host::v2_host::tests::triage: passed (12 tests).
- make ci-fast: passed. Its compiler-cache namespace probe reported the documented runner-level Bubblewrap user-namespace skip; the gate exited successfully.
- make ci-lint: passed.
- make goldens: passed.
- git diff --check: passed.
- cmp -s .orbit/resources/activities/triage_failed_runs.yaml crates/orbit-core/assets/activities/triage_failed_runs.yaml: passed.
- git status --short: five intended tracked modifications, no untracked files.

Assessment: The smallest guard-preserving repair is complete. Lifecycle and completion-evidence rules were not weakened, output disposition compatibility remains unchanged, and no files outside the authorized context changed.
Remaining risks or deviations: none.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12297-6aa50d4a`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra