### PR TITLE
Host-registry overview still assigns identity DTOs to orbit-common

### DIFF
--- a/docs/design/host-registry/1_overview.md
+++ b/docs/design/host-registry/1_overview.md
@@ -9,7 +9,7 @@ status: Accepted
 feature: host-registry
 doc_role: overview
 tags: [host-registry, machine-identity, workspace-catalog]
-paths: ["crates/orbit-common/src/types/host.rs", "crates/orbit-common/src/types/workspace.rs", "crates/orbit-registry/src/host_identity.rs", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-cmd/src/registry_runtime.rs", "crates/orbit-cli/src/command/init.rs", "crates/orbit-cli/src/command/host/**", "crates/orbit-cli/src/command/workspace/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-web/src/lib.rs", "crates/orbit-web/src/state.rs", "crates/orbit-mcp/src/remote/identity.rs", "crates/orbit-mcp/src/remote/discovery.rs"]
+paths: ["crates/orbit-types/src/identity/host.rs", "crates/orbit-types/src/workspace/registry.rs", "crates/orbit-registry/src/host_identity.rs", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-cmd/src/registry_runtime.rs", "crates/orbit-cli/src/command/init.rs", "crates/orbit-cli/src/command/host/**", "crates/orbit-cli/src/command/workspace/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-web/src/lib.rs", "crates/orbit-web/src/state.rs", "crates/orbit-mcp/src/remote/identity.rs", "crates/orbit-mcp/src/remote/discovery.rs"]
 related_features: [host-registry, mcp-session-context, remote-access, federated-mcp]
 related_artifacts: [ORB-11009]
 ---
@@ -24,14 +24,14 @@ It is not a fleet router. V1 has no host-registration, host-list, host-retiremen
 
 | Layer | Current responsibility |
 |---|---|
-| orbit-common | Persistence-neutral host and workspace primitives: identifier validators and constants, workspace/catalog DTOs, roles, status, and schema constants |
+| orbit-types | Persistence-neutral host and workspace primitives: identifier validators and constants, workspace/catalog DTOs, roles, status, and schema constants |
 | orbit-registry | host.toml lifecycle, workspaces.json catalog operations, validation, atomic file persistence, and checkout-path health |
 | orbit-cmd | RegisteredRuntimeFactory and the composition that joins a selected registry checkout to a Core runtime |
 | orbit-cli | Global initialization, workspace mutations and display, local host rename, and MCP server bootstrap |
 | orbit-web | Registry-backed workspace snapshots, health projection, lazy runtime caching, and HTTP selection |
 | orbit-mcp plus the CLI MCP server | Server identity presentation, local workspace discovery, and authoritative per-call workspace resolution |
 
-orbit-common does not read machine files. orbit-registry does not dispatch Core tools or own MCP or Web transport. orbit-cmd does not own the catalog schema.
+orbit-types does not read machine files. orbit-registry does not dispatch Core tools or own MCP or Web transport. orbit-cmd does not own the catalog schema.
 
 ## Live artifacts
 


### PR DESCRIPTION
## Task

[ORB-12313](https://orbit-cli.com/tasks/ORB-12313) — Host-registry overview still assigns identity DTOs to orbit-common

### Description

## Problem
`docs/design/host-registry/1_overview.md` still names `orbit-common` as the owner of persistence-neutral host/workspace identity DTOs and lists `crates/orbit-common/src/types/host.rs` and `crates/orbit-common/src/types/workspace.rs` in `paths`. Those files do not exist at `eb26940c037ce255b6c28c0378c9276ab38cc75e` (frozen delivery-qa through_inclusive) or at current `agent-main` HEAD. Sibling docs `2_design.md`, `3_vision.md`, `4_decisions.md`, and `references/glossary.md` already assign the same primitives to `orbit-types` (`crates/orbit-types/src/identity/host.rs`).

ORB-11572 / PR #1529 corrected `2_design.md` and `4_decisions.md` only. The overview was left stale and remains stale after later doc-duties runs (`last_validated: 2026-09-05`).

## Why It Matters
The overview is the entry document for host-registry ownership. Readers and later doc-duties passes can treat orbit-common as the identity DTO owner even though the code and the rest of the feature set moved to orbit-types.

## Reproduction
1. `ls crates/orbit-common/src/types/host.rs crates/orbit-common/src/types/workspace.rs` — missing.
2. `ls crates/orbit-types/src/identity/host.rs` — present.
3. `rg orbit-common docs/design/host-registry/1_overview.md` — paths frontmatter plus ownership table and following sentence.
4. Compare `docs/design/host-registry/2_design.md` layer table (`orbit-types`).

## Constraints / Notes
- Found during ORB-12311 delivery-qa of frozen batch 8776456c (PRs #1527–#1536 plus unattributed neighbors through `eb26940c`).
- Documentation-only; no runtime change.
- Keep the overview's other claims unless they fail a source check in the same edit.

### Acceptance Criteria

- docs/design/host-registry/1_overview.md paths and ownership table name orbit-types for persistence-neutral host/workspace identity DTOs, matching crates/orbit-types/src/identity/host.rs.
- The overview no longer cites crates/orbit-common/src/types/host.rs or crates/orbit-common/src/types/workspace.rs.
- Sibling host-registry design docs remain consistent on the same ownership.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `docs/design/host-registry/1_overview.md` paths to the canonical `orbit-types` identity and workspace registry files.
- Renamed the ownership-table layer from `orbit-common` to `orbit-types` and updated the adjacent boundary sentence.
- Scope remained limited to the existing context file; no new files or runtime code changed.

Acceptance criteria:
- Passed: overview paths and ownership table name `orbit-types` for persistence-neutral host/workspace identity DTOs, matching `crates/orbit-types/src/identity/host.rs`.
- Passed: overview contains no `orbit-common` ownership or stale host/workspace type paths.
- Passed: sibling host-registry docs remain consistent on `orbit-types` ownership; canonical source files `crates/orbit-types/src/identity/host.rs` and `crates/orbit-types/src/workspace/registry.rs` were verified present.

Validation:
- Passed: targeted documentation/source checks (overview stale-reference absence, sibling ownership consistency, canonical source-file presence).
- Passed: `make ci-fast` (exit 0).
- Passed: `git diff --check`.
- Passed: final `GIT_OPTIONAL_LOCKS=0 git status --short`; only the intended overview file is modified.
- Note: `make ci-fast` reported `test-compiler-cache-namespaces` skipped because this environment cannot create an unprivileged bubblewrap mount namespace; the remaining guardrails completed successfully.

Assessment: Documentation-only correction is complete and consistent with current code ownership. Remaining risk is limited to the environment-specific namespace subcheck not executing.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12313-6aa53594`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra