### PR TITLE
COPILOT_DEFAULT_MODEL pins `claude-sonnet-4.5`, which Copilot CLI 1.0.84 rejects; runs fail with an unsurfaced `--model` error

### DIFF
--- a/crates/orbit-common/src/model_defaults.rs
+++ b/crates/orbit-common/src/model_defaults.rs
@@ -88,12 +88,12 @@ pub const GROK_DEFAULT_MODEL: &str = "grok-4.6";
 /// Copilot routes to several vendors' models; Orbit pins an explicit id rather
 /// than letting the CLI fall back to `COPILOT_MODEL` or its persisted `/model`
 /// choice, so a run's model comes from the resolved crew and not from ambient
-/// operator state. Both ids below are present in the model catalog shipped
-/// with Copilot CLI 1.0.80. The provider identity stays `copilot` regardless of
-/// which vendor supplies the model. [ORB-10946]
-pub const COPILOT_DEFAULT_MODEL: &str = "claude-sonnet-4.5";
+/// operator state. Both ids below were verified against the account-visible
+/// model catalog in Copilot CLI 1.0.84. The provider identity stays `copilot`
+/// regardless of which vendor supplies the model. [ORB-10946]
+pub const COPILOT_DEFAULT_MODEL: &str = "claude-sonnet-5";
 
-/// Cheap-tier Copilot model used for the bounded system crew.
+/// Cheap-tier Claude model used for the bounded Copilot system crew.
 pub const COPILOT_CREW_MODEL: &str = "claude-haiku-4.5";
 
 /// Default model for the Cursor execution lane.

