### PR TITLE
[code-review] Synthetic gate/skip wait results still emit `status: "succeeded"`, a value the narrowed `invoke_and_wait` output enum no longer declares

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs
@@ -7,7 +7,7 @@ use orbit_tools::ToolContext;
 use orbit_types::policy::Role;
 use orbit_types::task::TaskStatus;
 use orbit_types::telemetry::AuditEventStatus;
-use orbit_types::workflow::ChildDispatchPhase;
+use orbit_types::workflow::{ChildDispatchPhase, JobRunState};
 use serde_json::Value;
 
 use super::child_dispatch;
@@ -178,7 +178,7 @@ where
     if invoke_output_skipped(&invoke_output) {
         return Ok(serde_json::json!({
             "skipped": true,
-            "status": "succeeded",
+            "status": wait_success_status(),
             "reason": "admissions_stopped",
             "job_name": job_name,
         }));
@@ -636,7 +636,7 @@ fn gate_admission_stop(
     )?;
     Ok(Some(gate_admission_stop_output(
         input,
-        "succeeded",
+        &wait_success_status(),
         "stale_noop",
         &reason,
         &task_statuses,
@@ -651,8 +651,15 @@ fn summarize_statuses(statuses: &[(String, String)]) -> String {
         .join(", ")
 }
 
+/// Canonical wait-envelope success token. Skip and stale-noop emitters, and
+/// the admission-stop `error` branch, share this so a spelling change cannot
+/// attach `error` to a successful stop.
+fn wait_success_status() -> String {
+    JobRunState::Success.to_string()
+}
+
 /// Build the synthetic child-run result an admission stop reports in place of a
-/// real dispatch. `status` drives the gate: `succeeded` lets
+/// real dispatch. `status` drives the gate: the canonical success token lets
 /// `pipeline_success_guard` pass, anything else fails the gate *after*
 /// `release_reservation` has run, and `error` is what the guard quotes.
 fn gate_admission_stop_output(
@@ -673,7 +680,7 @@ fn gate_admission_stop_output(
         "reason": reason,
         "task_statuses": task_statuses,
     });
-    if status != "succeeded" {
+    if status != wait_success_status() {
         output["error"] = Value::String(reason.to_string());
     }
     output

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/pipeline_actions.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/pipeline_actions.rs
@@ -246,7 +246,7 @@ use orbit_common::OrbitError;
 use orbit_store::contracts::{ChildJobRunAdmissionOutcome, ChildJobRunAdmissionParams};
 use orbit_types::telemetry::AuditEventStatus;
 use orbit_types::workflow::{
-    ChildCancellationPolicy, ChildDispatch, ChildDispatchPhase, PipelineState,
+    ChildCancellationPolicy, ChildDispatch, ChildDispatchPhase, JobRunState, PipelineState,
 };
 use serde_json::Value;
 use std::cell::RefCell;
@@ -375,7 +375,7 @@ fn stop_between_eligibility_observation_and_admission_creates_no_child() {
     .expect("admissions stop is an idempotent skip");
 
     assert_eq!(output["skipped"], true);
-    assert_eq!(output["status"], "succeeded");
+    assert_eq!(output["status"], JobRunState::Success.to_string());
     assert_eq!(output["reason"], "admissions_stopped");
     assert!(
         runtime
@@ -1026,7 +1026,7 @@ fn an_eligible_bundle_still_dispatches_after_the_gate_waited() {
     assert_eq!(recorded_dispatches(&runtime, &parent).len(), 1);
 }
 
-/// Positive control: already-shipped work keeps its succeeded no-op. Making
+/// Positive control: already-shipped work keeps its successful no-op. Making
 /// withdrawal fail the gate must not turn "this already landed" into a failure.
 #[test]
 fn already_shipped_work_still_reports_a_succeeded_noop() {
@@ -1036,8 +1036,12 @@ fn already_shipped_work_still_reports_a_succeeded_noop() {
 
     let output = dispatch_expecting_no_child(&runtime, &gate_dispatch_input(&parent, &[&task_id]));
 
-    assert_eq!(output["status"], "succeeded");
+    assert_eq!(output["status"], JobRunState::Success.to_string());
     assert_eq!(output["skipped"], json!(true));
+    assert!(
+        output.get("error").is_none(),
+        "a successful stop must not carry error: {output}"
+    );
     assert!(
         pipeline_success_guard(
             "pipeline_success_guard",
@@ -1047,6 +1051,80 @@ fn already_shipped_work_still_reports_a_succeeded_noop() {
         "a stale no-op must still pass the gate's success guard"
     );
     assert_eq!(audit_payloads(&runtime, GATE_STALE_NOOP_AUDIT).len(), 1);
+}
+
+/// [ORB-12299] Synthetic skip / stale-noop wait results must use a status the
+/// published `invoke_and_wait` enum actually declares, not the compatibility
+/// token `succeeded`.
+#[test]
+fn synthetic_skip_and_admission_stop_status_is_in_invoke_and_wait_enum() {
+    let statuses = published_invoke_and_wait_status_enum();
+    let canonical = JobRunState::Success.to_string();
+    assert!(
+        statuses.iter().any(|status| status == &canonical),
+        "published wait enum must contain {canonical}, got {statuses:?}"
+    );
+    assert!(
+        !statuses.iter().any(|status| status == "succeeded"),
+        "succeeded is a compatibility token, not a published wait status: {statuses:?}"
+    );
+
+    let (runtime, parent) = parent_runtime();
+    let skip = invoke_and_wait_with(
+        &runtime,
+        "invoke_and_wait",
+        &ship_leaves_input(&parent),
+        |_| {
+            Ok(json!({
+                "skipped": true,
+                "reason": "admissions_stopped",
+                "job_name": "task_auto_pipeline",
+            }))
+        },
+        |_| panic!("a skipped invoke must not wait on a child"),
+    )
+    .expect("admissions skip is a wait result");
+    let skip_status = skip["status"].as_str().expect("skip status");
+    assert!(
+        statuses.iter().any(|status| status == skip_status),
+        "skip status {skip_status:?} is not in the published enum {statuses:?}"
+    );
+    assert_eq!(skip_status, canonical);
+
+    let task_id = backlog_task(&runtime, "Landed while the gate waited");
+    ship_to_review(&runtime, &task_id);
+    let stop = dispatch_expecting_no_child(&runtime, &gate_dispatch_input(&parent, &[&task_id]));
+    let stop_status = stop["status"].as_str().expect("admission-stop status");
+    assert!(
+        statuses.iter().any(|status| status == stop_status),
+        "admission-stop status {stop_status:?} is not in the published enum {statuses:?}"
+    );
+    assert_eq!(stop_status, canonical);
+    assert!(
+        stop.get("error").is_none(),
+        "a successful admission stop must not carry error: {stop}"
+    );
+}
+
+fn published_invoke_and_wait_status_enum() -> Vec<String> {
+    use orbit_engine::activity_job::load_activity_asset;
+
+    let (_, yaml) = crate::runtime::assets::DEFAULT_ACTIVITY_FILES
+        .iter()
+        .find(|(name, _)| *name == "invoke_and_wait")
+        .expect("invoke_and_wait activity is seeded");
+    let wait = load_activity_asset(yaml).expect("parse invoke_and_wait");
+    wait.spec.output_schema_json["properties"]["status"]["enum"]
+        .as_array()
+        .expect("invoke_and_wait status enum")
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .expect("status enum values are strings")
+                .to_string()
+        })
+        .collect()
 }
 
 /// A task id that resolves to no task at all stays a hard activity failure:


### PR DESCRIPTION
## Task

[ORB-12299](https://orbit-cli.com/tasks/ORB-12299) — [code-review] Synthetic gate/skip wait results still emit `status: "succeeded"`, a value the narrowed `invoke_and_wait` output enum no longer declares

### Description

## Problem

ORB-12275 (`a68f50071`) narrowed the published `invoke_and_wait` output contract to the `JobRunState::Display` spelling and added a bootstrap test asserting that `succeeded` is *not* an advertised wait status:

- `crates/orbit-core/assets/activities/invoke_and_wait.yaml:68`: `enum: [success, failed, cancelled, interrupted, timeout, pending, running]`
- `crates/orbit-core/src/bootstrap/activity.rs:483-487`: `assert!(!statuses.contains(&"succeeded"), "succeeded is a compatibility token, not a published wait status")`

But two live emitters on the same activity's own code path still produce exactly that token — not as legacy data, as current output:

- `crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs:178-184` — when `pipeline.invoke` reports the dispatch was skipped, the wait result returned to the workflow is `{"skipped": true, "status": "succeeded", "reason": "admissions_stopped", …}`.
- `crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs:637-643` → `gate_admission_stop_output` (`:658-681`) — the stale/no-op admission stop builds its synthetic child result with `status: "succeeded"`.

So `invoke_and_wait` can return a `status` value its own published `output_schema_json` says is impossible. That schema is what workflow authors read (`crates/orbit-cli/src/command/activity/list.rs:77`).

## Why this is not covered by the compatibility token

`pipeline_wait_status_is_success` accepts both spellings (`crates/orbit-core/src/application/job/pipeline.rs:234-239`), so `pipeline_success_guard` and the in-repo `task_gate_pipeline` gate condition (`crates/orbit-core/assets/jobs/task_gate_pipeline.yaml:129`) still behave correctly — this is not an internal breakage. The defect is the advertised contract: a workflow author who writes a step condition from the declared enum (`… .output.status }} == success`) silently never matches the skip/admission-stop path, which is precisely the branch a sequencer wants to distinguish. `invoke_and_wait`'s own prose now describes that branch as returning "a successful no-op output with `skipped: true`" (`invoke_and_wait.yaml:32-34`), which reads as `status: success`.

There is also a latent trap: `gate_admission_stop_output` decides whether to attach `error` with a literal `if status != "succeeded"` comparison (`pipeline_actions.rs:676`). Anyone who later switches the emitted token to the canonical spelling without touching that line turns a successful stop into one carrying an `error`.

## Fix direction

Emit the canonical `JobRunState::Success` spelling from both synthetic paths (and drive the `error` decision off the same constant rather than a repeated literal), keeping `pipeline_wait_status_is_success`'s dual acceptance only for in-flight/persisted older results. Extend the ORB-12275 bootstrap assertion so the emitters are covered, not just the YAML.

### Acceptance Criteria

- The skip and admission-stop wait results returned by `invoke_and_wait` carry a `status` value that is present in the activity's published `output_schema_json` enum.
- A test asserts the synthetic skip/admission-stop output status against the declared `invoke_and_wait` enum, so the emitters and the published contract cannot drift apart again.
- The success/error branch inside `gate_admission_stop_output` is driven by the same canonical token as the emitted status rather than a duplicated string literal.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Synthetic `invoke_and_wait` skip and stale/no-op admission-stop results now emit `JobRunState::Success` (`success`) via a shared `wait_success_status()` helper.
- `gate_admission_stop_output` attaches `error` when `status != wait_success_status()`, so the success/error branch cannot drift from the emitted token.
- Focused tests assert skip and admission-stop output against the published `invoke_and_wait` status enum and that a successful stop does not carry `error`.
- `pipeline_wait_status_is_success` still accepts `succeeded` for persisted/in-flight older results. Withdrawal still emits `failed`. Real-child wait passthrough is unchanged.
Assessment: Smallest compatible token repair at the two live emitters. Neighboring rejection, compatibility-input, and lifecycle-refusal contracts were left in place.
Strategic decisions:
- Put the enum-drift test next to the emitters in `pipeline_actions` tests (loads the seeded `invoke_and_wait` YAML enum) rather than widening `pub(super) pipeline_actions` into bootstrap tests. Matches the task-pilot validation approach and the scoped source/test selectors.
Deviations from original plan:
- Did not edit `bootstrap/activity.rs`. The description suggested extending that assertion; the pilot and on-call comments kept the boundary to the two pipeline_actions files. The new test covers emitters against the published enum directly.
Criteria:
1. Skip and admission-stop wait `status` is `success`, which is in `invoke_and_wait` `output_schema_json` enum — met.
2. `synthetic_skip_and_admission_stop_status_is_in_invoke_and_wait_enum` asserts both live outputs against that enum — met.
3. Error attachment uses `wait_success_status()`, the same helper the emitters use — met.
Validation:
- `cargo test -p orbit-core --lib -- adapter::engine_host::v2_host::tests::pipeline_actions` — passed (28 tests, including the new contract test).
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- `make goldens` — passed.
- `git diff --check` — passed.
Risks:
- External workflows that compared skip/stop `status` to unpublished `succeeded` will now miss that branch; they should compare to `success` as the published contract already required.
- Uncommitted files: the two scoped pipeline_actions source/test files only. Pipeline owns commit/PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12299-6aa51017`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra