### PR TITLE
[code-review] `config get --scope X` and `config show --scope X` now report different values for the same unset key

### DIFF
--- a/crates/orbit-cli/src/command/config/get.rs
+++ b/crates/orbit-cli/src/command/config/get.rs
@@ -11,8 +11,12 @@ use super::support::{ConfigScopeArg, open_store_for_scope, runtime_config_roots}
 pub struct ConfigGetArgs {
     /// Dotted config.toml key, e.g. workflow.base_branch
     pub key: String,
+    /// Select the layered effective config or resolve one file in isolation,
+    /// including built-in defaults for keys that file omits.
     #[arg(long, value_enum, default_value_t = ConfigScopeArg::Effective)]
     pub scope: ConfigScopeArg,
+    /// Emit JSON. For global/workspace scope, `exists` reports whether the key
+    /// is explicitly set, even when `value` contains its resolved default.
     #[arg(long)]
     pub json: bool,
 }
@@ -40,14 +44,8 @@ impl Execute for ConfigGetArgs {
         let store = open_store_for_scope(runtime, self.scope)?;
         admit_config_key(&self.key)?;
         let file_exists = store.exists_on_disk();
-        let (value, exists) = if file_exists {
-            match store.explicit_value(&self.key)? {
-                Some(value) => (value, true),
-                None => (serde_json::Value::Null, false),
-            }
-        } else {
-            (serde_json::Value::Null, false)
-        };
+        let value = store.effective_value(&self.key)?;
+        let exists = store.is_key_set(&self.key);
         let path = if file_exists {
             serde_json::Value::String(store.path().to_string_lossy().into_owned())
         } else {

--- a/crates/orbit-cli/src/command/config/show.rs
+++ b/crates/orbit-cli/src/command/config/show.rs
@@ -12,8 +12,12 @@ use super::support::{
 
 #[derive(Args)]
 pub struct ConfigShowArgs {
+    /// Select the layered effective config or resolve one file in isolation,
+    /// including built-in defaults for keys that file omits.
     #[arg(long, value_enum, default_value_t = ConfigScopeArg::Effective)]
     pub scope: ConfigScopeArg,
+    /// Emit JSON. For global/workspace scope, `source.exists` reports whether
+    /// the selected config file exists, not whether individual keys are set.
     #[arg(long)]
     pub json: bool,
 }

--- a/crates/orbit-cli/src/command/config/tests/get.rs
+++ b/crates/orbit-cli/src/command/config/tests/get.rs
@@ -4,6 +4,7 @@ use crate::command::{CommandOutput, Execute};
 
 use super::super::get::ConfigGetArgs;
 use super::super::set::ConfigSetArgs;
+use super::super::show::ConfigShowArgs;
 use super::super::support::ConfigScopeArg;
 use super::test_runtime;
 
@@ -23,6 +24,10 @@ fn set_args(key: &str, value: &str) -> ConfigSetArgs {
         seed_from_global: false,
         fresh: false,
     }
+}
+
+fn show_args(scope: ConfigScopeArg) -> ConfigShowArgs {
+    ConfigShowArgs { scope, json: true }
 }
 
 fn write_sol_crew(path: &std::path::Path) {
@@ -157,11 +162,11 @@ fn get_without_json_flag_still_returns_a_payload() {
 }
 
 #[test]
-fn get_scoped_workspace_without_config_file_returns_explicit_absent() {
+fn get_scoped_workspace_without_config_file_returns_default_and_explicit_absent() {
     let (_root, runtime, global_root, _workspace_root) = test_runtime();
     fs::write(
         global_root.join("config.toml"),
-        "[scoring]\nenabled = true\n\n[workflow]\nbase_branch = \"custom-global\"\n",
+        "[scoring]\nenabled = false\n\n[workflow]\nbase_branch = \"custom-global\"\n",
     )
     .expect("write global config");
 
@@ -169,10 +174,16 @@ fn get_scoped_workspace_without_config_file_returns_explicit_absent() {
     args.scope = ConfigScopeArg::Workspace;
     let output = args.execute(&runtime).expect("get workspace scoring");
     let document = json_value(output);
+    let shown = json_value(
+        show_args(ConfigScopeArg::Workspace)
+            .execute(&runtime)
+            .expect("show workspace config"),
+    );
 
     assert_eq!(document["key"], "scoring.enabled");
     assert_eq!(document["scope"], "workspace");
-    assert_eq!(document["value"], serde_json::Value::Null);
+    assert_eq!(document["value"], true);
+    assert_eq!(document["value"], shown["settings"]["scoring.enabled"]);
     assert_eq!(document["exists"], false);
     assert!(
         document["path"].is_null(),
@@ -192,7 +203,7 @@ fn get_scoped_workspace_without_config_file_returns_explicit_absent() {
     let crate::output::payload::Block::Text(text) = &blocks[0] else {
         panic!("expected text block");
     };
-    assert_eq!(text, "null");
+    assert_eq!(text, &document["value"].to_string());
 }
 
 #[test]
@@ -218,9 +229,18 @@ fn get_scoped_workspace_with_file_distinguishes_set_and_unset_keys() {
     let mut unset_args = get_args("workflow.base_branch", true);
     unset_args.scope = ConfigScopeArg::Workspace;
     let unset_doc = json_value(unset_args.execute(&runtime).expect("get unset key"));
+    let shown = json_value(
+        show_args(ConfigScopeArg::Workspace)
+            .execute(&runtime)
+            .expect("show workspace config"),
+    );
     assert_eq!(unset_doc["key"], "workflow.base_branch");
     assert_eq!(unset_doc["scope"], "workspace");
-    assert_eq!(unset_doc["value"], serde_json::Value::Null);
+    assert_eq!(unset_doc["value"], "main");
+    assert_eq!(
+        unset_doc["value"], shown["settings"]["workflow.base_branch"],
+        "scoped get and show must resolve an omitted key identically"
+    );
     assert_eq!(unset_doc["exists"], false);
     assert_eq!(unset_doc["path"], ws_config.to_string_lossy().as_ref());
 }

--- a/crates/orbit-config/src/store.rs
+++ b/crates/orbit-config/src/store.rs
@@ -159,9 +159,9 @@ impl ConfigStore {
     }
 
     /// The fully resolved (defaulted) view of this document, as if it were
-    /// loaded as the effective `config.toml`. Used by both `orbit config
-    /// show` and `orbit config get` so they report identical values for the
-    /// same scope.
+    /// loaded as the effective `config.toml`. Scoped `orbit config show` uses
+    /// this to enumerate settings, and [`Self::validate`] uses it to verify an
+    /// edited document before saving.
     pub fn snapshot(&self) -> Result<ConfigSnapshot, OrbitError> {
         Ok(self.resolved()?.snapshot)
     }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -41,7 +41,9 @@ Three security-sensitive settings deliberately do not inherit from global whenev
 
 If the workspace file omits one of these, Orbit uses that setting's built-in default. This keeps repository agent sandboxing, approval, and environment passthrough deterministic instead of depending on a user's global policy. `execution.env.inherit` is not a configurable key: an agent subprocess environment is always composed from an allowlist — see [`[execution.env]` — the agent subprocess environment](#executionenv--the-agent-subprocess-environment).
 
-Run `orbit config show` for the effective merged view. Every setting is annotated as `workspace`, `global`, `built-in`, or `environment`, including the source file path where one applies. `orbit config show --json` exposes the same attribution in its `provenance` object. Use `--scope global` or `--scope workspace` to inspect either physical file alone.
+Run `orbit config show` for the effective merged view. Every setting is annotated as `workspace`, `global`, `built-in`, or `environment`, including the source file path where one applies. `orbit config show --json` exposes the same attribution in its `provenance` object.
+
+Use `--scope global` or `--scope workspace` to resolve either physical file in isolation, without values from the other file. Both `config show --scope <scope>` and `config get --scope <scope> <key>` include built-in defaults for keys omitted from the selected file, so they report the same value for a given key. In scoped `config get --json`, the top-level `exists` field instead reports whether that key is explicitly present in the selected file; it can be `false` while `value` contains a default. In scoped `config show --json`, `source.exists` reports whether the selected file itself exists. Settings are still resolved when the file is absent.
 
 The workspace identity file `.orbit/config.yaml` is a separate artifact (it stores `workspace_id` for the canonical task store binding) and is unrelated to runtime config.
 


### PR DESCRIPTION
## Task

[ORB-12276](https://orbit-cli.com/tasks/ORB-12276) — [code-review] `config get --scope X` and `config show --scope X` now report different values for the same unset key

### Description

ORB-12258 (`1df36e320`) changed `orbit config get --scope global|workspace` from reporting the scope's *resolved* value to reporting only an *explicitly set* one, without changing the sibling `config show --scope`, which still reports defaults. The two commands now disagree, and the doc comment that asserted they agree is stale.

## Evidence

`config get --scope <scope> <key>` returns `null` / `[unset]` when the key is not written in that scope's file:

- `crates/orbit-cli/src/command/config/get.rs:42-50` — `store.explicit_value(&self.key)` → `(Value::Null, false)` when absent
- `crates/orbit-config/src/store.rs:149-157` — `explicit_value` short-circuits on `!self.is_key_set(key)`

`config show --scope <scope>` still renders the resolved (defaulted) view:

- `crates/orbit-cli/src/command/config/show.rs:32-34` — `store.snapshot()?` then `snapshot.all_values()`
- `crates/orbit-config/src/store.rs:164-166` — `snapshot()` returns `self.resolved()?.snapshot`, built by `ResolvedConfig::from_raw_str` with defaults applied

Observable: on a workspace with no `.orbit/config.toml`, `orbit config show --scope workspace` prints each setting's default while `orbit config get --scope workspace <same key>` prints `[unset]`.

## Stale comment

`crates/orbit-config/src/store.rs:160-163` still reads:

> The fully resolved (defaulted) view of this document, as if it were loaded as the effective `config.toml`. **Used by both `orbit config show` and `orbit config get` so they report identical values for the same scope.**

`config get` no longer calls it. The agent guide treats a stale description of live behavior as a review blocker.

## Also undocumented

- `ConfigGetArgs`'s `--scope` help (`crates/orbit-cli/src/command/config/get.rs:14-15`) says nothing about explicit-only semantics.
- The new `exists` field on `config get --json` and on `config show --scope --json` (`show.rs:188`) is not described anywhere in `docs/CONFIG.md`; `1df36e320` changed no documentation file.

## What to decide

Pick one semantic for `--scope` and apply it to both commands: either both report explicit-only values (with `show` marking defaults as unset), or `get` keeps returning the scope's resolved value and signals explicitness through the already-added `exists` flag. Then fix the `snapshot()` doc comment and document `--scope`'s meaning plus the `exists` field.

### Acceptance Criteria

- For a key with no explicit entry in the selected scope's file, `orbit config get --scope <scope> <key>` and `orbit config show --scope <scope>` report the same value for that key.
- `ConfigStore::snapshot`'s doc comment describes its actual callers; no comment claims `config get` and `config show` share it if they do not.
- `--scope`'s value semantics (resolved vs explicit-only) and the `exists` field are documented on the CLI help and in `docs/CONFIG.md`.
- A test covers the unset-key case across both commands and fails if they diverge again.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Scoped config get now resolves the selected file with built-in defaults, matching scoped config show, while its exists field continues to report explicit key presence.
- CLI help and docs/CONFIG.md now define effective versus file-isolated scope semantics and distinguish config get exists from config show source.exists.
- ConfigStore::snapshot documentation now names its production callers accurately.
- Regression coverage compares config get and config show for omitted keys in both absent and present workspace files, verifies defaults, and verifies exists remains false.
Criteria evidence:
1. Scoped get uses ConfigStore::effective_value; tests compare its value with scoped show settings for omitted scoring.enabled and workflow.base_branch keys.
2. ConfigStore::snapshot documentation names scoped show and validation, with no claim that get calls snapshot.
3. Rendered help for both subcommands describes resolved defaults; JSON help and CONFIG.md document both exists meanings.
4. The focused config get suite includes cross-command absent-key comparisons that fail under the prior null-returning behavior.
Validation:
- cargo test -p orbit-cli --bin orbit command::config::tests::get — passed, 8 tests.
- cargo run -q -p orbit-cli -- config get --help and config show --help — passed; rendered help contains scope and exists contracts.
- make ci-fast — passed. Its compiler-cache namespace probe reported its designed skip because unprivileged mount namespaces are unavailable; all other guardrails passed.
- make goldens — passed, 11 tests across help, output, and MCP snapshots.
- make ci-lint — passed with warnings denied.
- git diff --check — passed.
- make ci — not run, per workspace policy reserving it for the PR merge gate.
Assessment: The change selects resolved scope semantics without importing the other file layer, preserves explicitness as independent metadata, and updates all affected current contracts.
Remaining risks: None specific to this change; the canonical full CI suite remains deferred to PR CI as required.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12276-6aa50ff9`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*

Orchestrated-By: astra