--- a/crates/orbit-config/src/tests/resolved.rs
+++ b/crates/orbit-config/src/tests/resolved.rs
@@ -69,7 +69,7 @@ fn built_in_crews_use_standard_model_specific_names() {
         ("gemini", "gemini", "gemini-3.8-flash"),
         ("antigravity", "antigravity", "gemini-3.8-flash-high"),
         ("grok", "grok", "grok-4.6"),
-        ("copilot", "copilot", "claude-sonnet-4.5"),
+        ("copilot", "copilot", "claude-sonnet-5"),
         ("cursor", "cursor", "gpt-5"),
         ("pi", "pi", "sonnet"),
         ("opencode", "opencode", "anthropic/claude-sonnet-4-5"),
@@ -84,7 +84,7 @@ fn built_in_crews_use_standard_model_specific_names() {
     // The Copilot lane keeps its own identity: it is never aliased to the
     // vendor supplying its model, nor to GitHub. [ORB-10946]
     assert!(!crews.contains_key("github"));
-    assert!(!crews.contains_key("claude-sonnet-4.5"));
+    assert!(!crews.contains_key("claude-sonnet-5"));
     assert!(!crews.contains_key("anysphere"));
 
     let config = ResolvedConfig::built_in(PersistenceConfig::default_for_data_root(Path::new(

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -33,8 +33,9 @@ use super::envelope::{
 use super::inspection::SourceInspection;
 use super::spawn::{
     CODEX_CA_CERTIFICATE_ENV, PreparedSandbox, SSL_CERT_FILE_ENV,
-    linux_bwrap_failed_write_diagnostic, macos_keychain_auth_diagnostic, orbit_tool_env,
-    prepare_sandbox_for_dispatch, resolve_provider_launcher,
+    copilot_model_unavailable_diagnostic, linux_bwrap_failed_write_diagnostic,
+    macos_keychain_auth_diagnostic, orbit_tool_env, prepare_sandbox_for_dispatch,
+    resolve_provider_launcher,
 };
 use super::supervisor::{
     DEFAULT_WALL_CLOCK_TIMEOUT_SECONDS, SpawnTraceContext, SpawnWithTimeoutRequest,
@@ -637,6 +638,28 @@ pub fn run_cli_backend(
         Some(
             sandbox_write_diagnostic
                 .clone()
+                // Copilot reports an unavailable explicit model only on
+                // stderr. Join it to the resolved crew before the generic
+                // exit-code path loses the configuration source.
+                .or_else(|| {
+                    input
+                        .get("crew")
+                        .and_then(Value::as_str)
+                        .and_then(|crew| {
+                            copilot_model_unavailable_diagnostic(
+                                &provider,
+                                crew,
+                                stderr_text.as_ref(),
+                            )
+                        })
+                        .map(|diagnostic| {
+                            format!(
+                                "{} {}",
+                                exit_message(),
+                                bounded_diagnostic(&diagnostic, &redaction)
+                            )
+                        })
+                })
                 // A Keychain-backed provider login reads as "expired" whether it
                 // really expired or the sandbox hid the credential. Orbit
                 // compiled the profile, so it is the layer that can say which

--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -677,6 +677,34 @@ fn keychain_auth_failure_marker(provider: &str) -> Option<&'static str> {
     }
 }
 
+/// Turn Copilot's rejected `--model` error into crew-scoped remediation.
+///
+/// The CLI's stderr names the unavailable id but does not identify the Orbit
+/// configuration that supplied it. The resolved crew is still present in the
+/// activity input, so join those facts before the generic exit-code path drops
+/// the actionable context.
+pub(super) fn copilot_model_unavailable_diagnostic(
+    provider: &str,
+    crew: &str,
+    output: &str,
+) -> Option<String> {
+    if Provider::parse(provider).ok()? != Provider::Copilot || crew.trim().is_empty() {
+        return None;
+    }
+
+    let (_, after_prefix) = output.split_once("Model \"")?;
+    let (model, _) = after_prefix.split_once("\" from --model flag is not available")?;
+    if model.is_empty() {
+        return None;
+    }
+
+    Some(format!(
+        "Copilot rejected model `{model}` supplied by crew `{crew}`. Start `copilot` and enter \
+         `/model` to list the ids available to this account, then update \
+         `crews.{crew}.model` and retry."
+    ))
+}
+
 /// Distinguish a sandbox Keychain denial from a genuinely expired provider
 /// login.
 ///

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -524,7 +524,7 @@ fn run_cli_backend_copilot_keychain_auth_failure_reaches_the_step_message() {
     let sink_for_writer: Arc<dyn AuditSink> = sink;
     let audit = Arc::new(V2AuditWriter::new(
         "job-copilot-keychain",
-        "copilot:claude-sonnet-4.5",
+        "copilot:claude-sonnet-5",
         sink_for_writer,
     ));
     let mut sandbox = sandbox_for_test();
@@ -587,6 +587,71 @@ fn run_cli_backend_copilot_keychain_auth_failure_reaches_the_step_message() {
         note.contains("macOS sandbox") && note.contains("copilot"),
         "workflow_run_failed must inline the diagnosis: {note}"
     );
+}
+
+#[test]
+fn run_cli_backend_copilot_unavailable_model_reaches_workflow_failure_note() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("copilot");
+    write_executable(
+        &script,
+        concat!(
+            "#!/bin/sh\ncat > /dev/null\n",
+            "printf '%s\\n' 'Error: Model \"retired-sonnet\" from --model flag is not available.' >&2\n",
+            "exit 1\n",
+        ),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-copilot-model",
+        "copilot:retired-sonnet",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let mut spec = test_agent_loop_spec(Duration::from_secs(5));
+    spec.provider = orbit_types::workflow::activity_job::Provider::Copilot;
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "implement_one",
+        "jrun-copilot-model",
+        audit,
+        &serde_json::json!({"prompt": "say ok", "crew": "nightly"}),
+        None,
+    )
+    .expect("the invocation outcome should be classified");
+
+    assert!(!outcome.success);
+    let message = outcome
+        .message
+        .as_deref()
+        .expect("failed step carries a message");
+    for expected in ["retired-sonnet", "crew `nightly`", "`crews.nightly.model`"] {
+        assert!(
+            message.contains(expected),
+            "step message must contain {expected:?}: {message}"
+        );
+    }
+
+    let update = crate::context::blocked_workflow_failure_update(
+        "task_pr_pipeline",
+        "jrun-copilot-model",
+        Some("AGENT_INVOCATION_FAILED"),
+        Some(message),
+    );
+    let note = update
+        .status_note
+        .as_deref()
+        .expect("blocked update carries a note");
+    for expected in ["retired-sonnet", "crew `nightly`", "`crews.nightly.model`"] {
+        assert!(
+            note.contains(expected),
+            "workflow_run_failed note must contain {expected:?}: {note}"
+        );
+    }
 }
 
 #[test]

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
@@ -8,8 +8,8 @@ use tempfile::tempdir;
 
 use super::super::super::dispatcher::ResolvedSandbox;
 use super::super::spawn::{
-    SUPPORTED_SYSTEM_BIN_DIRS, SpawnError, SpawnedChild, linux_bwrap_failed_write_diagnostic,
-    macos_keychain_auth_diagnostic_with, orbit_tool_env_with,
+    SUPPORTED_SYSTEM_BIN_DIRS, SpawnError, SpawnedChild, copilot_model_unavailable_diagnostic,
+    linux_bwrap_failed_write_diagnostic, macos_keychain_auth_diagnostic_with, orbit_tool_env_with,
     prepare_linux_sandbox_for_dispatch_with_probe, prepare_macos_codex_ca_environment_with,
     reject_unsatisfiable_managed_grants, resolve_provider_launcher_with,
     resolve_provider_launcher_with_extra_dirs, spawn_bare, spawn_macos_sandboxed_with,
@@ -415,6 +415,21 @@ fn keychain_auth_diagnostic_separates_a_real_expiry_from_a_sandbox_denial() {
         without_home.contains("HOME is unset"),
         "an unemitted keychain allow means re-authentication cannot help: {without_home}"
     );
+}
+
+#[test]
+fn copilot_unavailable_model_diagnostic_names_model_crew_and_config_key() {
+    let stderr = "Error: Model \"claude-sonnet-4.5\" from --model flag is not available.";
+
+    let diagnostic = copilot_model_unavailable_diagnostic("copilot", "qa", stderr)
+        .expect("Copilot unavailable-model stderr must be actionable");
+
+    assert!(diagnostic.contains("claude-sonnet-4.5"));
+    assert!(diagnostic.contains("crew `qa`"));
+    assert!(diagnostic.contains("`crews.qa.model`"));
+    assert!(diagnostic.contains("`/model`"));
+    assert!(copilot_model_unavailable_diagnostic("codex", "qa", stderr).is_none());
+    assert!(copilot_model_unavailable_diagnostic("copilot", "qa", "request timed out").is_none());
 }
 
 /// [ORB-10931] The third case: the operator's own `denyRead` outranks the

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -326,7 +326,7 @@ than on configuration.
 
 ```toml
 [crews.copilot]
-model = "claude-sonnet-4.5"
+model = "claude-sonnet-5"
 provider = "copilot"
 ```
 
@@ -334,8 +334,10 @@ Copilot routes to several vendors' models (`claude-*`, `gpt-*`, `gemini-*`).
 **The provider identity stays `copilot` regardless.** A crew running
 `gpt-5.4` through Copilot is a `copilot` run, not a `codex` run: the execution
 lane, its authentication, its policy, and its sandbox grants are Copilot's.
-Run `copilot --model <id>` or the interactive `/model` command to see the ids
-your organization currently allows.
+Start `copilot` and enter `/model` to list the ids the authenticated account
+currently allows. Orbit's Sonnet default and Haiku system-crew pin were checked
+against Copilot CLI 1.0.84; repeat that account-visible catalog check whenever
+the Copilot CLI is upgraded, then update affected `crews.<name>.model` pins.
 
 ### Sandbox and permissions
 

--- a/docs/runbooks/executor-onboarding.md
+++ b/docs/runbooks/executor-onboarding.md
@@ -106,6 +106,14 @@ On macOS, Orbit's `macos-sandbox-exec` profile denies `$HOME/Library/Keychains` 
 
 A failed keychain-backed step records Orbit's diagnosis — sandbox hid the item versus a real logout — on the run error and the task's `workflow_run_failed` note, not only `exited with code Some(1)`. Do not document a provider as file-backed on macOS from its state directory alone; inspect the CLI's credential store.
 
+### Copilot model pins
+
+Copilot's model catalog depends on the authenticated account and can change
+between CLI releases. Start `copilot` and enter `/model` to list the exact ids
+available to that account. Re-run this check after every Copilot CLI upgrade
+before retaining or changing a `crews.<name>.model` pin; a rejected pin fails
+closed rather than falling back to the CLI's ambient model choice.
+
 ## Add a deterministic local-shell executor
 
 Use a `local_shell` activity only for a bounded, reproducible command. Its `config` is the authority for `command`/`args` or for `shell`/`script`; rendered job input must never become child argv. The shared `local-shell` definition may supply a static command prefix, environment, and fallback timeout, but a shell action gets no agent prompt, model, tool allowlist, or workspace/registry identity variables.

--- a/website/src/content/docs/concepts/agents.md
+++ b/website/src/content/docs/concepts/agents.md
@@ -402,7 +402,7 @@ model = "grok-4.6"
 <div class="ose-panel" id="ose-panel-copilot">
 <dl class="ose-facts">
 <dt>Binary on <code>PATH</code></dt><dd><code>copilot</code> (npm <code>@github/copilot</code>)</dd>
-<dt>Example model</dt><dd><code>claude-sonnet-4.5</code></dd>
+<dt>Example model</dt><dd><code>claude-sonnet-5</code></dd>
 <dt>Reasoning effort</dt><dd>Not supported.</dd>
 </dl>
 <div class="ose-snippet">
@@ -412,7 +412,7 @@ default_crew = "copilot"
 
 [crews.copilot]
 provider = "copilot"
-model = "claude-sonnet-4.5"
+model = "claude-sonnet-5"
 </code></pre>
 
 <div class="ose-actions"><button class="ose-copy" type="button">Copy config</button><span class="ose-status" role="status" aria-live="polite"></span></div>


### PR DESCRIPTION
## Task

[ORB-12278](https://orbit-cli.com/tasks/ORB-12278) — COPILOT_DEFAULT_MODEL pins `claude-sonnet-4.5`, which Copilot CLI 1.0.84 rejects; runs fail with an unsurfaced `--model` error

### Description

Found on the Mac mini QA host after the ORB-12261 sandbox fix landed (jrun-20260912-0529-c2 on ws_nebula, DANI-10333). Copilot now authenticates under the sandbox, but the run still exits 1 in ~3 s with stderr:

    Error: Model "claude-sonnet-4.5" from --model flag is not available.

Orbit surfaced only `cli subprocess exited with code Some(1)`; the real message was only in the stderr blob.

Root cause: `crates/orbit-common/src/model_defaults.rs` pins `COPILOT_DEFAULT_MODEL = "claude-sonnet-4.5"` (used by `resolved.rs:242` as the fallback for a copilot crew with no model, and by `default_model_for("copilot")` at `model_defaults.rs:159`). The doc comment says the ids come from the Copilot CLI 1.0.80 catalog; on 1.0.84 that id is gone. Probed against a live account on 1.0.84: `claude-sonnet-5`, `claude-haiku-4.5`, `gpt-5.4`, `auto` are accepted; `claude-sonnet-4.5`, `claude-sonnet-4`, `claude-sonnet-4.6`, `claude-sonnet-4-6`, `claude-opus-4.1`, `claude-opus-4.6`, `claude-opus-4.7`, `gpt-5` are rejected.

Note the inconsistency: `orbit init` seeds `[crews.copilot]` with `COPILOT_CREW_MODEL = "claude-haiku-4.5"` (`seed.rs:280`, `init/agent_prompt.rs:131`), which still works — so a fresh init is fine but the resolved fallback and any crew that inherited the sonnet pin (this host's `~/.orbit/config.toml` had `model = "claude-sonnet-4.5"`) fail every run.

Host workaround applied: `orbit config set crews.copilot.model claude-sonnet-5 --global`.

The ORB-10946 rationale (pin an explicit id rather than let ambient `COPILOT_MODEL` / persisted `/model` state choose) still holds, but a pinned id needs to be one the current CLI ships, and a rejected id needs a real diagnosis instead of a bare exit code.

### Acceptance Criteria

- `COPILOT_DEFAULT_MODEL` is an id accepted by the current Copilot CLI (verified `claude-sonnet-5` on 1.0.84); the doc comment names the CLI version the catalog was checked against.
- `COPILOT_CREW_MODEL` is re-verified against the same CLI version and kept consistent with `COPILOT_DEFAULT_MODEL` in vendor/tier intent (haiku cheap-tier, sonnet default).
- The `crates/orbit-cli/src/command/init/tests/agent_detect.rs` and `crates/orbit-config` seed tests still pass; any frozen fixture constant in `orbit-common::test_fixtures` that mirrored the old id is updated deliberately, not silently.
- When the copilot subprocess stderr matches `Model "<id>" from --model flag is not available`, the run error / `workflow_run_failed` note names the rejected model id and the crew that supplied it, and points at `crews.<name>.model` — alongside the existing keychain diagnostic in `crates/orbit-engine/src/activity_job/cli_runner/spawn.rs`. Unit test next to `keychain_auth_diagnostic_separates_a_real_expiry_from_a_sandbox_denial`.
- `docs/runbooks/executor-onboarding.md` (or the copilot executor doc) tells operators how to list the account's available model ids and that the pin must be re-checked on Copilot CLI upgrades.
- `cargo test --workspace --no-fail-fast` is green.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated the Copilot provider default to `claude-sonnet-5`; documented that both the Sonnet default and Claude Haiku cheap-tier pin were checked against the account-visible Copilot CLI 1.0.84 catalog.
- Added a Copilot unavailable-model stderr diagnostic in the existing spawn diagnostic layer and wired it into nonzero-exit handling. The persisted step error and derived `workflow_run_failed` note now name the rejected id, the supplying crew, `crews.<name>.model`, and the interactive `/model` catalog command.
- Updated the resolved-config fixture plus CONFIG, executor onboarding, and maintained website examples. No `orbit_common::test_fixtures` constant mirrored the rejected id, so no fixture constant required alteration.
- Expanded task scope before edits to the orchestrator caller/test and maintained website example because they are direct consumers of the changed behavior/default.
Criteria evidence:
1. `COPILOT_DEFAULT_MODEL` is `claude-sonnet-5`; its comment names Copilot CLI 1.0.84 and the account-visible verification.
2. `COPILOT_CREW_MODEL` remains verified `claude-haiku-4.5`, explicitly documented as the cheap-tier Claude sibling to the Sonnet default.
3. All orbit-config tests passed, including seed tests; all six orbit-cli agent_detect tests passed.
4. New adjacent spawn unit coverage checks exact stderr classification, model, crew, config key, and `/model`; an end-to-end cli-runner test proves the same data reaches the step message and `workflow_run_failed` note.
5. CONFIG and executor onboarding explain starting `copilot`, entering `/model`, and re-checking pins after every CLI upgrade.
6. `cargo test --workspace --no-fail-fast` passed.
Validation:
- `cargo test -p orbit-engine copilot_unavailable_model_diagnostic_names_model_crew_and_config_key` — passed.
- `cargo test -p orbit-engine run_cli_backend_copilot_unavailable_model_reaches_workflow_failure_note` — passed.
- `cargo test -p orbit-config` — passed (122 tests).
- `cargo test -p orbit-cli agent_detect` — passed (6 tests).
- `make ci-fast` — passed; its optional compiler-cache mount-namespace probe reported a documented skip because this runner disallows unprivileged namespaces, while the gate exited zero.
- `make ci-lint` — passed.
- `make goldens` — passed.
- `cargo test --workspace --no-fail-fast` — passed after the final source edit.
- `git diff --check` — passed.
- `git status --short` — nine expected tracked task files modified; no untracked files.
Assessment: The diagnostic stays provider-specific, parses only Copilot stderr, preserves the generic exit code prefix, and uses the resolved activity crew as the authoritative configuration source.
Remaining risk: This Linux runner has Copilot CLI 1.0.83 and no authenticated 1.0.84 account catalog; `copilot --version` succeeded with a disposable XDG cache, but the model-id acceptance evidence remains the task authors live 1.0.84 account probe. No macOS-only execution was claimed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12278-6aa50982`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra