### PR TITLE
Recover delivery review/QA consumers after settings changes without losing coverage debt

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -214,6 +214,14 @@ The auxiliary task-key table preserves the v5 task/allocator format so older
 readers can ignore it during rollback. Accepted receipt bytes are immutable and
 independent of later artifact replacement.
 
+Operator recovery of a stalled delivery consumer [ORB-12295] reuses that same
+feature migration: consumer state records the resolved trigger its epoch came
+from, and `automation_recoveries` retains one immutable record per applied
+recovery. Adoption of a compatible configuration and an authorized reissue of a
+settled unevidenced action commit with their record under the existing
+generation fence; no recovery may move a cursor, drop an obligation or mint a
+receipt. Older binaries ignore both the table and the recorded trigger.
+
 Task artifacts retain their existing bundle/manifest format. The artifact Store
 reserves `automation-evidence-authority.json`, writing transport-supplied run
 origin and a digest alongside coverage bytes under the existing task lock.

--- a/crates/orbit-automation/src/delivery/mod.rs
+++ b/crates/orbit-automation/src/delivery/mod.rs
@@ -9,6 +9,7 @@ use sha2::{Digest, Sha256};
 
 pub mod evidence;
 mod observe;
+pub mod recovery;
 #[cfg(test)]
 mod tests;
 
@@ -100,6 +101,7 @@ pub fn evaluate(
                 members: None,
                 consumer: consumer.into(),
                 epoch: epoch.into(),
+                trigger: Some(trigger.clone()),
                 repository,
                 branch: trigger.branch.clone(),
                 generation: 0,
@@ -156,7 +158,7 @@ pub fn evaluate(
         && active.state == BatchState::Claimed
         && !dry_run
     {
-        if active.attempt > 1 && now > active.batch.retry_until {
+        if active.attempt > 1 && now > active.deadline() {
             let mut next = state.clone();
             if let Some(attempt) = &mut next.active {
                 attempt.state = BatchState::Exhausted;
@@ -326,6 +328,7 @@ pub fn evaluate(
         state: BatchState::Claimed,
         reason: None,
         retry_after: None,
+        reissue: None,
     };
 
     let mut next = state.clone();

--- a/crates/orbit-automation/src/delivery/recovery.rs
+++ b/crates/orbit-automation/src/delivery/recovery.rs
@@ -1,0 +1,402 @@
+//! Explicit, audited recovery for a delivery consumer stalled by a settings
+//! change [ORB-12295].
+//!
+//! Editing a definition moves its epoch, so the consumer stops admitting work
+//! while every obligation it already holds stays retained. The supported way
+//! forward is this operation, not a hand-edited state file: it adopts the new
+//! configuration identity when the change cannot alter what the retained debt
+//! means, and it reissues an action that settled without accepted evidence
+//! over the exact obligations already frozen for it.
+//!
+//! Nothing here covers, waives or discards debt. Coverage still requires valid
+//! evidence from the assigned executor of an admitted action.
+
+use crate::AutomationError;
+use chrono::{DateTime, Utc};
+use orbit_store::contracts::AutomationStoreBackend;
+use orbit_types::workflow::automation::recovery::*;
+use orbit_types::workflow::automation::*;
+
+/// How many audited recoveries a preview reports.
+const HISTORY_LIMIT: usize = 10;
+
+/// One additional attempt is authorized for the same window the frozen batch
+/// budget grants, so a reissue never quietly widens the retry deadline policy.
+const REISSUE_WINDOW_HOURS: i64 = 24;
+
+/// One recovery request against one consumer, already resolved by the host.
+pub struct Recovery<'a> {
+    pub consumer: &'a str,
+    /// Epoch the definition resolves to now.
+    pub epoch: &'a str,
+    /// Resolved trigger behind that epoch.
+    pub trigger: &'a DeliveryTrigger,
+    /// Repository identity the source adapter reports for the configured
+    /// branch now.
+    pub repository: &'a str,
+    /// A refusal the host already knows about, such as `owned_elsewhere`.
+    /// Recorded rather than re-derived; Automation owns no registry facts.
+    pub host_refusal: Option<&'a str>,
+    pub request: &'a RecoveryRequest,
+    pub by: &'a str,
+    pub now: DateTime<Utc>,
+}
+
+/// Project the consumer's recovery position without touching any state.
+///
+/// `refusals` always reports what would block a recovery of this consumer at
+/// all; the refusals specific to an operation are added only when the request
+/// asks for that operation.
+pub fn preview(
+    store: &dyn AutomationStoreBackend,
+    request: &Recovery<'_>,
+) -> Result<RecoveryPreview, AutomationError> {
+    let state = load(store, request.consumer)?;
+    project(store, request, request.request, &state, vec![])
+}
+
+/// Apply the requested recovery under a generation fence, retaining every
+/// covered, pending, unresolved, waived, excluded and accepted fact.
+///
+/// Any refusal aborts before the write, so a refused recovery changes nothing.
+pub fn apply(
+    store: &dyn AutomationStoreBackend,
+    request: &Recovery<'_>,
+) -> Result<RecoveryPreview, AutomationError> {
+    let state = load(store, request.consumer)?;
+
+    if !request.request.mutates() {
+        return project(store, request, request.request, &state, vec![]);
+    }
+
+    let refusals = refusals(store, request, request.request, &state)?;
+    if !refusals.is_empty() {
+        return Err(AutomationError::Refused(refusals.join(",")));
+    }
+
+    let (next, record) = plan(request, &state)?;
+
+    if !store.automation_recover(&state, &next, &record)? {
+        return Err(AutomationError::Deferred("concurrent_evaluation".into()));
+    }
+
+    let mut applied = vec![];
+    if record.adopted_settings {
+        applied.push(RecoveryPreview::ADOPTED_SETTINGS.to_string());
+    }
+    if record.reissued.is_some() {
+        applied.push(RecoveryPreview::REISSUED_ACTION.to_string());
+    }
+
+    // The applied document reports the position the recovery left behind, so
+    // its refusals describe the consumer rather than the request just settled.
+    project(store, request, &RecoveryRequest::default(), &next, applied)
+}
+
+fn load(
+    store: &dyn AutomationStoreBackend,
+    consumer: &str,
+) -> Result<AutomationState, AutomationError> {
+    let state = store
+        .automation_state(consumer)?
+        .ok_or_else(|| AutomationError::Refused(refusal::UNKNOWN_CONSUMER.into()))?;
+
+    if state.members.is_some() {
+        return Err(AutomationError::Refused(refusal::MEMBER_CONSUMER.into()));
+    }
+
+    Ok(state)
+}
+
+/// Build the durable next state and its audit record. Only the configuration
+/// identity and the settled attempt may move; every cursor and obligation is
+/// carried over untouched.
+fn plan(
+    request: &Recovery<'_>,
+    state: &AutomationState,
+) -> Result<(AutomationState, RecoveryRecord), AutomationError> {
+    let mut next = state.clone();
+    next.generation = state
+        .generation
+        .checked_add(1)
+        .ok_or_else(|| AutomationError::Deferred("generation_exhausted".into()))?;
+
+    if request.request.adopt_settings {
+        next.epoch = request.epoch.into();
+        next.trigger = Some(request.trigger.clone());
+    }
+
+    let reissued = if request.request.reissue_action {
+        Some(reissue(request, &mut next)?)
+    } else {
+        None
+    };
+
+    let record = RecoveryRecord {
+        consumer: state.consumer.clone(),
+        previous_epoch: state.epoch.clone(),
+        epoch: next.epoch.clone(),
+        previous_trigger: state.trigger.clone(),
+        trigger: next.trigger.clone(),
+        adopted_settings: request.request.adopt_settings,
+        reissued,
+        reason: request.request.reason.trim().into(),
+        by: request.by.trim().into(),
+        at: request.now,
+    };
+
+    Ok((next, record))
+}
+
+/// Replace the settled attempt with one authorized attempt over the identical
+/// frozen batch. The previous action is left exactly as it settled.
+fn reissue(
+    request: &Recovery<'_>,
+    next: &mut AutomationState,
+) -> Result<ReissuedAction, AutomationError> {
+    let attempt = next
+        .active
+        .as_mut()
+        .ok_or_else(|| AutomationError::Refused(refusal::NO_SETTLED_ACTION.into()))?;
+
+    let from_action_id = attempt.action_id.take();
+    let from_attempt = attempt.attempt;
+    let from_state = attempt.state;
+    let from_reason = attempt.reason.take();
+
+    let authorization = ActionReissue {
+        from_action_id: from_action_id.clone(),
+        reason: request.request.reason.trim().into(),
+        by: request.by.trim().into(),
+        at: request.now,
+        retry_until: request.now + chrono::Duration::hours(REISSUE_WINDOW_HOURS),
+    };
+
+    attempt.attempt = from_attempt
+        .checked_add(1)
+        .ok_or_else(|| AutomationError::Deferred("attempt_exhausted".into()))?;
+    attempt.action_key = format!("automation:{}:{}", attempt.batch.id, attempt.attempt);
+    attempt.state = BatchState::Claimed;
+    attempt.retry_after = None;
+    attempt.reissue = Some(authorization.clone());
+
+    Ok(ReissuedAction {
+        batch_id: attempt.batch.id.clone(),
+        from_action_id,
+        from_attempt,
+        from_state,
+        from_reason,
+        attempt: attempt.attempt,
+        authorization,
+    })
+}
+
+/// Everything that forbids `requested`, named deterministically. Refusals that
+/// block any recovery of this consumer are always reported; the ones specific
+/// to an operation only when it was asked for.
+fn refusals(
+    store: &dyn AutomationStoreBackend,
+    request: &Recovery<'_>,
+    requested: &RecoveryRequest,
+    state: &AutomationState,
+) -> Result<Vec<String>, AutomationError> {
+    let mut refusals = vec![];
+    let mut refuse = |reason: &str| refusals.push(reason.to_string());
+
+    if let Some(reason) = request.host_refusal {
+        refuse(reason);
+    }
+
+    // Adoption may only carry debt across a change that cannot alter what the
+    // debt means: the same repository, branch, owner and examination contract.
+    if state.branch != request.trigger.branch {
+        refuse(refusal::BRANCH_CHANGED);
+    }
+
+    if state.repository != request.repository {
+        refuse(refusal::REPOSITORY_CHANGED);
+    }
+
+    if state
+        .trigger
+        .as_ref()
+        .is_some_and(|recorded| recorded.owner_machine != request.trigger.owner_machine)
+    {
+        refuse(refusal::OWNER_CHANGED);
+    }
+
+    match recorded_coverage(state) {
+        Some(coverage) if coverage != request.trigger.coverage => refuse(refusal::COVERAGE_CHANGED),
+        Some(_) => {}
+        None => refuse(refusal::COVERAGE_UNVERIFIABLE),
+    }
+
+    // Live execution is never interrupted; its action has to settle first.
+    if state
+        .active
+        .as_ref()
+        .is_some_and(|active| matches!(active.state, BatchState::Claimed | BatchState::Admitted))
+    {
+        refuse(refusal::ACTIVE_EXECUTION);
+    }
+
+    if requested.mutates()
+        && (request.request.reason.trim().is_empty() || request.by.trim().is_empty())
+    {
+        refuse(refusal::MISSING_AUTHORIZATION);
+    }
+
+    if requested.adopt_settings
+        && state.epoch == request.epoch
+        && state.trigger.as_ref() == Some(request.trigger)
+    {
+        refuse(refusal::SETTINGS_UNCHANGED);
+    }
+
+    if requested.reissue_action {
+        match state.active.as_ref() {
+            Some(active) if matches!(active.state, BatchState::Failed | BatchState::Exhausted) => {
+                if store
+                    .automation_receipt(&state.consumer, &active.batch.id)?
+                    .is_some()
+                {
+                    refuse(refusal::ACTION_EVIDENCED);
+                }
+            }
+            _ => refuse(refusal::NO_SETTLED_ACTION),
+        }
+
+        // A reissued claim admits nothing while the recorded identity is stale,
+        // so the same request has to adopt the configuration it will run under.
+        if !requested.adopt_settings && state.epoch != request.epoch {
+            refuse(refusal::DEFINITION_CHANGED);
+        }
+    }
+
+    Ok(refusals)
+}
+
+/// The examination contract the retained debt was accumulated under. The
+/// recorded trigger answers; otherwise the frozen batch does, and a consumer
+/// with neither cannot prove it.
+fn recorded_coverage(state: &AutomationState) -> Option<CoverageClass> {
+    state
+        .trigger
+        .as_ref()
+        .map(|trigger| trigger.coverage)
+        .or_else(|| state.active.as_ref().map(|active| active.batch.coverage))
+}
+
+fn project(
+    store: &dyn AutomationStoreBackend,
+    request: &Recovery<'_>,
+    requested: &RecoveryRequest,
+    state: &AutomationState,
+    applied: Vec<String>,
+) -> Result<RecoveryPreview, AutomationError> {
+    let receipts = store.automation_receipts(request.consumer, 100)?;
+    let reissuable = |active: &BatchAttempt| {
+        matches!(active.state, BatchState::Failed | BatchState::Exhausted)
+            && !receipts
+                .iter()
+                .any(|receipt| receipt.batch_id == active.batch.id)
+    };
+
+    Ok(RecoveryPreview {
+        consumer: state.consumer.clone(),
+        reason: stall_reason(state, request).into(),
+        identity: RecoveryIdentity {
+            recorded_epoch: state.epoch.clone(),
+            configured_epoch: request.epoch.into(),
+            changes: changes(state, request),
+            recorded_trigger: state.trigger.clone(),
+            configured_trigger: request.trigger.clone(),
+        },
+        debt: CoverageDebt {
+            baseline: state.baseline.clone(),
+            covered: state.covered.clone(),
+            observed: state.observed.clone(),
+            pending_deliveries: state.pending.len(),
+            pending_commits: state.pending_commits.len(),
+            unresolved: state.unresolved.len(),
+            waived: state.waived.len(),
+            excluded: state.excluded.len(),
+            receipts: receipts.len(),
+        },
+        action: state.active.as_ref().map(|active| StalledAction {
+            batch_id: active.batch.id.clone(),
+            attempt: active.attempt,
+            state: active.state,
+            action_id: active.action_id.clone(),
+            reason: active.reason.clone(),
+            obligations: active
+                .batch
+                .deliveries
+                .iter()
+                .map(|delivery| delivery.key.clone())
+                .collect(),
+            commits: active.batch.commits.len(),
+            reissuable: reissuable(active),
+        }),
+        refusals: refusals(store, request, requested, state)?,
+        applied,
+        history: store.automation_recoveries(request.consumer, HISTORY_LIMIT)?,
+    })
+}
+
+/// Why this consumer is or is not stalled, in the evaluator's own precedence:
+/// an edited definition first, then a settled action needing attention.
+fn stall_reason(state: &AutomationState, request: &Recovery<'_>) -> &'static str {
+    if state.epoch != request.epoch || state.branch != request.trigger.branch {
+        return super::DEFINITION_CHANGED;
+    }
+
+    match state.active.as_ref().map(|active| active.state) {
+        Some(BatchState::Failed | BatchState::Exhausted) => "needs_attention",
+        Some(_) => "batch_pending",
+        None => "not_stalled",
+    }
+}
+
+/// Name each configured setting that differs from the recorded one. A consumer
+/// that never recorded its trigger can only report that the identity differs.
+fn changes(state: &AutomationState, request: &Recovery<'_>) -> Vec<String> {
+    let Some(recorded) = state.trigger.as_ref() else {
+        return if state.epoch == request.epoch {
+            vec![]
+        } else {
+            vec!["configuration_identity".into()]
+        };
+    };
+
+    let configured = request.trigger;
+    let mut changes = vec![];
+
+    for (name, differs) in [
+        (
+            "owner_machine",
+            recorded.owner_machine != configured.owner_machine,
+        ),
+        ("branch", recorded.branch != configured.branch),
+        ("coverage", recorded.coverage != configured.coverage),
+        ("threshold", recorded.threshold != configured.threshold),
+        (
+            "max_wait_minutes",
+            recorded.max_wait_minutes != configured.max_wait_minutes,
+        ),
+        ("max_items", recorded.max_items != configured.max_items),
+        ("retries", recorded.retries != configured.retries),
+    ] {
+        if differs {
+            changes.push(name.to_string());
+        }
+    }
+
+    // Whatever else the epoch covers — the task template, dedupe policy or a
+    // routine's target and policy — is visible only as a different epoch.
+    if changes.is_empty() && state.epoch != request.epoch {
+        changes.push("definition".into());
+    }
+
+    changes
+}

--- a/crates/orbit-automation/src/delivery/tests/mod.rs
+++ b/crates/orbit-automation/src/delivery/tests/mod.rs
@@ -1,2 +1,3 @@
 mod evidence;
 mod observe;
+mod recovery;

--- a/crates/orbit-automation/src/delivery/tests/recovery.rs
+++ b/crates/orbit-automation/src/delivery/tests/recovery.rs
@@ -1,0 +1,465 @@
+//! Recovery keeps every obligation and never substitutes authorization for
+//! evidence [ORB-12295].
+
+use super::evidence::{Host, evaluate, landing, now, revision, setup};
+use crate::{
+    AutomationError,
+    delivery::{self, Evaluation, recovery},
+};
+use orbit_store::contracts::AutomationStoreBackend;
+use orbit_types::workflow::automation::recovery::{RecoveryPreview, RecoveryRequest, refusal};
+use orbit_types::workflow::automation::*;
+use std::sync::atomic::Ordering;
+
+const CONSUMER: &str = "ws/qa";
+
+fn request(adopt: bool, reissue: bool) -> RecoveryRequest {
+    RecoveryRequest {
+        adopt_settings: adopt,
+        reissue_action: reissue,
+        reason: "tonight's retuning keeps the same QA contract".into(),
+    }
+}
+
+fn recovery<'a>(
+    trigger: &'a DeliveryTrigger,
+    epoch: &'a str,
+    request: &'a RecoveryRequest,
+) -> recovery::Recovery<'a> {
+    recovery::Recovery {
+        consumer: CONSUMER,
+        epoch,
+        trigger,
+        repository: "owner/repo",
+        host_refusal: None,
+        request,
+        by: "operator",
+        now: now(),
+    }
+}
+
+/// Drive a consumer to a settled failed action over two retained landings,
+/// exactly as an archived unevidenced task leaves it.
+fn stalled() -> (
+    std::sync::Arc<dyn AutomationStoreBackend>,
+    Host,
+    DeliveryTrigger,
+    CoverageBatch,
+) {
+    let (store, host, trigger) = setup();
+    host.page(0, 2);
+    let batch = evaluate(store.as_ref(), &host, &trigger, true)
+        .state
+        .unwrap()
+        .active
+        .unwrap()
+        .batch;
+
+    // Spend the frozen retry budget: the worker fails, the automatic retry is
+    // admitted after its backoff, and that attempt fails too.
+    host.page(2, 2);
+    host.failed.store(true, Ordering::SeqCst);
+    evaluate(store.as_ref(), &host, &trigger, true);
+    delivery::evaluate(
+        store.as_ref(),
+        &host,
+        Evaluation {
+            consumer: CONSUMER,
+            epoch: "v1",
+            trigger: &trigger,
+            enabled: true,
+            dry_run: false,
+            now: now() + chrono::Duration::minutes(6),
+        },
+    )
+    .unwrap();
+    let settled = evaluate(store.as_ref(), &host, &trigger, true)
+        .state
+        .unwrap()
+        .active
+        .unwrap();
+    assert_eq!(settled.state, BatchState::Exhausted);
+    assert_eq!(settled.attempt, 2);
+    host.failed.store(false, Ordering::SeqCst);
+
+    (store, host, trigger, batch)
+}
+
+/// The settings the operator retuned tonight: a lower threshold over the same
+/// branch, repository and examination contract.
+fn retuned(trigger: &DeliveryTrigger) -> DeliveryTrigger {
+    DeliveryTrigger {
+        threshold: 1,
+        max_wait_minutes: 30,
+        ..trigger.clone()
+    }
+}
+
+#[test]
+fn preview_reports_the_stall_and_its_debt_without_writing() {
+    let (store, _host, trigger, batch) = stalled();
+    let before = store.automation_state(CONSUMER).unwrap();
+    let retuned = retuned(&trigger);
+    let request = RecoveryRequest::default();
+
+    let preview = recovery::preview(store.as_ref(), &recovery(&retuned, "v2", &request)).unwrap();
+
+    assert_eq!(preview.reason, delivery::DEFINITION_CHANGED);
+    assert_eq!(preview.identity.recorded_epoch, "v1");
+    assert_eq!(preview.identity.configured_epoch, "v2");
+    assert_eq!(
+        preview.identity.changes,
+        vec!["threshold".to_string(), "max_wait_minutes".to_string()]
+    );
+    assert_eq!(preview.debt.pending_deliveries, 2);
+    assert_eq!(preview.debt.pending_commits, 2);
+    assert_eq!(preview.debt.covered, revision(0));
+    assert_eq!(preview.debt.receipts, 0);
+
+    let action = preview.action.expect("a settled action is retained");
+    assert_eq!(action.batch_id, batch.id);
+    assert_eq!(action.obligations, vec![landing(1).key, landing(2).key]);
+    assert!(action.reissuable);
+    assert!(preview.refusals.is_empty());
+    assert!(preview.applied.is_empty());
+
+    assert_eq!(store.automation_state(CONSUMER).unwrap(), before);
+    assert!(
+        store
+            .automation_recoveries(CONSUMER, 10)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn adopting_settings_retains_every_obligation_and_records_the_old_identity() {
+    let (store, host, trigger, batch) = stalled();
+    let retuned = retuned(&trigger);
+    let request = request(true, false);
+
+    let applied = recovery::apply(store.as_ref(), &recovery(&retuned, "v2", &request)).unwrap();
+    assert_eq!(applied.applied, vec![RecoveryPreview::ADOPTED_SETTINGS]);
+    assert!(
+        applied.refusals.is_empty(),
+        "a completed recovery reports the position it left, not the request it settled"
+    );
+
+    let state = store.automation_state(CONSUMER).unwrap().unwrap();
+    assert_eq!(state.epoch, "v2");
+    assert_eq!(state.trigger.as_ref(), Some(&retuned));
+    assert_eq!(state.covered, revision(0), "adoption covers nothing");
+    assert_eq!(state.pending.len(), 2, "retained debt survives adoption");
+    assert_eq!(state.pending_commits.len(), 2);
+    assert_eq!(
+        state.active.as_ref().unwrap().batch,
+        batch,
+        "the frozen obligations are untouched"
+    );
+
+    let record = store.automation_recoveries(CONSUMER, 10).unwrap();
+    assert_eq!(record.len(), 1);
+    assert_eq!(record[0].previous_epoch, "v1");
+    assert_eq!(record[0].epoch, "v2");
+    assert_eq!(record[0].previous_trigger.as_ref(), Some(&trigger));
+    assert!(record[0].adopted_settings);
+    assert!(record[0].reissued.is_none());
+
+    // The adopted consumer evaluates again under its new settings instead of
+    // stalling, and still reports the settled action as needing attention.
+    let resumed = delivery::evaluate(
+        store.as_ref(),
+        &host,
+        Evaluation {
+            consumer: CONSUMER,
+            epoch: "v2",
+            trigger: &retuned,
+            enabled: true,
+            dry_run: false,
+            now: now(),
+        },
+    )
+    .unwrap();
+    assert_eq!(resumed.reason, "needs_attention");
+}
+
+#[test]
+fn a_reissued_action_admits_a_new_task_and_covers_only_with_fresh_evidence() {
+    let (store, host, trigger, batch) = stalled();
+    let retuned = retuned(&trigger);
+    let settled_action = store
+        .automation_state(CONSUMER)
+        .unwrap()
+        .unwrap()
+        .active
+        .unwrap()
+        .action_id
+        .unwrap();
+    let request = request(true, true);
+
+    let applied = recovery::apply(store.as_ref(), &recovery(&retuned, "v2", &request)).unwrap();
+    assert_eq!(
+        applied.applied,
+        vec![
+            RecoveryPreview::ADOPTED_SETTINGS,
+            RecoveryPreview::REISSUED_ACTION
+        ]
+    );
+
+    let claim = store
+        .automation_state(CONSUMER)
+        .unwrap()
+        .unwrap()
+        .active
+        .unwrap();
+    assert_eq!(
+        claim.batch, batch,
+        "the same frozen obligations are reissued"
+    );
+    assert_eq!(claim.attempt, 3);
+    assert_eq!(claim.state, BatchState::Claimed);
+    assert!(claim.action_id.is_none());
+    assert_eq!(
+        claim.reissue.as_ref().unwrap().from_action_id.as_ref(),
+        Some(&settled_action)
+    );
+
+    // The reissued claim admits a new action past the frozen retry deadline,
+    // which the operator authorization explicitly extended.
+    host.page(2, 2);
+    let admitted = delivery::evaluate(
+        store.as_ref(),
+        &host,
+        Evaluation {
+            consumer: CONSUMER,
+            epoch: "v2",
+            trigger: &retuned,
+            enabled: true,
+            dry_run: false,
+            now: now() + chrono::Duration::hours(2),
+        },
+    )
+    .unwrap()
+    .state
+    .unwrap()
+    .active
+    .unwrap();
+    assert_eq!(admitted.state, BatchState::Admitted);
+    assert_ne!(admitted.action_id, Some(settled_action));
+    assert_eq!(host.actions.lock().unwrap().len(), 3);
+    assert_eq!(
+        store.automation_state(CONSUMER).unwrap().unwrap().covered,
+        revision(0),
+        "authorizing a retry never advances coverage"
+    );
+
+    host.evidence(&admitted);
+    let covered = delivery::evaluate(
+        store.as_ref(),
+        &host,
+        Evaluation {
+            consumer: CONSUMER,
+            epoch: "v2",
+            trigger: &retuned,
+            enabled: true,
+            dry_run: false,
+            now: now() + chrono::Duration::hours(3),
+        },
+    )
+    .unwrap();
+    assert_eq!(covered.state.unwrap().covered, revision(2));
+    assert_eq!(covered.receipts.len(), 1);
+}
+
+#[test]
+fn evidence_frozen_against_the_replaced_attempt_cannot_cover_the_reissue() {
+    let (store, host, trigger, _batch) = stalled();
+    let stale = store
+        .automation_state(CONSUMER)
+        .unwrap()
+        .unwrap()
+        .active
+        .unwrap();
+    host.evidence(&stale);
+
+    let retuned = retuned(&trigger);
+    let request = request(true, true);
+    recovery::apply(store.as_ref(), &recovery(&retuned, "v2", &request)).unwrap();
+
+    host.page(2, 2);
+    let state = delivery::evaluate(
+        store.as_ref(),
+        &host,
+        Evaluation {
+            consumer: CONSUMER,
+            epoch: "v2",
+            trigger: &retuned,
+            enabled: true,
+            dry_run: false,
+            now: now() + chrono::Duration::hours(2),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        state.state.unwrap().covered,
+        revision(0),
+        "the archived action's evidence names an attempt that no longer exists"
+    );
+    assert!(state.receipts.is_empty());
+}
+
+#[test]
+fn incompatible_and_unauthorized_changes_are_refused_without_touching_state() {
+    let (store, _host, trigger, _batch) = stalled();
+    let before = store.automation_state(CONSUMER).unwrap();
+
+    let mut branch = retuned(&trigger);
+    branch.branch = "main".into();
+    let mut coverage = retuned(&trigger);
+    coverage.coverage = CoverageClass::LandedCodeReviewV1;
+    let mut owner = retuned(&trigger);
+    owner.owner_machine = Some("another-machine".into());
+
+    let adopt = request(true, false);
+    let unexplained = RecoveryRequest {
+        reason: "   ".into(),
+        ..request(true, false)
+    };
+
+    for (expected, trigger, epoch, request, repository) in [
+        (refusal::BRANCH_CHANGED, &branch, "v2", &adopt, "owner/repo"),
+        (
+            refusal::COVERAGE_CHANGED,
+            &coverage,
+            "v2",
+            &adopt,
+            "owner/repo",
+        ),
+        (refusal::OWNER_CHANGED, &owner, "v2", &adopt, "owner/repo"),
+        (
+            refusal::REPOSITORY_CHANGED,
+            &branch,
+            "v2",
+            &adopt,
+            "owner/moved",
+        ),
+        (
+            refusal::MISSING_AUTHORIZATION,
+            &retuned(&trigger),
+            "v2",
+            &unexplained,
+            "owner/repo",
+        ),
+        (
+            refusal::SETTINGS_UNCHANGED,
+            &trigger,
+            "v1",
+            &adopt,
+            "owner/repo",
+        ),
+    ] {
+        let mut recovery = recovery(trigger, epoch, request);
+        recovery.repository = repository;
+
+        let error = recovery::apply(store.as_ref(), &recovery).expect_err("refused");
+        let AutomationError::Refused(reasons) = error else {
+            panic!("expected a typed refusal, got {error}");
+        };
+        assert!(reasons.contains(expected), "{reasons} lacks {expected}");
+        assert_eq!(store.automation_state(CONSUMER).unwrap(), before);
+        assert!(
+            store
+                .automation_recoveries(CONSUMER, 10)
+                .unwrap()
+                .is_empty()
+        );
+    }
+}
+
+#[test]
+fn a_live_action_and_an_evidenced_batch_are_never_recovered() {
+    let (store, host, trigger) = setup();
+    host.page(0, 2);
+    let admitted = evaluate(store.as_ref(), &host, &trigger, true)
+        .state
+        .unwrap()
+        .active
+        .unwrap();
+    assert_eq!(admitted.state, BatchState::Admitted);
+
+    let retuned = retuned(&trigger);
+    let request = request(true, true);
+    let error = recovery::apply(store.as_ref(), &recovery(&retuned, "v2", &request))
+        .expect_err("a running action is never interrupted");
+    let AutomationError::Refused(reasons) = error else {
+        panic!("expected a typed refusal, got {error}");
+    };
+    assert!(reasons.contains(refusal::ACTIVE_EXECUTION), "{reasons}");
+    assert!(reasons.contains(refusal::NO_SETTLED_ACTION), "{reasons}");
+
+    // Once the batch is covered there is nothing left to reissue either.
+    host.evidence(&admitted);
+    host.page(2, 2);
+    assert_eq!(
+        evaluate(store.as_ref(), &host, &trigger, true)
+            .state
+            .unwrap()
+            .covered,
+        revision(2)
+    );
+    let error = recovery::apply(store.as_ref(), &recovery(&retuned, "v2", &request))
+        .expect_err("an evidenced batch is not reissuable");
+    let AutomationError::Refused(reasons) = error else {
+        panic!("expected a typed refusal, got {error}");
+    };
+    assert!(reasons.contains(refusal::NO_SETTLED_ACTION), "{reasons}");
+    assert_eq!(
+        store.automation_state(CONSUMER).unwrap().unwrap().epoch,
+        "v1",
+        "one refused operation refuses the whole request"
+    );
+}
+
+#[test]
+fn a_reissue_alone_cannot_strand_a_claim_under_a_stale_identity() {
+    let (store, _host, trigger, _batch) = stalled();
+    let retuned = retuned(&trigger);
+    let request = request(false, true);
+
+    let error = recovery::apply(store.as_ref(), &recovery(&retuned, "v2", &request))
+        .expect_err("a claim under a stale identity would never admit");
+    let AutomationError::Refused(reasons) = error else {
+        panic!("expected a typed refusal, got {error}");
+    };
+    assert!(reasons.contains(refusal::DEFINITION_CHANGED), "{reasons}");
+}
+
+#[test]
+fn an_unknown_consumer_and_a_host_refusal_stop_before_any_write() {
+    let (store, _host, trigger, _batch) = stalled();
+    let retuned = retuned(&trigger);
+    let request = request(true, false);
+
+    let mut unknown = recovery(&retuned, "v2", &request);
+    unknown.consumer = "ws/absent";
+    let error = recovery::apply(store.as_ref(), &unknown).expect_err("nothing to recover");
+    assert!(matches!(
+        error,
+        AutomationError::Refused(reasons) if reasons == refusal::UNKNOWN_CONSUMER
+    ));
+
+    let mut elsewhere = recovery(&retuned, "v2", &request);
+    elsewhere.host_refusal = Some(refusal::OWNED_ELSEWHERE);
+    let error = recovery::apply(store.as_ref(), &elsewhere).expect_err("not this host's consumer");
+    let AutomationError::Refused(reasons) = error else {
+        panic!("expected a typed refusal, got {error}");
+    };
+    assert!(reasons.contains(refusal::OWNED_ELSEWHERE), "{reasons}");
+    assert!(
+        store
+            .automation_recoveries(CONSUMER, 10)
+            .unwrap()
+            .is_empty()
+    );
+}

--- a/crates/orbit-automation/src/error.rs
+++ b/crates/orbit-automation/src/error.rs
@@ -8,6 +8,10 @@ pub enum AutomationError {
     Evidence(String),
     #[error("automation deferred: {0}")]
     Deferred(String),
+    /// An explicit operator operation the current state forbids, naming every
+    /// refusal that applies. Nothing was changed.
+    #[error("recovery refused: {0}")]
+    Refused(String),
     #[error(transparent)]
     Boundary(#[from] OrbitError),
 }
@@ -20,6 +24,9 @@ pub fn automation_error_to_orbit(error: AutomationError) -> OrbitError {
         }
         AutomationError::Deferred(reason) => {
             OrbitError::Execution(format!("automation_deferred: {reason}"))
+        }
+        AutomationError::Refused(reasons) => {
+            OrbitError::InvalidInput(format!("recovery_refused: {reasons}"))
         }
         AutomationError::Boundary(error) => error,
     }

--- a/crates/orbit-automation/src/members/mod.rs
+++ b/crates/orbit-automation/src/members/mod.rs
@@ -126,6 +126,8 @@ pub fn evaluate(
                 members: Some(MemberState::default()),
                 consumer: consumer.into(),
                 epoch: epoch.into(),
+                // State members carry no delivery trigger identity.
+                trigger: None,
                 repository,
                 branch: trigger.branch.clone(),
                 generation: 0,

--- a/crates/orbit-cli/src/command/auto_task/command.rs
+++ b/crates/orbit-cli/src/command/auto_task/command.rs
@@ -6,6 +6,7 @@ use crate::command::{CommandOut, Execute};
 use super::add::AutoTaskAddArgs;
 use super::list::AutoTaskListArgs;
 use super::mint::AutoTaskMintArgs;
+use super::recover::AutoTaskRecoverArgs;
 use super::show::AutoTaskShowArgs;
 use super::toggle::AutoTaskToggleArgs;
 use super::update::AutoTaskUpdateArgs;
@@ -38,6 +39,9 @@ pub enum AutoTaskSubcommand {
     /// Mint a task from a definition now (ignores schedule, dedupe, and
     /// `enabled`; leaves the scheduler cursor untouched)
     Mint(AutoTaskMintArgs),
+    /// Preview or apply the audited recovery for a delivery consumer stalled
+    /// by a settings change (retains all coverage debt)
+    Recover(AutoTaskRecoverArgs),
 }
 
 impl Execute for AutoTaskSubcommand {
@@ -49,6 +53,7 @@ impl Execute for AutoTaskSubcommand {
             AutoTaskSubcommand::Update(args) => args.execute(runtime),
             AutoTaskSubcommand::Toggle(args) => args.execute(runtime),
             AutoTaskSubcommand::Mint(args) => args.execute(runtime),
+            AutoTaskSubcommand::Recover(args) => args.execute(runtime),
         }
     }
 }

--- a/crates/orbit-cli/src/command/auto_task/mod.rs
+++ b/crates/orbit-cli/src/command/auto_task/mod.rs
@@ -3,6 +3,7 @@ mod command;
 mod list;
 mod mint;
 pub(crate) mod output;
+mod recover;
 mod schedule_args;
 mod show;
 mod toggle;

--- a/crates/orbit-cli/src/command/auto_task/recover.rs
+++ b/crates/orbit-cli/src/command/auto_task/recover.rs
@@ -1,0 +1,113 @@
+use clap::Args;
+use orbit_core::{OrbitError, OrbitRuntime};
+use orbit_types::workflow::automation::recovery::{RecoveryPreview, RecoveryRequest};
+
+use crate::command::{CommandOut, Execute, Payload};
+
+/// Recover a delivery consumer that stalled on a settings change.
+///
+/// Without `--adopt-settings` or `--reissue-action` this is a read-only
+/// preview. Neither operation covers, waives or discards an obligation, and
+/// state files are never edited by hand.
+#[derive(Args)]
+pub struct AutoTaskRecoverArgs {
+    /// Definition name
+    pub name: String,
+    /// Adopt the definition's current settings, retaining every pending,
+    /// unresolved and accepted fact. Refused when the repository, branch,
+    /// owner or coverage class changed, or while an action is executing.
+    #[arg(long)]
+    pub adopt_settings: bool,
+    /// Reissue the settled action that closed without accepted evidence, as a
+    /// new task over its existing frozen obligations. The closed task is left
+    /// exactly as it settled.
+    #[arg(long)]
+    pub reissue_action: bool,
+    /// Operator explanation, retained in the recovery audit record. Required
+    /// for either operation.
+    #[arg(long)]
+    pub reason: Option<String>,
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for AutoTaskRecoverArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        let definition = runtime.auto_task_show(&self.name)?.ok_or_else(|| {
+            OrbitError::InvalidInput(format!("no such auto-task '{}'", self.name))
+        })?;
+
+        let request = RecoveryRequest {
+            adopt_settings: self.adopt_settings,
+            reissue_action: self.reissue_action,
+            reason: self.reason.unwrap_or_default(),
+        };
+
+        let preview = orbit_core::application::automation::recover_auto_task(
+            runtime,
+            &definition,
+            &request,
+            chrono::Utc::now(),
+        )?;
+
+        let document = serde_json::to_value(&preview)
+            .map_err(|error| OrbitError::InvalidInput(error.to_string()))?;
+
+        Ok(Payload::detail(document, summary(&self.name, &preview)).into())
+    }
+}
+
+fn summary(name: &str, preview: &RecoveryPreview) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+    let _ = writeln!(out, "{name} ({})", preview.reason);
+    let _ = writeln!(out, "  consumer: {}", preview.consumer);
+    let _ = writeln!(
+        out,
+        "  identity: {} -> {}",
+        preview.identity.recorded_epoch, preview.identity.configured_epoch
+    );
+    if !preview.identity.changes.is_empty() {
+        let _ = writeln!(out, "  changed: {}", preview.identity.changes.join(", "));
+    }
+
+    let debt = &preview.debt;
+    let _ = writeln!(out, "  covered: {}", debt.covered.commit);
+    let _ = writeln!(
+        out,
+        "  debt: {} pending deliveries, {} pending commits, {} unresolved, {} waived, {} excluded, {} receipts",
+        debt.pending_deliveries,
+        debt.pending_commits,
+        debt.unresolved,
+        debt.waived,
+        debt.excluded,
+        debt.receipts
+    );
+
+    if let Some(action) = &preview.action {
+        let _ = writeln!(
+            out,
+            "  action: {} attempt {} ({:?}), {} obligations, {} commits, reissuable={}",
+            action.batch_id,
+            action.attempt,
+            action.state,
+            action.obligations.len(),
+            action.commits,
+            action.reissuable
+        );
+    }
+
+    if preview.applied.is_empty() {
+        let _ = writeln!(out, "  applied: none (preview)");
+    } else {
+        let _ = writeln!(out, "  applied: {}", preview.applied.join(", "));
+    }
+
+    if !preview.refusals.is_empty() {
+        let _ = writeln!(out, "  refusals: {}", preview.refusals.join(", "));
+    }
+
+    out
+}

--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -731,6 +731,7 @@ impl Commands {
                     AutoTaskSubcommand::Update(args) => ("update", Some(args.name.as_str())),
                     AutoTaskSubcommand::Toggle(args) => ("toggle", Some(args.name.as_str())),
                     AutoTaskSubcommand::Mint(args) => ("mint", Some(args.name.as_str())),
+                    AutoTaskSubcommand::Recover(args) => ("recover", Some(args.name.as_str())),
                 };
                 CommandOperation::new(
                     RuntimeNeed::Required,

--- a/crates/orbit-cli/src/command/tests/auto_task.rs
+++ b/crates/orbit-cli/src/command/tests/auto_task.rs
@@ -270,3 +270,90 @@ fn delivery_schedule_summary_uses_coverage_wire_names() {
         );
     }
 }
+
+#[test]
+fn auto_task_recover_parses_both_operations_and_their_reason() {
+    let cli = Cli::try_parse_from([
+        "orbit",
+        "auto-task",
+        "recover",
+        "delivery-qa",
+        "--adopt-settings",
+        "--reissue-action",
+        "--reason",
+        "adopt tonight's threshold and re-examine the unpaid landing",
+    ])
+    .expect("parse auto-task recover");
+
+    let Commands::AutoTask(auto_task) = cli.command else {
+        panic!("expected auto-task command");
+    };
+    let AutoTaskSubcommand::Recover(args) = auto_task.command else {
+        panic!("expected auto-task recover command");
+    };
+
+    assert_eq!(args.name, "delivery-qa");
+    assert!(args.adopt_settings);
+    assert!(args.reissue_action);
+    assert_eq!(
+        args.reason.as_deref(),
+        Some("adopt tonight's threshold and re-examine the unpaid landing")
+    );
+}
+
+#[test]
+fn auto_task_recover_defaults_to_a_preview_and_needs_a_delivery_definition() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    runtime
+        .auto_task_add(AutoTaskAddParams {
+            name: "interval".to_string(),
+            description: "Not a delivery consumer.".to_string(),
+            schedule: AutoTaskSchedule::Interval { every_minutes: 5 },
+            template: AutoTaskTemplate {
+                title: "Sweep".to_string(),
+                description: String::new(),
+                acceptance_criteria: vec![],
+                task_type: TaskType::Chore,
+                tags: vec![],
+                required_tools: vec![],
+                priority: TaskPriority::Medium,
+                crew: None,
+                status: TaskStatus::Backlog,
+            },
+            dedupe: DedupePolicy::SkipIfOpen,
+        })
+        .expect("add interval auto-task");
+
+    let cli = Cli::try_parse_from(["orbit", "auto-task", "recover", "interval"])
+        .expect("parse auto-task recover");
+    let Commands::AutoTask(auto_task) = cli.command else {
+        panic!("expected auto-task command");
+    };
+    let AutoTaskSubcommand::Recover(args) = auto_task.command else {
+        panic!("expected auto-task recover command");
+    };
+    assert!(!args.adopt_settings && !args.reissue_action && args.reason.is_none());
+
+    let error = args
+        .execute(&runtime)
+        .expect_err("only delivery consumers accumulate coverage debt");
+    assert!(
+        error.to_string().contains("not a delivery definition"),
+        "{error}"
+    );
+
+    let missing = Cli::try_parse_from(["orbit", "auto-task", "recover", "ghost"])
+        .expect("parse auto-task recover");
+    let Commands::AutoTask(auto_task) = missing.command else {
+        panic!("expected auto-task command");
+    };
+    let AutoTaskSubcommand::Recover(args) = auto_task.command else {
+        panic!("expected auto-task recover command");
+    };
+    assert!(
+        args.execute(&runtime)
+            .expect_err("unknown definition")
+            .to_string()
+            .contains("no such auto-task 'ghost'")
+    );
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_source.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_source.rs
@@ -840,6 +840,7 @@ fn state_member_apply_preserves_resulting_provenance_without_promotion() {
         members: Some(MemberState::default()),
         consumer: consumer.clone(),
         epoch,
+        trigger: None,
         repository: "fixture".into(),
         branch: LANDING.into(),
         generation: 0,

--- a/crates/orbit-core/src/application/automation/inspect.rs
+++ b/crates/orbit-core/src/application/automation/inspect.rs
@@ -172,7 +172,7 @@ fn scheduling_reason(
     if active_is_settled {
         "needs_attention"
     } else if claim_awaiting_admission
-        .is_some_and(|active| active.attempt > 1 && now > active.batch.retry_until)
+        .is_some_and(|active| active.attempt > 1 && now > active.deadline())
     {
         "retry_deadline_expired"
     } else if claim_awaiting_admission

--- a/crates/orbit-core/src/application/automation/mod.rs
+++ b/crates/orbit-core/src/application/automation/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod members;
 mod ownership;
 pub(crate) mod preparation;
 mod provider;
+mod recovery;
 pub(crate) mod source;
 mod task;
 #[cfg(test)]
@@ -22,6 +23,7 @@ mod tests;
 
 pub(crate) use direct::record_direct_landing_intent;
 pub use inspect::{inspect_auto_task, inspect_routine};
+pub use recovery::recover_auto_task;
 
 pub const COVERAGE_ARTIFACT: &str = "automation-coverage.json";
 

--- a/crates/orbit-core/src/application/automation/recovery.rs
+++ b/crates/orbit-core/src/application/automation/recovery.rs
@@ -1,0 +1,70 @@
+//! Operator recovery for a delivery auto-task consumer stalled by a settings
+//! change [ORB-12295].
+//!
+//! Core resolves the same ownership, epoch and source facts the evaluator uses
+//! and hands them to the shared rule; Automation decides what may be adopted
+//! and Store commits the fenced checkpoint with its audit record. There is no
+//! second scheduler, evaluator or state writer here.
+
+use crate::OrbitRuntime;
+use chrono::{DateTime, Utc};
+use orbit_automation::automation_error_to_orbit;
+use orbit_automation::delivery::recovery;
+use orbit_common::OrbitError;
+use orbit_types::workflow::automation::recovery::{RecoveryPreview, RecoveryRequest};
+use orbit_types::workflow::{AutoTaskDefinition, AutoTaskSchedule};
+
+use super::{ownership, source::Source};
+
+/// Preview or apply a recovery for one delivery auto-task.
+///
+/// A request that asks for nothing is a read-only preview; adoption or reissue
+/// commits exactly one audited checkpoint. Either way the returned document
+/// reports the stalled identity, the retained debt and the frozen obligations.
+pub fn recover_auto_task(
+    runtime: &OrbitRuntime,
+    definition: &AutoTaskDefinition,
+    request: &RecoveryRequest,
+    now: DateTime<Utc>,
+) -> Result<RecoveryPreview, OrbitError> {
+    let AutoTaskSchedule::Deliveries {
+        deliveries_landed: declared,
+    } = &definition.schedule
+    else {
+        return Err(OrbitError::InvalidInput("not a delivery definition".into()));
+    };
+
+    let ownership = ownership::resolve(runtime, declared.owner_machine.as_deref());
+    let trigger = ownership::with_resolved_owner(declared, &ownership);
+    let epoch = ownership::auto_task_epoch(definition, &trigger)?;
+
+    // The repository the debt was observed in is a compatibility fact, so it is
+    // read from the configured branch rather than the executor's HEAD.
+    let source = Source::new(&runtime.paths().repo_root);
+    let (repository, _) = source
+        .head(&trigger.branch)
+        .map_err(automation_error_to_orbit)?;
+
+    let consumer = super::consumer_key(runtime, "auto-task", &definition.name)?;
+    let by = runtime.actor().resolve_write_label(None, None)?;
+    let operation = recovery::Recovery {
+        consumer: &consumer,
+        epoch: &epoch,
+        trigger: &trigger,
+        repository: &repository,
+        host_refusal: ownership.refusal(),
+        request,
+        by: &by,
+        now,
+    };
+
+    let store = runtime.automation_store()?;
+
+    if !request.mutates() {
+        return recovery::preview(store.as_ref(), &operation).map_err(automation_error_to_orbit);
+    }
+
+    runtime.ensure_coordination_task_write_permitted()?;
+
+    recovery::apply(store.as_ref(), &operation).map_err(automation_error_to_orbit)
+}

--- a/crates/orbit-core/src/application/automation/task.rs
+++ b/crates/orbit-core/src/application/automation/task.rs
@@ -32,6 +32,21 @@ pub(super) fn mint(
         "\n\nEvidence template (replace action_id with this task ID and fill actual checks/findings):\n```json\n{evidence_template}\n```"
     ));
 
+    // A reissued attempt examines obligations an earlier action left unpaid, so
+    // the new task names that action instead of appearing unrelated to it.
+    if let Some(reissue) = &attempt.reissue {
+        let replaced = reissue
+            .from_action_id
+            .as_deref()
+            .unwrap_or("an unadmitted claim");
+        params.description.push_str(&format!(
+            "\n\nThis action was reissued by {} on {}: {replaced} closed without accepted coverage evidence. Reason: {}. The obligations above are unchanged; coverage still requires evidence from this task's assigned executor.",
+            reissue.by,
+            reissue.at.to_rfc3339(),
+            reissue.reason
+        ));
+    }
+
     runtime
         .add_task_admitted(params, None, None, Some(&attempt.action_key))
         .map(|task| task.id)

--- a/crates/orbit-core/src/application/automation/tests/consumer.rs
+++ b/crates/orbit-core/src/application/automation/tests/consumer.rs
@@ -808,3 +808,196 @@ fn job_only_evidence_comes_from_persisted_step_and_matches_frozen_input() {
     attempt.input_digest = "changed".into();
     assert!(super::super::task::job_outcome(&runtime, &source, &attempt).is_err());
 }
+
+/// The live incident shape: a delivery consumer whose examination task was
+/// archived without evidence, then stalled by tonight's threshold retuning
+/// [ORB-12295].
+#[test]
+fn recovery_adopts_retuned_settings_and_reissues_an_archived_unevidenced_action() {
+    use orbit_types::workflow::automation::recovery::{RecoveryPreview, RecoveryRequest};
+
+    let runtime = runtime();
+    let definition = definition(&runtime, "delivery-qa", CoverageClass::IntegratedQaV1);
+    let baseline = evaluate_auto_task(&runtime, &definition, false, Utc::now())
+        .unwrap()
+        .state
+        .unwrap()
+        .baseline;
+
+    let landed = commit(&runtime.paths().repo_root, "unexamined change");
+    let delivery_run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("direct_fixture", 1, Utc::now(), Some(json!({})), None)
+        .unwrap();
+    record_direct_landing_intent(
+        &runtime,
+        &DirectLandingRequest {
+            run_id: delivery_run.run_id,
+            branch: "agent-main".into(),
+            before_commit: baseline.commit.clone(),
+            after_commit: landed.clone(),
+        },
+    )
+    .unwrap();
+
+    let archived_task = evaluate_auto_task(&runtime, &definition, false, Utc::now())
+        .unwrap()
+        .state
+        .unwrap()
+        .active
+        .unwrap()
+        .action_id
+        .unwrap();
+
+    // The examination task is closed without ever attaching coverage evidence.
+    runtime
+        .update_task(
+            &archived_task,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Rejected),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let settled = evaluate_auto_task(&runtime, &definition, false, Utc::now())
+        .unwrap()
+        .state
+        .unwrap()
+        .active
+        .unwrap();
+    assert_eq!(settled.state, BatchState::Failed);
+    assert_eq!(
+        settled.reason.as_deref(),
+        Some("task_closed_without_accepted_evidence")
+    );
+
+    // Tonight's retuning stalls the consumer: it stops examining new landings.
+    let mut retuned = definition.clone();
+    let AutoTaskSchedule::Deliveries { deliveries_landed } = &mut retuned.schedule else {
+        unreachable!("delivery fixture")
+    };
+    deliveries_landed.threshold = 2;
+    deliveries_landed.max_wait_minutes = 30;
+    assert_eq!(
+        evaluate_auto_task(&runtime, &retuned, false, Utc::now())
+            .unwrap()
+            .reason,
+        "definition_changed"
+    );
+
+    let preview = super::super::recover_auto_task(
+        &runtime,
+        &retuned,
+        &RecoveryRequest::default(),
+        Utc::now(),
+    )
+    .unwrap();
+    assert_eq!(preview.reason, "definition_changed");
+    assert_eq!(
+        preview.identity.changes,
+        vec!["threshold".to_string(), "max_wait_minutes".to_string()]
+    );
+    assert_eq!(preview.debt.pending_deliveries, 1);
+    assert_eq!(preview.debt.covered, baseline);
+    assert!(preview.refusals.is_empty());
+    assert!(preview.applied.is_empty());
+    let action = preview.action.expect("the archived action is retained");
+    assert_eq!(action.action_id.as_ref(), Some(&archived_task));
+    assert!(action.reissuable);
+
+    let applied = super::super::recover_auto_task(
+        &runtime,
+        &retuned,
+        &RecoveryRequest {
+            adopt_settings: true,
+            reissue_action: true,
+            reason: "adopt tonight's QA threshold and re-examine the unpaid landing".into(),
+        },
+        Utc::now(),
+    )
+    .unwrap();
+    assert_eq!(
+        applied.applied,
+        vec![
+            RecoveryPreview::ADOPTED_SETTINGS,
+            RecoveryPreview::REISSUED_ACTION
+        ]
+    );
+    assert_eq!(applied.history.len(), 1);
+
+    // The reissue mints a new linked task; the archived one is left closed.
+    let reissued = evaluate_auto_task(&runtime, &retuned, false, Utc::now())
+        .unwrap()
+        .state
+        .unwrap()
+        .active
+        .unwrap();
+    let reissued_task = reissued.action_id.clone().unwrap();
+    assert_ne!(reissued_task, archived_task);
+    assert_eq!(reissued.state, BatchState::Admitted);
+    assert_eq!(
+        reissued.batch, settled.batch,
+        "the obligations are unchanged"
+    );
+    assert_eq!(
+        runtime.get_task(&archived_task).unwrap().status,
+        TaskStatus::Rejected,
+        "recovery never reopens a terminal task"
+    );
+    assert!(
+        runtime
+            .get_task(&reissued_task)
+            .unwrap()
+            .description
+            .contains(&archived_task),
+        "the reissued task names the action it replaces"
+    );
+    assert_eq!(
+        evaluate_auto_task(&runtime, &retuned, false, Utc::now())
+            .unwrap()
+            .state
+            .unwrap()
+            .covered,
+        baseline,
+        "an authorized retry is not coverage"
+    );
+
+    // Only evidence from the reissued task's assigned executor covers the debt.
+    let worker = runtime
+        .stores()
+        .jobs()
+        .insert_job_run(
+            "examination",
+            1,
+            Utc::now(),
+            Some(json!({ "task_id": reissued_task })),
+            None,
+        )
+        .unwrap();
+    runtime
+        .update_task(
+            &reissued_task,
+            TaskUpdateParams {
+                job_run_id: Some(Some(worker.run_id.clone())),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let mut evidence = evidence_template(&reissued);
+    evidence.examination_complete = true;
+    evidence.checks = vec![ExaminationCheck {
+        subject: "reissued obligations".into(),
+        method: "fixture examination".into(),
+        observation: "examined the unpaid landing".into(),
+    }];
+    attach(&runtime, &reissued, Some(&worker.run_id), &evidence);
+
+    let covered = evaluate_auto_task(&runtime, &retuned, false, Utc::now()).unwrap();
+    assert_eq!(covered.state.unwrap().covered.commit, landed);
+    assert_eq!(covered.receipts.len(), 1);
+    assert_eq!(
+        covered.receipts[0].action_id, reissued_task,
+        "coverage is attributed to the reissued action"
+    );
+}

--- a/crates/orbit-core/src/application/operation/tests/pipeline.rs
+++ b/crates/orbit-core/src/application/operation/tests/pipeline.rs
@@ -178,6 +178,7 @@ fn seed_assessment(fixture: &Fixture, task_id: &str, fingerprint: &str, ready: b
                 members: Some(MemberState::default()),
                 consumer: consumer.clone(),
                 epoch: "epoch".to_string(),
+                trigger: None,
                 repository: "repo".to_string(),
                 branch: "main".to_string(),
                 generation: 0,

--- a/crates/orbit-core/src/application/review/tests/gate.rs
+++ b/crates/orbit-core/src/application/review/tests/gate.rs
@@ -1077,6 +1077,7 @@ fn page_for(delivery: &Delivery) -> (AutomationState, SourcePage) {
         members: None,
         consumer: "hm/ws/auto-task/delivery-code-review".into(),
         epoch: "e".into(),
+        trigger: None,
         repository: delivery.repository.clone(),
         branch: "main".into(),
         generation: 1,

--- a/crates/orbit-core/src/runtime/tests/store_reuse.rs
+++ b/crates/orbit-core/src/runtime/tests/store_reuse.rs
@@ -43,6 +43,7 @@ fn automation_state(consumer: &str) -> AutomationState {
         members: None,
         consumer: consumer.into(),
         epoch: "epoch".into(),
+        trigger: None,
         repository: "repo".into(),
         branch: "agent-main".into(),
         generation: 0,

--- a/crates/orbit-store/src/contracts/automation.rs
+++ b/crates/orbit-store/src/contracts/automation.rs
@@ -1,6 +1,7 @@
 //! Atomic scheduler checkpoints and immutable accepted coverage.
 
 use orbit_common::OrbitError;
+use orbit_types::workflow::automation::recovery::RecoveryRecord;
 use orbit_types::workflow::automation::{AcceptedCoverage, AutomationState, BatchWaiver, Delivery};
 
 pub trait AutomationStoreBackend: Send + Sync {
@@ -20,6 +21,30 @@ pub trait AutomationStoreBackend: Send + Sync {
         _consumer: &str,
         _limit: usize,
     ) -> Result<Vec<BatchWaiver>, OrbitError> {
+        Ok(vec![])
+    }
+
+    /// Adopt a new configuration identity and/or an authorized reissue under
+    /// the same generation fence, writing the audit record in one transaction.
+    /// The checkpoint may move nothing else: every cursor, obligation and
+    /// accepted fact is carried over unchanged.
+    fn automation_recover(
+        &self,
+        _previous: &AutomationState,
+        _next: &AutomationState,
+        _record: &RecoveryRecord,
+    ) -> Result<bool, OrbitError> {
+        Err(OrbitError::Store(
+            "consumer recovery persistence unavailable".into(),
+        ))
+    }
+
+    /// Audited recoveries for a consumer, newest first.
+    fn automation_recoveries(
+        &self,
+        _consumer: &str,
+        _limit: usize,
+    ) -> Result<Vec<RecoveryRecord>, OrbitError> {
         Ok(vec![])
     }
 

--- a/crates/orbit-store/src/driver/sqlite/automation/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/automation/mod.rs
@@ -4,6 +4,7 @@ use crate::Store;
 use crate::contracts::AutomationStoreBackend;
 use crate::driver::sqlite::migration::FeatureMigration;
 use orbit_common::OrbitError;
+use orbit_types::workflow::automation::recovery::RecoveryRecord;
 use orbit_types::workflow::automation::{AcceptedCoverage, AutomationState, Delivery};
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
 
@@ -24,6 +25,13 @@ pub(crate) fn initialize(store: &Store) -> Result<(), OrbitError> {
             FeatureMigration::new(2, "retry_lineage_index", |conn| {
                 conn.execute_batch(
                     "CREATE INDEX IF NOT EXISTS job_runs_retry_lineage ON job_runs(workspace_id,retry_source_run_id)",
+                )
+                .map_err(|error| OrbitError::Store(error.to_string()))
+            }),
+            FeatureMigration::new(3, "consumer_recovery_records", |conn| {
+                conn.execute_batch(
+                    "CREATE TABLE automation_recoveries (record_id TEXT PRIMARY KEY, consumer TEXT NOT NULL, recorded_at TEXT NOT NULL, record_json TEXT NOT NULL);
+            CREATE INDEX automation_recoveries_consumer ON automation_recoveries(consumer, recorded_at);",
                 )
                 .map_err(|error| OrbitError::Store(error.to_string()))
             }),
@@ -56,6 +64,23 @@ impl AutomationStoreBackend for Store {
         limit: usize,
     ) -> Result<Vec<orbit_types::workflow::automation::BatchWaiver>, OrbitError> {
         waivers::list(self, consumer, limit)
+    }
+
+    fn automation_recover(
+        &self,
+        previous: &AutomationState,
+        next: &AutomationState,
+        record: &RecoveryRecord,
+    ) -> Result<bool, OrbitError> {
+        recovery::commit(self, previous, next, record)
+    }
+
+    fn automation_recoveries(
+        &self,
+        consumer: &str,
+        limit: usize,
+    ) -> Result<Vec<RecoveryRecord>, OrbitError> {
+        recovery::list(self, consumer, limit)
     }
 
     fn automation_receipt(
@@ -246,6 +271,7 @@ fn validate_transition(
 
     if previous.consumer != next.consumer
         || previous.epoch != next.epoch
+        || previous.trigger != next.trigger
         || previous.repository != next.repository
         || previous.branch != next.branch
         || previous.baseline != next.baseline
@@ -266,6 +292,7 @@ fn validate_transition(
         if let Some(new) = &next.active {
             if old.batch != new.batch
                 || old.input_digest != new.input_digest
+                || old.reissue != new.reissue
                 || new.attempt < old.attempt
             {
                 return Err(invalid());
@@ -484,6 +511,7 @@ fn validate_excluded_prefix_retirement(
 }
 
 mod intents;
+mod recovery;
 #[cfg(test)]
 mod tests;
 mod waivers;

--- a/crates/orbit-store/src/driver/sqlite/automation/recovery.rs
+++ b/crates/orbit-store/src/driver/sqlite/automation/recovery.rs
@@ -1,0 +1,191 @@
+//! Audited configuration adoption and action reissue for a delivery consumer
+//! [ORB-12295]. The checkpoint and its immutable record commit together.
+
+use super::{decode, encode};
+use crate::Store;
+use orbit_common::OrbitError;
+use orbit_types::workflow::automation::recovery::{RecoveryRecord, ReissuedAction};
+use orbit_types::workflow::automation::{AutomationState, BatchAttempt, BatchState};
+use rusqlite::{TransactionBehavior, params};
+use sha2::{Digest, Sha256};
+
+pub(super) fn commit(
+    store: &Store,
+    previous: &AutomationState,
+    next: &AutomationState,
+    record: &RecoveryRecord,
+) -> Result<bool, OrbitError> {
+    validate(previous, next, record)?;
+
+    let record_json = encode(record)?;
+    let record_id = format!("{:x}", Sha256::digest(record_json.as_bytes()));
+
+    store.with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+        let conn = tx.connection();
+
+        let changed = conn
+            .execute(
+                "UPDATE automation_consumers SET generation=?1,state_json=?2 WHERE consumer=?3 AND generation=?4 AND state_json=?5",
+                params![
+                    next.generation,
+                    encode(next)?,
+                    previous.consumer,
+                    previous.generation,
+                    encode(previous)?
+                ],
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        if changed == 0 {
+            return Ok(false);
+        }
+
+        conn.execute(
+            "INSERT INTO automation_recoveries VALUES (?1,?2,?3,?4)",
+            params![
+                record_id,
+                previous.consumer,
+                record.at.to_rfc3339(),
+                record_json
+            ],
+        )
+        .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        Ok(true)
+    })
+}
+
+pub(super) fn list(
+    store: &Store,
+    consumer: &str,
+    limit: usize,
+) -> Result<Vec<RecoveryRecord>, OrbitError> {
+    store.with_read_connection(|conn| {
+        let mut stmt = conn
+            .prepare(
+                "SELECT record_json FROM automation_recoveries WHERE consumer=?1 ORDER BY recorded_at DESC,rowid DESC LIMIT ?2",
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        let rows = stmt
+            .query_map(params![consumer, limit.min(100)], |row| {
+                row.get::<_, String>(0)
+            })
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        rows.map(|row| decode(&row.map_err(|e| OrbitError::Store(e.to_string()))?))
+            .collect()
+    })
+}
+
+/// A recovery may move the recorded configuration identity and replace one
+/// settled attempt. Everything else — the cursors, the pending window, waived
+/// and excluded landings, unresolved evidence and the frozen batch itself —
+/// must arrive unchanged, so no recovery can skip or cover an obligation.
+fn validate(
+    previous: &AutomationState,
+    next: &AutomationState,
+    record: &RecoveryRecord,
+) -> Result<(), OrbitError> {
+    let invalid = || OrbitError::InvalidInput("invalid automation recovery transition".into());
+
+    if previous.consumer != next.consumer
+        || previous.consumer != record.consumer
+        || previous.generation.checked_add(1) != Some(next.generation)
+        || previous.members.is_some()
+        || next.members.is_some()
+        || previous.repository != next.repository
+        || previous.branch != next.branch
+        || previous.baseline != next.baseline
+        || previous.covered != next.covered
+        || previous.observed != next.observed
+        || previous.pending != next.pending
+        || previous.pending_commits != next.pending_commits
+        || previous.waived != next.waived
+        || previous.excluded != next.excluded
+        || previous.unresolved != next.unresolved
+        || previous.associations != next.associations
+    {
+        return Err(invalid());
+    }
+
+    if record.reason.trim().is_empty() || record.by.trim().is_empty() {
+        return Err(invalid());
+    }
+
+    // The record is the audit of this exact identity change, in both directions.
+    if record.previous_epoch != previous.epoch
+        || record.epoch != next.epoch
+        || record.previous_trigger != previous.trigger
+        || record.trigger != next.trigger
+    {
+        return Err(invalid());
+    }
+
+    // Adoption is the only way the identity moves, and it has to move something.
+    if record.adopted_settings {
+        if next.epoch == previous.epoch && next.trigger == previous.trigger {
+            return Err(invalid());
+        }
+    } else if next.epoch != previous.epoch || next.trigger != previous.trigger {
+        return Err(invalid());
+    }
+
+    match (&previous.active, &next.active, &record.reissued) {
+        (Some(settled), Some(claim), Some(reissued)) => {
+            validate_reissue(settled, claim, reissued, record)
+        }
+        (settled, claim, None) if settled == claim => Ok(()),
+        _ => Err(invalid()),
+    }
+}
+
+/// The reissued attempt keeps the frozen batch and its obligations, takes the
+/// next attempt number, and carries the operator authorization that grants it.
+fn validate_reissue(
+    settled: &BatchAttempt,
+    claim: &BatchAttempt,
+    reissued: &ReissuedAction,
+    record: &RecoveryRecord,
+) -> Result<(), OrbitError> {
+    let invalid = || OrbitError::InvalidInput("invalid automation recovery transition".into());
+
+    if settled.batch != claim.batch
+        || settled.input_digest != claim.input_digest
+        || !matches!(settled.state, BatchState::Failed | BatchState::Exhausted)
+        || claim.state != BatchState::Claimed
+        || claim.action_id.is_some()
+        || claim.reason.is_some()
+        || claim.retry_after.is_some()
+        || claim.attempt != settled.attempt.saturating_add(1)
+        || claim.action_key != format!("automation:{}:{}", claim.batch.id, claim.attempt)
+    {
+        return Err(invalid());
+    }
+
+    let Some(authorization) = &claim.reissue else {
+        return Err(invalid());
+    };
+
+    if authorization != &reissued.authorization
+        || authorization.from_action_id != settled.action_id
+        || authorization.by != record.by
+        || authorization.reason != record.reason
+        || authorization.at != record.at
+        || authorization.retry_until <= record.at
+    {
+        return Err(invalid());
+    }
+
+    if reissued.batch_id != settled.batch.id
+        || reissued.from_action_id != settled.action_id
+        || reissued.from_attempt != settled.attempt
+        || reissued.from_state != settled.state
+        || reissued.from_reason != settled.reason
+        || reissued.attempt != claim.attempt
+    {
+        return Err(invalid());
+    }
+
+    Ok(())
+}

--- a/crates/orbit-store/src/driver/sqlite/automation/tests/checkpoints.rs
+++ b/crates/orbit-store/src/driver/sqlite/automation/tests/checkpoints.rs
@@ -1,5 +1,7 @@
+use crate::contracts::AutomationStoreBackend;
 use crate::{Store, compose};
 use chrono::{TimeZone, Utc};
+use orbit_types::workflow::automation::recovery::{RecoveryRecord, ReissuedAction};
 use orbit_types::workflow::automation::*;
 
 fn state() -> AutomationState {
@@ -11,6 +13,7 @@ fn state() -> AutomationState {
         members: None,
         consumer: "owner/ws/qa".into(),
         epoch: "epoch".into(),
+        trigger: None,
         repository: "repo".into(),
         branch: "agent-main".into(),
         generation: 0,
@@ -151,4 +154,325 @@ fn excluded_prefix_cannot_drop_pending_debt() {
         store.automation_state(&old.consumer).unwrap(),
         Some(observed)
     );
+}
+
+fn at() -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 9, 8, 0, 0, 0).unwrap()
+}
+
+fn landing() -> Delivery {
+    Delivery {
+        key: "pr:repo:1".into(),
+        repository: "repo".into(),
+        branch: "agent-main".into(),
+        before: SourceRevision {
+            commit: "a".into(),
+            tree: "tree-a".into(),
+        },
+        after: SourceRevision {
+            commit: "b".into(),
+            tree: "tree-b".into(),
+        },
+        commits: vec!["b".into()],
+        task_ids: vec!["ORB-1".into()],
+        evidence_reference: "https://example.test/pr/1".into(),
+        evidence_digest: "digest".into(),
+        landed_at: at(),
+    }
+}
+
+/// A consumer holding one unpaid landing whose action settled without evidence,
+/// exactly the shape an archived unevidenced task leaves behind.
+fn settled(store: &dyn AutomationStoreBackend) -> AutomationState {
+    let baseline = state();
+    assert!(store.automation_initialize(&baseline).unwrap());
+
+    let landing = landing();
+    let mut observed = baseline.clone();
+    observed.generation = 1;
+    observed.observed = landing.after.clone();
+    observed.pending_commits = landing.commits.clone();
+    observed.pending = vec![landing.clone()];
+    assert!(store.automation_commit(&baseline, &observed, None).unwrap());
+
+    let batch = CoverageBatch {
+        schema_version: 1,
+        id: "batch-1".into(),
+        consumer: observed.consumer.clone(),
+        epoch: observed.epoch.clone(),
+        repository: observed.repository.clone(),
+        branch: observed.branch.clone(),
+        coverage: CoverageClass::IntegratedQaV1,
+        from_exclusive: observed.covered.clone(),
+        through_inclusive: landing.after.clone(),
+        commits: landing.commits.clone(),
+        deliveries: vec![landing],
+        exclusions: vec![],
+        created_at: at(),
+        max_attempts: 1,
+        retry_until: at(),
+    };
+    let mut claimed = observed.clone();
+    claimed.generation = 2;
+    claimed.active = Some(BatchAttempt {
+        action_key: format!("automation:{}:1", batch.id),
+        batch,
+        input_digest: "frozen".into(),
+        attempt: 1,
+        action_id: None,
+        state: BatchState::Claimed,
+        reason: None,
+        retry_after: None,
+        reissue: None,
+    });
+    assert!(store.automation_commit(&observed, &claimed, None).unwrap());
+
+    let mut settled = claimed.clone();
+    settled.generation = 3;
+    if let Some(active) = &mut settled.active {
+        active.action_id = Some("ORB-11743".into());
+        active.state = BatchState::Failed;
+        active.reason = Some("task_closed_without_accepted_evidence".into());
+    }
+    assert!(store.automation_commit(&claimed, &settled, None).unwrap());
+
+    settled
+}
+
+fn retuned(state: &AutomationState) -> DeliveryTrigger {
+    DeliveryTrigger {
+        owner_machine: Some("machine".into()),
+        branch: state.branch.clone(),
+        threshold: 3,
+        max_wait_minutes: 60,
+        coverage: CoverageClass::IntegratedQaV1,
+        max_items: 20,
+        retries: 0,
+    }
+}
+
+fn adoption(previous: &AutomationState, next: &AutomationState) -> RecoveryRecord {
+    RecoveryRecord {
+        consumer: previous.consumer.clone(),
+        previous_epoch: previous.epoch.clone(),
+        epoch: next.epoch.clone(),
+        previous_trigger: previous.trigger.clone(),
+        trigger: next.trigger.clone(),
+        adopted_settings: true,
+        reissued: None,
+        reason: "threshold retuned tonight".into(),
+        by: "operator".into(),
+        at: at(),
+    }
+}
+
+/// The adopted identity moves and nothing else does.
+fn adopted(previous: &AutomationState) -> AutomationState {
+    let mut next = previous.clone();
+    next.generation = previous.generation + 1;
+    next.epoch = "retuned".into();
+    next.trigger = Some(retuned(previous));
+    next
+}
+
+#[test]
+fn recovery_adopts_an_identity_and_records_it_without_touching_debt() {
+    let store = compose::automation_store(Store::open_in_memory().unwrap()).unwrap();
+    let previous = settled(store.as_ref());
+    let next = adopted(&previous);
+
+    assert!(
+        store
+            .automation_recover(&previous, &next, &adoption(&previous, &next))
+            .unwrap()
+    );
+
+    let stored = store.automation_state(&previous.consumer).unwrap().unwrap();
+    assert_eq!(stored.epoch, "retuned");
+    assert_eq!(stored.covered, previous.covered);
+    assert_eq!(stored.pending, previous.pending);
+    assert_eq!(stored.active, previous.active);
+    assert_eq!(
+        store
+            .automation_recoveries(&previous.consumer, 10)
+            .unwrap()
+            .len(),
+        1
+    );
+    assert!(
+        store
+            .automation_receipts(&previous.consumer, 10)
+            .unwrap()
+            .is_empty(),
+        "recovery never mints coverage"
+    );
+}
+
+#[test]
+fn recovery_cannot_skip_debt_or_advance_coverage() {
+    let store = compose::automation_store(Store::open_in_memory().unwrap()).unwrap();
+    let previous = settled(store.as_ref());
+
+    let mut covered = adopted(&previous);
+    covered.covered = previous.observed.clone();
+    covered.pending.clear();
+    covered.pending_commits.clear();
+
+    let mut waived = adopted(&previous);
+    waived.waived = waived.pending.drain(..).collect();
+
+    let mut discarded = adopted(&previous);
+    discarded.active = None;
+
+    for forged in [covered, waived, discarded] {
+        let record = adoption(&previous, &forged);
+        assert!(
+            store
+                .automation_recover(&previous, &forged, &record)
+                .is_err()
+        );
+        assert_eq!(
+            store.automation_state(&previous.consumer).unwrap(),
+            Some(previous.clone())
+        );
+    }
+}
+
+#[test]
+fn recovery_requires_an_audit_record_of_the_exact_change() {
+    let store = compose::automation_store(Store::open_in_memory().unwrap()).unwrap();
+    let previous = settled(store.as_ref());
+    let next = adopted(&previous);
+
+    let unexplained = RecoveryRecord {
+        reason: "  ".into(),
+        ..adoption(&previous, &next)
+    };
+    let undeclared = RecoveryRecord {
+        adopted_settings: false,
+        ..adoption(&previous, &next)
+    };
+    let misattributed = RecoveryRecord {
+        previous_epoch: "some other epoch".into(),
+        ..adoption(&previous, &next)
+    };
+
+    for record in [unexplained, undeclared, misattributed] {
+        assert!(store.automation_recover(&previous, &next, &record).is_err());
+        assert_eq!(
+            store.automation_state(&previous.consumer).unwrap(),
+            Some(previous.clone())
+        );
+    }
+}
+
+#[test]
+fn a_reissue_keeps_the_frozen_batch_and_names_the_action_it_replaces() {
+    let store = compose::automation_store(Store::open_in_memory().unwrap()).unwrap();
+    let previous = settled(store.as_ref());
+    let settled_attempt = previous.active.clone().unwrap();
+
+    let authorization = ActionReissue {
+        from_action_id: settled_attempt.action_id.clone(),
+        reason: "reissued for the unpaid QA obligations".into(),
+        by: "operator".into(),
+        at: at(),
+        retry_until: at() + chrono::Duration::hours(24),
+    };
+    let mut next = previous.clone();
+    next.generation = previous.generation + 1;
+    if let Some(active) = &mut next.active {
+        active.attempt = 2;
+        active.action_key = format!("automation:{}:2", active.batch.id);
+        active.action_id = None;
+        active.reason = None;
+        active.state = BatchState::Claimed;
+        active.reissue = Some(authorization.clone());
+    }
+    let record = RecoveryRecord {
+        consumer: previous.consumer.clone(),
+        previous_epoch: previous.epoch.clone(),
+        epoch: previous.epoch.clone(),
+        previous_trigger: previous.trigger.clone(),
+        trigger: previous.trigger.clone(),
+        adopted_settings: false,
+        reissued: Some(ReissuedAction {
+            batch_id: settled_attempt.batch.id.clone(),
+            from_action_id: settled_attempt.action_id.clone(),
+            from_attempt: settled_attempt.attempt,
+            from_state: settled_attempt.state,
+            from_reason: settled_attempt.reason.clone(),
+            attempt: 2,
+            authorization: authorization.clone(),
+        }),
+        reason: authorization.reason.clone(),
+        by: authorization.by.clone(),
+        at: authorization.at,
+    };
+
+    // A reissue that quietly rewrites the frozen obligations is refused.
+    let mut refrozen = next.clone();
+    if let Some(active) = &mut refrozen.active {
+        active.batch.deliveries.clear();
+        active.batch.commits.clear();
+    }
+    assert!(
+        store
+            .automation_recover(&previous, &refrozen, &record)
+            .is_err()
+    );
+
+    // So is one whose record does not name the action it replaced.
+    let mislinked = RecoveryRecord {
+        reissued: record.reissued.clone().map(|reissued| ReissuedAction {
+            from_action_id: Some("ORB-99999".into()),
+            ..reissued
+        }),
+        ..record.clone()
+    };
+    assert!(
+        store
+            .automation_recover(&previous, &next, &mislinked)
+            .is_err()
+    );
+
+    assert!(store.automation_recover(&previous, &next, &record).unwrap());
+    let stored = store.automation_state(&previous.consumer).unwrap().unwrap();
+    assert_eq!(stored.active.as_ref().unwrap().batch, settled_attempt.batch);
+    assert_eq!(stored.pending, previous.pending);
+    assert_eq!(stored.covered, previous.covered);
+}
+
+#[test]
+fn an_ordinary_checkpoint_cannot_move_the_identity_or_forge_an_authorization() {
+    let store = compose::automation_store(Store::open_in_memory().unwrap()).unwrap();
+    let previous = settled(store.as_ref());
+
+    let mut adopted_without_audit = previous.clone();
+    adopted_without_audit.generation = previous.generation + 1;
+    adopted_without_audit.epoch = "retuned".into();
+
+    let mut retriggered = previous.clone();
+    retriggered.generation = previous.generation + 1;
+    retriggered.trigger = Some(retuned(&previous));
+
+    let mut self_authorized = previous.clone();
+    self_authorized.generation = previous.generation + 1;
+    if let Some(active) = &mut self_authorized.active {
+        active.reissue = Some(ActionReissue {
+            from_action_id: None,
+            reason: "no operator asked for this".into(),
+            by: "scheduler".into(),
+            at: at(),
+            retry_until: at() + chrono::Duration::hours(240),
+        });
+    }
+
+    for forged in [adopted_without_audit, retriggered, self_authorized] {
+        assert!(store.automation_commit(&previous, &forged, None).is_err());
+        assert_eq!(
+            store.automation_state(&previous.consumer).unwrap(),
+            Some(previous.clone())
+        );
+    }
 }

--- a/crates/orbit-types/src/workflow/automation/mod.rs
+++ b/crates/orbit-types/src/workflow/automation/mod.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 pub mod members;
+pub mod recovery;
 
 /// Supported examination contracts; QA and review never share acceptance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -182,6 +183,36 @@ pub struct BatchAttempt {
     pub state: BatchState,
     pub reason: Option<String>,
     pub retry_after: Option<DateTime<Utc>>,
+    /// Operator authorization for the current attempt, present only when a
+    /// recovery reissued a settled action over this same frozen batch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reissue: Option<ActionReissue>,
+}
+
+impl BatchAttempt {
+    /// Latest moment this attempt may still reach admission. The frozen batch
+    /// budget governs, unless an operator explicitly authorized a reissue.
+    pub fn deadline(&self) -> DateTime<Utc> {
+        self.reissue
+            .as_ref()
+            .map_or(self.batch.retry_until, |reissue| reissue.retry_until)
+    }
+}
+
+/// Recorded authorization for one additional attempt over an already frozen
+/// batch, after the previous action settled without accepted evidence. It
+/// grants exactly one attempt and never touches the batch or its obligations.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ActionReissue {
+    /// The settled action this attempt replaces, when one was admitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub from_action_id: Option<String>,
+    pub reason: String,
+    pub by: String,
+    pub at: DateTime<Utc>,
+    /// Authorized admission deadline for this attempt alone.
+    pub retry_until: DateTime<Utc>,
 }
 
 /// Small current scheduler state; completed batches/receipts are separate rows.
@@ -191,6 +222,12 @@ pub struct AutomationState {
     pub members: Option<members::MemberState>,
     pub consumer: String,
     pub epoch: String,
+    /// The resolved trigger this consumer's epoch was derived from. Baselining
+    /// records it and only an audited recovery replaces it, so the settings the
+    /// retained debt was accumulated under stay provable. Absent on consumers
+    /// baselined before it was recorded, and on state-member consumers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger: Option<DeliveryTrigger>,
     pub repository: String,
     pub branch: String,
     pub generation: u64,

--- a/crates/orbit-types/src/workflow/automation/recovery.rs
+++ b/crates/orbit-types/src/workflow/automation/recovery.rs
@@ -1,0 +1,177 @@
+//! Operator recovery contracts for a stalled delivery consumer [ORB-12295].
+//!
+//! A delivery consumer stalls when its definition is edited: the persisted
+//! epoch no longer matches the configured one, so nothing is admitted and the
+//! retained obligations sit still. These types describe the explicit, audited
+//! way out — what the operator asks for, what the consumer currently owes, and
+//! what was actually changed. Nothing here waives, covers or discards debt.
+
+use super::{BatchState, DeliveryTrigger, SourceRevision};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// What an operator explicitly authorizes for one stalled consumer. Both
+/// operations are opt-in: an empty request previews and changes nothing.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RecoveryRequest {
+    /// Adopt the definition's current compatible settings, retaining every
+    /// covered, pending, unresolved and accepted fact the consumer holds.
+    #[serde(default)]
+    pub adopt_settings: bool,
+    /// Reissue the settled action that closed without accepted evidence, over
+    /// its existing frozen obligations.
+    #[serde(default)]
+    pub reissue_action: bool,
+    /// Operator explanation, retained verbatim in the audit record.
+    #[serde(default)]
+    pub reason: String,
+}
+
+impl RecoveryRequest {
+    /// True when the request asks for a durable change rather than a preview.
+    pub fn mutates(&self) -> bool {
+        self.adopt_settings || self.reissue_action
+    }
+}
+
+/// The configuration identity a consumer carries, against the configured one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecoveryIdentity {
+    /// Epoch the persisted consumer was admitted under.
+    pub recorded_epoch: String,
+    /// Epoch the definition resolves to now.
+    pub configured_epoch: String,
+    /// The resolved trigger the consumer recorded, absent for a consumer
+    /// baselined before recovery existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recorded_trigger: Option<DeliveryTrigger>,
+    pub configured_trigger: DeliveryTrigger,
+    /// Named compatible differences, such as `threshold` or `template`.
+    pub changes: Vec<String>,
+}
+
+/// Everything the consumer still owes, preserved across any recovery.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CoverageDebt {
+    pub baseline: SourceRevision,
+    pub covered: SourceRevision,
+    pub observed: SourceRevision,
+    pub pending_deliveries: usize,
+    pub pending_commits: usize,
+    pub unresolved: usize,
+    pub waived: usize,
+    pub excluded: usize,
+    pub receipts: usize,
+}
+
+/// The frozen action a stalled consumer is holding, and whether this recovery
+/// may reissue it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StalledAction {
+    pub batch_id: String,
+    pub attempt: u32,
+    pub state: BatchState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Exact delivery keys frozen into the batch; a reissue carries these over
+    /// unchanged.
+    pub obligations: Vec<String>,
+    pub commits: usize,
+    pub reissuable: bool,
+}
+
+/// One applied recovery, retained as immutable audit. It records the replaced
+/// identity, so the pre-recovery configuration stays readable afterwards.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecoveryRecord {
+    pub consumer: String,
+    pub previous_epoch: String,
+    pub epoch: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_trigger: Option<DeliveryTrigger>,
+    /// The trigger the consumer carries after this recovery.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger: Option<DeliveryTrigger>,
+    pub adopted_settings: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reissued: Option<ReissuedAction>,
+    pub reason: String,
+    pub by: String,
+    pub at: DateTime<Utc>,
+}
+
+/// The settled action a recovery reissued, and the attempt it authorized.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReissuedAction {
+    pub batch_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub from_action_id: Option<String>,
+    pub from_attempt: u32,
+    pub from_state: BatchState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub from_reason: Option<String>,
+    pub attempt: u32,
+    pub authorization: super::ActionReissue,
+}
+
+/// Read-only projection of a consumer's recovery position. Preview and apply
+/// return the same document, so an operator verifies exactly what changed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecoveryPreview {
+    pub consumer: String,
+    /// Current scheduling reason, in the shared inspection vocabulary.
+    pub reason: String,
+    pub identity: RecoveryIdentity,
+    pub debt: CoverageDebt,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action: Option<StalledAction>,
+    /// Named refusals blocking the requested recovery; empty means it may run.
+    pub refusals: Vec<String>,
+    /// What this call durably changed. Always empty for a preview.
+    pub applied: Vec<String>,
+    /// Recent audited recoveries for this consumer, newest first.
+    pub history: Vec<RecoveryRecord>,
+}
+
+impl RecoveryPreview {
+    /// Label recorded in `applied` when settings were adopted.
+    pub const ADOPTED_SETTINGS: &'static str = "adopted_settings";
+    /// Label recorded in `applied` when the settled action was reissued.
+    pub const REISSUED_ACTION: &'static str = "reissued_action";
+}
+
+/// Why a recovery cannot run. Each variant names one deterministic refusal so
+/// operators and tests share the vocabulary.
+pub mod refusal {
+    /// This host holds no persisted state for the definition.
+    pub const UNKNOWN_CONSUMER: &str = "unknown_consumer";
+    /// The consumer is a state-member consumer, not a delivery consumer.
+    pub const MEMBER_CONSUMER: &str = "member_consumer";
+    /// An admitted or claimed action is still executing.
+    pub const ACTIVE_EXECUTION: &str = "active_execution";
+    /// The configured branch differs from the branch the debt was observed on.
+    pub const BRANCH_CHANGED: &str = "branch_changed";
+    /// The source repository identity differs from the recorded one.
+    pub const REPOSITORY_CHANGED: &str = "repository_changed";
+    /// The resolved owner machine differs from the recorded one.
+    pub const OWNER_CHANGED: &str = "owner_changed";
+    /// The examination contract differs; QA and review never share coverage.
+    pub const COVERAGE_CHANGED: &str = "coverage_changed";
+    /// Nothing proves which examination contract the retained debt was for.
+    pub const COVERAGE_UNVERIFIABLE: &str = "coverage_unverifiable";
+    /// This host may not admit work for the definition.
+    pub const OWNED_ELSEWHERE: &str = "owned_elsewhere";
+    /// Adoption was requested but the configured identity already matches.
+    pub const SETTINGS_UNCHANGED: &str = "settings_unchanged";
+    /// A reissue was requested with no settled unevidenced action to reissue.
+    pub const NO_SETTLED_ACTION: &str = "no_settled_action";
+    /// The action already produced accepted coverage evidence.
+    pub const ACTION_EVIDENCED: &str = "action_evidenced";
+    /// A reissue would never admit while the recorded identity is stale.
+    pub const DEFINITION_CHANGED: &str = "definition_changed";
+    /// A durable recovery requires a non-empty operator explanation and actor.
+    pub const MISSING_AUTHORIZATION: &str = "missing_authorization";
+}

--- a/docs/design/automation-triggers/5_operations.md
+++ b/docs/design/automation-triggers/5_operations.md
@@ -2,7 +2,7 @@
 type: design
 summary: "Delivery automation operations [ORB-11330]"
 tags: [automation-triggers]
-last_validated: 2026-09-07
+last_validated: 2026-09-12
 ---
 
 # Delivery automation operations [ORB-11330]
@@ -197,7 +197,8 @@ the frozen batch and become the next obligations.
 
 Disablement retains debt and still permits reconciliation of an already admitted
 action. Definition edits retain the old epoch/input and pause new admission; restore
-the original definition to resume that epoch. Do not delete state to clear an error.
+the original definition to resume that epoch, or adopt the new one through the
+audited recovery below. Do not delete state to clear an error.
 Unreadable existing task bundles are retained for repair rather than erased during
 key replay. Restore missing source objects or repair the recorded bundle before
 retrying. Exhausted, failed and waived states are distinct from coverage; waivers are explicit through the existing definition update:
@@ -210,8 +211,73 @@ orbit tool run orbit.auto_task.update --input '{"name":"delivery-qa","waive_batc
 Only the current settled failed/exhausted batch may be waived. The archived
 disposition removes its landings from threshold eligibility, retains the full
 code gap and never advances coverage. A later examination can still cover that
-code as neighboring context. General epoch-transfer/reset workflows remain
-separately scoped.
+code as neighboring context.
+
+### Recovering a consumer stalled by a settings change [ORB-12295]
+
+Retuning a threshold, wait, batch size, retry count, template or crew moves the
+definition's epoch, so the consumer reports `definition_changed` and admits
+nothing while every obligation it already holds stays retained. `orbit auto-task
+recover` is the supported way forward for a delivery auto-task. It never waives
+a batch, advances the covered cursor, reopens a terminal task or edits a state
+file.
+
+Preview first; with neither operation flag the command only reads:
+
+```sh
+orbit auto-task recover delivery-qa --json
+```
+
+The preview reports the consumer key, the recorded and configured epoch, the
+settings that differ by name, the retained debt (covered/observed boundaries,
+pending landings and commits, unresolved evidence, waived and excluded landings,
+accepted receipts), the frozen obligations of any stalled action, the refusals
+that apply, and the audited recoveries already recorded.
+
+Adopt the retuned settings, then reissue an action that closed without accepted
+evidence, in one explicitly authorized request:
+
+```sh
+orbit auto-task recover delivery-qa \
+  --adopt-settings --reissue-action \
+  --reason "adopt tonight's QA threshold and re-examine the unpaid landing"
+```
+
+Adoption replaces only the recorded configuration identity. The covered cursor,
+pending window, unresolved evidence, waived and excluded landings, accepted
+receipt bytes and the frozen batch all arrive unchanged, and the replaced
+identity is retained in an immutable recovery record.
+
+A reissue authorizes exactly one further attempt over the *same* frozen batch:
+the next evaluation admits a new task under a new action key, carrying the
+identical obligations and naming the action it replaces. The closed task is left
+exactly as it settled — nothing reopens it — and the authorized attempt has its
+own 24-hour admission deadline rather than a widened retry policy. Coverage
+still requires complete evidence from the reissued task's assigned executor;
+evidence frozen against the replaced attempt cannot certify it, and a second
+failure settles the batch again until another explicit reissue.
+
+Any refusal aborts the whole request before the write, naming every reason that
+applied: `unknown_consumer`, `member_consumer`, `owned_elsewhere`,
+`branch_changed`, `repository_changed`, `owner_changed`, `coverage_changed`,
+`coverage_unverifiable`, `active_execution`, `settings_unchanged`,
+`no_settled_action`, `action_evidenced`, `definition_changed` (a reissue that
+does not also adopt the identity it would run under) or `missing_authorization`
+(no reason or actor). A change of workspace, owner machine, repository, branch
+or coverage class is never adopted: those change what the retained debt means,
+so settle the old consumer's debt and preview a new baseline instead. An action
+that is claimed or admitted has to settle first.
+
+Only this host, as the resolved owner, may recover its own consumer, and only
+delivery auto-tasks are covered: delivery routines and state-member consumers
+still follow the restore-the-definition path. A consumer baselined before its
+resolved trigger was recorded proves its examination contract from the frozen
+batch instead; one with neither is refused as `coverage_unverifiable`.
+
+Verify a recovery from its own response, whose `applied` names exactly what
+changed, and afterwards from a fresh preview: `history` carries the audit
+record, and `orbit auto-task show delivery-qa --json` must still report the same
+covered boundary and pending membership as before.
 
 ## Rollback and limits
 


### PR DESCRIPTION
## Task

[ORB-12295](https://orbit-cli.com/tasks/ORB-12295) — Recover delivery review/QA consumers after settings changes without losing coverage debt

### Description

## Observed incident
On-call scheduler run jrun-20260912-0748-t1 reports definition_changed for delivery-code-review and delivery-qa, so neither examines newly landed fixes. Desired versioned settings are review threshold 3, QA threshold 10 / crew grok (previous 10, 15 / luna). State retains failed active actions ORB-11743/11744 from Sep 7, archived Sep 8 without artifacts, summary or retirement rationale. Their failure is task_closed_without_accepted_evidence. No state or coverage was reset.

## Why recovery is needed
Current epoch includes the full schedule/template/dedupe, and inspection stops before admission on a mismatch. Current operations docs recommend restoring the old definition and explicitly defer general epoch transfer. That means routine threshold/crew adjustments strand the consumer, and archived unevidenced work cannot proceed through ordinary task lifecycle. Simply restoring old settings loses tonight's intended operational tuning and does not itself execute the unpaid work.

## Bounded outcome
Provide a supported, explicit and audited operator recovery for this configuration-change case. Preview old/new identity and exact outstanding obligations; preserve covered/baseline, pending and unresolved work, accepted receipts, frozen batch input, and lineage. Allow adoption only when repository, workspace/owner, branch and coverage meaning remain compatible; refuse incompatible scope or live/unsettled action without changing state. A failed archived action must be recoverable by an explicitly authorized replacement using its exact frozen obligations and new assigned executor evidence, without reopening terminal tasks through an agent force override. Reuse existing automation/CLI admission boundaries and evidence contracts; do not create another scheduler or broad policy framework. Pilot should identify whether existing lower-level recovery primitives can satisfy this with a small extension. State files must never be hand-edited.

## Safeguards
No implicit rebaseline, waiver, dropped debt, synthetic receipts, accepted evidence fabricated outside the assigned executor, deadline/attempt bypass without recorded operator authorization, or successful status substituted for typed coverage. Preserve old snapshots for audit. Keep current source config choices and unrelated consumers unchanged. Implement and validate in isolated fixtures; root orchestrator will invoke the supported recovery on live state after deployment, then actually execute outstanding review/QA. No live state mutation by the implementation worker.

### Acceptance Criteria

- A documented operator preview identifies the stalled definition/action, old/new configuration identity, and preserved coverage debt without writes.
- Compatible threshold/crew configuration changes can be adopted through an explicit audited operation while preserving all prior covered/pending/unresolved/receipt evidence and frozen obligations.
- A failed archived unevidenced action can be explicitly reissued as a linked new action with the same frozen obligation set, never force-reopening the archived task or claiming coverage before valid assigned-executor evidence.
- Incompatible workspace/owner/repository/branch/coverage changes, active execution and invalid evidence are refused atomically; deterministic tests prove debt is neither skipped nor marked covered.
- Existing delivery automation and artifact acceptance regressions pass; current docs/help explain recovery, its limits, and verification without suggesting direct state edits.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented `orbit auto-task recover`: an explicit, audited operator recovery for a delivery consumer stalled by a compatible settings change. Nothing in it waives, covers or discards debt; no live state was touched by this worker (all validation ran in isolated fixtures).

## Design

- **Recorded identity** — `AutomationState.trigger` now carries the resolved `DeliveryTrigger` its epoch came from (set at baseline, replaced only by an audited recovery). `BatchAttempt.reissue: Option<ActionReissue>` records one operator-authorized attempt, and `BatchAttempt::deadline()` (batch budget unless a reissue extends it) is used by both the evaluator and inspection.
- **Domain rules** (`orbit-automation::delivery::recovery`) — `preview` projects the stall, the old/new epoch, the named settings differences, the retained debt and the frozen obligations without any write; `apply` computes refusals first, then one next state plus an audit record. Adoption moves only epoch+trigger. Reissue replaces the settled attempt over the *identical* frozen batch: attempt+1, new action key, `Claimed`, no action id, plus an `ActionReissue` granting a 24-hour admission window.
- **Durable invariants** (`orbit-store`) — new `automation_recover`/`automation_recoveries` contract methods, an `automation_recoveries` table (automation feature migration v3), and a fenced validator that refuses any recovery moving a cursor, dropping an obligation or mismatching its record. The ordinary checkpoint validator now pins `trigger` and `reissue`, so only an audited recovery can move them.
- **Composition** (`orbit-core`) — `recover_auto_task` resolves the same ownership, epoch and source repository the evaluator uses and delegates; `task::mint` names the replaced action in the reissued task's description.
- **Surface** — CLI-only (`orbit auto-task recover <name>`, preview by default), following the task-pilot surface warning; no new MCP tool and no change to `orbit.auto_task.update`.

## Criteria

1. *Documented preview without writes* — met. `recover` with no operation flag returns consumer, `reason`, recorded/configured epoch, named changes, debt counts, the stalled action with its exact obligation keys, refusals and audit history. Proved by `preview_reports_the_stall_and_its_debt_without_writing` (asserts state and recovery history unchanged) and the core end-to-end test.
2. *Compatible adoption preserving evidence* — met. `--adopt-settings` retains covered/observed/baseline, pending, unresolved, associations, waived, excluded, receipts and the frozen batch; the replaced identity is retained in the record. Proved by `adopting_settings_retains_every_obligation_and_records_the_old_identity` and `recovery_adopts_an_identity_and_records_it_without_touching_debt`.
3. *Reissue of an archived unevidenced action* — met. `--reissue-action` mints a new linked task over the same frozen obligations; the closed task stays `Rejected`; coverage only lands from the reissued task's assigned executor. Proved by `a_reissued_action_admits_a_new_task_and_covers_only_with_fresh_evidence`, `evidence_frozen_against_the_replaced_attempt_cannot_cover_the_reissue`, and the core incident-shaped test.
4. *Atomic refusals* — met. `branch_changed`, `repository_changed`, `owner_changed`, `coverage_changed`, `coverage_unverifiable`, `active_execution`, `owned_elsewhere`, `unknown_consumer`, `member_consumer`, `settings_unchanged`, `no_settled_action`, `action_evidenced`, `definition_changed`, `missing_authorization` — all abort before the write. Workspace/owner changes additionally yield a different consumer key. Proved by `incompatible_and_unauthorized_changes_are_refused_without_touching_state`, `a_live_action_and_an_evidenced_batch_are_never_recovered`, `a_reissue_alone_cannot_strand_a_claim_under_a_stale_identity`, `an_unknown_consumer_and_a_host_refusal_stop_before_any_write`, `recovery_cannot_skip_debt_or_advance_coverage`, `recovery_requires_an_audit_record_of_the_exact_change`, `a_reissue_keeps_the_frozen_batch_and_names_the_action_it_replaces`, `an_ordinary_checkpoint_cannot_move_the_identity_or_forge_an_authorization`.
5. *Regressions and docs* — met, with one pre-existing unrelated failure noted below. `docs/design/automation-triggers/5_operations.md` gained a recovery section (preview, both operations, refusal vocabulary, limits, verification steps) and `ARCHITECTURE.md` records the new persistence; both state plainly that state files are never hand-edited.

## Validation

Passed: `make ci-fast`; `make ci-lint`; `make goldens`; `cargo test -p orbit-automation` (118); `cargo test -p orbit-store --lib` (530); `cargo test -p orbit-cli` (all targets); `cargo test -p orbit-types -p orbit-web`; `cargo test -p orbit-core --test '*'`.

`cargo test -p orbit-core --lib`: 1498 passed, 1 failed — `application::job::tests::exec::task_gate_noops_when_task_reaches_review_after_reservation` expects `status: "succeeded"` while the skipped-dispatch path emits `"success"`. Confirmed **pre-existing on HEAD 81074be8** by restoring every modified file from `git show HEAD:<path>` into a `/tmp` copy and re-running the single test there (identical failure with none of this work present). Unrelated to automation recovery; filed as friction F2026-09-145.

Not run: full `make ci` (per workspace policy it is the PR merge gate, not a per-task local run).

## Risks and notes

- A consumer baselined before this change has no recorded trigger, so its examination contract is proven from the frozen batch; a consumer with neither is refused `coverage_unverifiable` rather than adopted. The two live consumers each retain a failed batch, so both are recoverable.
- Recovery covers delivery **auto-tasks** only; delivery routines and state-member consumers still use the restore-the-definition path, stated in the docs.
- Temporary evidence (`/tmp/orb12295-head`, `/tmp/orb12295-target`) was cleaned up; `git status --short` shows only intended changes and `git diff --check` is clean.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12295-6aa518a6`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra