### PR TITLE
Fix Clippy drain_collect failure in automation recovery checkpoint test

### DIFF
--- a/crates/orbit-store/src/driver/sqlite/automation/tests/checkpoints.rs
+++ b/crates/orbit-store/src/driver/sqlite/automation/tests/checkpoints.rs
@@ -319,7 +319,7 @@ fn recovery_cannot_skip_debt_or_advance_coverage() {
     covered.pending_commits.clear();
 
     let mut waived = adopted(&previous);
-    waived.waived = waived.pending.drain(..).collect();
+    waived.waived = std::mem::take(&mut waived.pending);
 
     let mut discarded = adopted(&previous);
     discarded.active = None;


### PR DESCRIPTION
## Task

[ORB-12308](https://orbit-cli.com/tasks/ORB-12308) — Fix Clippy drain_collect failure in automation recovery checkpoint test

### Description

Hosted agent-main CI34687833285 at c26f6bb009700b891d49ad4cc1f8923b90206dd8 fails Check/Clippy/Test before tests: Rust1.98 clippy::drain_collect at crates/orbit-store/src/driver/sqlite/automation/tests/checkpoints.rs:322: waived.waived = waived.pending.drain(..).collect();. Suggested std::mem::take(&mut waived.pending) preserves moving all pending items and leaving the source empty. This recovery checkpoint test came from ORB-12295. Make the minimal idiomatic ownership transfer without lint suppression or changing recovery assertions/production behavior. Run focused checkpoint tests and required checks, recording toolchain versions. Root will verify hosted CI afterward; do not claim a local pass proves hosted Rust1.98 parity unless tested. Exact all-status drain_collect search returned no owner; hybrid results were unrelated historic lint tasks. Separate from resolved TZ baseline flake12307/12268.

### Acceptance Criteria

- The checkpoint fixture preserves transferred items and empty pending state while compiling without drain_collect under the CI toolchain.
- Focused automation checkpoint tests and required guardrails pass; report toolchain identity and any CI-only validation gap. No lint allowance or unrelated changes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced `waived.pending.drain(..).collect()` with `std::mem::take(&mut waived.pending)` in `crates/orbit-store/src/driver/sqlite/automation/tests/checkpoints.rs`.
- The existing recovery fixture assertions remain unchanged, so all pending entries are transferred to `waived` and the source `pending` vector is empty; no production code, lint allowance, or unrelated file changed.
Criteria evidence:
- Criterion 1: passed. The focused test compiled and passed with the idiomatic ownership transfer, and the scoped file contains no remaining `drain_collect` occurrence.
- Criterion 2: passed locally. Focused automation test and all required guardrails completed successfully; toolchain identity and the hosted CI gap are recorded below.
Validation:
- `rustc --version`: passed — `rustc 1.96.0 (ac68faa20 2026-05-25)`.
- `cargo --version`: passed — `cargo 1.96.0 (30a34c682 2026-05-25)`.
- `cargo test -p orbit-store recovery_cannot_skip_debt_or_advance_coverage`: passed — 1 passed, 0 failed.
- `make ci-fast`: passed — exit 0; its `test-compiler-cache-namespaces` subcheck was skipped because this environment cannot create an unprivileged bubblewrap namespace.
- `make ci-lint`: passed — workspace all-target clippy with `-D warnings` exited 0.
- `make goldens`: passed — all help/output/MCP golden tests exited 0.
- `git diff --check`: passed.
- `GIT_OPTIONAL_LOCKS=0 git status --short`: passed — only the intended checkpoint file is modified.
Assessment: Minimal, idiomatic test-fixture-only fix. Hosted CI Rust 1.98 parity was not available locally and remains for root/hosted verification; local Rust 1.96 validation does not prove that parity.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12308-6aa52896`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra