### PR TITLE
Show per-task auto-drain readiness reasons and blockers in the dashboard

### DIFF
--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -4585,6 +4585,33 @@
       .operation-clock-summary { justify-content: flex-start; flex-wrap: wrap; margin-bottom: 14px; overflow-wrap: anywhere; }
       .operation-cadence { min-width: 0; max-width: 100%; }
       .operation-clock-actions { justify-content: flex-start; flex-wrap: wrap; margin-top: 14px; }
+      .auto-drain-readiness { min-width: 0; margin-top: 16px; }
+      .auto-drain-readiness-title {
+        margin: 0 0 8px; color: var(--fg); font: 12px var(--font-sans);
+        text-transform: uppercase; letter-spacing: .08em;
+      }
+      .auto-drain-task-list { min-width: 0; margin: 0; padding: 0; list-style: none; }
+      .auto-drain-task { min-width: 0; }
+      .auto-drain-task-head {
+        display: grid; grid-template-columns: minmax(120px, auto) auto minmax(0, 1fr);
+        align-items: center; gap: 8px 12px; min-width: 0;
+      }
+      .auto-drain-reference { color: var(--accent); overflow-wrap: anywhere; }
+      .auto-drain-reason { min-width: 0; color: var(--fg); font: 11px/1.4 var(--font-mono); overflow-wrap: anywhere; }
+      .auto-drain-missing-id { color: var(--state-failed); font: 11px/1.4 var(--font-mono); overflow-wrap: anywhere; }
+      .auto-drain-evidence {
+        display: flex; flex-direction: column; gap: 5px; min-width: 0;
+        margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--hair);
+      }
+      .auto-drain-evidence-row {
+        display: grid; grid-template-columns: 110px minmax(0, 1fr); gap: 8px; min-width: 0;
+      }
+      .auto-drain-evidence-label {
+        color: var(--fg-dim); font: 9px/1.5 var(--font-sans); text-transform: uppercase; letter-spacing: .08em;
+      }
+      .auto-drain-evidence-values { display: flex; flex-wrap: wrap; gap: 4px 10px; min-width: 0; }
+      .auto-drain-evidence-value { min-width: 0; color: var(--fg-dim); font: 10px/1.5 var(--font-mono); overflow-wrap: anywhere; }
+      .auto-drain-empty { padding: 10px 0; }
 
       @media (max-width: 900px) {
         .operations-layout { grid-template-columns: 1fr; }
@@ -4595,6 +4622,8 @@
         .operation-row-head { grid-template-columns: minmax(0, 1fr); }
         .operation-card-actions { width: 100%; }
         .operation-mint-warning { overflow-wrap: anywhere; }
+        .auto-drain-task-head, .auto-drain-evidence-row { grid-template-columns: minmax(0, 1fr); }
+        .auto-drain-task-head .operation-state { justify-self: start; }
       }
       @media (max-width: 600px) {
         .operations-layout { display: block; padding: 8px; }

--- a/crates/orbit-web/assets/dashboard/operations.js
+++ b/crates/orbit-web/assets/dashboard/operations.js
@@ -598,8 +598,192 @@ function autoDrainReasons(payload) {
 
 function autoDrainCounts(payload) {
   const tasks = Array.isArray(payload.tasks) ? payload.tasks : [];
-  const eligible = tasks.filter((task) => task.eligible).length;
+  const eligible = tasks.filter((task) => task.eligible === true).length;
   return { eligible, waiting: tasks.length - eligible };
+}
+
+const AUTO_DRAIN_REASON_LABELS = {
+  ready: "Ready for admission",
+  ready_as_epic: "Ready as the next epic",
+  not_backlog: "Not in backlog",
+  unmet_dependency: "Waiting on a dependency",
+  task_pilot_preparation_required: "Task-pilot preparation required",
+  crew_not_allowed: "Crew excluded by this drain",
+  epic_managed: "Managed by an epic",
+  admissions_stopped: "Admissions stopped",
+  epic_run_active: "Another epic run is active",
+  queued_behind_epic: "Queued behind another epic",
+  context_lock_conflict: "Context is locked",
+  group_member_conflict: "A grouped task conflicts",
+  claimed_by_live_child: "Claimed by a live child run",
+  outside_grant_scope: "Outside the active grant scope",
+  grant_expired: "The active grant expired",
+  grant_stopped: "The active grant stopped admitting",
+  grant_revoked: "The active grant was revoked",
+  outside_candidate_pool: "Outside the examined candidate pool",
+  conflict_deferred: "Deferred behind a conflicting candidate",
+  capacity_saturated: "No admission capacity",
+};
+
+function autoDrainTaskLink(taskId, workspace) {
+  const link = el("a", { class: "auto-drain-reference mono", text: taskId, title: `Open task ${taskId}` });
+  link.href = `?workspace=${encodeURIComponent(workspace.id)}#tasks?status=all&q=${encodeURIComponent(taskId)}`;
+  return link;
+}
+
+function autoDrainRunLink(runId, workspace) {
+  const link = el("a", { class: "auto-drain-reference mono", text: runId, title: `Open run ${runId}` });
+  link.href = `?workspace=${encodeURIComponent(workspace.id)}#runs/${encodeURIComponent(runId)}`;
+  link.addEventListener("click", (event) => {
+    event.preventDefault();
+    navigateToRun(runId, workspace.id);
+  });
+  return link;
+}
+
+function autoDrainEvidenceRow(label, values) {
+  return el("div", { class: "auto-drain-evidence-row" }, [
+    el("span", { class: "auto-drain-evidence-label", text: label }),
+    el("div", { class: "auto-drain-evidence-values" }, values),
+  ]);
+}
+
+function autoDrainTextValues(values) {
+  return values
+    .filter((value) => value != null && String(value).trim() !== "")
+    .map((value) => el("span", { class: "auto-drain-evidence-value mono", text: String(value) }));
+}
+
+function autoDrainMissingEvidence(task, reason, evidence) {
+  if (reason === "unmet_dependency" && evidence.dependencies === 0) {
+    return "Dependency details were not supplied.";
+  }
+  if (["context_lock_conflict", "group_member_conflict", "conflict_deferred"].includes(reason)
+    && evidence.conflicts === 0 && evidence.blockers === 0) {
+    return "Conflict details were not supplied.";
+  }
+  if (reason === "claimed_by_live_child" && evidence.claimingRuns === 0) {
+    return "Claiming run details were not supplied.";
+  }
+  if (reason === "capacity_saturated" && evidence.activeRuns === 0) {
+    return "Active run details were not supplied.";
+  }
+  if (reason === "crew_not_allowed" && task.crew == null && !Array.isArray(task.allowed_crews)) {
+    return "Crew restriction details were not supplied.";
+  }
+  if (["outside_grant_scope", "grant_expired", "grant_stopped", "grant_revoked"].includes(reason) && !task.grant_id) {
+    return "Grant details were not supplied.";
+  }
+  if (!AUTO_DRAIN_REASON_LABELS[reason] && evidence.rows === 0) {
+    return "No additional evidence was supplied for this server reason.";
+  }
+  return "";
+}
+
+function autoDrainTaskEvidence(task, workspace) {
+  const rows = [];
+  if (task.status && task.status !== "backlog") {
+    rows.push(autoDrainEvidenceRow("Task status", autoDrainTextValues([task.status])));
+  }
+  const dependencies = Array.isArray(task.dependencies) ? task.dependencies : [];
+  if (dependencies.length > 0) {
+    rows.push(autoDrainEvidenceRow("Dependencies", dependencies.map((dependency) => {
+      const taskId = typeof dependency === "string" ? dependency : dependency?.task_id;
+      const value = el("span", { class: "auto-drain-evidence-value" });
+      if (taskId) value.appendChild(autoDrainTaskLink(taskId, workspace));
+      else value.appendChild(el("span", { text: "Unknown dependency" }));
+      if (dependency?.status) value.appendChild(el("span", { text: ` · ${dependency.status}` }));
+      return value;
+    })));
+  }
+
+  const conflicts = Array.isArray(task.conflicts) ? task.conflicts : [];
+  if (conflicts.length > 0) {
+    rows.push(autoDrainEvidenceRow("Conflicts", conflicts.map((conflict) => {
+      const value = el("span", { class: "auto-drain-evidence-value" });
+      value.appendChild(el("span", { class: "mono", text: conflict?.requested_file || "File not supplied" }));
+      if (conflict?.locking_task_id) {
+        value.append(el("span", { text: " · held by " }), autoDrainTaskLink(conflict.locking_task_id, workspace));
+      }
+      return value;
+    })));
+  }
+
+  const blockingTaskIds = Array.isArray(task.blocking_task_ids) ? task.blocking_task_ids : [];
+  if (blockingTaskIds.length > 0) {
+    rows.push(autoDrainEvidenceRow("Blocking tasks", blockingTaskIds.map((taskId) => autoDrainTaskLink(taskId, workspace))));
+  }
+  const liveRunIds = Array.isArray(task.run_ids) ? task.run_ids : [];
+  if (liveRunIds.length > 0) {
+    rows.push(autoDrainEvidenceRow("Claiming runs", liveRunIds.map((runId) => autoDrainRunLink(runId, workspace))));
+  }
+  const activeRunIds = Array.isArray(task.active_run_ids) ? task.active_run_ids : [];
+  if (activeRunIds.length > 0) {
+    rows.push(autoDrainEvidenceRow("Active runs", activeRunIds.map((runId) => autoDrainRunLink(runId, workspace))));
+  }
+  if (task.crew != null || Array.isArray(task.allowed_crews)) {
+    const allowed = Array.isArray(task.allowed_crews) && task.allowed_crews.length > 0
+      ? task.allowed_crews.join(", ")
+      : "none supplied";
+    rows.push(autoDrainEvidenceRow("Crew", autoDrainTextValues([`${task.crew ?? "not supplied"} · allowed: ${allowed}`])));
+  }
+  if (task.grant_id) rows.push(autoDrainEvidenceRow("Grant", autoDrainTextValues([task.grant_id])));
+  if (task.epic_run_id) rows.push(autoDrainEvidenceRow("Active epic run", [autoDrainRunLink(task.epic_run_id, workspace)]));
+  if (task.next_epic_task_id) rows.push(autoDrainEvidenceRow("Next epic", [autoDrainTaskLink(task.next_epic_task_id, workspace)]));
+
+  const reason = typeof task.reason === "string" && task.reason.trim() ? task.reason : "unknown";
+  const evidenceMissing = autoDrainMissingEvidence(task, reason, {
+    dependencies: dependencies.length,
+    conflicts: conflicts.length,
+    blockers: blockingTaskIds.length,
+    claimingRuns: liveRunIds.length,
+    activeRuns: activeRunIds.length,
+    rows: rows.length,
+  });
+  if (evidenceMissing) rows.push(autoDrainEvidenceRow("Details", autoDrainTextValues([evidenceMissing])));
+
+  return rows;
+}
+
+function autoDrainReadinessList(payload, workspace) {
+  const tasks = Array.isArray(payload.tasks) ? payload.tasks : [];
+  const section = el("section", { class: "auto-drain-readiness" });
+  const heading = el("h3", { class: "auto-drain-readiness-title", text: "Task readiness" });
+  heading.id = "auto-drain-readiness-title";
+  section.setAttribute("aria-labelledby", heading.id);
+  section.appendChild(heading);
+  if (tasks.length === 0) {
+    section.appendChild(el("div", {
+      class: "empty-state auto-drain-empty",
+      text: "No readiness rows were returned in this bounded snapshot. This does not establish that the workspace has no backlog tasks.",
+    }));
+    return section;
+  }
+
+  const list = el("ul", { class: "auto-drain-task-list" });
+  for (const task of tasks) {
+    const taskId = typeof task.task_id === "string" && task.task_id.trim() ? task.task_id : "Task ID not supplied";
+    const reason = typeof task.reason === "string" && task.reason.trim() ? task.reason : "unknown";
+    const eligible = task.eligible === true;
+    const state = eligible ? "eligible" : "waiting";
+    const item = el("li", { class: `operation-card auto-drain-task ${state}` });
+    const identity = taskId === "Task ID not supplied"
+      ? el("strong", { class: "auto-drain-missing-id", text: taskId })
+      : autoDrainTaskLink(taskId, workspace);
+    item.appendChild(el("div", { class: "auto-drain-task-head" }, [
+      identity,
+      el("span", { class: `operation-state ${eligible ? "enabled" : "blocked"}`, text: state }),
+      el("span", {
+        class: "auto-drain-reason",
+        text: `${AUTO_DRAIN_REASON_LABELS[reason] || "Unknown readiness reason"} · ${reason}`,
+      }),
+    ]));
+    const evidence = autoDrainTaskEvidence(task, workspace);
+    if (evidence.length > 0) item.appendChild(el("div", { class: "auto-drain-evidence" }, evidence));
+    list.appendChild(item);
+  }
+  section.appendChild(list);
+  return section;
 }
 
 function autoDrainStartButton(payload) {
@@ -665,18 +849,36 @@ function renderAutoDrain(payload) {
   }
   const counts = autoDrainCounts(payload);
   const capacity = payload.capacity || {};
+  const occupancyPhases = Object.entries(capacity.occupancy?.phases || {})
+    .filter(([, count]) => Number(count) > 0)
+    .map(([phase, count]) => `${count} ${phase.replaceAll("_", "-")}`)
+    .join(", ");
+  const candidatePool = capacity.candidate_pool_size == null
+    ? "—"
+    : `${capacity.candidate_pool_size}${capacity.candidate_pool_truncated ? " · truncated" : ""}`;
   body.append(
     el("div", { class: "operation-grid" }, [
       field("Active leaf runs", `${capacity.active_leaf_runs ?? "—"} / ${capacity.max_active_leaf_runs ?? "—"}`),
       field("Free slots", capacity.free_slots),
       field("Eligible now", counts.eligible),
       field("Waiting", counts.waiting),
+      field("Candidate pool", candidatePool),
+      field("Occupied slot phases", occupancyPhases || "None supplied"),
     ]),
   );
   body.appendChild(el("p", {
     class: "operation-control-note",
-    text: "Proposed tasks are never drained automatically; promote a task to backlog first. This snapshot can change the instant after it is read.",
+    text: payload.snapshot?.limitations || "Snapshot only: eligibility can change immediately and does not guarantee a task will start.",
   }));
+  body.appendChild(el("p", {
+    class: "operation-control-note",
+    text: `The server returned a bounded snapshot of ${counts.eligible + counts.waiting} task${counts.eligible + counts.waiting === 1 ? "" : "s"}; these counts are not a workspace total.${capacity.candidate_pool_truncated ? " The candidate pool was truncated before all available slots could be filled." : ""}`,
+  }));
+  body.appendChild(el("p", {
+    class: "operation-control-note",
+    text: "Proposed tasks are never drained automatically; promote a task to backlog first.",
+  }));
+  body.appendChild(autoDrainReadinessList(payload, workspace));
 
   const durationSelect = el("select", { class: "operation-cadence", title: "Bounded drain window" });
   for (const value of AUTO_DRAIN_DURATIONS) {

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -698,6 +698,7 @@ fn dashboard_auto_drain_action_is_bounded_governed_and_guarded() {
     let index = include_str!("../../assets/dashboard/index.html");
     let operations = include_str!("../../assets/dashboard/operations.js");
     let router = include_str!("../../assets/dashboard/router.js");
+    let css = include_str!("../../assets/dashboard/dashboard.css");
 
     for id in [
         "operations-auto-drain-main",
@@ -752,6 +753,32 @@ fn dashboard_auto_drain_action_is_bounded_governed_and_guarded() {
     assert!(
         operations.contains("Proposed tasks are never drained automatically"),
         "the panel must explain proposed tasks require separate authorization"
+    );
+    assert!(
+        operations.contains("autoDrainReadinessList(payload, workspace)"),
+        "the panel must render every server-provided readiness row"
+    );
+    assert!(
+        operations.contains("task.task_id")
+            && operations.contains("task.reason")
+            && operations.contains("task.dependencies")
+            && operations.contains("task.conflicts")
+            && operations.contains("task.run_ids")
+            && operations.contains("task.active_run_ids")
+            && operations.contains("task.allowed_crews")
+            && operations.contains("task.grant_id"),
+        "readiness rows must expose the server's reason-specific evidence"
+    );
+    assert!(
+        operations.contains("these counts are not a workspace total")
+            && operations.contains("candidate_pool_truncated")
+            && operations.contains("No additional evidence was supplied"),
+        "bounded, truncated, and unknown snapshots must remain honest"
+    );
+    assert!(
+        css.contains(".auto-drain-task-head, .auto-drain-evidence-row { grid-template-columns: minmax(0, 1fr); }")
+            && css.contains(".auto-drain-reference { color: var(--accent); overflow-wrap: anywhere; }"),
+        "readiness evidence must stack and wrap at narrow widths"
     );
 
     // Failure recovery: an error must surface, not silently no-op, and must

--- a/crates/orbit-web/src/tests/dashboard_operations.mjs
+++ b/crates/orbit-web/src/tests/dashboard_operations.mjs
@@ -19,6 +19,17 @@ let releaseGet = null;
 let nextTask = 1;
 const requests = [];
 const confirmations = [];
+const readinessTasks = [
+  { task_id: 'ORB-1', status: 'backlog', eligible: true, reason: 'ready' },
+  { task_id: 'ORB-2', status: 'backlog', eligible: false, reason: 'unmet_dependency', dependencies: [{ task_id: 'ORB-20', status: 'in-progress' }] },
+  { task_id: 'ORB-3', status: 'backlog', eligible: false, reason: 'conflict_deferred', blocking_task_ids: ['ORB-30'], conflicts: [{ requested_file: 'file:crates/shared/src/lib.rs', locking_task_id: 'ORB-30' }] },
+  { task_id: 'ORB-4', status: 'backlog', eligible: false, reason: 'claimed_by_live_child', run_ids: ['jrun-claimed-child'] },
+  { task_id: 'ORB-5', status: 'backlog', eligible: false, reason: 'capacity_saturated', active_run_ids: ['jrun-active-leaf'] },
+  { task_id: 'ORB-6', status: 'backlog', eligible: false, reason: 'crew_not_allowed', crew: 'luna', allowed_crews: ['sol', 'terra'] },
+  { task_id: 'ORB-7', status: 'backlog', eligible: false, reason: 'outside_grant_scope', grant_id: 'opg-fixture' },
+  { task_id: 'ORB-8', status: 'backlog', eligible: false, reason: 'future_server_reason' },
+  { task_id: 'ORB-9', status: 'backlog', eligible: false, reason: 'unmet_dependency' },
+];
 window.confirm = message => { confirmations.push(message); return true; };
 const response = (payload, status = 200) => ({ ok: status === 200, status, json: async () => payload, text: async () => JSON.stringify(payload) });
 globalThis.fetch = async (path, options = {}) => {
@@ -47,8 +58,14 @@ globalThis.fetch = async (path, options = {}) => {
   });
   if (url.pathname === '/api/workflows/auto/readiness') return response({
     controls_authorized: true,
-    capacity: { active_leaf_runs: 1, max_active_leaf_runs: 4, free_slots: 3 },
-    tasks: [{ id: 'ORB-1', eligible: true }, { id: 'ORB-2', eligible: false }],
+    snapshot: { read_only: true, limitations: 'Fixture snapshot only; eligibility can change immediately and does not guarantee a task will start.' },
+    capacity: {
+      active_leaf_runs: 4, max_active_leaf_runs: 4, free_slots: 0,
+      candidate_pool_size: 8, candidate_pool_truncated: true,
+      occupancy: { phases: { implementing: 2, lock_waiting: 1, post_implementation: 1, unknown: 0 } },
+      deferred_conflicts: [{ task_id: 'ORB-3', blocking_task_ids: ['ORB-30'] }],
+    },
+    tasks: readinessTasks,
   });
   if (url.pathname === '/api/operation/explain') return response({
     controls_authorized: true,
@@ -61,6 +78,28 @@ globalThis.fetch = async (path, options = {}) => {
 };
 setWorkspace('one');
 initOperations({ getWorkspaces: () => ['one', 'two'].map(id => ({ id, name: id, status: 'active' })), formatAbsoluteTime: value => value });
+await fetchAndRenderOperations();
+const readiness = get('auto-drain-body');
+const readinessText = readiness.textContent;
+for (const value of ['ORB-1', 'ready', 'ORB-20', 'in-progress', 'conflict_deferred', 'file:crates/shared/src/lib.rs', 'ORB-30', 'jrun-claimed-child', 'jrun-active-leaf', 'luna', 'sol, terra', 'opg-fixture', 'future_server_reason']) {
+  assert(readinessText.includes(value), `readiness diagnostic exposes ${value}`);
+}
+assert(readinessText.includes('Eligible now1') && readinessText.includes('Waiting8'), 'readiness counts use strict server eligibility');
+assert(readinessText.includes('candidate pool was truncated'), 'candidate-pool truncation is explicit');
+assert(readinessText.includes('2 implementing, 1 lock-waiting, 1 post-implementation'), 'capacity occupancy phases are visible');
+assert(readinessText.includes('No additional evidence was supplied for this server reason.'), 'unknown reasons disclose absent evidence');
+assert(readinessText.includes('Dependency details were not supplied.'), 'known reasons disclose missing optional details');
+assert(readinessText.includes('not a workspace total'), 'bounded snapshot counts are not presented as a total');
+const readinessCards = descendants(readiness).filter(node => String(node.className || '').includes('auto-drain-task '));
+assert(readinessCards.length === readinessTasks.length, 'every returned readiness row is rendered');
+assert(readinessCards.every(card => !descendants(card).some(node => node.type === 'button')), 'readiness rows remain read-only');
+const readinessLinks = descendants(readiness).filter(node => String(node.className || '').includes('auto-drain-reference'));
+assert(readinessLinks.some(link => String(link.href).includes('workspace=one') && String(link.href).includes('q=ORB-20')), 'task evidence links stay workspace-qualified');
+assert(readinessLinks.some(link => String(link.href).includes('workspace=one') && String(link.href).includes('#runs/jrun-active-leaf')), 'run evidence links stay workspace-qualified');
+const populatedReadiness = readinessTasks.splice(0, readinessTasks.length);
+await fetchAndRenderOperations();
+assert(get('auto-drain-body').textContent.includes('No readiness rows were returned in this bounded snapshot.'), 'empty readiness snapshot avoids claiming the workspace has no backlog');
+readinessTasks.push(...populatedReadiness);
 await fetchAndRenderOperations();
 assert(!button('auto-tasks-body', 'Disable').disabled, 'authorized toggle available');
 assert(!button('auto-tasks-body', 'Mint now').disabled, 'authorized mint available');

--- a/crates/orbit-web/src/tests/dashboard_operations_browser.mjs
+++ b/crates/orbit-web/src/tests/dashboard_operations_browser.mjs
@@ -95,21 +95,24 @@ try {
           const box = bounds(node);
           return box.width > 0 && box.height > 0 && box.right > 0 && box.left < window.innerWidth;
         };
-        const clipped = Array.from(panel.querySelectorAll('button, select, .operation-row-head, .operation-clock-summary')).some((node) => {
+        const clipped = Array.from(panel.querySelectorAll('button, select, .operation-row-head, .operation-clock-summary, .auto-drain-task-head, .auto-drain-evidence-row')).some((node) => {
           const box = bounds(node);
           return box.right > window.innerWidth + 1;
         });
+        const readinessRows = name === 'auto-drain' ? panel.querySelectorAll('.auto-drain-task').length : null;
         return {
           subtab: onscreen(button),
           panel: panel && !panel.hidden,
           workspace: workspace && onscreen(workspace),
           clipped,
+          readinessRows,
         };
       }, tab);
       if (!reachable.subtab) throw new Error(`${tab} subtab not reachable at ${viewport.name}`);
       if (!reachable.panel) throw new Error(`${tab} panel hidden at ${viewport.name}`);
       if (!reachable.workspace) throw new Error(`workspace selector not reachable at ${viewport.name} / ${tab}`);
       if (reachable.clipped) throw new Error(`Clipped Operations control at ${viewport.name} / ${tab}`);
+      if (tab === 'auto-drain' && reachable.readinessRows !== 9) throw new Error(`Auto-drain diagnostics missing at ${viewport.name}: ${reachable.readinessRows}`);
       await assertNoOverflow(`${viewport.name} / ${tab}`);
       await page.screenshot({ path: path.join(evidence, `${tab}-${viewport.name}.png`), fullPage: true });
     }


### PR DESCRIPTION
## Task

[ORB-12293](https://orbit-cli.com/tasks/ORB-12293) — Show per-task auto-drain readiness reasons and blockers in the dashboard

### Description

## Problem
The dashboard auto-drain panel in crates/orbit-web/assets/dashboard/operations.js reduces payload.tasks to eligible/waiting counts (around 599-602,654-679), hiding the diagnostic reason and evidence already supplied by the readiness API. Operators see 0 eligible / N waiting but cannot distinguish dependencies, context conflicts, active claims, crew restrictions, grant restrictions or capacity.

## Existing coverage and scope
ORB-11218 delivered the domain/CLI readiness projection; ORB-11973 extended conflict/capacity evidence. Reuse that server response rather than implementing eligibility rules or a second scheduler in JavaScript. Render a bounded, accessible per-task explanation with links/identifiers already present in the response, while keeping aggregate counts and snapshot/truncation limitations. Handle unknown reasons and absent optional evidence honestly. Maintain read-only behavior and explicit workspace routing; do not add automatic promotion/cancellation or other mutation controls. Existing dashboard_assets tests currently use empty readiness fixtures and should cover realistic blocked rows.

## Validation
Use current readiness payload shapes to test representative dependency, conflict/claim, capacity, crew/grant and unknown cases in the existing DOM/asset harness. Check the panel with non-empty data and narrow-screen layout. Operator browser setup is available for final sweep; do not claim unavailable browser validation passed.

### Acceptance Criteria

- Each returned readiness row exposes task ID and server-provided eligible/waiting reason, with relevant dependency/blocker/run/crew/grant evidence where supplied.
- Counts, bounded/truncated snapshot limitations, empty states, unknown reasons and missing optional details remain clear without false eligibility claims.
- Rendering remains read-only and workspace-qualified; no new scheduling rules or automatic mutation behavior is introduced.
- Existing UI tests include non-empty dependency and conflict/capacity payloads and verify visible diagnostic evidence; layout remains usable at narrow width.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Rendered every readiness row with task ID, strict eligible/waiting state, the server reason, and supplied dependency, conflict/blocker, claiming/active-run, crew, grant, epic, and task-status evidence. Task and run references are workspace-qualified links.
- Preserved aggregate snapshot counts and added honest server-limit, candidate-pool truncation, occupancy-phase, empty-state, unknown-reason, and missing-detail explanations without introducing client-side scheduling rules or row mutations.
- Added responsive readiness cards and expanded the existing DOM, Rust asset, and Chromium harness coverage with realistic dependency, conflict, claim, capacity, crew, grant, unknown, missing-detail, and empty payloads.
Criteria evidence:
1. The DOM fixture renders all 9 returned rows and asserts visible task IDs, raw reasons, dependency status, conflict file/blocker, live run IDs, crew allowlist, and grant ID.
2. Strict boolean eligibility produces 1 eligible and 8 waiting; tests assert bounded/non-total copy, candidate-pool truncation, occupancy phases, empty state, unknown reason, and absent dependency detail.
3. Readiness rows contain no buttons; the implementation only projects the GET payload and workspace-qualified references, leaving the existing bounded-window action unchanged.
4. Chromium exercised populated rows at 1440, 672, 390, and 375x812 with clipping and horizontal-overflow assertions; screenshots were visually reviewed at desktop and 375px.
Validation:
- passed: node --check crates/orbit-web/assets/dashboard/operations.js crates/orbit-web/src/tests/dashboard_operations.mjs crates/orbit-web/src/tests/dashboard_operations_browser.mjs
- passed: cargo test -p orbit-web dashboard_assets -- --nocapture (66 passed)
- passed: PLAYWRIGHT_BROWSERS_PATH=~/.cache/orbit-operator-tools/browser-qa/browsers LD_LIBRARY_PATH=~/.cache/orbit-operator-tools/browser-qa/sysroot/usr/lib/x86_64-linux-gnu node crates/orbit-web/src/tests/dashboard_operations_browser.mjs ~/.cache/orbit-operator-tools/browser-qa/node_modules/playwright/index.mjs /tmp/orbit-12293-browser-final.DRlTQ9
- passed: make ci-fast (the optional mount-namespace probe self-reported its expected environment skip; the gate exited 0)
- passed: make ci-lint
- passed: make goldens
- passed: git diff --check
Assessment: The dashboard remains a read-only projection of the current server payload and degrades explicitly when optional evidence is absent or a future reason appears.
Deviations from original plan: none.
Remaining risk: The browser run used the shipped asset fixture rather than a live Orbit server. Per the task comment, independent browser/QA release sign-off remains required.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12293-6aa531de`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra