### PR TITLE
Use the bounded ETXTBSY test helper for the provider PATH-resolution launcher fixture

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
@@ -657,10 +657,11 @@ fn spawn_io_error_classification_table() {
     let table = [
         (ErrorKind::NotFound, true),
         (ErrorKind::PermissionDenied, true),
-        (ErrorKind::WouldBlock, false),  // EAGAIN
-        (ErrorKind::OutOfMemory, false), // ENOMEM
-        (ErrorKind::Interrupted, false), // EINTR
-        (ErrorKind::Other, false),       // unknown → conservative: retryable
+        (ErrorKind::WouldBlock, false),         // EAGAIN
+        (ErrorKind::OutOfMemory, false),        // ENOMEM
+        (ErrorKind::Interrupted, false),        // EINTR
+        (ErrorKind::ExecutableFileBusy, false), // ETXTBSY: classified transient; spawn_bare does not retry
+        (ErrorKind::Other, false),              // unknown → conservative: retryable
     ];
     for (kind, expect_permanent) in table {
         let classified = SpawnError::from_spawn_io("prog", &Error::new(kind, "boom"));
@@ -847,18 +848,37 @@ fn homebrew_style_prefix(root: &std::path::Path) -> std::path::PathBuf {
     root.join("opt").join("homebrew").join("bin")
 }
 
+/// Launch a just-written resolver fixture.
+///
+/// A raw test-only `Command` keeps `io::ErrorKind` so Linux can reuse
+/// [`orbit_common::test_process::retry_executable_busy`] at this boundary.
+/// Other Unix targets still launch once. Fixture env matches `spawn_bare`:
+/// cleared environment plus the launchd-style `PATH`.
 fn launch_resolved_provider(program: &str) -> String {
-    let spawned = spawn_bare(
-        program,
-        &[],
-        &[("PATH".to_string(), MACOS_LAUNCHD_PATH.to_string())],
-        None,
-    )
-    .expect("spawn resolved provider launcher");
-    let output = spawned
-        .child
-        .wait_with_output()
-        .expect("wait for resolved provider");
+    let mut command = std::process::Command::new(program);
+    command
+        .env_clear()
+        .env("PATH", MACOS_LAUNCHD_PATH)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+
+    let output = {
+        #[cfg(target_os = "linux")]
+        {
+            orbit_common::test_process::retry_executable_busy(|| command.output())
+                .expect("spawn resolved provider launcher")
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            command.output().expect("spawn resolved provider launcher")
+        }
+    };
     assert!(
         output.status.success(),
         "resolved launcher must exit 0: {}",
@@ -971,6 +991,80 @@ fn path_executable_wins_over_homebrew_style_fallback() {
 
     assert_eq!(resolved, path_launcher.to_string_lossy());
     assert_eq!(launch_resolved_provider(&resolved), "path\n");
+}
+
+/// The fixture launch helper must wait out a sibling writer the same way
+/// `a_fresh_test_launcher_waits_for_a_writer_to_close` does, without changing
+/// the resolver assertions above.
+#[cfg(target_os = "linux")]
+#[test]
+fn launch_resolved_provider_retries_executable_file_busy() {
+    let temp = tempdir().expect("tempdir");
+    let launcher = temp.path().join("codex");
+    write_executable(&launcher, "#!/bin/sh\nprintf 'path\\n'\n");
+    let writer = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&launcher)
+        .expect("hold launcher open for writing");
+    let error = std::process::Command::new(&launcher)
+        .spawn()
+        .expect_err("Linux must reject an executable that is open for writing");
+    assert_eq!(error.kind(), std::io::ErrorKind::ExecutableFileBusy);
+
+    let release_writer = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(75));
+        drop(writer);
+    });
+    let stdout = launch_resolved_provider(launcher.to_str().expect("utf-8 launcher path"));
+    release_writer.join().expect("release launcher writer");
+
+    assert_eq!(stdout, "path\n");
+}
+
+/// Only `ExecutableFileBusy` is in the retry window; other spawn errors must
+/// fail on the first attempt so the fixture does not mask a real resolver
+/// or permission problem.
+#[cfg(target_os = "linux")]
+#[test]
+fn retry_executable_busy_returns_non_busy_errors_immediately() {
+    use std::io::{Error, ErrorKind};
+    use std::time::Instant;
+
+    use orbit_common::test_process::retry_executable_busy;
+
+    for kind in [
+        ErrorKind::NotFound,
+        ErrorKind::PermissionDenied,
+        ErrorKind::Other,
+    ] {
+        let mut attempts = 0;
+        let started = Instant::now();
+        let error = retry_executable_busy(|| {
+            attempts += 1;
+            Err::<(), _>(Error::new(kind, "boom"))
+        })
+        .expect_err("non-busy errors must surface immediately");
+        assert_eq!(error.kind(), kind);
+        assert_eq!(attempts, 1, "{kind:?} must not be retried");
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(200),
+            "{kind:?} must not wait for the executable-busy window"
+        );
+    }
+
+    let mut remaining_busy = 2;
+    let mut attempts = 0;
+    retry_executable_busy(|| {
+        attempts += 1;
+        if remaining_busy > 0 {
+            remaining_busy -= 1;
+            Err(Error::new(ErrorKind::ExecutableFileBusy, "busy"))
+        } else {
+            Ok(())
+        }
+    })
+    .expect("ExecutableFileBusy must retry until success");
+    assert_eq!(attempts, 3);
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Task

[ORB-12300](https://orbit-cli.com/tasks/ORB-12300) — Use the bounded ETXTBSY test helper for the provider PATH-resolution launcher fixture

### Description

## Observed failure
Hosted CI 34681571164 at 96a546ba failed only Coverage / Collect workspace coverage. `activity_job::cli_runner::tests::spawn::path_executable_wins_over_homebrew_style_fallback` panicked at spawn.rs:842: SpawnError permanent:false, failed to spawn /tmp/.tmpnUeOVI/path-bin/codex: Text file busy (os error 26). 692 engine tests passed, 1 failed. Main Check/Clippy/Test, Linux sandbox and MSRV passed. Newer descendant a68f5007 CI34681912926 is fully green.

## Cause and existing remedy
The resolver fixture writes a launcher then immediately executes it. Parallel Linux forks can briefly inherit the writable descriptor before exec. This is the same race previously repaired in other fixtures by ORB-11340 and ORB-12174. `crates/orbit-common/src/test_process.rs` already provides retry_executable_busy: only ExecutableFileBusy retries, 25ms spacing, maximum 2 seconds; all other errors return immediately. The production spawn path correctly classifies the error transient but the fixture expects immediate success.

## Narrow scope
Reuse the existing bounded test-only helper at the fixture launch boundary. Preserve the exact resolver precedence/path and stdout assertions, environment setup, and meaningful launch behavior coverage. If using a raw test-only Command to retain io::ErrorKind, keep its fixture semantics equivalent. Do not add broad production retries, sleep blindly, parse localized error strings, serialize/skip the suite, or weaken resolver assertions. No new generic retry framework.

## Validation
Run the exact test repeatedly under normal parallel test load, the relevant orbit-engine spawn/resolver suite, and existing helper tests proving only ExecutableFileBusy retries while other errors fail immediately. A finite successful stress run improves confidence but is not proof that all races are impossible. Record exact commands, iteration counts and outcomes. Root will watch hosted coverage after delivery.

### Acceptance Criteria

- The affected fixture launch reuses bounded test-only ExecutableFileBusy handling without changing production provider retry policy.
- Resolver precedence, resolved executable, output and relevant environment assertions remain intact; PermissionDenied/NotFound and unrelated errors are not retried.
- Focused fixture/helper tests and a documented repeated parallel-load run pass, followed by required repository gates; no tests are disabled or assertions weakened.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Rewrote the resolver fixture helper `launch_resolved_provider` to launch a just-written executable with a test-only `Command` (env-clear + launchd-style PATH, Unix process group) so Linux can reuse `orbit_common::test_process::retry_executable_busy`. Other Unix still launches once.
- Production `spawn_bare` / `SpawnError::from_spawn_io` are unchanged. The classification table now also records `ExecutableFileBusy` as transient without adding a production retry.
- Added Linux-only coverage: a writer-held ETXTBSY launch through the fixture helper, plus helper-contract checks that NotFound/PermissionDenied/Other fail on the first attempt while ExecutableFileBusy retries to success.
- Resolver precedence, resolved-path, stdout, and environment assertions in the three Homebrew-style fixture tests are unchanged.
Criteria evidence:
1. Fixture launch is the only retry site; it calls the existing Linux-only helper (25ms, 2s, ExecutableFileBusy only). `spawn.rs` production spawn path has no new retry loop.
2. PATH-beats-Homebrew, explicit-path, and scheduled/interactive resolver tests still assert resolved paths and stdout (`path` / `override` / `codex-fixture-0.153.4`). Helper test proves non-busy kinds attempt exactly once; spawn classification still marks NotFound/PermissionDenied permanent.
3. Focused spawn tests, 36-test spawn module, 20 parallel-load iterations, existing mcp_roundtrip writer-close regression, then `make ci-fast`, `make ci-lint`, and `make goldens` all passed. No tests disabled or assertions weakened.
Validation:
- `cargo test -p orbit-engine --lib -- activity_job::cli_runner::tests::spawn::path_executable_wins_over_homebrew_style_fallback … launch_resolved_provider_retries_executable_file_busy … retry_executable_busy_returns_non_busy_errors_immediately … spawn_io_error_classification_table … explicit_launcher_path_wins_over_homebrew_style_prefix … minimal_macos_path_resolves_homebrew_style_provider` — passed (6 tests).
- `cargo test -p orbit-engine --lib activity_job::cli_runner::tests::spawn -- --test-threads=16` — passed (36 tests).
- Same spawn-module command, 20 iterations, `--test-threads=16` — passed 20/20. Finite stress run; not proof that every ETXTBSY race is impossible.
- `cargo test -p orbit-cli --test mcp_roundtrip a_fresh_test_launcher_waits_for_a_writer_to_close -- --exact` — passed.
- `make ci-fast` — passed. `test-compiler-cache-namespaces` skipped (bwrap cannot create a mount namespace on this runner); the gate exited 0.
- `make ci-lint` — passed.
- `make goldens` — passed.
- `git diff --check` — passed.
- `git status --short` — only `crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs` modified; uncommitted as required.
Assessment: Narrow fixture-only repair matching ORB-11340/ORB-12174. Linux-gated retry; macOS/other Unix keep a single launch. Remaining risk: hosted Coverage load can still surface ETXTBSY at unrepaired write-then-exec sites; this call site now uses the shared helper. Root will watch hosted coverage after delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12300-6aa50ff9`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra