### PR TITLE
Recover detached worker startup from bounded SQLite contention and identify the failed store

### DIFF
--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -31,6 +31,8 @@ pub struct CommandMeta {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeNeed {
     Required,
+    /// The hidden detached worker may outlive one transient SQLite writer.
+    PipelineWorker,
     /// Read an existing workspace without stale-run reconciliation on open.
     ReadOnly,
     Forbidden,
@@ -791,8 +793,14 @@ impl Commands {
                     };
                 let mut meta = admin_meta("job", Some(subcommand), Some(target_type), target_id);
                 meta.job_run_id = job_run_id.map(String::from);
+                let runtime_need = if matches!(command.command, JobSubcommand::RunPipelineWorker(_))
+                {
+                    RuntimeNeed::PipelineWorker
+                } else {
+                    RuntimeNeed::Required
+                };
                 CommandOperation::new(
-                    RuntimeNeed::Required,
+                    runtime_need,
                     Some(meta),
                     None,
                     false,

--- a/crates/orbit-cli/src/command/tests/operation_mode.rs
+++ b/crates/orbit-cli/src/command/tests/operation_mode.rs
@@ -137,6 +137,15 @@ fn operation_commands_need_a_runtime_and_carry_admin_audit_metadata() {
 }
 
 #[test]
+fn hidden_pipeline_worker_uses_bounded_bootstrap_recovery() {
+    let cli = Cli::parse_from(["orbit", "job", "run-pipeline-worker", "jrun-child"]);
+    assert_eq!(
+        cli.command.operation().runtime_need,
+        RuntimeNeed::PipelineWorker
+    );
+}
+
+#[test]
 fn run_auto_grant_conflicts_with_blanket_completion() {
     assert!(
         Cli::try_parse_from(["orbit", "run", "auto", "--grant", "ogrant-1", "--complete"]).is_err()

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -254,6 +254,12 @@ fn main() {
             root_override.as_deref(),
             workspace_selector.as_deref(),
         ),
+        RuntimeNeed::PipelineWorker => {
+            RegisteredRuntimeFactory::initialize_pipeline_worker_with_overrides(
+                root_override.as_deref(),
+                workspace_selector.as_deref(),
+            )
+        }
         RuntimeNeed::ReadOnly => RegisteredRuntimeFactory::initialize_read_only_with_overrides(
             root_override.as_deref(),
             workspace_selector.as_deref(),

--- a/crates/orbit-cmd/src/registry_runtime.rs
+++ b/crates/orbit-cmd/src/registry_runtime.rs
@@ -1,6 +1,8 @@
 //! Application composition over Registry's workspace catalog and Core's runtime seams.
 
 use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use orbit_common::OrbitError;
 use orbit_core::OrbitRuntime;
@@ -64,7 +66,26 @@ pub fn resolved_workspace_binding(
 /// Core workspace binding.
 pub struct RegisteredRuntimeFactory;
 
+/// Admit retry attempts for fifteen seconds. An attempt already in SQLite may
+/// consume its five-second busy timeout, so wall-clock bootstrap is bounded to
+/// twenty seconds. The parent observer has no shorter kill deadline and keeps
+/// supervising an unclaimed pending child throughout this recovery window.
+const PIPELINE_WORKER_BOOTSTRAP_RETRY_DEADLINE: Duration = Duration::from_secs(15);
+const PIPELINE_WORKER_BOOTSTRAP_RETRY_INTERVAL: Duration = Duration::from_millis(100);
+
 impl RegisteredRuntimeFactory {
+    /// Bootstrap the hidden detached worker with lock-only bounded recovery.
+    pub fn initialize_pipeline_worker_with_overrides(
+        root_override: Option<&Path>,
+        workspace_selector: Option<&str>,
+    ) -> Result<OrbitRuntime, OrbitError> {
+        retry_pipeline_worker_bootstrap(
+            || Self::initialize_with_overrides(root_override, workspace_selector),
+            PIPELINE_WORKER_BOOTSTRAP_RETRY_DEADLINE,
+            PIPELINE_WORKER_BOOTSTRAP_RETRY_INTERVAL,
+        )
+    }
+
     pub fn resolve_roots_for_cwd(
         cwd: &Path,
         root_override: Option<&Path>,
@@ -356,6 +377,24 @@ impl RegisteredRuntimeFactory {
                 }
                 Self::open_registered_checkout(&global_root, workspace, checkout).map(Some)
             }
+        }
+    }
+}
+
+pub(crate) fn retry_pipeline_worker_bootstrap<T>(
+    mut bootstrap: impl FnMut() -> Result<T, OrbitError>,
+    timeout: Duration,
+    retry_interval: Duration,
+) -> Result<T, OrbitError> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match bootstrap() {
+            Ok(runtime) => return Ok(runtime),
+            Err(error) if error.sqlite_contention().is_some() && Instant::now() < deadline => {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                thread::sleep(retry_interval.min(remaining));
+            }
+            Err(error) => return Err(error),
         }
     }
 }

--- a/crates/orbit-cmd/src/tests/registry_runtime.rs
+++ b/crates/orbit-cmd/src/tests/registry_runtime.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use orbit_common::{NotFoundKind, OrbitError};
@@ -17,9 +17,112 @@ use orbit_registry::workspace_registry::{
 };
 
 use crate::registry_runtime::{
-    RegisteredRuntimeFactory, resolved_workspace_binding, select_workspace_for_cwd_and_roots,
-    sync_task_prefix, workspace_runtime_binding,
+    RegisteredRuntimeFactory, resolved_workspace_binding, retry_pipeline_worker_bootstrap,
+    select_workspace_for_cwd_and_roots, sync_task_prefix, workspace_runtime_binding,
 };
+
+#[test]
+fn pipeline_worker_bootstrap_retries_only_typed_sqlite_contention() {
+    let contention = || {
+        OrbitError::SqliteContention(Box::new(orbit_common::SqliteContention {
+            path: "/isolated/audit.db".to_string(),
+            phase: "set synchronous=NORMAL".to_string(),
+            detail: "database is locked".to_string(),
+        }))
+    };
+    let mut attempts = 0;
+    let recovered = retry_pipeline_worker_bootstrap(
+        || {
+            attempts += 1;
+            if attempts < 3 {
+                Err(contention())
+            } else {
+                Ok("claimed-once")
+            }
+        },
+        Duration::from_secs(1),
+        Duration::from_millis(1),
+    )
+    .expect("contention released inside the worker budget");
+    assert_eq!(recovered, "claimed-once");
+    assert_eq!(attempts, 3);
+
+    let started = Instant::now();
+    let error = retry_pipeline_worker_bootstrap(
+        || Err::<(), _>(OrbitError::InvalidInput("unchanged".to_string())),
+        Duration::from_secs(1),
+        Duration::from_millis(50),
+    )
+    .expect_err("non-lock failures are not retried");
+    assert!(matches!(error, OrbitError::InvalidInput(message) if message == "unchanged"));
+    assert!(started.elapsed() < Duration::from_millis(500));
+}
+
+#[test]
+fn pipeline_worker_bootstrap_deadline_returns_precise_last_contention() {
+    let started = Instant::now();
+    let error = retry_pipeline_worker_bootstrap(
+        || {
+            Err::<(), _>(OrbitError::SqliteContention(Box::new(
+                orbit_common::SqliteContention {
+                    path: "/isolated/tasks/registry.db".to_string(),
+                    phase: "task prefix write admission".to_string(),
+                    detail: "database is busy".to_string(),
+                },
+            )))
+        },
+        Duration::from_millis(20),
+        Duration::from_millis(2),
+    )
+    .expect_err("deadline exhaustion returns the last typed failure");
+    assert!(started.elapsed() >= Duration::from_millis(20));
+    assert!(started.elapsed() < Duration::from_millis(500));
+    let message = error.to_string();
+    assert!(message.contains("/isolated/tasks/registry.db"), "{message}");
+    assert!(message.contains("task prefix write admission"), "{message}");
+}
+
+#[test]
+fn managed_worker_bootstrap_recovers_after_real_audit_store_busy_timeout() {
+    let fixture = managed_worktree_fixture();
+    let audit_db = fixture.registry_root.join("orbit.db");
+    let (locked, ready) = mpsc::sync_channel(1);
+    let blocker = std::thread::spawn(move || {
+        let store = orbit_store::Store::open(&audit_db).expect("open audit blocker");
+        store
+            .with_transaction(|tx| {
+                tx.connection()
+                    .execute(
+                        "UPDATE schema_meta SET value = value WHERE key = 'fixture-lock'",
+                        [],
+                    )
+                    .map_err(|error| OrbitError::Store(error.to_string()))?;
+                locked.send(()).expect("signal held audit lock");
+                std::thread::sleep(Duration::from_millis(5_250));
+                Ok(())
+            })
+            .expect("release audit writer");
+    });
+    ready.recv().expect("audit lock held");
+
+    let started = Instant::now();
+    let runtime = RegisteredRuntimeFactory::initialize_pipeline_worker_with_overrides(
+        Some(&fixture.registry_root),
+        Some(&fixture.repo_root.to_string_lossy()),
+    )
+    .expect("worker bootstrap recovers inside its bounded budget");
+    blocker.join().expect("audit blocker");
+
+    assert!(started.elapsed() > Duration::from_secs(5));
+    assert!(started.elapsed() < Duration::from_secs(20));
+    let shown = run_tool(
+        &runtime,
+        "orbit.task.show",
+        json!({ "id": fixture.task_id }),
+    )
+    .expect("recovered worker runtime retains authoritative task ownership");
+    assert_eq!(shown["id"], fixture.task_id);
+}
 
 fn workspace(id: &str, ship_mode: &str) -> Workspace {
     Workspace {

--- a/crates/orbit-common/src/error.rs
+++ b/crates/orbit-common/src/error.rs
@@ -118,6 +118,17 @@ pub struct WorkspaceClaimHeld {
     pub expires_at: String,
 }
 
+/// A SQLite bootstrap operation exhausted the connection's busy timeout.
+///
+/// The native SQLite code is classified before crossing the storage boundary,
+/// so detached-worker recovery never depends on matching an error string.
+#[derive(Debug, Serialize)]
+pub struct SqliteContention {
+    pub path: String,
+    pub phase: String,
+    pub detail: String,
+}
+
 #[derive(Debug, Error, Serialize)]
 #[non_exhaustive]
 /// Keep this widely propagated error below its 128-byte size budget. Box the
@@ -253,6 +264,11 @@ pub enum OrbitError {
     FileLockTimeout(Box<crate::fs::io::FileLockTimeout>),
     #[error("store error: {0}")]
     Store(String),
+    #[error(
+        "store error: SQLite database '{}' remained locked during {}: {}",
+        .0.path, .0.phase, .0.detail
+    )]
+    SqliteContention(Box<SqliteContention>),
     #[error("invalid task status transition: {0}")]
     TaskStatusTransition(String),
     /// A workflow run was refused because a dependency that reached `done` has
@@ -436,6 +452,13 @@ impl OrbitError {
     pub fn file_lock_timeout(&self) -> Option<&crate::fs::io::FileLockTimeout> {
         match self {
             Self::FileLockTimeout(timeout) => Some(timeout),
+            _ => None,
+        }
+    }
+
+    pub fn sqlite_contention(&self) -> Option<&SqliteContention> {
+        match self {
+            Self::SqliteContention(contention) => Some(contention),
             _ => None,
         }
     }

--- a/crates/orbit-common/src/lib.rs
+++ b/crates/orbit-common/src/lib.rs
@@ -35,7 +35,7 @@ pub mod test_process;
 
 pub use error::{
     ArtifactOrigin, ArtifactOriginMode, DependencyNotDelivered, FrictionNotLocal, NotFoundKind,
-    OrbitError, RecoverableVcsConflict, WorkspaceClaimHeld,
+    OrbitError, RecoverableVcsConflict, SqliteContention, WorkspaceClaimHeld,
 };
 pub use fs::task_io::{prune_missing_context_files, task_artifact_from_source_file};
 pub use model::pricing::{derive_cost_usd, normalize_token_usage};

--- a/crates/orbit-common/src/security/redaction.rs
+++ b/crates/orbit-common/src/security/redaction.rs
@@ -252,6 +252,9 @@ pub fn redact_sensitive_env_error(error: OrbitError) -> OrbitError {
             redact_file_lock_timeout(*timeout, redact_sensitive_env_text),
         ),
         OrbitError::Store(m) => OrbitError::Store(redact_sensitive_env_text(&m)),
+        OrbitError::SqliteContention(contention) => OrbitError::SqliteContention(
+            redact_sqlite_contention(*contention, redact_sensitive_env_text),
+        ),
         OrbitError::TaskStatusTransition(m) => {
             OrbitError::TaskStatusTransition(redact_sensitive_env_text(&m))
         }
@@ -398,6 +401,9 @@ pub fn redact_all_error(error: OrbitError) -> OrbitError {
             OrbitError::FileLockTimeout(redact_file_lock_timeout(*timeout, redact_all))
         }
         OrbitError::Store(m) => OrbitError::Store(redact_all(&m)),
+        OrbitError::SqliteContention(contention) => {
+            OrbitError::SqliteContention(redact_sqlite_contention(*contention, redact_all))
+        }
         OrbitError::TaskStatusTransition(m) => OrbitError::TaskStatusTransition(redact_all(&m)),
         OrbitError::DependencyNotDelivered(diagnostic) => OrbitError::DependencyNotDelivered(
             redact_dependency_not_delivered(*diagnostic, redact_all),
@@ -429,6 +435,16 @@ fn redact_file_lock_timeout(
         holder.label = redact(&holder.label);
     }
     Box::new(timeout)
+}
+
+fn redact_sqlite_contention(
+    mut contention: crate::SqliteContention,
+    redact: fn(&str) -> String,
+) -> Box<crate::SqliteContention> {
+    contention.path = redact(&contention.path);
+    contention.phase = redact(&contention.phase);
+    contention.detail = redact(&contention.detail);
+    Box::new(contention)
 }
 
 fn redact_friction_not_local(

--- a/crates/orbit-common/src/storage/sqlite.rs
+++ b/crates/orbit-common/src/storage/sqlite.rs
@@ -15,7 +15,7 @@ use std::path::{Component, Path, PathBuf};
 
 use rusqlite::{Connection, OpenFlags};
 
-use crate::OrbitError;
+use crate::{OrbitError, SqliteContention};
 
 /// Default `busy_timeout` applied to every Orbit SQLite connection, in
 /// milliseconds. Writers under WAL still serialize; this bounds how long a
@@ -89,11 +89,21 @@ pub fn open_private(path: &Path) -> Result<OpenedConnection, OrbitError> {
             path.display()
         ))
     })?;
-    let pragmas = apply_default_pragmas(&connection)?;
+    let pragmas = apply_default_pragmas_for_path(&connection, &path)?;
     if pragmas.write_denied || filesystem_is_read_only(&path)? {
         drop(connection);
         return open_observational(&path, ObservationRequirement::PublishedMainFile);
     }
+    // Establish one typed write-admission boundary before store-specific
+    // bootstrap runs. Current-schema opens otherwise encounter contention in
+    // whichever later pragma, migration probe, or registry bind happens to
+    // need the writer, after the native SQLite code and database path have
+    // often been erased by several adapter layers.
+    connection
+        .execute_batch("BEGIN IMMEDIATE; ROLLBACK;")
+        .map_err(|error| {
+            sqlite_operation_error(Some(&path), "bootstrap write admission", &error)
+        })?;
     harden_sqlite_files(&path)?;
 
     Ok(OpenedConnection {
@@ -351,13 +361,27 @@ impl PragmaOutcome {
 ///   that need commit-durable acks (e.g. the task registry) override to
 ///   `FULL` after calling this.
 pub fn apply_default_pragmas(conn: &Connection) -> Result<PragmaOutcome, OrbitError> {
+    apply_default_pragmas_inner(conn, None)
+}
+
+fn apply_default_pragmas_for_path(
+    conn: &Connection,
+    path: &Path,
+) -> Result<PragmaOutcome, OrbitError> {
+    apply_default_pragmas_inner(conn, Some(path))
+}
+
+fn apply_default_pragmas_inner(
+    conn: &Connection,
+    path: Option<&Path>,
+) -> Result<PragmaOutcome, OrbitError> {
     let (journal_mode, mut write_denied) = request_wal_journal_mode(conn);
     conn.pragma_update(None, "busy_timeout", DEFAULT_BUSY_TIMEOUT_MS)
-        .map_err(|e| OrbitError::Store(format!("failed to set busy_timeout: {e}")))?;
+        .map_err(|error| sqlite_operation_error(path, "set busy_timeout", &error))?;
     conn.pragma_update(None, "foreign_keys", "ON")
-        .map_err(|e| OrbitError::Store(format!("failed to enable foreign keys: {e}")))?;
+        .map_err(|error| sqlite_operation_error(path, "enable foreign keys", &error))?;
     if let Err(error) = conn.pragma_update(None, "synchronous", "NORMAL") {
-        let mapped = OrbitError::Store(format!("failed to set synchronous=NORMAL: {error}"));
+        let mapped = sqlite_operation_error(path, "set synchronous=NORMAL", &error);
         if mapped.is_readonly_or_access_failure() {
             write_denied = true;
             tracing::warn!(
@@ -373,6 +397,30 @@ pub fn apply_default_pragmas(conn: &Connection) -> Result<PragmaOutcome, OrbitEr
         journal_mode,
         write_denied,
     })
+}
+
+fn sqlite_operation_error(path: Option<&Path>, phase: &str, error: &rusqlite::Error) -> OrbitError {
+    use rusqlite::ErrorCode;
+
+    let contention = matches!(
+        error.sqlite_error_code(),
+        Some(ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked)
+    );
+    if contention && let Some(path) = path {
+        return OrbitError::SqliteContention(Box::new(SqliteContention {
+            path: path.display().to_string(),
+            phase: phase.to_string(),
+            detail: error.to_string(),
+        }));
+    }
+
+    let message = match phase {
+        "set busy_timeout" => format!("failed to set busy_timeout: {error}"),
+        "enable foreign keys" => format!("failed to enable foreign keys: {error}"),
+        "set synchronous=NORMAL" => format!("failed to set synchronous=NORMAL: {error}"),
+        _ => error.to_string(),
+    };
+    OrbitError::Store(message)
 }
 
 /// What a caller needs from an observational open.

--- a/crates/orbit-core/src/application/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/application/tests/job_pipeline.rs
@@ -630,6 +630,68 @@ fn routine_style_detached_worker_is_claimed_within_ownership_window() {
     assert_child_reaped(worker_pid);
 }
 
+/// Gate and leaf workers may both spend longer than SQLite's five-second busy
+/// timeout in bootstrap recovery. Their parent observers must keep supervising
+/// the still-live, unclaimed children and preserve each exact persisted owner.
+#[cfg(unix)]
+#[test]
+fn concurrent_gate_and_leaf_workers_claim_after_extended_bootstrap() {
+    let (_root, runtime) = test_runtime();
+    let gate = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("workspace_auto_pipeline", 1, Utc::now(), None, None)
+        .expect("insert gate run");
+    let leaf = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("task_gate_pipeline", 1, Utc::now(), None, None)
+        .expect("insert leaf run");
+
+    let mut workers = Vec::new();
+    for run in [&gate, &leaf] {
+        let mut command = Command::new("sh");
+        command.args(["-c", "sleep 5.75"]);
+        let worker_log =
+            configure_pipeline_worker_stdio(&mut command, &runtime.paths().logs_dir, &run.run_id)
+                .expect("configure delayed worker log");
+        let pid = runtime
+            .spawn_pipeline_worker_process(
+                &run.run_id,
+                Some("nested-supervisor"),
+                command,
+                worker_log,
+            )
+            .expect("spawn delayed worker");
+        workers.push((run.run_id.clone(), pid));
+    }
+
+    thread::sleep(Duration::from_millis(5_250));
+    for (run_id, pid) in &workers {
+        assert!(
+            runtime
+                .stores()
+                .jobs()
+                .claim_pending_job_run_owner(run_id, *pid)
+                .expect("claim delayed worker exactly once")
+        );
+        let stored = wait_for_worker_ownership_outcome(&runtime, run_id);
+        assert_eq!(stored.state, JobRunState::Pending);
+        assert_eq!(stored.pid, Some(*pid));
+        wait_for_pipeline_audit_event(&runtime, None, "delayed worker claim", |audit| {
+            audit.tool_name.as_deref() == Some("pipeline.worker.claimed")
+                && audit.target_id.as_deref() == Some(run_id.as_str())
+        });
+    }
+
+    for (run_id, pid) in workers {
+        let terminal = wait_for_worker_terminal(&runtime, &run_id);
+        assert_eq!(terminal.state, JobRunState::Interrupted);
+        assert_eq!(terminal.pid, Some(pid));
+        assert_child_reaped(pid);
+    }
+}
+
 #[test]
 fn observer_read_counts_isolate_identical_run_ids_in_independent_stores() {
     let (_first_root, first) = test_runtime();

--- a/crates/orbit-store/src/driver/sqlite/tests/connection.rs
+++ b/crates/orbit-store/src/driver/sqlite/tests/connection.rs
@@ -190,6 +190,36 @@ fn schema_version_matches_binary_after_open() {
     );
 }
 
+#[test]
+fn current_store_bootstrap_names_locked_write_admission_after_busy_timeout() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("store.db");
+    drop(Store::open(&path).expect("initialize current store"));
+
+    let blocker = rusqlite::Connection::open(&path).expect("open blocker");
+    blocker
+        .execute_batch("BEGIN EXCLUSIVE")
+        .expect("hold SQLite write lock");
+    let started = std::time::Instant::now();
+    let error = match Store::open(&path) {
+        Ok(_) => panic!("bootstrap must exhaust the busy timeout"),
+        Err(error) => error,
+    };
+
+    assert!(
+        started.elapsed()
+            >= std::time::Duration::from_millis(u64::from(
+                orbit_common::storage::sqlite::DEFAULT_BUSY_TIMEOUT_MS,
+            )),
+        "the regression must exercise SQLite's real busy timeout"
+    );
+    let contention = error
+        .sqlite_contention()
+        .expect("lock failure remains typed across the store boundary");
+    assert_eq!(contention.path, path.display().to_string());
+    assert_eq!(contention.phase, "bootstrap write admission");
+}
+
 #[cfg(unix)]
 #[test]
 fn file_store_is_private_under_permissive_umask() {


### PR DESCRIPTION
## Task

[ORB-12302](https://orbit-cli.com/tasks/ORB-12302) — Recover detached worker startup from bounded SQLite contention and identify the failed store

### Description

On-call production evidence: ORB-12299 ship jrun-20260912-0836-t1 failed because leaf jrun-20260912-0836-c2 exited before claiming its persisted run with `store error: database is locked`. Leaf created08:36:45.843, started_at null, wrapper duration5.136s; config initialization ended08:36:45.967, exit08:36:50.980. No step/provider/audit/claim/worktree evidence. Installed binary0.21.0 source34555aa5ca648b60614d74eed3168b995bcc15df. Normal retry0840-t3 started successfully; this does not repair the defect.

Read-only dedup found completed ORB-11650/PR1558 (merge8a3d1bd8e already ancestor of installed code) fixes concurrent schema migrations through BEGIN IMMEDIATE and in-transaction ledger re-read, but ordinary current-schema startup still fails. Captured post-fix worker logs show matching failures jrun-20260907-2328/-2/-3/-4, 20260908-0043,0417-2/-3,20260907-2329-3. No current matching owner/friction found.

Evidence localizes the likely boundary: CLI builds required OrbitRuntime before worker dispatch, builder Store::open(persistence.audit_db), writable store bootstrap shared pragmas/schema probe, common SQLite busy timeout5000ms. Bare error lacks database path/phase, so audit vs subsequent registry open is not yet proven. Verify the exact operation through deterministic reproduction before selecting fix. Add useful path/phase diagnostics and bounded lock-only bootstrap recovery (or equivalent safe admission serialization) for detached workers. Preserve non-lock error semantics, strict claim ownership and terminalization. Coordinate recovery deadline with parent startup supervision so a legitimate bounded retry is not killed prematurely. No global infinite retry, generic message matching, weaker SQLite durability or lock safety, manual DB edits, silent error suppression, or broad unrelated refactor. Authoritative durable bookkeeping must use ws_orbit MCP; fixtures use isolated scratch stores only.

### Acceptance Criteria

- Deterministic regression reproduces actual runtime bootstrap contention beyond the current 5s busy timeout and identifies the contended store/operation; release inside a documented bounded budget lets the pending worker claim exactly once and execute.
- Deadline exhaustion terminalizes once with precise database path/phase and preserves no duplicate worker/task/worktree claim; non-lock failures return promptly unchanged.
- Concurrent nested gate/leaf startup coverage preserves persisted run ownership and confirms bounded recovery works with parent supervision; existing migration-race tests remain green.
- Focused tests and repository required checks pass; evidence distinguishes actual reproduction from inferred boundaries.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a typed SQLite contention error carrying the canonical database path, bootstrap phase, and native detail, including existing secret-redaction handling.
- Added a shared BEGIN IMMEDIATE/ROLLBACK bootstrap write-admission probe after standard pragmas. This preserves SQLite durability settings and identifies current-schema writer contention before adapter layers erase its native code and path.
- Routed only the hidden detached-worker command through bounded lock-only recovery: retry admission lasts 15 seconds and an in-flight five-second SQLite busy timeout bounds total bootstrap to 20 seconds. Ordinary CLI and non-lock errors remain immediate.
- Added deterministic evidence that a real audit-store writer held beyond the existing five-second busy timeout reports phase bootstrap write admission and that release at 5.25 seconds lets a managed worker runtime recover against the authoritative task store.
- Added deadline/non-lock retry tests, CLI operation routing coverage, and concurrent gate/leaf parent-observer coverage proving both delayed children retain exact persisted PIDs and terminalize without duplicate ownership.

Acceptance criteria:
1. Passed: current_store_bootstrap_names_locked_write_admission_after_busy_timeout exercises the actual SQLite busy timeout for 5.03 seconds and identifies the database path plus bootstrap write admission; managed_worker_bootstrap_recovers_after_real_audit_store_busy_timeout releases the actual audit writer at 5.25 seconds and the production-shaped RegisteredRuntimeFactory succeeds once.
2. Passed: pipeline_worker_bootstrap_deadline_returns_precise_last_contention proves bounded exhaustion returns the final typed path/phase; pipeline_worker_bootstrap_retries_only_typed_sqlite_contention proves non-lock errors return promptly and unchanged; worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic and duplicate_worker_cannot_replace_the_persisted_owner preserve single terminalization and exact ownership.
3. Passed: concurrent_gate_and_leaf_workers_claim_after_extended_bootstrap holds two supervised children unclaimed beyond five seconds, then verifies exact persisted ownership and terminal outcomes; cargo test -p orbit-store concurrent_ kept both migration races and all 15 concurrent-store tests green.
4. Passed: focused tests and all required repository checks passed.

Validation:
- cargo test -p orbit-store current_store_bootstrap_names_locked_write_admission_after_busy_timeout -- --nocapture: passed; real contention took 5.03s.
- cargo test -p orbit-cmd pipeline_worker_bootstrap -- --nocapture: passed, 2 tests.
- cargo test -p orbit-cmd managed_worker_bootstrap_recovers_after_real_audit_store_busy_timeout -- --nocapture: passed; real managed bootstrap recovery took 5.65s.
- cargo test -p orbit-cli hidden_pipeline_worker_uses_bounded_bootstrap_recovery -- --nocapture: passed.
- cargo test -p orbit-core concurrent_gate_and_leaf_workers_claim_after_extended_bootstrap -- --nocapture: passed; two concurrent supervised workers delayed 5.25s.
- cargo test -p orbit-core worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic -- --nocapture: passed.
- cargo test -p orbit-core duplicate_worker_cannot_replace_the_persisted_owner -- --nocapture: passed.
- cargo test -p orbit-store concurrent_ -- --nocapture: passed, 15 tests including both migration races.
- cargo test -p orbit-common redact_all_error -- --nocapture: passed, 3 tests.
- make ci-fast: passed. Its compiler-cache namespace probe reported the established environment skip because unprivileged mount namespaces are unavailable; the gate exited 0.
- make ci-lint: passed.
- make goldens: passed.
- git diff --check: passed.
- git status --short: 11 expected tracked modifications, no untracked files.

Assessment: The repair is confined to shared SQLite bootstrap classification and the hidden worker bootstrap path. Actual lock reproduction is distinguished above from synthetic deadline/error-classification tests and existing ownership tests.
Remaining risks: The regression exercises Linux SQLite locking and parent process supervision. Other operating systems are covered by compilation and shared SQLite semantics, not an OS-specific contention run.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12302-6aa5172f`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra