### PR TITLE
[code-review] Remove artificial SQLite write admission and validate real worker bootstrap contention

### DIFF
--- a/crates/orbit-cli/tests/worktree_resolution.rs
+++ b/crates/orbit-cli/tests/worktree_resolution.rs
@@ -84,12 +84,11 @@ fn config_show_reports_shared_and_local_roots_for_git_worktrees_and_overrides() 
     );
 }
 
-/// [ORB-10821] `orbit --root <custom> run job` must execute in that custom
-/// store. Before the fix the parent persisted the run under `--root` and
-/// reported `submitted`, then the detached worker rediscovered `$HOME/.orbit`
-/// and exited with `job run not found`, leaving the run pending forever.
+/// The real detached worker must bootstrap, claim, and finish its run while an
+/// unrelated WAL writer holds the already-current task registry. The parent
+/// keeps supervising the child; no fixture claims the run on its behalf.
 #[test]
-fn run_job_with_explicit_root_completes_instead_of_staying_pending() {
+fn detached_worker_bootstraps_and_claims_while_registry_writer_is_held() {
     let temp = tempdir().expect("tempdir");
     let home = temp.path().join("home");
     let repo = temp.path().join("repo");
@@ -110,6 +109,12 @@ fn run_job_with_explicit_root_completes_instead_of_staying_pending() {
         None,
     );
     pin_default_crew_for_isolated_root(&custom_root);
+
+    let registry_path = custom_root.join("tasks/registry.db");
+    let registry_writer = rusqlite::Connection::open(&registry_path).expect("open registry writer");
+    registry_writer
+        .execute_batch("BEGIN IMMEDIATE")
+        .expect("hold registry WAL writer");
 
     let job_path = repo.join("root-override-smoke.yaml");
     fs::write(
@@ -135,6 +140,7 @@ spec:
 
     let custom_root_arg = custom_root.to_string_lossy().into_owned();
     let job_path_arg = job_path.to_string_lossy().into_owned();
+    let submitted_at = Instant::now();
     let submitted = run_orbit_json(
         &repo,
         &home,
@@ -148,11 +154,18 @@ spec:
         ],
         None,
     );
+    assert!(
+        submitted_at.elapsed() < Duration::from_secs(4),
+        "current-schema parent/worker bootstrap waited for the registry writer"
+    );
     let run_id = submitted["run_id"]
         .as_str()
         .unwrap_or_else(|| panic!("expected run_id in {submitted}"))
         .to_string();
     assert_eq!(submitted["state"].as_str(), Some("submitted"));
+    registry_writer
+        .execute_batch("ROLLBACK")
+        .expect("release registry writer");
 
     let shown = wait_for_run_terminal_state(&repo, &home, &custom_root, &run_id);
     let state = shown["run"]["state"].as_str().unwrap_or("missing");
@@ -161,6 +174,10 @@ spec:
         "success",
         "{}",
         detached_worker_diagnostic(&custom_root, &run_id, &shown)
+    );
+    assert!(
+        shown["run"]["pid"].as_u64().is_some(),
+        "the real worker must claim its persisted run: {shown}"
     );
 }
 

--- a/crates/orbit-cmd/src/tests/registry_runtime.rs
+++ b/crates/orbit-cmd/src/tests/registry_runtime.rs
@@ -83,38 +83,24 @@ fn pipeline_worker_bootstrap_deadline_returns_precise_last_contention() {
 }
 
 #[test]
-fn managed_worker_bootstrap_recovers_after_real_audit_store_busy_timeout() {
+fn managed_worker_current_schema_bootstrap_does_not_wait_for_audit_writer() {
     let fixture = managed_worktree_fixture();
     let audit_db = fixture.registry_root.join("orbit.db");
-    let (locked, ready) = mpsc::sync_channel(1);
-    let blocker = std::thread::spawn(move || {
-        let store = orbit_store::Store::open(&audit_db).expect("open audit blocker");
-        store
-            .with_transaction(|tx| {
-                tx.connection()
-                    .execute(
-                        "UPDATE schema_meta SET value = value WHERE key = 'fixture-lock'",
-                        [],
-                    )
-                    .map_err(|error| OrbitError::Store(error.to_string()))?;
-                locked.send(()).expect("signal held audit lock");
-                std::thread::sleep(Duration::from_millis(5_250));
-                Ok(())
-            })
-            .expect("release audit writer");
-    });
-    ready.recv().expect("audit lock held");
+    let blocker_store = orbit_store::Store::open(&audit_db).expect("open audit blocker");
+    let blocker_connection = blocker_store.connection();
+    let blocker = blocker_connection.lock().expect("lock audit blocker");
+    blocker
+        .execute_batch("BEGIN IMMEDIATE")
+        .expect("hold audit WAL writer");
 
     let started = Instant::now();
     let runtime = RegisteredRuntimeFactory::initialize_pipeline_worker_with_overrides(
         Some(&fixture.registry_root),
         Some(&fixture.repo_root.to_string_lossy()),
     )
-    .expect("worker bootstrap recovers inside its bounded budget");
-    blocker.join().expect("audit blocker");
+    .expect("current-schema worker bootstrap only observes the audit store");
 
-    assert!(started.elapsed() > Duration::from_secs(5));
-    assert!(started.elapsed() < Duration::from_secs(20));
+    assert!(started.elapsed() < Duration::from_secs(4));
     let shown = run_tool(
         &runtime,
         "orbit.task.show",
@@ -122,6 +108,9 @@ fn managed_worker_bootstrap_recovers_after_real_audit_store_busy_timeout() {
     )
     .expect("recovered worker runtime retains authoritative task ownership");
     assert_eq!(shown["id"], fixture.task_id);
+    blocker
+        .execute_batch("ROLLBACK")
+        .expect("release audit writer");
 }
 
 fn workspace(id: &str, ship_mode: &str) -> Workspace {

--- a/crates/orbit-common/src/storage/sqlite.rs
+++ b/crates/orbit-common/src/storage/sqlite.rs
@@ -94,16 +94,6 @@ pub fn open_private(path: &Path) -> Result<OpenedConnection, OrbitError> {
         drop(connection);
         return open_observational(&path, ObservationRequirement::PublishedMainFile);
     }
-    // Establish one typed write-admission boundary before store-specific
-    // bootstrap runs. Current-schema opens otherwise encounter contention in
-    // whichever later pragma, migration probe, or registry bind happens to
-    // need the writer, after the native SQLite code and database path have
-    // often been erased by several adapter layers.
-    connection
-        .execute_batch("BEGIN IMMEDIATE; ROLLBACK;")
-        .map_err(|error| {
-            sqlite_operation_error(Some(&path), "bootstrap write admission", &error)
-        })?;
     harden_sqlite_files(&path)?;
 
     Ok(OpenedConnection {

--- a/crates/orbit-core/src/application/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/application/tests/job_pipeline.rs
@@ -630,68 +630,6 @@ fn routine_style_detached_worker_is_claimed_within_ownership_window() {
     assert_child_reaped(worker_pid);
 }
 
-/// Gate and leaf workers may both spend longer than SQLite's five-second busy
-/// timeout in bootstrap recovery. Their parent observers must keep supervising
-/// the still-live, unclaimed children and preserve each exact persisted owner.
-#[cfg(unix)]
-#[test]
-fn concurrent_gate_and_leaf_workers_claim_after_extended_bootstrap() {
-    let (_root, runtime) = test_runtime();
-    let gate = runtime
-        .stores()
-        .jobs()
-        .insert_job_run("workspace_auto_pipeline", 1, Utc::now(), None, None)
-        .expect("insert gate run");
-    let leaf = runtime
-        .stores()
-        .jobs()
-        .insert_job_run("task_gate_pipeline", 1, Utc::now(), None, None)
-        .expect("insert leaf run");
-
-    let mut workers = Vec::new();
-    for run in [&gate, &leaf] {
-        let mut command = Command::new("sh");
-        command.args(["-c", "sleep 5.75"]);
-        let worker_log =
-            configure_pipeline_worker_stdio(&mut command, &runtime.paths().logs_dir, &run.run_id)
-                .expect("configure delayed worker log");
-        let pid = runtime
-            .spawn_pipeline_worker_process(
-                &run.run_id,
-                Some("nested-supervisor"),
-                command,
-                worker_log,
-            )
-            .expect("spawn delayed worker");
-        workers.push((run.run_id.clone(), pid));
-    }
-
-    thread::sleep(Duration::from_millis(5_250));
-    for (run_id, pid) in &workers {
-        assert!(
-            runtime
-                .stores()
-                .jobs()
-                .claim_pending_job_run_owner(run_id, *pid)
-                .expect("claim delayed worker exactly once")
-        );
-        let stored = wait_for_worker_ownership_outcome(&runtime, run_id);
-        assert_eq!(stored.state, JobRunState::Pending);
-        assert_eq!(stored.pid, Some(*pid));
-        wait_for_pipeline_audit_event(&runtime, None, "delayed worker claim", |audit| {
-            audit.tool_name.as_deref() == Some("pipeline.worker.claimed")
-                && audit.target_id.as_deref() == Some(run_id.as_str())
-        });
-    }
-
-    for (run_id, pid) in workers {
-        let terminal = wait_for_worker_terminal(&runtime, &run_id);
-        assert_eq!(terminal.state, JobRunState::Interrupted);
-        assert_eq!(terminal.pid, Some(pid));
-        assert_child_reaped(pid);
-    }
-}
-
 #[test]
 fn observer_read_counts_isolate_identical_run_ids_in_independent_stores() {
     let (_first_root, first) = test_runtime();

--- a/crates/orbit-store/src/driver/sqlite/connection.rs
+++ b/crates/orbit-store/src/driver/sqlite/connection.rs
@@ -99,7 +99,7 @@ impl Store {
         let conn = opened.connection;
         let read_only = opened.read_only;
 
-        if let Err(error) = migration::apply_schema(&conn) {
+        if let Err(error) = migration::apply_schema_at_path(&conn, path) {
             if read_only && error.is_readonly_or_access_failure() {
                 orbit_common::tracing::warn!(
                     target: "orbit.store.sqlite",

--- a/crates/orbit-store/src/driver/sqlite/migration/ledger.rs
+++ b/crates/orbit-store/src/driver/sqlite/migration/ledger.rs
@@ -23,7 +23,9 @@
 //!   idempotent schema code, so running it on an existing database is a
 //!   no-op that then records version 1.
 
-use orbit_common::OrbitError;
+use std::path::Path;
+
+use orbit_common::{OrbitError, SqliteContention};
 use rusqlite::{Connection, ErrorCode, Transaction, TransactionBehavior, params};
 
 /// One entry in the migration registry.
@@ -189,6 +191,22 @@ pub(crate) fn run_migrations(
     conn: &Connection,
     migrations: &[Migration],
 ) -> Result<(), OrbitError> {
+    run_migrations_inner(conn, migrations, None)
+}
+
+pub(crate) fn run_migrations_at_path(
+    conn: &Connection,
+    migrations: &[Migration],
+    path: &Path,
+) -> Result<(), OrbitError> {
+    run_migrations_inner(conn, migrations, Some(path))
+}
+
+fn run_migrations_inner(
+    conn: &Connection,
+    migrations: &[Migration],
+    path: Option<&Path>,
+) -> Result<(), OrbitError> {
     validate_registry(migrations)?;
     let current = current_schema_version(conn)?;
     let supported = migrations.last().map(|m| m.version).unwrap_or(0);
@@ -205,7 +223,7 @@ pub(crate) fn run_migrations(
     // re-reads the ledger under BEGIN IMMEDIATE and skips anything another
     // opener already committed while this connection waited.
     for migration in migrations.iter().filter(|m| m.version > current) {
-        apply_one(conn, migration, supported)?;
+        apply_one(conn, migration, supported, path)?;
     }
 
     Ok(())
@@ -256,19 +274,20 @@ pub(crate) fn applied_migrations(conn: &Connection) -> Result<Vec<AppliedMigrati
     Ok(applied)
 }
 
-fn apply_one(conn: &Connection, migration: &Migration, supported: u32) -> Result<(), OrbitError> {
+fn apply_one(
+    conn: &Connection,
+    migration: &Migration,
+    supported: u32,
+    path: Option<&Path>,
+) -> Result<(), OrbitError> {
     // BEGIN IMMEDIATE takes the reserved lock before any read so a WAL
     // snapshot cannot be pinned under DEFERRED while another opener
     // commits. `new_unchecked` is the `&Connection` form of
     // `transaction_with_behavior(TransactionBehavior::Immediate)`.
     // Drop rolls back, so a failure or panic leaves neither partial
     // schema nor a ledger row behind.
-    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate).map_err(|e| {
-        OrbitError::Migration(format!(
-            "failed to begin transaction for migration v{} ({}): {e}",
-            migration.version, migration.name
-        ))
-    })?;
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)
+        .map_err(|error| migration_begin_error(path, migration, error))?;
 
     let current = current_schema_version(&tx)?;
     if current > supported {
@@ -313,6 +332,32 @@ fn apply_one(conn: &Connection, migration: &Migration, supported: u32) -> Result
         "applied store schema migration",
     );
     Ok(())
+}
+
+fn migration_begin_error(
+    path: Option<&Path>,
+    migration: &Migration,
+    error: rusqlite::Error,
+) -> OrbitError {
+    if matches!(
+        error.sqlite_error_code(),
+        Some(ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked)
+    ) && let Some(path) = path
+    {
+        return OrbitError::SqliteContention(Box::new(SqliteContention {
+            path: path.display().to_string(),
+            phase: format!(
+                "begin migration v{} ({})",
+                migration.version, migration.name
+            ),
+            detail: error.to_string(),
+        }));
+    }
+
+    OrbitError::Migration(format!(
+        "failed to begin transaction for migration v{} ({}): {error}",
+        migration.version, migration.name
+    ))
 }
 
 fn newer_than_supported(current: u32, supported: u32) -> OrbitError {

--- a/crates/orbit-store/src/driver/sqlite/migration/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/migration/mod.rs
@@ -21,6 +21,10 @@ pub(crate) fn apply_schema(conn: &Connection) -> Result<(), OrbitError> {
     ledger::run_migrations(conn, ledger::MIGRATIONS)
 }
 
+pub(crate) fn apply_schema_at_path(conn: &Connection, path: &Path) -> Result<(), OrbitError> {
+    ledger::run_migrations_at_path(conn, ledger::MIGRATIONS, path)
+}
+
 /// Registry metadata for one schema migration not yet recorded as applied,
 /// as surfaced by `orbit migrate --dry-run` (ORB-10012).
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/orbit-store/src/driver/sqlite/tests/connection.rs
+++ b/crates/orbit-store/src/driver/sqlite/tests/connection.rs
@@ -191,33 +191,59 @@ fn schema_version_matches_binary_after_open() {
 }
 
 #[test]
-fn current_store_bootstrap_names_locked_write_admission_after_busy_timeout() {
+fn current_store_opens_and_reads_while_a_wal_writer_is_held() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("store.db");
     drop(Store::open(&path).expect("initialize current store"));
 
     let blocker = rusqlite::Connection::open(&path).expect("open blocker");
     blocker
-        .execute_batch("BEGIN EXCLUSIVE")
+        .execute_batch("BEGIN IMMEDIATE")
         .expect("hold SQLite write lock");
     let started = std::time::Instant::now();
-    let error = match Store::open(&path) {
-        Ok(_) => panic!("bootstrap must exhaust the busy timeout"),
-        Err(error) => error,
-    };
+    let store = Store::open(&path).expect("current-schema open needs no writer reservation");
+    assert_eq!(
+        store
+            .schema_version()
+            .expect("read schema while writer held"),
+        SUPPORTED_SCHEMA_VERSION
+    );
 
     assert!(
-        started.elapsed()
-            >= std::time::Duration::from_millis(u64::from(
-                orbit_common::storage::sqlite::DEFAULT_BUSY_TIMEOUT_MS,
-            )),
-        "the regression must exercise SQLite's real busy timeout"
+        started.elapsed() < std::time::Duration::from_secs(4),
+        "current-schema observation waited for the unrelated WAL writer"
     );
+    blocker.execute_batch("ROLLBACK").expect("release writer");
+}
+
+#[test]
+fn pending_migration_contention_names_the_required_write_boundary() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("store.db");
+    let blocker = rusqlite::Connection::open(&path).expect("create pre-migration database");
+    blocker
+        .pragma_update(None, "journal_mode", "WAL")
+        .expect("enable WAL");
+    blocker
+        .execute_batch("BEGIN IMMEDIATE")
+        .expect("hold writer before the required migration");
+
+    let error = match Store::open(&path) {
+        Ok(_) => panic!("pending migration requires the writer"),
+        Err(error) => error,
+    };
     let contention = error
         .sqlite_contention()
-        .expect("lock failure remains typed across the store boundary");
+        .expect("migration lock remains typed across Store::open");
     assert_eq!(contention.path, path.display().to_string());
-    assert_eq!(contention.phase, "bootstrap write admission");
+    assert!(
+        contention.phase.starts_with("begin migration v1 ("),
+        "{}",
+        contention.phase
+    );
+
+    blocker.execute_batch("ROLLBACK").expect("release writer");
+    Store::open(&path).expect("migration succeeds after contention clears");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Task

[ORB-12306](https://orbit-cli.com/tasks/ORB-12306) — [code-review] Remove artificial SQLite write admission and validate real worker bootstrap contention

### Description

Independent read-only review confirmed a P1 regression in ORB-12302/PR2049, merged102f5490e45e354e12c7a88a01d1a3f45b303088 (candidate6e21f9c1a). Not yet installed: live binary remains34555aa5, so fix before next deployment.

crates/orbit-common/src/storage/sqlite.rs:97-106 adds unconditional BEGIN IMMEDIATE; ROLLBACK to shared open_private. It is used by writable-path Store/TaskRegistry/VectorStore opens, including logical read-only CLI initialization (main.rs263-266 initialize_read_only_with_overrides -> runtime/builder.rs58 Store::open). Prepatch current-schema WAL bootstrap returned after pragmas and had an explicit current==supported no-write migration fast path. The new probe needlessly reserves the single writer even for reads/current-schema opens, broadening contention.

The claimed production localization is circular: current_store_bootstrap_names_locked_write_admission_after_busy_timeout holds a writer and asserts failure at newly added `bootstrap write admission`; managed_worker_bootstrap_recovers_after_real_audit_store_busy_timeout (orbit-cmd/tests/registry_runtime.rs85-124) retries the same new probe. Neither reproduces original08:36 startup failure against prepatch code. The parent-ownership test (core/application/tests/job_pipeline.rs638-693) uses sleeping shell processes and manual claims, not real RegisteredRuntimeFactory retry+claim integration.

Remove the unconditional shared write-admission probe. Preserve useful typed path/phase diagnostics around actual preexisting SQLite operations and bounded hidden-worker-only lock recovery, without string matching or changing normal error semantics. Reproduce/instrument the original prepatch worker bootstrap failure at the genuine failing operation (schema/migration, registry binding, etc.) before asserting its cause; do not manufacture an unrelated write as a substitute. A current-schema observation/bootstrap must remain successful with a concurrent WAL writer where no actual write is required. Add a real child-worker bootstrap/retry/claim regression instead of conflating delayed shell/manual claims with that integration. If held-WAL-writer prepatch startup succeeds, state that honestly and continue locating the actual failure; no ungrounded full-resolution claim. Existing migration concurrency safety, read-only fallback, durability and exact-once ownership must remain intact. Original incident evidence is in ORB-12302 and its parent ORB-12299 comments. Current open tasks were inspected; no duplicate owner exists.

### Acceptance Criteria

- Shared current-schema opens no longer acquire an artificial write reservation; regression demonstrates observation/reads alongside a held WAL writer without waiting for its release.
- Prepatch/control comparison identifies a genuine existing operation that produces the original typed BUSY/LOCKED startup failure, or explicitly records remaining uncertainty instead of presenting the removed probe as reproduction; recovery targets real required operations only.
- Real worker bootstrap plus claim/parent supervision is exercised under bounded contention and deadline/non-lock cases, preserving exact-once ownership and diagnostics; no shell/manual-claim substitute for bootstrap integration.
- Relevant store/registry/worker/readonly/migration regressions and full workspace/required checks pass; record exact evidence and remaining production-risk limits.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Removed the unconditional BEGIN IMMEDIATE/ROLLBACK from shared open_private, so already-current writable handles can bootstrap and read under a concurrent WAL writer without reserving SQLite writer ownership.
- Replaced the circular artificial-probe regressions with Store and RegisteredRuntimeFactory controls that hold real WAL writers and prove current-schema opens/reads complete before SQLite busy_timeout.
- Preserved typed recovery at a genuine required operation: file-backed Store migrations now translate BUSY/LOCKED at BEGIN IMMEDIATE into SqliteContention carrying the database path and exact migration phase; the regression proves failure while held and success after release. In-memory/direct ledger callers retain the prior Migration error contract because no path is available.
- Replaced the shell/manual-claim extended-bootstrap test with an orbit-cli integration that runs the real detached orbit worker under a held current task-registry WAL writer, observes successful parent submission/supervision, and verifies the worker-owned PID and terminal success. Existing focused worker tests continue to prove duplicate workers cannot replace the persisted owner, pre-claim/after-claim diagnostics, deadline exhaustion, and prompt unchanged non-lock propagation.
Criteria evidence:
1. current_store_opens_and_reads_while_a_wal_writer_is_held and managed_worker_current_schema_bootstrap_does_not_wait_for_audit_writer pass while BEGIN IMMEDIATE remains held and enforce a four-second ceiling below the five-second busy timeout.
2. The removed bootstrap write-admission probe is not presented as incident reproduction. pending_migration_contention_names_the_required_write_boundary demonstrates typed path/phase BUSY at the genuine migration transaction and recovery after release. The original production 08:36 database path and operation remain unknown; current-schema audit and already-bound registry controls succeed, so this change does not claim full incident localization.
3. detached_worker_bootstraps_and_claims_while_registry_writer_is_held uses the actual orbit binary, RegisteredRuntimeFactory worker bootstrap, self-claim, persisted PID, terminal success, and parent supervisor. orbit-core job_pipeline tests pass for exact-once duplicate ownership and startup/claimed-exit diagnostics; orbit-cmd registry_runtime tests pass for bounded typed retry, deadline, and non-lock cases.
4. Store, registry, migration, worker, read-only, lint, guardrail, and golden checks pass.
Validation:
- cargo test -p orbit-store — passed: 532 passed, 7 ignored slow/helper fixtures.
- cargo test -p orbit-cmd registry_runtime — passed: 26 passed.
- cargo test -p orbit-core application::tests::job_pipeline — passed: 34 passed.
- cargo test -p orbit-cli --test worktree_resolution detached_worker_bootstraps_and_claims_while_registry_writer_is_held — passed: 1 passed.
- make ci-fast — passed; its compiler-cache namespace subcheck reported the documented environment skip because bwrap cannot create an unprivileged mount namespace, while the enclosing required gate exited 0.
- make ci-lint — passed workspace/all-target clippy with warnings denied.
- make goldens — passed CLI help, output, and MCP snapshots.
- git diff --check — passed.
- git status --short — eight intended tracked modifications, no untracked files.
Assessment: The artificial contention regression is removed at its shared source, and retryable diagnostics now attach only to a real required migration write. The integration evidence covers Linux/process/SQLite behavior in this runner.
Design weaknesses / risks: Original production localization remains uncertain because the incident did not record a database path or SQLite phase; another genuine startup write outside migration may still contend. Independent post-implementation review and deployment observation remain required.
Deviations from original plan:
- No cross-revision build was manufactured: existing incident/Pilot evidence and the new controls show the prepatch current-schema path does not require a writer, but cannot identify the historical failing operation. This uncertainty is recorded explicitly as required.
- Added file:crates/orbit-store/src/driver/sqlite/connection.rs to scope because Store::open owns the path required for typed migration diagnostics.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12306-6aa52592`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra