### PR TITLE
Limit dashboard status choices and undo to valid task lifecycle transitions

### DIFF
--- a/crates/orbit-core/src/application/task/lifecycle.rs
+++ b/crates/orbit-core/src/application/task/lifecycle.rs
@@ -42,7 +42,7 @@ pub(crate) const FORCED_STATUS_EVENT: &str = "forced";
 /// quietly reopened — a regression gets a new task with a `regression_from`
 /// relation. Reconsidering a rejection is the single exception, because a
 /// rejection closes a proposal rather than recording delivery.
-pub(crate) fn task_status_transition_allowed(from: TaskStatus, to: TaskStatus) -> bool {
+pub fn task_status_transition_allowed(from: TaskStatus, to: TaskStatus) -> bool {
     use TaskStatus::{
         Archived, Backlog, Blocked, Done, InProgress, Proposed, Rejected, Review, Someday,
     };
@@ -63,6 +63,39 @@ pub(crate) fn task_status_transition_allowed(from: TaskStatus, to: TaskStatus) -
         (Someday, target) => matches!(target, Backlog | InProgress | Rejected),
         (InProgress, target) => matches!(target, Backlog | Someday | Review | Rejected),
         (Review, target) => matches!(target, Backlog | InProgress | Done | Rejected),
+    }
+}
+
+/// The companion field an otherwise-legal transition still needs from its
+/// caller, if the task does not already carry equivalent evidence.
+///
+/// This is the read-side counterpart of [`ensure_status_change_allowed`]. UI
+/// projections use it to collect evidence before submitting a mutation while
+/// the guarded update path remains the authority that accepts or refuses it.
+pub fn task_status_transition_required_field(
+    runtime: &OrbitRuntime,
+    task: &Task,
+    target: TaskStatus,
+) -> Result<Option<&'static str>, OrbitError> {
+    if !task_status_transition_allowed(task.status, target) || task.status == target {
+        return Ok(None);
+    }
+
+    match target {
+        TaskStatus::InProgress if in_progress_transition_requires_plan(task.status) => {
+            let plan = task.plan.trim();
+            if plan.is_empty() || plan == UNAUTHORED_TASK_PLAN_PLACEHOLDER {
+                Ok(Some("plan"))
+            } else {
+                Ok(None)
+            }
+        }
+        TaskStatus::Done
+            if !completion_evidence_present(runtime, task, &TaskUpdateParams::default())? =>
+        {
+            Ok(Some("execution_summary"))
+        }
+        _ => Ok(None),
     }
 }
 

--- a/crates/orbit-core/src/application/task/mod.rs
+++ b/crates/orbit-core/src/application/task/mod.rs
@@ -21,6 +21,7 @@ pub use params::{TaskAddParams, TaskUpdateParams};
 
 pub(crate) use helpers::{SYSTEM_ACTOR_LABEL, TaskAttributionInput, assemble_task_attribution};
 pub(crate) use lifecycle::{ensure_task_has_execution_plan, in_progress_transition_requires_plan};
+pub use lifecycle::{task_status_transition_allowed, task_status_transition_required_field};
 pub(crate) use paths::{
     canonicalize_context_files_for_read, compute_task_add_warnings, context_workspace_root,
 };

--- a/crates/orbit-web/assets/dashboard/app.js
+++ b/crates/orbit-web/assets/dashboard/app.js
@@ -51,7 +51,6 @@ const STATUS_ORDER = [
 ];
 
 const DEFAULT_INACTIVE_STATUSES = new Set(["someday", "done", "rejected", "archived"]);
-const STATUS_UPDATE_TARGETS = STATUS_ORDER;
 // ORB-10874: the statuses shown when no `status` filter is represented in the
 // URL — a single source both the initial in-memory state and the hash-parsing
 // default (applyTasksHashQuery) read from, so they cannot drift apart.
@@ -126,7 +125,6 @@ function taskContext() {
     setActiveStatuses: (statuses) => { activeStatuses = statuses; },
     statusOrder: STATUS_ORDER,
     defaultActiveStatuses: DEFAULT_ACTIVE_STATUSES,
-    statusUpdateTargets: STATUS_UPDATE_TARGETS,
     fmtAbsTime,
     refreshDashboard,
   };

--- a/crates/orbit-web/assets/dashboard/tasks.js
+++ b/crates/orbit-web/assets/dashboard/tasks.js
@@ -72,10 +72,14 @@ function statusOrder(context) {
   return context && Array.isArray(context.statusOrder) ? context.statusOrder : [];
 }
 
-function statusUpdateTargets(context) {
-  return context && Array.isArray(context.statusUpdateTargets)
-    ? context.statusUpdateTargets
+function statusTransitions(task) {
+  return Array.isArray(task && task.status_transitions)
+    ? task.status_transitions.filter((transition) => transition && transition.status)
     : [];
+}
+
+function statusTransition(task, targetStatus) {
+  return statusTransitions(task).find((transition) => transition.status === targetStatus) || null;
 }
 
 function fmtAbsTimeValue(context, value) {
@@ -1213,7 +1217,7 @@ function buildActionsRow(task, detail, context) {
     });
     actions.appendChild(btn);
   }
-  if (task.status !== "archived") {
+  if (statusTransition(task, "archived")) {
     const btn = el("button", { class: "action archive", text: "archive" });
     btn.addEventListener("click", (e) => {
       e.stopPropagation();
@@ -1228,7 +1232,7 @@ function buildActionsRow(task, detail, context) {
 
 function buildStatusUpdateControl(task, context) {
   const cell = el("span", { class: "status-cell" });
-  const targets = statusUpdateTargets(context).filter((status) => status !== task.status);
+  const targets = statusTransitions(task).map((transition) => transition.status);
   const color = `var(--status-${task.status}, var(--fg))`;
   const mutable = canMutateTask(task);
   const feedback = statusFeedback.get(task.id);
@@ -1341,17 +1345,45 @@ function buildCrewUpdateControl(task, context) {
 
 async function applyTaskStatusChange(task, nextStatus, context) {
   if (!nextStatus || nextStatus === task.status || !canMutateTask(task)) return;
+  const transition = statusTransition(task, nextStatus);
+  if (!transition) {
+    statusFeedback.set(task.id, {
+      kind: "error",
+      text: `status update unavailable: ${task.status} cannot move to ${nextStatus}`,
+    });
+    renderTasks(taskList(context), context);
+    return;
+  }
+
+  const payload = { status: nextStatus };
+  if (transition.required_field) {
+    const evidence = collectStatusTransitionEvidence(task, nextStatus, transition.required_field);
+    if (!evidence) {
+      statusFeedback.set(task.id, {
+        kind: "error",
+        text: statusTransitionEvidenceUnavailable(transition.required_field),
+      });
+      renderTasks(taskList(context), context);
+      return;
+    }
+    payload[transition.required_field] = evidence;
+  }
+
   const previousValue = task.status;
   statusFeedback.set(task.id, { kind: "pending", text: "saving…" });
   renderTasks(taskList(context), context);
   try {
-    const updatedTask = await patchJson(taskMutationPath(task), { status: nextStatus });
+    const updatedTask = await patchJson(taskMutationPath(task), payload);
     applyUpdatedTask(updatedTask, context);
-    statusFeedback.set(task.id, {
+    const feedback = {
       kind: "success",
       text: "status saved",
-      undo: { previousValue, expiresAt: Date.now() + MUTATION_UNDO_WINDOW_MS },
-    });
+    };
+    const reverse = statusTransition(updatedTask, previousValue);
+    if (reverse && !reverse.required_field) {
+      feedback.undo = { previousValue, expiresAt: Date.now() + MUTATION_UNDO_WINDOW_MS };
+    }
+    statusFeedback.set(task.id, feedback);
   } catch (error) {
     statusFeedback.set(task.id, {
       kind: "error",
@@ -1361,6 +1393,22 @@ async function applyTaskStatusChange(task, nextStatus, context) {
   }
   renderTasks(taskList(context), context);
   scheduleFeedbackExpiry(statusFeedback, task.id, context, MUTATION_UNDO_WINDOW_MS + 500);
+}
+
+function collectStatusTransitionEvidence(task, nextStatus, requiredField) {
+  if (typeof window.prompt !== "function") return null;
+  const label = requiredField === "plan" ? "execution plan" : "completion summary";
+  const currentValue = requiredField === "plan" ? task.plan : task.execution_summary;
+  const value = window.prompt(
+    `A non-empty ${label} is required before moving ${task.id} to ${nextStatus}.`,
+    currentValue || "",
+  );
+  return value && value.trim() ? value.trim() : null;
+}
+
+function statusTransitionEvidenceUnavailable(requiredField) {
+  const label = requiredField === "plan" ? "execution plan" : "completion summary";
+  return `status update unavailable: a non-empty ${label} is required`;
 }
 
 async function applyTaskCrewChange(task, nextValue, context) {

--- a/crates/orbit-web/src/api/tests/task_listing.rs
+++ b/crates/orbit-web/src/api/tests/task_listing.rs
@@ -216,6 +216,14 @@ async fn list_and_detail_reuse_bundle_sidecars_with_response_parity() {
     expected["artifacts"] = crate::projections::task_artifact_manifest_to_json(
         &runtime.get_task_artifact_manifest(&task.id).unwrap(),
     );
+    expected["status_transitions"] = json!([
+        { "status": "in-progress", "required_field": null },
+        { "status": "blocked", "required_field": null },
+        { "status": "proposed", "required_field": null },
+        { "status": "someday", "required_field": null },
+        { "status": "rejected", "required_field": null },
+        { "status": "archived", "required_field": null },
+    ]);
     if let Some(crew) = runtime.resolved_crew_projection(&task).unwrap() {
         expected["resolved_crew"] = json!(crew.name);
         expected["crew_model"] = json!(crew.model);

--- a/crates/orbit-web/src/api/tests/tasks.rs
+++ b/crates/orbit-web/src/api/tests/tasks.rs
@@ -1591,6 +1591,28 @@ async fn update_task_refuses_to_fabricate_or_reopen_a_completion() {
     let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
     let task = seed_backlog_task(&runtime, "Dashboard status governance");
 
+    let proposed = seed_task_with_status(
+        &runtime,
+        "Proposed dashboard status governance",
+        TaskStatus::Proposed,
+    );
+    let skipped = patch_task(runtime.clone(), &proposed.id, json!({ "status": "done" })).await;
+    assert_eq!(skipped.status(), StatusCode::BAD_REQUEST);
+
+    let missing_plan = patch_task(
+        runtime.clone(),
+        &proposed.id,
+        json!({ "status": "in-progress" }),
+    )
+    .await;
+    assert_eq!(missing_plan.status(), StatusCode::BAD_REQUEST);
+    assert!(
+        body_json(missing_plan).await["error"]
+            .as_str()
+            .expect("error message")
+            .contains("execution plan")
+    );
+
     let skipped = patch_task(runtime.clone(), &task.id, json!({ "status": "done" })).await;
     assert_eq!(skipped.status(), StatusCode::BAD_REQUEST);
     assert!(
@@ -1605,16 +1627,30 @@ async fn update_task_refuses_to_fabricate_or_reopen_a_completion() {
             "in-progress",
             json!({ "status": "in-progress", "plan": "1) do it" }),
         ),
-        (
-            "review",
-            json!({ "status": "review", "execution_summary": "did it" }),
-        ),
-        ("done", json!({ "status": "done" })),
+        ("review", json!({ "status": "review" })),
     ] {
         let response = patch_task(runtime.clone(), &task.id, body).await;
         assert_eq!(response.status(), StatusCode::OK, "{status}");
         assert_eq!(body_json(response).await["status"], json!(status));
     }
+
+    let missing_summary = patch_task(runtime.clone(), &task.id, json!({ "status": "done" })).await;
+    assert_eq!(missing_summary.status(), StatusCode::BAD_REQUEST);
+    assert!(
+        body_json(missing_summary).await["error"]
+            .as_str()
+            .expect("error message")
+            .contains("execution summary")
+    );
+
+    let completed = patch_task(
+        runtime.clone(),
+        &task.id,
+        json!({ "status": "done", "execution_summary": "did it" }),
+    )
+    .await;
+    assert_eq!(completed.status(), StatusCode::OK);
+    assert_eq!(body_json(completed).await["status"], json!("done"));
 
     let reopened = patch_task(runtime.clone(), &task.id, json!({ "status": "backlog" })).await;
     assert_eq!(reopened.status(), StatusCode::BAD_REQUEST);
@@ -1633,6 +1669,80 @@ async fn update_task_refuses_to_fabricate_or_reopen_a_completion() {
             .iter()
             .any(|entry| { entry["from_status"] == "review" && entry["to_status"] == "done" })
     );
+}
+
+#[tokio::test]
+async fn task_projection_exposes_only_canonical_status_transitions_and_missing_evidence() {
+    let runtime = Arc::new(OrbitRuntime::in_memory().expect("build runtime"));
+    let fixtures = [
+        (
+            TaskStatus::Proposed,
+            json!([
+                { "status": "in-progress", "required_field": "plan" },
+                { "status": "blocked", "required_field": null },
+                { "status": "backlog", "required_field": null },
+                { "status": "someday", "required_field": null },
+                { "status": "rejected", "required_field": null },
+                { "status": "archived", "required_field": null }
+            ]),
+        ),
+        (
+            TaskStatus::Backlog,
+            json!([
+                { "status": "in-progress", "required_field": null },
+                { "status": "blocked", "required_field": null },
+                { "status": "proposed", "required_field": null },
+                { "status": "someday", "required_field": null },
+                { "status": "rejected", "required_field": null },
+                { "status": "archived", "required_field": null }
+            ]),
+        ),
+        (
+            TaskStatus::Blocked,
+            json!([
+                { "status": "in-progress", "required_field": "plan" },
+                { "status": "backlog", "required_field": null },
+                { "status": "archived", "required_field": null }
+            ]),
+        ),
+        (
+            TaskStatus::Review,
+            json!([
+                { "status": "in-progress", "required_field": "plan" },
+                { "status": "blocked", "required_field": null },
+                { "status": "backlog", "required_field": null },
+                { "status": "done", "required_field": "execution_summary" },
+                { "status": "rejected", "required_field": null },
+                { "status": "archived", "required_field": null }
+            ]),
+        ),
+        (TaskStatus::Done, json!([])),
+        (TaskStatus::Archived, json!([])),
+    ];
+
+    for (status, expected) in fixtures {
+        let task = if status == TaskStatus::Archived {
+            let task = seed_task_with_status(
+                &runtime,
+                &format!("Projected {status}"),
+                TaskStatus::Backlog,
+            );
+            runtime
+                .archive_task(&task.id)
+                .expect("archive fixture task");
+            runtime.get_task(&task.id).expect("read archived fixture")
+        } else {
+            seed_task_with_status(&runtime, &format!("Projected {status}"), status)
+        };
+        let response = request_shared(runtime.clone(), &format!("/tasks/{}", task.id)).await;
+
+        assert_eq!(response.status(), StatusCode::OK, "{status}");
+        assert_eq!(
+            body_json(response).await["status_transitions"],
+            expected,
+            "{status}"
+        );
+    }
 }
 
 /// ORB-10648: `priority` is now a declared update field. It was undeclared

--- a/crates/orbit-web/src/projections.rs
+++ b/crates/orbit-web/src/projections.rs
@@ -6,6 +6,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use orbit_core::application::job::JobCatalogEntry;
+use orbit_core::application::task::{
+    task_status_transition_allowed, task_status_transition_required_field,
+};
 use orbit_core::{
     AuditEvent, JobRun, OrbitError, OrbitRuntime, ResolvedCrewProjection, Task, TaskStatus,
     resolve_task_dependencies,
@@ -203,6 +206,10 @@ pub(crate) fn task_row_to_json(
         "artifacts".to_string(),
         task_artifact_manifest_to_json(&row.artifacts),
     );
+    object.insert(
+        "status_transitions".to_string(),
+        dashboard_status_transitions(runtime, task)?,
+    );
     if let Some(projection) = dashboard_resolved_crew_projection(runtime, task)? {
         object.insert("resolved_crew".to_string(), Value::String(projection.name));
         object.insert("crew_model".to_string(), Value::String(projection.model));
@@ -213,6 +220,34 @@ pub(crate) fn task_row_to_json(
         object.insert("review".to_string(), review);
     }
     Ok(value)
+}
+
+fn dashboard_status_transitions(runtime: &OrbitRuntime, task: &Task) -> Result<Value, OrbitError> {
+    const STATUS_ORDER: [TaskStatus; 9] = [
+        TaskStatus::InProgress,
+        TaskStatus::Review,
+        TaskStatus::Blocked,
+        TaskStatus::Proposed,
+        TaskStatus::Backlog,
+        TaskStatus::Someday,
+        TaskStatus::Done,
+        TaskStatus::Rejected,
+        TaskStatus::Archived,
+    ];
+
+    STATUS_ORDER
+        .into_iter()
+        .filter(|target| {
+            *target != task.status && task_status_transition_allowed(task.status, *target)
+        })
+        .map(|target| {
+            Ok(json!({
+                "status": target.to_string(),
+                "required_field": task_status_transition_required_field(runtime, task, target)?,
+            }))
+        })
+        .collect::<Result<Vec<_>, OrbitError>>()
+        .map(Value::Array)
 }
 
 fn dashboard_resolved_crew_projection(

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -1313,7 +1313,7 @@ fn dashboard_task_filter_hash_round_trips_default_all_someday_and_none() {
 }
 
 #[test]
-fn dashboard_renders_every_other_status_for_a_done_task() {
+fn dashboard_renders_only_projected_lifecycle_transitions() {
     let app = include_str!("../../assets/dashboard/app.js");
     for status in [
         "in-progress",
@@ -1360,25 +1360,159 @@ Object.defineProperty(globalThis, "navigator", { value: { clipboard: { writeText
 globalThis.setTimeout = () => 0;
 
 const statuses = ["in-progress", "review", "blocked", "proposed", "backlog", "someday", "done", "rejected", "archived"];
-const task = { id: "ORB-1", title: "Done task", status: "done", history: [], artifacts: [] };
 const { renderTasks } = await import("./tasks.js");
-renderTasks([task], {
-  getTasks: () => [task], getTasksMeta: () => null, getSearchQuery: () => "",
-  getActiveStatuses: () => new Set(["done"]), statusOrder: statuses,
-  statusUpdateTargets: statuses, fmtAbsTime: (value) => value,
-  refreshDashboard: () => Promise.resolve(),
-});
 
 function find(node, predicate) {
   if (predicate(node)) return node;
   for (const child of node.children || []) { const match = find(child, predicate); if (match) return match; }
   return null;
 }
-const select = find(get("tasks-body"), (node) => node.className === "task-status-select mono");
-if (!select) throw new Error("status select did not render");
-const values = select.children.map((option) => option.value).filter(Boolean);
-const expected = statuses.filter((status) => status !== "done");
-if (JSON.stringify(values) !== JSON.stringify(expected)) throw new Error(`status options ${JSON.stringify(values)} != ${JSON.stringify(expected)}`);
+
+const fixtures = [
+  ["proposed", ["in-progress", "blocked", "backlog", "someday", "rejected", "archived"]],
+  ["backlog", ["in-progress", "blocked", "proposed", "someday", "rejected", "archived"]],
+  ["blocked", ["in-progress", "backlog", "archived"]],
+  ["review", ["in-progress", "blocked", "backlog", "done", "rejected", "archived"]],
+  ["done", []],
+  ["archived", []],
+];
+for (const [status, targets] of fixtures) {
+  const task = {
+    id: `ORB-${status}`, title: `${status} task`, status, history: [], artifacts: [],
+    status_transitions: targets.map((target) => ({ status: target, required_field: null })),
+  };
+  renderTasks([task], {
+    getTasks: () => [task], getTasksMeta: () => null, getSearchQuery: () => "",
+    getActiveStatuses: () => new Set([status]), statusOrder: statuses,
+    fmtAbsTime: (value) => value, refreshDashboard: () => Promise.resolve(),
+  });
+  const select = find(get("tasks-body"), (node) => node.className === "task-status-select mono");
+  if (!select) throw new Error(`status select did not render for ${status}`);
+  const values = select.children.map((option) => option.value).filter(Boolean);
+  if (JSON.stringify(values) !== JSON.stringify(targets)) {
+    throw new Error(`${status} options ${JSON.stringify(values)} != ${JSON.stringify(targets)}`);
+  }
+  if ((status === "done" || status === "archived") && !select.disabled) {
+    throw new Error(`${status} status select must be disabled`);
+  }
+}
+"#,
+    );
+}
+
+#[test]
+fn dashboard_collects_status_evidence_and_suppresses_invalid_reverse_undo() {
+    run_dashboard_javascript_test(
+        r#"
+class Node {
+  constructor() { this.children = []; this.dataset = {}; this.style = {}; this.listeners = {}; this.className = ""; this._text = ""; this.parentNode = null; this.disabled = false; }
+  appendChild(child) { this.children.push(child); child.parentNode = this; return child; }
+  insertBefore(child, before) { const old = child.parentNode; if (old) old.children = old.children.filter((candidate) => candidate !== child); const index = this.children.indexOf(before); this.children.splice(index < 0 ? this.children.length : index, 0, child); child.parentNode = this; return child; }
+  removeChild(child) { this.children = this.children.filter((candidate) => candidate !== child); child.parentNode = null; return child; }
+  addEventListener(name, callback) { this.listeners[name] = callback; }
+  setAttribute(name, value) { this[name] = String(value); }
+  get textContent() { return this._text + this.children.map((child) => child.textContent || "").join(""); }
+  set textContent(value) { this._text = String(value); this.children = []; }
+  get lastElementChild() { return this.children[this.children.length - 1]; }
+  get classList() { return { add: (...names) => { this.className = `${this.className} ${names.join(" ")}`.trim(); } }; }
+}
+const nodes = new Map();
+const get = (id) => nodes.get(id) || (nodes.set(id, new Node()), nodes.get(id));
+globalThis.document = {
+  getElementById: get,
+  createElement: () => new Node(),
+  createTextNode: (text) => Object.assign(new Node(), { textContent: text }),
+  createDocumentFragment: () => new Node(),
+};
+const location = new URL("http://dashboard.test/#tasks");
+let promptValue = "";
+globalThis.window = { location, addEventListener: () => {}, confirm: () => false, prompt: () => promptValue };
+Object.defineProperty(globalThis, "navigator", { value: { clipboard: { writeText: () => Promise.resolve() } }, configurable: true });
+globalThis.setTimeout = () => 0;
+
+let task = {
+  id: "ORB-1", title: "Proposed task", status: "proposed", plan: "", execution_summary: "",
+  history: [], artifacts: [],
+  status_transitions: [{ status: "in-progress", required_field: "plan" }],
+};
+const requests = [];
+globalThis.fetch = async (_path, options) => {
+  const request = JSON.parse(options.body);
+  requests.push(request);
+  const statusTransitions = request.status === "blocked"
+    ? [{ status: "backlog", required_field: null }]
+    : [];
+  task = {
+    ...task, status: request.status, status_transitions: statusTransitions,
+  };
+  return { ok: true, text: async () => JSON.stringify(task) };
+};
+const statuses = ["in-progress", "review", "blocked", "proposed", "backlog", "someday", "done", "rejected", "archived"];
+const context = {
+  getTasks: () => [task], getTasksMeta: () => null, getSearchQuery: () => "",
+  getActiveStatuses: () => new Set([task.status]), statusOrder: statuses,
+  replaceTask: (updated) => { task = updated; }, fmtAbsTime: (value) => value,
+  refreshDashboard: () => Promise.resolve(),
+};
+const { renderTasks } = await import("./tasks.js");
+
+function find(node, predicate) {
+  if (predicate(node)) return node;
+  for (const child of node.children || []) { const match = find(child, predicate); if (match) return match; }
+  return null;
+}
+function selectStatus(target) {
+  const select = find(get("tasks-body"), (node) => node.className === "task-status-select mono");
+  select.value = target;
+  select.listeners.change({ stopPropagation: () => {} });
+}
+
+renderTasks([task], context);
+selectStatus("in-progress");
+if (requests.length !== 0) throw new Error("missing plan must not be submitted");
+const unavailable = find(get("tasks-body"), (node) => node.className.includes("mutation-feedback error"));
+if (!unavailable || !unavailable.textContent.includes("execution plan is required")) {
+  throw new Error("missing plan reason was not shown");
+}
+
+promptValue = "1. implement and verify";
+selectStatus("in-progress");
+await new Promise(setImmediate);
+if (requests.length !== 1 || requests[0].plan !== promptValue) {
+  throw new Error(`plan evidence was not submitted: ${JSON.stringify(requests)}`);
+}
+if (find(get("tasks-body"), (node) => node.className === "mutation-undo")) {
+  throw new Error("undo was offered for an invalid in-progress to proposed reverse transition");
+}
+
+task = {
+  ...task, status: "review", execution_summary: "",
+  status_transitions: [{ status: "done", required_field: "execution_summary" }],
+};
+promptValue = "Completed and verified";
+renderTasks([task], context);
+selectStatus("done");
+await new Promise(setImmediate);
+if (requests.length !== 2 || requests[1].execution_summary !== promptValue) {
+  throw new Error(`completion evidence was not submitted: ${JSON.stringify(requests)}`);
+}
+if (find(get("tasks-body"), (node) => node.className === "mutation-undo")) {
+  throw new Error("undo was offered for a terminal done task");
+}
+
+task = {
+  ...task, status: "backlog",
+  status_transitions: [{ status: "blocked", required_field: null }],
+};
+renderTasks([task], context);
+selectStatus("blocked");
+await new Promise(setImmediate);
+if (requests.length !== 3 || requests[2].status !== "blocked") {
+  throw new Error(`valid status change was not submitted: ${JSON.stringify(requests)}`);
+}
+if (!find(get("tasks-body"), (node) => node.className === "mutation-undo")) {
+  throw new Error("undo was not offered for a valid blocked to backlog reverse transition");
+}
 "#,
     );
 }
@@ -1889,6 +2023,10 @@ fn dashboard_inline_task_edits_report_pending_success_failure_and_offer_undo() {
     assert!(
         tasks.contains("(feedback && feedback.kind === \"pending\")"),
         "the control must disable itself while its own change is pending"
+    );
+    assert!(
+        tasks.contains("if (statusTransition(task, \"archived\"))"),
+        "archive must be offered only when the canonical projection allows it"
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-12292](https://orbit-cli.com/tasks/ORB-12292) — Limit dashboard status choices and undo to valid task lifecycle transitions

### Description

## Problem
Read-only on-call audit found dashboard app.js sets STATUS_UPDATE_TARGETS to every status, and tasks.js buildStatusUpdateControl removes only the current status. canMutateTask checks workspace routing, not lifecycle. applyTaskStatusChange PATCHes only {status}, then unconditionally offers undo. Proposed tasks therefore offer done, terminal tasks offer reopening, and transitions requiring missing plan/evidence fail after selection. Undo can likewise offer an invalid reverse transition. The server remains the authority and must continue refusing invalid mutations.

## Scope and evidence
crates/orbit-web/assets/dashboard/app.js status constants; tasks.js statusUpdateTargets/buildStatusUpdateControl/applyTaskStatusChange. API update_task_action invokes normal lifecycle validation. ORB-00185 fixed in-progress serialization but did not address choice validity. Derive available transitions from canonical lifecycle behavior rather than inventing independent rules. Prefer the smallest integration with existing task/API data. For companion evidence requirements, collect the required input or present an explicit unavailable reason; do not silently fabricate plans/summaries or disable backend guards. Preserve aggregate-workspace routing and accessibility. No force override or new lifecycle surface.

## Validation
Use existing dashboard/API test harness with realistic task fixtures, and verify proposed, backlog, blocked, review, done and archived cases plus undo behavior. Browser evidence may use the established operator QA setup; do not claim unavailable browser checks passed.

### Acceptance Criteria

- The dashboard does not offer transitions the normal server lifecycle rejects; terminal tasks expose no ordinary reopening choices.
- A transition needing missing plan/completion evidence is not submitted blindly: required data is collected or a clear unavailable reason is shown.
- Undo is offered only when a valid reverse transition can be performed without bypassing lifecycle or evidence requirements.
- Existing dashboard/API tests cover invalid proposed-to-done, terminal reopen, required evidence, and invalid reverse undo; backend safeguards and aggregate routing remain intact.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Exported the canonical orbit-core lifecycle transition predicate and a read-side missing-evidence query, then added valid status transitions and required companion fields to each dashboard task projection.
- Updated dashboard status and archive controls to consume projected transitions, collect non-empty plans or completion summaries before PATCHing, show a clear unavailable reason when evidence is not supplied, and expose undo only when the returned task permits the reverse transition without more evidence.
- Expanded API and shipped-JavaScript behavior tests across proposed, backlog, blocked, review, done, and archived states; covered invalid proposed-to-done, terminal reopening, missing plan/summary, valid and invalid reverse undo, list/detail parity, and preserved aggregate mutation routing.

Acceptance criteria:
1. Passed — status choices and archive actions come only from the server projection of the canonical lifecycle; done and archived project no transitions.
2. Passed — required plan and completion-summary evidence is projected, prompted for, included in the same PATCH, or reported locally as unavailable without a request.
3. Passed — undo is created only when the mutation response projects the prior status as a reverse target with no missing evidence; behavior tests cover valid and invalid reverse cases.
4. Passed — API safeguards reject invalid completion/reopen and missing evidence; the complete orbit-web suite, including aggregate routing tests, passes.

Validation:
- Passed: cargo test -p orbit-core application::task::tests::lifecycle — 9 passed.
- Passed: cargo test -p orbit-web — 389 passed, 1 ignored.
- Passed: make ci-fast — guardrails passed; its compiler-cache namespace probe reported the existing environment limitation that unprivileged mount namespaces are unavailable and skipped that subcheck.
- Passed: make ci-lint — workspace all-target clippy completed with warnings denied.
- Passed: make goldens — CLI help/output/MCP golden checks passed.
- Passed: cargo fmt --all -- --check.
- Passed: git diff --check.
- Inspected: git status --short accounts for eight modified task-scoped files and no untracked paths.

Assessment: The server remains authoritative; the dashboard consumes an additive projection rather than duplicating lifecycle policy or bypassing validation. The directly affected list/detail parity test was added to task scope after the new projection exposed its stale expected payload.

Remaining risk: Independent real-browser/operator QA was not run in this executor and remains required before release sign-off per the authorized task comment. The Node harness validates the shipped ES modules and observable DOM/request behavior.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12292-6aa51716`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra