### PR TITLE
Extract PipelineWorkerSupervisor from OrbitRuntime's worker lifecycle methods

### DIFF
--- a/crates/orbit-core/src/application/job/pipeline/mod.rs
+++ b/crates/orbit-core/src/application/job/pipeline/mod.rs
@@ -69,7 +69,7 @@ pub use wait::{PipelineWaitEntry, PipelineWaitResult, pipeline_wait_status_is_su
 #[cfg(test)]
 pub(crate) use worker::command::{
     configure_pipeline_worker_command, pipeline_worker_profile_file, pipeline_worker_root_override,
-    resolve_pipeline_worker_executable, worker_command_override, worker_observer_read_counter,
+    resolve_pipeline_worker_executable, worker_command_override,
 };
 pub(crate) use worker::command::{run_definition_snapshot_path, workspace_auto_run_input};
 #[cfg(test)]
@@ -77,6 +77,8 @@ pub(crate) use worker::log::configure_pipeline_worker_stdio;
 pub(crate) use worker::log::pipeline_worker_log_path;
 #[cfg(all(test, unix))]
 pub(crate) use worker::log::pipeline_worker_log_test_hook;
+#[cfg(test)]
+pub(crate) use worker::supervisor::worker_observer_read_counter;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct PipelineInvokeResult {

--- a/crates/orbit-core/src/application/job/pipeline/worker/command.rs
+++ b/crates/orbit-core/src/application/job/pipeline/worker/command.rs
@@ -191,81 +191,36 @@ pub(crate) mod worker_command_override {
     }
 }
 
-#[cfg(test)]
-pub(crate) mod worker_observer_read_counter {
-    use std::collections::HashMap;
-    use std::path::PathBuf;
-    use std::sync::{LazyLock, Mutex};
-
-    use crate::OrbitRuntime;
-
-    type StoreRun = (PathBuf, String);
-
-    static COUNTS: LazyLock<Mutex<HashMap<StoreRun, usize>>> =
-        LazyLock::new(|| Mutex::new(HashMap::new()));
-
-    pub(crate) struct Counter {
-        key: StoreRun,
-    }
-
-    fn key(runtime: &OrbitRuntime, run_id: &str) -> StoreRun {
-        // Run IDs are local to a database. Its resolved path remains stable
-        // across runtime clones while isolating independent temporary stores.
-        (
-            runtime.context.persistence().audit_db.clone(),
-            run_id.to_string(),
-        )
-    }
-
-    pub(crate) fn track(runtime: &OrbitRuntime, run_id: &str) -> Counter {
-        let key = key(runtime, run_id);
-        COUNTS
-            .lock()
-            .expect("test observer counters are not poisoned")
-            .insert(key.clone(), 0);
-        Counter { key }
-    }
-
-    pub(crate) fn record(runtime: &OrbitRuntime, run_id: &str) {
-        if let Some(count) = COUNTS
-            .lock()
-            .expect("test observer counters are not poisoned")
-            .get_mut(&key(runtime, run_id))
-        {
-            *count += 1;
-        }
-    }
-
-    impl Counter {
-        pub(crate) fn reads(&self) -> usize {
-            *COUNTS
-                .lock()
-                .expect("test observer counters are not poisoned")
-                .get(&self.key)
-                .expect("tracked observer counter exists")
-        }
-    }
-
-    impl Drop for Counter {
-        fn drop(&mut self) {
-            COUNTS
-                .lock()
-                .expect("test observer counters are not poisoned")
-                .remove(&self.key);
-        }
-    }
+/// How this workspace launches a detached worker process.
+///
+/// Production re-execs this same `orbit` binary at the hidden worker
+/// subcommand; workspace context comes from the child's cwd. The one piece of
+/// launch policy that cannot be derived at the call site is whether the parent
+/// runtime was pinned to a single root, so this carries it.
+#[derive(Clone, Debug)]
+pub(crate) struct WorkerCommandConfig {
+    /// `--root` to forward to the worker, so the child opens the same global
+    /// store the parent used to persist the run [ORB-10821]. `None` for the
+    /// default split-root layout; see [`pipeline_worker_root_override`].
+    root_override: Option<PathBuf>,
 }
 
-impl OrbitRuntime {
-    /// The program a detached worker runs: this same `orbit` binary, re-entered
-    /// at the hidden worker subcommand. Workspace context is discovered by cwd;
-    /// an explicit parent `--root` is forwarded so the child opens the same
-    /// global store the parent used to persist the run [ORB-10821].
-    pub(super) fn pipeline_worker_command(&self, run_id: &str) -> Result<Command, OrbitError> {
-        let paths = self.paths();
+impl WorkerCommandConfig {
+    pub(crate) fn for_paths(paths: &WorkspacePaths) -> Self {
+        Self {
+            root_override: pipeline_worker_root_override(paths).map(Path::to_path_buf),
+        }
+    }
+
+    /// The command that runs `run_id`'s worker from `workspace`.
+    pub(crate) fn build(&self, workspace: &Path, run_id: &str) -> Result<Command, OrbitError> {
         #[cfg(test)]
         {
-            worker_command_override::command(&paths.repo_root, run_id).ok_or_else(|| {
+            // A test binary must never re-exec itself, so an in-crate test
+            // substitutes its own program and there is no `orbit` invocation
+            // left to forward the pinned root to.
+            let _pinned_root = self.root_override.as_deref();
+            worker_command_override::command(workspace, run_id).ok_or_else(|| {
                 OrbitError::Execution(
                     "test pipeline worker requires an explicit worker command override".to_string(),
                 )
@@ -280,81 +235,11 @@ impl OrbitRuntime {
             let mut command = Command::new(resolve_pipeline_worker_executable(current_exe));
             configure_pipeline_worker_command(
                 &mut command,
-                &paths.repo_root,
+                workspace,
                 run_id,
-                pipeline_worker_root_override(paths),
+                self.root_override.as_deref(),
             );
             Ok(command)
         }
-    }
-    pub(crate) fn spawn_pipeline_worker_process(
-        &self,
-        run_id: &str,
-        actor: Option<&str>,
-        mut command: Command,
-        worker_log: PipelineWorkerLog,
-    ) -> Result<u32, OrbitError> {
-        let PipelineWorkerLog {
-            path: worker_log,
-            reader: worker_log_reader,
-        } = worker_log;
-
-        #[cfg(unix)]
-        unsafe {
-            command.pre_exec(|| {
-                if libc::setsid() == -1 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                Ok(())
-            });
-        }
-
-        // Start the observer before the process so every successfully spawned
-        // worker has a parent-side path that can terminalize a pre-claim exit.
-        // Cwd still carries the registered workspace. `--root` is forwarded
-        // only when the parent itself was pinned (see
-        // `pipeline_worker_root_override`); passing the workspace `.orbit`
-        // path here used to pin both roots and disconnect the worker from
-        // `$HOME/.orbit/orbit.db`.
-        let (sender, receiver) = mpsc::sync_channel::<Child>(1);
-        let runtime = self.clone();
-        let run_id_for_observer = run_id.to_string();
-        let actor_for_observer = actor.map(ToOwned::to_owned);
-        let workspace_for_observer = self.paths().repo_root.clone();
-        let worker_log_for_observer = worker_log.clone();
-        thread::Builder::new()
-            .name(format!("pipeline-start-{run_id}"))
-            .spawn(move || {
-                let Ok(child) = receiver.recv() else {
-                    return;
-                };
-                if let Err(error) = runtime.monitor_pipeline_worker_startup(
-                    &run_id_for_observer,
-                    child,
-                    &workspace_for_observer,
-                    &worker_log_for_observer,
-                    worker_log_reader,
-                    actor_for_observer.as_deref(),
-                ) {
-                    tracing::error!(
-                        target: "orbit.core.job_run",
-                        run_id = run_id_for_observer,
-                        error = %error,
-                        "failed to observe pipeline worker startup",
-                    );
-                }
-            })
-            .map_err(|error| {
-                OrbitError::Execution(format!("spawn pipeline worker observer: {error}"))
-            })?;
-
-        let child = command
-            .spawn()
-            .map_err(|error| OrbitError::Execution(format!("spawn pipeline worker: {error}")))?;
-        let child_pid = child.id();
-        sender.send(child).map_err(|error| {
-            OrbitError::Execution(format!("hand pipeline worker to startup observer: {error}"))
-        })?;
-        Ok(child_pid)
     }
 }

--- a/crates/orbit-core/src/application/job/pipeline/worker/mod.rs
+++ b/crates/orbit-core/src/application/job/pipeline/worker/mod.rs
@@ -1,12 +1,32 @@
+//! The worker side of a pipeline run, split by who owns which half.
+//!
+//! - `command` / `log` — how a worker process is launched and where its stdio
+//!   lands.
+//! - `supervisor` — the parent-side [`PipelineWorkerSupervisor`] that spawns a
+//!   worker, watches its startup, and settles a run whose worker died.
+//! - `record` — the store writes both sides share.
+//!
+//! What stays on [`OrbitRuntime`] here is the *child* process's own work:
+//! executing the run it was handed, plus thin delegations to the supervisor
+//! for callers that already hold a runtime.
+
+use std::sync::Arc;
+
 use super::*;
 use command::*;
 use log::*;
+use supervisor::PipelineWorkerSupervisor;
 
 use super::admission::pipeline_run_is_runnable;
 use super::wait::PIPELINE_WAIT_MIN_POLL_SECONDS;
 
 pub(super) mod command;
 pub(super) mod log;
+mod record;
+pub(super) mod supervisor;
+
+#[cfg(test)]
+mod tests;
 
 impl OrbitRuntime {
     pub fn execute_pipeline_run_worker(&self, run_id: &str) -> Result<(), OrbitError> {
@@ -254,48 +274,15 @@ impl OrbitRuntime {
         message: &str,
         state: JobRunState,
     ) -> Result<(), OrbitError> {
-        let current = self
-            .get_job_run_backend(&run.run_id)?
-            .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run.run_id.clone()))?;
-        let already_has_error = current
-            .steps
-            .iter()
-            .any(|step| step.error_code.is_some() || step.error_message.is_some());
-        if already_has_error {
-            return Ok(());
-        }
-
-        let step_index = current
-            .steps
-            .iter()
-            .map(|step| step.step_index)
-            .max()
-            .map(|index| index.saturating_add(1) as usize)
-            .unwrap_or(0);
-        let duration_ms = Some(
-            finished_at
-                .signed_duration_since(started_at)
-                .num_milliseconds()
-                .max(0) as u64,
-        );
-        let params = JobRunStepParams {
-            step_index,
-            target_type: JobTargetType::Job,
-            target_id: run.job_id.clone(),
+        record::diagnostic_step(
+            self.stores().jobs(),
+            run,
             started_at,
             finished_at,
-            duration_ms,
-            exit_code: None,
-            agent_response_json: None,
+            error_code,
+            message,
             state,
-            error_code: error_code.map(str::to_string),
-            error_message: Some(message.to_string()),
-        };
-        let _ = self
-            .stores()
-            .jobs()
-            .complete_job_run_step(&run.run_id, &params)?;
-        Ok(())
+        )
     }
     /// [ORB-12038] Read a run's own `<run_id>.worker.log`, for a caller (`orbit
     /// run logs`) that found no audited CLI-invocation blobs to show. A run
@@ -325,165 +312,44 @@ impl OrbitRuntime {
         let content = read_pipeline_worker_log_tail(&mut file);
         Ok(Some(PipelineWorkerLogSnapshot { path, content }))
     }
+    /// Worker supervision for this runtime's workspace.
+    ///
+    /// Built per call: supervision is a short-lived unit of work, and a fresh
+    /// one always reflects the runtime's current handles.
+    fn pipeline_worker_supervisor(&self) -> PipelineWorkerSupervisor {
+        PipelineWorkerSupervisor::new(
+            Arc::clone(&self.stores().job_run),
+            Arc::clone(&self.stores().audit_event),
+            self.paths().clone(),
+            self.event_log.clone(),
+            WorkerCommandConfig::for_paths(self.paths()),
+            Arc::new(self.clone()),
+        )
+    }
     pub(super) fn spawn_pipeline_worker(
         &self,
         run_id: &str,
         actor: Option<&str>,
     ) -> Result<(), OrbitError> {
-        let mut command = self.pipeline_worker_command(run_id)?;
-        let worker_log =
-            configure_pipeline_worker_stdio(&mut command, &self.paths().logs_dir, run_id)?;
-        self.spawn_pipeline_worker_process(run_id, actor, command, worker_log)
-            .map(|_| ())
+        self.pipeline_worker_supervisor().spawn(run_id, actor)
     }
-    pub(crate) fn monitor_pipeline_worker_startup(
+    /// Spawn an already-built worker command. Production spawns go through
+    /// [`PipelineWorkerSupervisor::spawn`]; this is the runtime-shaped entry
+    /// point in-crate tests use to launch a worker fixture.
+    #[cfg(test)]
+    pub(crate) fn spawn_pipeline_worker_process(
         &self,
         run_id: &str,
-        mut child: Child,
-        workspace: &Path,
-        worker_log: &Path,
-        mut worker_log_reader: File,
         actor: Option<&str>,
-    ) -> Result<(), OrbitError> {
-        let child_pid = child.id();
-        let mut claimed = false;
-        loop {
-            #[cfg(test)]
-            worker_observer_read_counter::record(self, run_id);
-            let run = self
-                .get_job_run_backend(run_id)?
-                .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string()))?;
-            if run.pid == Some(child_pid) && !claimed {
-                let _ = self.record_pipeline_audit(
-                    "pipeline.worker.claimed",
-                    Some(run_id),
-                    actor,
-                    AuditEventStatus::Success,
-                    json!({
-                        "run_id": run_id,
-                        "worker_pid": child_pid,
-                        "owner_pid": child_pid,
-                        "workspace": workspace,
-                        "worker_log": worker_log,
-                        "state": run.state.to_string(),
-                    }),
-                    None,
-                );
-                claimed = true;
-            }
-
-            // A persisted owner or non-pending state settles the only startup
-            // question this observer owns. Waiting for the child avoids a
-            // full run/step SQLite read every 25ms throughout normal work.
-            let status = if run.pid.is_some() || run.state != JobRunState::Pending {
-                Some(child.wait().map_err(|error| {
-                    OrbitError::Execution(format!(
-                        "wait for pipeline worker process for run '{run_id}': {error}"
-                    ))
-                })?)
-            } else {
-                child.try_wait().map_err(|error| {
-                    OrbitError::Execution(format!(
-                        "observe pipeline worker process for run '{run_id}': {error}"
-                    ))
-                })?
-            };
-
-            if let Some(status) = status {
-                // The worker may have changed the run after the last startup
-                // observation. Exit handling must use fresh state so duplicate
-                // ownership, cancellation, and terminal outcomes stay
-                // authoritative.
-                #[cfg(test)]
-                worker_observer_read_counter::record(self, run_id);
-                let run = self.get_job_run_backend(run_id)?.ok_or_else(|| {
-                    OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string())
-                })?;
-                let output = read_pipeline_worker_log_tail(&mut worker_log_reader);
-                let output_detail = output
-                    .as_deref()
-                    .filter(|value| !value.is_empty())
-                    .map(|value| format!("; worker output:\n{value}"))
-                    .unwrap_or_default();
-                // [ORB-11116] A second worker can lose the atomic Start race
-                // and exit successfully while the incumbent's PID remains on
-                // the run. Only this observer's exact child PID establishes
-                // ownership; another non-null PID is a benign duplicate
-                // delivery, not evidence that this child abandoned the run.
-                if let Some(owner_pid) = run.pid.filter(|owner_pid| *owner_pid != child_pid) {
-                    tracing::info!(
-                        target: "orbit.core.job_run",
-                        run_id,
-                        worker_pid = child_pid,
-                        owner_pid,
-                        exit_status = %status,
-                        "duplicate pipeline worker exited without owning the persisted run",
-                    );
-                    let _ = self.record_pipeline_audit(
-                        "pipeline.worker.duplicate",
-                        Some(run_id),
-                        actor,
-                        AuditEventStatus::Success,
-                        json!({
-                            "run_id": run_id,
-                            "worker_pid": child_pid,
-                            "owner_pid": owner_pid,
-                            "workspace": workspace,
-                            "worker_log": worker_log,
-                            "state": run.state.to_string(),
-                            "exit_status": status.to_string(),
-                        }),
-                        None,
-                    );
-                    return Ok(());
-                }
-                #[cfg(unix)]
-                if let Some(signal) = status
-                    .signal()
-                    .filter(|signal| matches!(*signal, libc::SIGTERM | libc::SIGKILL))
-                    && self.record_pipeline_worker_cancellation_exit(
-                        &run,
-                        signal,
-                        &status.to_string(),
-                        actor,
-                    )?
-                {
-                    // The cancelling caller owns terminalization after it has
-                    // verified both the recorded leader and process group are
-                    // gone. Reaping the worker proves only the leader exited;
-                    // finalizing here could release reservations while a
-                    // run-owned child remains alive.
-                    return Ok(());
-                }
-                if run.state.is_terminal() {
-                    return Ok(());
-                }
-                let ownership = if run.pid == Some(child_pid) {
-                    "after claiming"
-                } else {
-                    "before claiming"
-                };
-                let message = format!(
-                    "pipeline worker for run '{run_id}' exited with status {status} {ownership} \
-                     the persisted run from registered workspace '{}'; worker log: \
-                     '{}'{output_detail}; verify workspace registration, worker root discovery, \
-                     and action availability",
-                    workspace.display(),
-                    worker_log.display(),
-                );
-                self.finalize_pipeline_worker_exit_failure(&run, &message, actor)?;
-                return Ok(());
-            }
-
-            thread::sleep(Duration::from_millis(25));
-        }
+        command: Command,
+        worker_log: PipelineWorkerLog,
+    ) -> Result<u32, OrbitError> {
+        self.pipeline_worker_supervisor()
+            .spawn_process(run_id, actor, command, worker_log)
     }
-    /// Record a TERM/KILL worker exit that belongs to an outstanding
-    /// cancellation request, without terminalizing the run. The signalling
-    /// caller performs the authoritative liveness verification and then
-    /// finalizes `cancelled`; this observer only preserves the completion
-    /// cause and suppresses the misleading generic worker-failure path.
-    #[cfg(unix)]
+    /// Runtime-shaped entry point for the cancellation-race test; the
+    /// observer itself records this through the supervisor.
+    #[cfg(all(test, unix))]
     pub(crate) fn record_pipeline_worker_cancellation_exit(
         &self,
         run: &JobRun,
@@ -491,89 +357,8 @@ impl OrbitRuntime {
         exit_status: &str,
         actor: Option<&str>,
     ) -> Result<bool, OrbitError> {
-        let Some(request_id) = self.active_job_run_cancellation_request(&run.run_id)? else {
-            return Ok(false);
-        };
-        self.record_pipeline_audit(
-            CANCELLATION_WORKER_EXIT_AUDIT,
-            Some(&run.run_id),
-            actor,
-            AuditEventStatus::Success,
-            json!({
-                "request_id": request_id,
-                "run_id": run.run_id,
-                "owner_pid": run.pid,
-                "signal": signal,
-                "signal_name": worker_cancellation_signal_name(signal),
-                "exit_status": exit_status,
-                "observed_at": Utc::now().to_rfc3339(),
-            }),
-            None,
-        )?;
-        Ok(true)
-    }
-    /// Terminalize a worker process that exited while it still owned a
-    /// non-terminal run. `try_wait` has already reaped the process when this is
-    /// called. Pending exits are interrupted startup; a worker that reached
-    /// running failed its claimed execution.
-    fn finalize_pipeline_worker_exit_failure(
-        &self,
-        run: &JobRun,
-        message: &str,
-        actor: Option<&str>,
-    ) -> Result<(), OrbitError> {
-        let current = self
-            .get_job_run_backend(&run.run_id)?
-            .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run.run_id.clone()))?;
-        let (state, started_at, audit_name) = match current.state {
-            JobRunState::Pending => (
-                JobRunState::Interrupted,
-                current.scheduled_at,
-                "pipeline.worker.startup",
-            ),
-            JobRunState::Running => (
-                JobRunState::Failed,
-                current.started_at.unwrap_or(current.scheduled_at),
-                "pipeline.worker.exit",
-            ),
-            _ => return Ok(()),
-        };
-        let finished_at = Utc::now();
-        self.record_pipeline_diagnostic_step(
-            &current,
-            started_at,
-            finished_at,
-            None,
-            message,
-            state,
-        )?;
-        let changed = self.finalize_job_run_with_reservation_cleanup(
-            &current.run_id,
-            state,
-            finished_at,
-            None,
-            TaskReservationReleaseReason::RunTerminal,
-        )?;
-        if changed {
-            self.record_event(OrbitEvent::JobRunCompleted {
-                job_id: current.job_id.clone(),
-                run_id: current.run_id.clone(),
-                state: state.to_string(),
-            })?;
-        }
-        let worker_log = pipeline_worker_log_path(&self.paths().logs_dir, &current.run_id)?;
-        self.record_pipeline_audit(
-            audit_name,
-            Some(&current.run_id),
-            actor,
-            AuditEventStatus::Failure,
-            json!({
-                "run_id": current.run_id,
-                "workspace": self.paths().repo_root,
-                "worker_log": worker_log,
-            }),
-            Some(message.to_string()),
-        )
+        self.pipeline_worker_supervisor()
+            .record_cancellation_exit(run, signal, exit_status, actor)
     }
     pub(super) fn finalize_pipeline_worker_startup_failure(
         &self,
@@ -581,50 +366,8 @@ impl OrbitRuntime {
         message: &str,
         actor: Option<&str>,
     ) -> Result<(), OrbitError> {
-        let current = self.show_job_run(&run.run_id)?;
-        if current.state != JobRunState::Pending || current.pid.is_some() {
-            return Ok(());
-        }
-
-        let finished_at = Utc::now();
-        // Persist the diagnostic step before terminalizing the run: an observer
-        // polling for a terminal state must never be able to see one without its
-        // startup diagnostic already durable.
-        self.record_pipeline_diagnostic_step(
-            run,
-            run.scheduled_at,
-            finished_at,
-            None,
-            message,
-            JobRunState::Interrupted,
-        )?;
-        let changed = self.finalize_job_run_with_reservation_cleanup(
-            &run.run_id,
-            JobRunState::Interrupted,
-            finished_at,
-            None,
-            TaskReservationReleaseReason::RunTerminal,
-        )?;
-        if changed {
-            self.record_event(OrbitEvent::JobRunCompleted {
-                job_id: run.job_id.clone(),
-                run_id: run.run_id.clone(),
-                state: JobRunState::Interrupted.to_string(),
-            })?;
-        }
-        let worker_log = pipeline_worker_log_path(&self.paths().logs_dir, &run.run_id)?;
-        self.record_pipeline_audit(
-            "pipeline.worker.startup",
-            Some(&run.run_id),
-            actor,
-            AuditEventStatus::Failure,
-            json!({
-                "run_id": run.run_id,
-                "workspace": self.paths().repo_root,
-                "worker_log": worker_log,
-            }),
-            Some(message.to_string()),
-        )
+        self.pipeline_worker_supervisor()
+            .finalize_startup_failure(run, message, actor)
     }
     pub(crate) fn record_pipeline_audit(
         &self,
@@ -635,56 +378,17 @@ impl OrbitRuntime {
         arguments: Value,
         error_message: Option<String>,
     ) -> Result<(), OrbitError> {
-        let arguments_json = serde_json::to_string(&arguments).map_err(|error| {
-            OrbitError::Store(format!("serialize pipeline audit args: {error}"))
-        })?;
-        let execution_id = audit_execution_id("exec");
-        self.record_audit_event(&AuditEventInsertParams {
-            execution_id,
-            command: "tool".to_string(),
-            subcommand: Some("run".to_string()),
-            tool_name: Some(tool_name.to_string()),
-            target_type: Some("job_run".to_string()),
-            target_id: target_id.map(ToOwned::to_owned),
-            role: "admin".to_string(),
-            status,
-            exit_code: if status == AuditEventStatus::Success {
-                0
-            } else {
-                1
+        record::pipeline_audit(
+            self.stores().audit_events(),
+            &self.paths().repo_root,
+            record::PipelineAuditRow {
+                tool_name,
+                target_id,
+                actor,
+                status,
+                arguments,
+                error_message,
             },
-            duration_ms: 0,
-            working_directory: self.paths().repo_root.display().to_string(),
-            arguments_json: Some(arguments_json),
-            stdout_truncated: None,
-            stderr_truncated: None,
-            error_message,
-            host: actor.map(ToOwned::to_owned),
-            pid: std::process::id(),
-            session_id: None,
-            workspace_id: None,
-            caller_machine_id: None,
-            caller_host_id: None,
-            process_machine_id: None,
-            process_host_id: None,
-            transport: None,
-            effective_capabilities: Default::default(),
-            origin_session_id: None,
-            mcp_call_id: None,
-            lease_id: None,
-            task_id: None,
-            job_run_id: target_id.map(ToOwned::to_owned),
-            activity_id: None,
-            step_index: None,
-        })
-    }
-}
-
-#[cfg(unix)]
-fn worker_cancellation_signal_name(signal: i32) -> &'static str {
-    match signal {
-        libc::SIGTERM => "SIGTERM",
-        libc::SIGKILL => "SIGKILL",
-        _ => "unknown",
+        )
     }
 }

--- a/crates/orbit-core/src/application/job/pipeline/worker/record.rs
+++ b/crates/orbit-core/src/application/job/pipeline/worker/record.rs
@@ -1,0 +1,126 @@
+//! Store-level writers for the two rows worker supervision persists: a run's
+//! terminal diagnostic step and a pipeline audit event.
+//!
+//! Both are plain store writes, so they take the backend they write through
+//! rather than a runtime. [`OrbitRuntime`](crate::OrbitRuntime) and
+//! [`PipelineWorkerSupervisor`](super::supervisor::PipelineWorkerSupervisor)
+//! share these implementations instead of keeping two copies of the row shape.
+
+use chrono::DateTime;
+use orbit_store::contracts::{AuditEventStoreBackend, JobRunStoreBackend};
+
+use super::*;
+
+/// One pipeline audit row, as its callers describe it.
+pub(crate) struct PipelineAuditRow<'a> {
+    pub(crate) tool_name: &'a str,
+    pub(crate) target_id: Option<&'a str>,
+    pub(crate) actor: Option<&'a str>,
+    pub(crate) status: AuditEventStatus,
+    pub(crate) arguments: Value,
+    pub(crate) error_message: Option<String>,
+}
+
+pub(crate) fn pipeline_audit(
+    audit_events: &dyn AuditEventStoreBackend,
+    working_directory: &Path,
+    row: PipelineAuditRow<'_>,
+) -> Result<(), OrbitError> {
+    let arguments_json = serde_json::to_string(&row.arguments)
+        .map_err(|error| OrbitError::Store(format!("serialize pipeline audit args: {error}")))?;
+    let execution_id = audit_execution_id("exec");
+    audit_events.insert_audit_event_record(&AuditEventInsertParams {
+        execution_id,
+        command: "tool".to_string(),
+        subcommand: Some("run".to_string()),
+        tool_name: Some(row.tool_name.to_string()),
+        target_type: Some("job_run".to_string()),
+        target_id: row.target_id.map(ToOwned::to_owned),
+        role: "admin".to_string(),
+        status: row.status,
+        exit_code: if row.status == AuditEventStatus::Success {
+            0
+        } else {
+            1
+        },
+        duration_ms: 0,
+        working_directory: working_directory.display().to_string(),
+        arguments_json: Some(arguments_json),
+        stdout_truncated: None,
+        stderr_truncated: None,
+        error_message: row.error_message,
+        host: row.actor.map(ToOwned::to_owned),
+        pid: std::process::id(),
+        session_id: None,
+        workspace_id: None,
+        caller_machine_id: None,
+        caller_host_id: None,
+        process_machine_id: None,
+        process_host_id: None,
+        transport: None,
+        effective_capabilities: Default::default(),
+        origin_session_id: None,
+        mcp_call_id: None,
+        lease_id: None,
+        task_id: None,
+        job_run_id: row.target_id.map(ToOwned::to_owned),
+        activity_id: None,
+        step_index: None,
+    })
+}
+
+/// [ORB-10002] Record a terminal diagnostic step with an explicit state
+/// (`failed` for job errors, `interrupted` for orphan reconciliation).
+///
+/// The first recorded error wins: a run that already carries one keeps it, so
+/// a later supervisor observation cannot overwrite the cause the worker
+/// itself reported.
+pub(crate) fn diagnostic_step(
+    runs: &dyn JobRunStoreBackend,
+    run: &JobRun,
+    started_at: DateTime<Utc>,
+    finished_at: DateTime<Utc>,
+    error_code: Option<&str>,
+    message: &str,
+    state: JobRunState,
+) -> Result<(), OrbitError> {
+    let current = runs
+        .get_job_run(&run.run_id)?
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run.run_id.clone()))?;
+    let already_has_error = current
+        .steps
+        .iter()
+        .any(|step| step.error_code.is_some() || step.error_message.is_some());
+    if already_has_error {
+        return Ok(());
+    }
+
+    let step_index = current
+        .steps
+        .iter()
+        .map(|step| step.step_index)
+        .max()
+        .map(|index| index.saturating_add(1) as usize)
+        .unwrap_or(0);
+    let duration_ms = Some(
+        finished_at
+            .signed_duration_since(started_at)
+            .num_milliseconds()
+            .max(0) as u64,
+    );
+    let params = JobRunStepParams {
+        step_index,
+        target_type: JobTargetType::Job,
+        target_id: run.job_id.clone(),
+        started_at,
+        finished_at,
+        duration_ms,
+        exit_code: None,
+        agent_response_json: None,
+        state,
+        error_code: error_code.map(str::to_string),
+        error_message: Some(message.to_string()),
+    };
+    let _ = runs.complete_job_run_step(&run.run_id, &params)?;
+    Ok(())
+}

--- a/crates/orbit-core/src/application/job/pipeline/worker/supervisor.rs
+++ b/crates/orbit-core/src/application/job/pipeline/worker/supervisor.rs
@@ -1,0 +1,589 @@
+//! Supervision of a detached pipeline worker process.
+//!
+//! A submitted run is executed by a child `orbit` process. Between spawning
+//! that child and its exit, something on the parent side must watch it: record
+//! when it claims the persisted run, reap it, and translate an exit that left
+//! the run non-terminal into a diagnostic step, a terminal state, and an audit
+//! row. That is one job, and [`PipelineWorkerSupervisor`] owns it.
+//!
+//! The supervisor is built from the handles that work needs — the run and
+//! audit stores, workspace paths, the session event log, the worker command
+//! configuration, and a [`PipelineRunHost`] for the two run-lifecycle steps it
+//! must not own — so its failure paths can be exercised against a store alone.
+//! [`OrbitRuntime`] keeps its worker methods as thin delegations.
+
+use std::sync::Arc;
+
+use chrono::DateTime;
+use orbit_store::contracts::{AuditEventStoreBackend, JobRunStoreBackend};
+
+use super::command::WorkerCommandConfig;
+use super::record::{self, PipelineAuditRow};
+use super::*;
+use crate::runtime::event_bus::EventLog;
+
+#[cfg(unix)]
+use crate::application::job::run::active_cancellation_request;
+
+/// The run-lifecycle steps worker supervision delegates back to its host.
+///
+/// Terminalizing a run releases the run's task reservations and blocks the
+/// tasks coupled to it, and a reconciled read repairs stale run records:
+/// task-domain and reconciliation work that belongs to [`OrbitRuntime`], not
+/// to a process supervisor. Keeping exactly those two steps behind this seam
+/// is what lets the rest of supervision run without a runtime.
+pub(crate) trait PipelineRunHost: Send + Sync {
+    /// The run as `orbit run show` reports it, after stale-run reconciliation.
+    fn reconciled_run(&self, run_id: &str) -> Result<JobRun, OrbitError>;
+
+    /// Terminalize `run_id`, releasing the task reservations it owns. Returns
+    /// whether this call performed the terminal write.
+    fn terminalize_run(
+        &self,
+        run_id: &str,
+        state: JobRunState,
+        finished_at: DateTime<Utc>,
+    ) -> Result<bool, OrbitError>;
+}
+
+impl PipelineRunHost for OrbitRuntime {
+    fn reconciled_run(&self, run_id: &str) -> Result<JobRun, OrbitError> {
+        self.show_job_run(run_id)
+    }
+
+    fn terminalize_run(
+        &self,
+        run_id: &str,
+        state: JobRunState,
+        finished_at: DateTime<Utc>,
+    ) -> Result<bool, OrbitError> {
+        self.finalize_job_run_with_reservation_cleanup(
+            run_id,
+            state,
+            finished_at,
+            None,
+            TaskReservationReleaseReason::RunTerminal,
+        )
+    }
+}
+
+/// Owns one workspace's detached worker processes: spawning them, watching
+/// startup, and terminalizing a run whose worker died.
+///
+/// Cloneable and `'static` because the startup observer runs on its own
+/// thread: it outlives the spawning call and must carry its own handles.
+#[derive(Clone)]
+pub(crate) struct PipelineWorkerSupervisor {
+    runs: Arc<dyn JobRunStoreBackend>,
+    audit_events: Arc<dyn AuditEventStoreBackend>,
+    paths: WorkspacePaths,
+    event_log: EventLog,
+    command: WorkerCommandConfig,
+    host: Arc<dyn PipelineRunHost>,
+}
+
+impl PipelineWorkerSupervisor {
+    pub(crate) fn new(
+        runs: Arc<dyn JobRunStoreBackend>,
+        audit_events: Arc<dyn AuditEventStoreBackend>,
+        paths: WorkspacePaths,
+        event_log: EventLog,
+        command: WorkerCommandConfig,
+        host: Arc<dyn PipelineRunHost>,
+    ) -> Self {
+        Self {
+            runs,
+            audit_events,
+            paths,
+            event_log,
+            command,
+            host,
+        }
+    }
+
+    /// The registered workspace every worker of this supervisor runs in, and
+    /// the one named in its audit rows.
+    fn workspace(&self) -> &Path {
+        &self.paths.repo_root
+    }
+
+    /// Launch a detached worker for `run_id` and start watching its startup.
+    pub(crate) fn spawn(&self, run_id: &str, actor: Option<&str>) -> Result<(), OrbitError> {
+        let mut command = self.command.build(self.workspace(), run_id)?;
+        let worker_log =
+            configure_pipeline_worker_stdio(&mut command, &self.paths.logs_dir, run_id)?;
+        self.spawn_process(run_id, actor, command, worker_log)
+            .map(|_| ())
+    }
+
+    /// Spawn `command` as this run's worker, returning its PID.
+    ///
+    /// The startup observer is started *before* the process so every
+    /// successfully spawned worker has a parent-side path that can terminalize
+    /// a pre-claim exit.
+    pub(crate) fn spawn_process(
+        &self,
+        run_id: &str,
+        actor: Option<&str>,
+        mut command: Command,
+        worker_log: PipelineWorkerLog,
+    ) -> Result<u32, OrbitError> {
+        let PipelineWorkerLog {
+            path: worker_log,
+            reader: worker_log_reader,
+        } = worker_log;
+
+        #[cfg(unix)]
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+
+        let (sender, receiver) = mpsc::sync_channel::<Child>(1);
+        let supervisor = self.clone();
+        let run_id_for_observer = run_id.to_string();
+        let actor_for_observer = actor.map(ToOwned::to_owned);
+        let worker_log_for_observer = worker_log.clone();
+        thread::Builder::new()
+            .name(format!("pipeline-start-{run_id}"))
+            .spawn(move || {
+                let Ok(child) = receiver.recv() else {
+                    return;
+                };
+                if let Err(error) = supervisor.monitor_startup(
+                    &run_id_for_observer,
+                    child,
+                    &worker_log_for_observer,
+                    worker_log_reader,
+                    actor_for_observer.as_deref(),
+                ) {
+                    tracing::error!(
+                        target: "orbit.core.job_run",
+                        run_id = run_id_for_observer,
+                        error = %error,
+                        "failed to observe pipeline worker startup",
+                    );
+                }
+            })
+            .map_err(|error| {
+                OrbitError::Execution(format!("spawn pipeline worker observer: {error}"))
+            })?;
+
+        let child = command
+            .spawn()
+            .map_err(|error| OrbitError::Execution(format!("spawn pipeline worker: {error}")))?;
+        let child_pid = child.id();
+        sender.send(child).map_err(|error| {
+            OrbitError::Execution(format!("hand pipeline worker to startup observer: {error}"))
+        })?;
+        Ok(child_pid)
+    }
+
+    /// Watch `child` until it claims the run or exits, then settle the run.
+    pub(crate) fn monitor_startup(
+        &self,
+        run_id: &str,
+        mut child: Child,
+        worker_log: &Path,
+        mut worker_log_reader: File,
+        actor: Option<&str>,
+    ) -> Result<(), OrbitError> {
+        let workspace = self.workspace();
+        let child_pid = child.id();
+        let mut claimed = false;
+        loop {
+            #[cfg(test)]
+            worker_observer_read_counter::record_in(self.runs.as_ref(), run_id);
+            let run = self
+                .runs
+                .get_job_run(run_id)?
+                .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string()))?;
+            if run.pid == Some(child_pid) && !claimed {
+                let _ = self.record_audit(
+                    "pipeline.worker.claimed",
+                    Some(run_id),
+                    actor,
+                    AuditEventStatus::Success,
+                    json!({
+                        "run_id": run_id,
+                        "worker_pid": child_pid,
+                        "owner_pid": child_pid,
+                        "workspace": workspace,
+                        "worker_log": worker_log,
+                        "state": run.state.to_string(),
+                    }),
+                    None,
+                );
+                claimed = true;
+            }
+
+            // A persisted owner or non-pending state settles the only startup
+            // question this observer owns. Waiting for the child avoids a
+            // full run/step SQLite read every 25ms throughout normal work.
+            let status = if run.pid.is_some() || run.state != JobRunState::Pending {
+                Some(child.wait().map_err(|error| {
+                    OrbitError::Execution(format!(
+                        "wait for pipeline worker process for run '{run_id}': {error}"
+                    ))
+                })?)
+            } else {
+                child.try_wait().map_err(|error| {
+                    OrbitError::Execution(format!(
+                        "observe pipeline worker process for run '{run_id}': {error}"
+                    ))
+                })?
+            };
+
+            if let Some(status) = status {
+                // The worker may have changed the run after the last startup
+                // observation. Exit handling must use fresh state so duplicate
+                // ownership, cancellation, and terminal outcomes stay
+                // authoritative.
+                #[cfg(test)]
+                worker_observer_read_counter::record_in(self.runs.as_ref(), run_id);
+                let run = self.runs.get_job_run(run_id)?.ok_or_else(|| {
+                    OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string())
+                })?;
+                let output = read_pipeline_worker_log_tail(&mut worker_log_reader);
+                let output_detail = output
+                    .as_deref()
+                    .filter(|value| !value.is_empty())
+                    .map(|value| format!("; worker output:\n{value}"))
+                    .unwrap_or_default();
+                // [ORB-11116] A second worker can lose the atomic Start race
+                // and exit successfully while the incumbent's PID remains on
+                // the run. Only this observer's exact child PID establishes
+                // ownership; another non-null PID is a benign duplicate
+                // delivery, not evidence that this child abandoned the run.
+                if let Some(owner_pid) = run.pid.filter(|owner_pid| *owner_pid != child_pid) {
+                    tracing::info!(
+                        target: "orbit.core.job_run",
+                        run_id,
+                        worker_pid = child_pid,
+                        owner_pid,
+                        exit_status = %status,
+                        "duplicate pipeline worker exited without owning the persisted run",
+                    );
+                    let _ = self.record_audit(
+                        "pipeline.worker.duplicate",
+                        Some(run_id),
+                        actor,
+                        AuditEventStatus::Success,
+                        json!({
+                            "run_id": run_id,
+                            "worker_pid": child_pid,
+                            "owner_pid": owner_pid,
+                            "workspace": workspace,
+                            "worker_log": worker_log,
+                            "state": run.state.to_string(),
+                            "exit_status": status.to_string(),
+                        }),
+                        None,
+                    );
+                    return Ok(());
+                }
+                #[cfg(unix)]
+                if let Some(signal) = status
+                    .signal()
+                    .filter(|signal| matches!(*signal, libc::SIGTERM | libc::SIGKILL))
+                    && self.record_cancellation_exit(&run, signal, &status.to_string(), actor)?
+                {
+                    // The cancelling caller owns terminalization after it has
+                    // verified both the recorded leader and process group are
+                    // gone. Reaping the worker proves only the leader exited;
+                    // finalizing here could release reservations while a
+                    // run-owned child remains alive.
+                    return Ok(());
+                }
+                if run.state.is_terminal() {
+                    return Ok(());
+                }
+                let ownership = if run.pid == Some(child_pid) {
+                    "after claiming"
+                } else {
+                    "before claiming"
+                };
+                let message = format!(
+                    "pipeline worker for run '{run_id}' exited with status {status} {ownership} \
+                     the persisted run from registered workspace '{}'; worker log: \
+                     '{}'{output_detail}; verify workspace registration, worker root discovery, \
+                     and action availability",
+                    workspace.display(),
+                    worker_log.display(),
+                );
+                self.finalize_exit_failure(&run, &message, actor)?;
+                return Ok(());
+            }
+
+            thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    /// Record a TERM/KILL worker exit that belongs to an outstanding
+    /// cancellation request, without terminalizing the run. The signalling
+    /// caller performs the authoritative liveness verification and then
+    /// finalizes `cancelled`; this observer only preserves the completion
+    /// cause and suppresses the misleading generic worker-failure path.
+    #[cfg(unix)]
+    pub(crate) fn record_cancellation_exit(
+        &self,
+        run: &JobRun,
+        signal: i32,
+        exit_status: &str,
+        actor: Option<&str>,
+    ) -> Result<bool, OrbitError> {
+        let Some(request_id) =
+            active_cancellation_request(self.audit_events.as_ref(), &run.run_id)?
+        else {
+            return Ok(false);
+        };
+        self.record_audit(
+            CANCELLATION_WORKER_EXIT_AUDIT,
+            Some(&run.run_id),
+            actor,
+            AuditEventStatus::Success,
+            json!({
+                "request_id": request_id,
+                "run_id": run.run_id,
+                "owner_pid": run.pid,
+                "signal": signal,
+                "signal_name": worker_cancellation_signal_name(signal),
+                "exit_status": exit_status,
+                "observed_at": Utc::now().to_rfc3339(),
+            }),
+            None,
+        )?;
+        Ok(true)
+    }
+
+    /// Terminalize a worker process that exited while it still owned a
+    /// non-terminal run. `try_wait` has already reaped the process when this is
+    /// called. Pending exits are interrupted startup; a worker that reached
+    /// running failed its claimed execution.
+    fn finalize_exit_failure(
+        &self,
+        run: &JobRun,
+        message: &str,
+        actor: Option<&str>,
+    ) -> Result<(), OrbitError> {
+        let current = self
+            .runs
+            .get_job_run(&run.run_id)?
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run.run_id.clone()))?;
+        let (state, started_at, audit_name) = match current.state {
+            JobRunState::Pending => (
+                JobRunState::Interrupted,
+                current.scheduled_at,
+                "pipeline.worker.startup",
+            ),
+            JobRunState::Running => (
+                JobRunState::Failed,
+                current.started_at.unwrap_or(current.scheduled_at),
+                "pipeline.worker.exit",
+            ),
+            _ => return Ok(()),
+        };
+        let finished_at = Utc::now();
+        self.record_diagnostic_step(&current, started_at, finished_at, message, state)?;
+        self.terminalize(&current, state, finished_at)?;
+        self.record_worker_failure_audit(audit_name, &current.run_id, message, actor)
+    }
+
+    /// Terminalize a run whose worker never started at all.
+    pub(crate) fn finalize_startup_failure(
+        &self,
+        run: &JobRun,
+        message: &str,
+        actor: Option<&str>,
+    ) -> Result<(), OrbitError> {
+        let current = self.host.reconciled_run(&run.run_id)?;
+        if current.state != JobRunState::Pending || current.pid.is_some() {
+            return Ok(());
+        }
+
+        let finished_at = Utc::now();
+        // Persist the diagnostic step before terminalizing the run: an observer
+        // polling for a terminal state must never be able to see one without its
+        // startup diagnostic already durable.
+        self.record_diagnostic_step(
+            run,
+            run.scheduled_at,
+            finished_at,
+            message,
+            JobRunState::Interrupted,
+        )?;
+        self.terminalize(run, JobRunState::Interrupted, finished_at)?;
+        self.record_worker_failure_audit("pipeline.worker.startup", &run.run_id, message, actor)
+    }
+
+    /// Terminalize the run and announce the completion the write produced.
+    /// A replayed terminalization changes nothing and emits nothing.
+    fn terminalize(
+        &self,
+        run: &JobRun,
+        state: JobRunState,
+        finished_at: DateTime<Utc>,
+    ) -> Result<(), OrbitError> {
+        let changed = self.host.terminalize_run(&run.run_id, state, finished_at)?;
+        if changed {
+            self.event_log.append(OrbitEvent::JobRunCompleted {
+                job_id: run.job_id.clone(),
+                run_id: run.run_id.clone(),
+                state: state.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    fn record_diagnostic_step(
+        &self,
+        run: &JobRun,
+        started_at: DateTime<Utc>,
+        finished_at: DateTime<Utc>,
+        message: &str,
+        state: JobRunState,
+    ) -> Result<(), OrbitError> {
+        record::diagnostic_step(
+            self.runs.as_ref(),
+            run,
+            started_at,
+            finished_at,
+            None,
+            message,
+            state,
+        )
+    }
+
+    /// The audit row both failure paths write: same shape, different name.
+    fn record_worker_failure_audit(
+        &self,
+        audit_name: &str,
+        run_id: &str,
+        message: &str,
+        actor: Option<&str>,
+    ) -> Result<(), OrbitError> {
+        let worker_log = pipeline_worker_log_path(&self.paths.logs_dir, run_id)?;
+        self.record_audit(
+            audit_name,
+            Some(run_id),
+            actor,
+            AuditEventStatus::Failure,
+            json!({
+                "run_id": run_id,
+                "workspace": self.workspace(),
+                "worker_log": worker_log,
+            }),
+            Some(message.to_string()),
+        )
+    }
+
+    fn record_audit(
+        &self,
+        tool_name: &str,
+        target_id: Option<&str>,
+        actor: Option<&str>,
+        status: AuditEventStatus,
+        arguments: Value,
+        error_message: Option<String>,
+    ) -> Result<(), OrbitError> {
+        record::pipeline_audit(
+            self.audit_events.as_ref(),
+            self.workspace(),
+            PipelineAuditRow {
+                tool_name,
+                target_id,
+                actor,
+                status,
+                arguments,
+                error_message,
+            },
+        )
+    }
+}
+
+#[cfg(unix)]
+fn worker_cancellation_signal_name(signal: i32) -> &'static str {
+    match signal {
+        libc::SIGTERM => "SIGTERM",
+        libc::SIGKILL => "SIGKILL",
+        _ => "unknown",
+    }
+}
+
+/// Counts the run-store reads the startup observer performs, so a test can
+/// prove a claimed worker stops polling.
+///
+/// Keyed by the run store the observer reads through — shared by a runtime,
+/// its clones, and the supervisors they build, while independent temporary
+/// databases stay isolated — paired with the run ID.
+#[cfg(test)]
+pub(crate) mod worker_observer_read_counter {
+    use std::collections::HashMap;
+    use std::sync::{LazyLock, Mutex};
+
+    use orbit_store::contracts::JobRunStoreBackend;
+
+    use crate::OrbitRuntime;
+
+    type StoreRun = (usize, String);
+
+    static COUNTS: LazyLock<Mutex<HashMap<StoreRun, usize>>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
+
+    pub(crate) struct Counter {
+        key: StoreRun,
+    }
+
+    fn key(runs: &dyn JobRunStoreBackend, run_id: &str) -> StoreRun {
+        (
+            runs as *const dyn JobRunStoreBackend as *const () as usize,
+            run_id.to_string(),
+        )
+    }
+
+    pub(crate) fn track(runtime: &OrbitRuntime, run_id: &str) -> Counter {
+        let key = key(runtime.stores().jobs(), run_id);
+        COUNTS
+            .lock()
+            .expect("test observer counters are not poisoned")
+            .insert(key.clone(), 0);
+        Counter { key }
+    }
+
+    pub(crate) fn record(runtime: &OrbitRuntime, run_id: &str) {
+        record_in(runtime.stores().jobs(), run_id);
+    }
+
+    pub(crate) fn record_in(runs: &dyn JobRunStoreBackend, run_id: &str) {
+        if let Some(count) = COUNTS
+            .lock()
+            .expect("test observer counters are not poisoned")
+            .get_mut(&key(runs, run_id))
+        {
+            *count += 1;
+        }
+    }
+
+    impl Counter {
+        pub(crate) fn reads(&self) -> usize {
+            *COUNTS
+                .lock()
+                .expect("test observer counters are not poisoned")
+                .get(&self.key)
+                .expect("tracked observer counter exists")
+        }
+    }
+
+    impl Drop for Counter {
+        fn drop(&mut self) {
+            COUNTS
+                .lock()
+                .expect("test observer counters are not poisoned")
+                .remove(&self.key);
+        }
+    }
+}

--- a/crates/orbit-core/src/application/job/pipeline/worker/tests/mod.rs
+++ b/crates/orbit-core/src/application/job/pipeline/worker/tests/mod.rs
@@ -1,0 +1,10 @@
+//! Worker-module tests.
+//!
+//! - `supervisor` — [`PipelineWorkerSupervisor`](super::supervisor::PipelineWorkerSupervisor)
+//!   failure paths, driven against a store without an `OrbitRuntime`.
+//!
+//! Worker behavior that needs a composed runtime (spawning real child
+//! processes, submission, routine dispatch) is exercised from
+//! `application/tests/job_pipeline.rs`.
+
+mod supervisor;

--- a/crates/orbit-core/src/application/job/pipeline/worker/tests/supervisor.rs
+++ b/crates/orbit-core/src/application/job/pipeline/worker/tests/supervisor.rs
@@ -1,0 +1,289 @@
+//! Supervisor failure paths, exercised without an `OrbitRuntime`.
+//!
+//! The fixture builds a supervisor from a temporary SQLite store, a recording
+//! [`PipelineRunHost`], and an event log — which is the point of the type: a
+//! worker that dies during startup, or one killed by an outstanding
+//! cancellation, can be settled and asserted without composing a runtime.
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use chrono::{DateTime, Utc};
+use orbit_common::OrbitError;
+use orbit_store::Store;
+use orbit_store::compose::{audit_event_store_sqlite, workspace_job_run_store};
+use orbit_store::contracts::{AuditEventFilter, AuditEventStoreBackend, JobRunStoreBackend};
+use orbit_types::record::OrbitEvent;
+use orbit_types::telemetry::{AuditEvent, AuditEventStatus};
+use orbit_types::workflow::{JobRun, JobRunState};
+use orbit_types::workspace::WorkspacePaths;
+use tempfile::TempDir;
+
+use crate::application::job::pipeline::worker::command::WorkerCommandConfig;
+use crate::application::job::pipeline::worker::record::{self, PipelineAuditRow};
+use crate::application::job::pipeline::worker::supervisor::{
+    PipelineRunHost, PipelineWorkerSupervisor,
+};
+use crate::runtime::event_bus::EventLog;
+
+#[cfg(unix)]
+use crate::application::job::run::{CANCELLATION_REQUEST_AUDIT, CANCELLATION_WORKER_EXIT_AUDIT};
+
+const WORKSPACE_ID: &str = "supervisor-fixture";
+
+/// A terminalization the supervisor asked its host to perform.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Terminalization {
+    run_id: String,
+    state: JobRunState,
+}
+
+/// Records the run-lifecycle calls the supervisor delegates, and applies them
+/// to the same store the supervisor reads, so later reads see the outcome.
+struct RecordingHost {
+    runs: Arc<dyn JobRunStoreBackend>,
+    terminalizations: Mutex<Vec<Terminalization>>,
+}
+
+impl RecordingHost {
+    fn terminalizations(&self) -> Vec<Terminalization> {
+        self.terminalizations
+            .lock()
+            .expect("host recordings are not poisoned")
+            .clone()
+    }
+}
+
+impl PipelineRunHost for RecordingHost {
+    fn reconciled_run(&self, run_id: &str) -> Result<JobRun, OrbitError> {
+        self.runs
+            .get_job_run(run_id)?
+            .ok_or_else(|| OrbitError::Execution(format!("run '{run_id}' is missing")))
+    }
+
+    fn terminalize_run(
+        &self,
+        run_id: &str,
+        state: JobRunState,
+        finished_at: DateTime<Utc>,
+    ) -> Result<bool, OrbitError> {
+        self.terminalizations
+            .lock()
+            .expect("host recordings are not poisoned")
+            .push(Terminalization {
+                run_id: run_id.to_string(),
+                state,
+            });
+        self.runs.finalize_job_run(run_id, state, finished_at, None)
+    }
+}
+
+struct Fixture {
+    _root: TempDir,
+    supervisor: PipelineWorkerSupervisor,
+    runs: Arc<dyn JobRunStoreBackend>,
+    audit_events: Arc<dyn AuditEventStoreBackend>,
+    host: Arc<RecordingHost>,
+    event_log: EventLog,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let root = TempDir::new().expect("tempdir");
+        let store = Store::open(&root.path().join("orbit.db")).expect("open fixture store");
+        let runs = workspace_job_run_store(store.clone(), WORKSPACE_ID);
+        let audit_events = audit_event_store_sqlite(store);
+        let paths = WorkspacePaths::new(
+            root.path().join("repo"),
+            root.path().join("repo/.orbit"),
+            root.path().join("global"),
+        );
+        let event_log = EventLog::default();
+        let host = Arc::new(RecordingHost {
+            runs: Arc::clone(&runs),
+            terminalizations: Mutex::new(Vec::new()),
+        });
+        let supervisor = PipelineWorkerSupervisor::new(
+            Arc::clone(&runs),
+            Arc::clone(&audit_events),
+            paths.clone(),
+            event_log.clone(),
+            WorkerCommandConfig::for_paths(&paths),
+            Arc::clone(&host) as Arc<dyn PipelineRunHost>,
+        );
+        Self {
+            _root: root,
+            supervisor,
+            runs,
+            audit_events,
+            host,
+            event_log,
+        }
+    }
+
+    fn pending_run(&self, job_id: &str) -> JobRun {
+        self.runs
+            .insert_job_run(job_id, 1, Utc::now(), None, None)
+            .expect("insert pending run")
+    }
+
+    fn audits(&self, run_id: &str) -> Vec<AuditEvent> {
+        self.audit_events
+            .list_audit_events(&AuditEventFilter {
+                job_run_id: Some(run_id.to_string()),
+                limit: 50,
+                ..AuditEventFilter::default()
+            })
+            .expect("list fixture audits")
+    }
+}
+
+#[test]
+fn startup_failure_records_diagnostic_state_event_and_audit() {
+    let fixture = Fixture::new();
+    let run = fixture.pending_run("startup_failure_pipeline");
+
+    fixture
+        .supervisor
+        .finalize_startup_failure(&run, "worker could not start", Some("test-actor"))
+        .expect("finalize startup failure");
+
+    assert_eq!(
+        fixture.host.terminalizations(),
+        vec![Terminalization {
+            run_id: run.run_id.clone(),
+            state: JobRunState::Interrupted,
+        }]
+    );
+
+    let stored = fixture
+        .runs
+        .get_job_run(&run.run_id)
+        .expect("read settled run")
+        .expect("settled run exists");
+    assert_eq!(stored.state, JobRunState::Interrupted);
+    let diagnostic = stored.steps.last().expect("startup diagnostic step");
+    assert_eq!(diagnostic.state, JobRunState::Interrupted);
+    assert_eq!(
+        diagnostic.error_message.as_deref(),
+        Some("worker could not start")
+    );
+
+    let completions = fixture
+        .event_log
+        .snapshot()
+        .into_iter()
+        .filter_map(|event| match event {
+            OrbitEvent::JobRunCompleted { run_id, state, .. } if run_id == run.run_id => {
+                Some(state)
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(completions, vec![JobRunState::Interrupted.to_string()]);
+
+    let audit = fixture
+        .audits(&run.run_id)
+        .into_iter()
+        .find(|audit| audit.tool_name.as_deref() == Some("pipeline.worker.startup"))
+        .expect("startup failure audit");
+    assert_eq!(audit.status, AuditEventStatus::Failure);
+    assert_eq!(audit.host.as_deref(), Some("test-actor"));
+    assert_eq!(
+        audit.error_message.as_deref(),
+        Some("worker could not start")
+    );
+}
+
+/// A worker that claimed the run owns its own outcome: the startup path that
+/// races with it must write nothing.
+#[test]
+fn startup_failure_leaves_a_claimed_run_to_its_worker() {
+    let fixture = Fixture::new();
+    let run = fixture.pending_run("claimed_startup_pipeline");
+    fixture
+        .runs
+        .claim_pending_job_run_owner(&run.run_id, 424_242)
+        .expect("claim run for a live worker");
+
+    fixture
+        .supervisor
+        .finalize_startup_failure(&run, "worker could not start", None)
+        .expect("finalize startup failure");
+
+    assert!(fixture.host.terminalizations().is_empty());
+    let stored = fixture
+        .runs
+        .get_job_run(&run.run_id)
+        .expect("read claimed run")
+        .expect("claimed run exists");
+    assert_eq!(stored.state, JobRunState::Pending);
+    assert!(stored.steps.is_empty());
+    assert!(fixture.event_log.snapshot().is_empty());
+    assert!(fixture.audits(&run.run_id).is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn cancellation_exit_is_recorded_without_terminalizing_the_run() {
+    let fixture = Fixture::new();
+    let run = fixture.pending_run("cancelled_worker_pipeline");
+    // The request the cancelling caller would have written; only its tool name
+    // and `request_id` matter to the lookup under test.
+    record::pipeline_audit(
+        fixture.audit_events.as_ref(),
+        Path::new("/repo"),
+        PipelineAuditRow {
+            tool_name: CANCELLATION_REQUEST_AUDIT,
+            target_id: Some(&run.run_id),
+            actor: Some("operator"),
+            status: AuditEventStatus::Success,
+            arguments: serde_json::json!({ "request_id": "cancel-1", "run_id": run.run_id }),
+            error_message: None,
+        },
+    )
+    .expect("record cancellation request");
+
+    let recorded = fixture
+        .supervisor
+        .record_cancellation_exit(
+            &run,
+            libc::SIGTERM,
+            "signal: 15 (SIGTERM)",
+            Some("observer"),
+        )
+        .expect("record cancellation exit");
+
+    assert!(recorded, "an outstanding request owns this TERM exit");
+    assert!(fixture.host.terminalizations().is_empty());
+    let audit = fixture
+        .audits(&run.run_id)
+        .into_iter()
+        .find(|audit| audit.tool_name.as_deref() == Some(CANCELLATION_WORKER_EXIT_AUDIT))
+        .expect("worker-exit cancellation audit");
+    let arguments = audit
+        .arguments_json
+        .as_deref()
+        .map(|raw| serde_json::from_str::<serde_json::Value>(raw).expect("audit arguments"))
+        .expect("audit carries arguments");
+    assert_eq!(arguments["request_id"], "cancel-1");
+    assert_eq!(arguments["signal_name"], "SIGTERM");
+    assert_eq!(arguments["exit_status"], "signal: 15 (SIGTERM)");
+}
+
+/// Without an outstanding request, a TERM exit is not a cancellation: the
+/// observer must fall through to its ordinary worker-failure path.
+#[cfg(unix)]
+#[test]
+fn unrequested_signal_exit_is_not_treated_as_a_cancellation() {
+    let fixture = Fixture::new();
+    let run = fixture.pending_run("signalled_worker_pipeline");
+
+    let recorded = fixture
+        .supervisor
+        .record_cancellation_exit(&run, libc::SIGKILL, "signal: 9 (SIGKILL)", None)
+        .expect("record cancellation exit");
+
+    assert!(!recorded);
+    assert!(fixture.audits(&run.run_id).is_empty());
+}

--- a/crates/orbit-core/src/application/job/run/actions.rs
+++ b/crates/orbit-core/src/application/job/run/actions.rs
@@ -7,9 +7,9 @@ use std::collections::HashSet;
 use chrono::Utc;
 use orbit_common::observability::audit_id::audit_execution_id;
 use orbit_common::{NotFoundKind, OrbitError};
-#[cfg(unix)]
-use orbit_store::contracts::AuditEventFilter;
 use orbit_store::contracts::TaskReservationReleaseReason;
+#[cfg(unix)]
+use orbit_store::contracts::{AuditEventFilter, AuditEventStoreBackend};
 use orbit_types::record::OrbitEvent;
 use orbit_types::telemetry::AuditEventStatus;
 use orbit_types::workflow::{
@@ -298,62 +298,15 @@ impl OrbitRuntime {
         )
     }
 
-    /// The newest cancellation request that has not conclusively failed or
-    /// observed a pre-existing terminal outcome. Worker observers use this to
-    /// avoid converting an expected TERM/KILL exit into a run failure before
-    /// the signalling caller verifies that every owned target stopped.
-    #[cfg(unix)]
+    /// The newest cancellation request still outstanding for `run_id`, read
+    /// through this runtime's audit store. Worker supervision answers the same
+    /// question through [`active_cancellation_request`] directly.
+    #[cfg(all(test, unix))]
     pub(crate) fn active_job_run_cancellation_request(
         &self,
         run_id: &str,
     ) -> Result<Option<String>, OrbitError> {
-        let audits = self.list_audit_events_filtered(&AuditEventFilter {
-            job_run_id: Some(run_id.to_string()),
-            limit: 200,
-            ..AuditEventFilter::default()
-        })?;
-        let mut completions = HashMap::<String, String>::new();
-        let mut requests = Vec::new();
-        for audit in audits {
-            let Some(tool) = audit.tool_name.as_deref() else {
-                continue;
-            };
-            if !matches!(
-                tool,
-                CANCELLATION_REQUEST_AUDIT | CANCELLATION_COMPLETION_AUDIT
-            ) {
-                continue;
-            }
-            let Some(arguments) = audit
-                .arguments_json
-                .as_deref()
-                .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
-            else {
-                continue;
-            };
-            let Some(request_id) = arguments.get("request_id").and_then(Value::as_str) else {
-                continue;
-            };
-            if tool == CANCELLATION_COMPLETION_AUDIT {
-                if let Some(outcome) = arguments.get("outcome").and_then(Value::as_str) {
-                    completions
-                        .entry(request_id.to_string())
-                        .or_insert_with(|| outcome.to_string());
-                }
-            } else {
-                requests.push(request_id.to_string());
-            }
-        }
-        let inactive: HashSet<&str> = completions
-            .iter()
-            .filter_map(|(request_id, outcome)| {
-                matches!(outcome.as_str(), "failed" | "already_terminal")
-                    .then_some(request_id.as_str())
-            })
-            .collect();
-        Ok(requests
-            .into_iter()
-            .find(|request_id| !inactive.contains(request_id.as_str())))
+        active_cancellation_request(self.stores().audit_events(), run_id)
     }
 
     pub fn archive_job_run(&self, run_id: &str) -> Result<(), OrbitError> {
@@ -592,4 +545,64 @@ fn cancellation_result(
         signal_attempted,
         signal_outcome,
     }
+}
+
+/// The newest cancellation request that has not conclusively failed or
+/// observed a pre-existing terminal outcome. Worker supervision uses this to
+/// avoid converting an expected TERM/KILL exit into a run failure before the
+/// signalling caller verifies that every owned target stopped.
+///
+/// A pure read of the run's own audit trail, so a supervisor can answer it
+/// from the audit store alone.
+#[cfg(unix)]
+pub(crate) fn active_cancellation_request(
+    audit_events: &dyn AuditEventStoreBackend,
+    run_id: &str,
+) -> Result<Option<String>, OrbitError> {
+    let audits = audit_events.list_audit_events(&AuditEventFilter {
+        job_run_id: Some(run_id.to_string()),
+        limit: 200,
+        ..AuditEventFilter::default()
+    })?;
+    let mut completions = HashMap::<String, String>::new();
+    let mut requests = Vec::new();
+    for audit in audits {
+        let Some(tool) = audit.tool_name.as_deref() else {
+            continue;
+        };
+        if !matches!(
+            tool,
+            CANCELLATION_REQUEST_AUDIT | CANCELLATION_COMPLETION_AUDIT
+        ) {
+            continue;
+        }
+        let Some(arguments) = audit
+            .arguments_json
+            .as_deref()
+            .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+        else {
+            continue;
+        };
+        let Some(request_id) = arguments.get("request_id").and_then(Value::as_str) else {
+            continue;
+        };
+        if tool == CANCELLATION_COMPLETION_AUDIT {
+            if let Some(outcome) = arguments.get("outcome").and_then(Value::as_str) {
+                completions
+                    .entry(request_id.to_string())
+                    .or_insert_with(|| outcome.to_string());
+            }
+        } else {
+            requests.push(request_id.to_string());
+        }
+    }
+    let inactive: HashSet<&str> = completions
+        .iter()
+        .filter_map(|(request_id, outcome)| {
+            matches!(outcome.as_str(), "failed" | "already_terminal").then_some(request_id.as_str())
+        })
+        .collect();
+    Ok(requests
+        .into_iter()
+        .find(|request_id| !inactive.contains(request_id.as_str())))
 }

--- a/crates/orbit-core/src/application/job/run/mod.rs
+++ b/crates/orbit-core/src/application/job/run/mod.rs
@@ -23,8 +23,12 @@ mod worker_limit;
 #[cfg(test)]
 mod tests;
 
+/// The request audit a supervisor test seeds before asserting the worker-exit
+/// record that answers it.
+#[cfg(all(test, unix))]
+pub(crate) use actions::CANCELLATION_REQUEST_AUDIT;
 #[cfg(unix)]
-pub(crate) use actions::CANCELLATION_WORKER_EXIT_AUDIT;
+pub(crate) use actions::{CANCELLATION_WORKER_EXIT_AUDIT, active_cancellation_request};
 pub use admissions_stop::{
     DrainAdmissionsStopChange, DrainAdmissionsStopRequest, DrainAdmissionsStopResult,
     RemainingDrainChild,


### PR DESCRIPTION
## Task

[ORB-12271](https://orbit-cli.com/tasks/ORB-12271) — Extract PipelineWorkerSupervisor from OrbitRuntime's worker lifecycle methods

### Description

## Why

After ORB-12270 splits `pipeline.rs` by concern, the worker lifecycle (~700 lines: `execute_pipeline_run_worker`, `preflight_pipeline_worker_store`, `execute_pipeline_run_now`, `spawn_pipeline_worker`, `pipeline_worker_command`, `spawn_pipeline_worker_process`, `monitor_pipeline_worker_startup`, `record_pipeline_worker_cancellation_exit`, `finalize_pipeline_worker_exit_failure`, `finalize_pipeline_worker_startup_failure`, `record_pipeline_failure_step`, `record_pipeline_diagnostic_step`, `record_pipeline_audit`) will still be methods on `OrbitRuntime`. They read as runtime methods but are really a process supervisor: they own a child process, watch its startup, interpret its exit, and terminalize the run. Testing any of them today requires a full runtime.

This task turns that group into a unit with explicit dependencies so it can be tested in isolation and reasoned about without the rest of `OrbitRuntime` (which carries context, workspace binding, coordination write owner, automation identity, workspace catalog, and the event log).

## Shape

```rust
pub(crate) struct PipelineWorkerSupervisor<'a> {
    store: ...,            // whatever preflight_pipeline_worker_store and the finalize_* paths write through
    paths: &'a WorkspacePaths,
    event_log: &'a EventLog,
    command: WorkerCommandConfig, // resolved executable, root override, profile file, stdio/log config from worker/command.rs
}

impl PipelineWorkerSupervisor<'_> {
    pub(crate) fn spawn(&self, run: &JobRun, ...) -> Result<SpawnedWorker, OrbitError>;
    pub(crate) fn monitor_startup(&self, worker: &mut SpawnedWorker, ...) -> ...;
    #[cfg(unix)] pub(crate) fn record_cancellation_exit(&self, ...);
    fn finalize_exit_failure(&self, ...);
    fn finalize_startup_failure(&self, ...);
    fn record_audit(&self, ...);
}
```

The implementer decides the exact field set by reading what the moved methods actually touch on `self`; the list above is a starting point, not a contract. Keep the `#[cfg(test)]` command-override branches and the `worker_observer_read_counter` hook working: they gate the spawn path and the cli_runner orchestrator tests depend on them.

`OrbitRuntime` keeps its existing `pub`/`pub(crate)` methods as one-line delegations that build a supervisor from its own fields, so no caller changes.

## Rules

- Behavior-preserving. Same audit rows, same `OrbitEvent` emissions, same terminal statuses and `expired_reason`/completion causes, same log banner and tail semantics.
- Land after ORB-12270; the split must be on `agent-main` first so this diff is only the extraction.
- Add the isolated unit tests in the same PR; that is the point of the change.

## Out of scope

Changing how workers are launched, the log hardening in worker/log.rs, or the submission/admission path.

### Acceptance Criteria

- A `PipelineWorkerSupervisor` type in application/job/pipeline/worker/ owns spawn, startup monitoring, cancellation-exit recording, and exit/startup failure finalization; OrbitRuntime keeps thin delegating methods with unchanged signatures
- The supervisor is constructed from explicit dependencies (store handle, workspace paths, event log, worker command configuration) and has at least one unit test that exercises a startup failure and a cancellation exit without building an OrbitRuntime
- No behavior change: the same audit rows, event log entries, run terminal states, and worker log contents as before; existing pipeline, cli_runner orchestrator, and mcp roundtrip tests pass unchanged
- cargo test --workspace --no-fail-fast green; cargo clippy clean on the new type
- Depends on ORB-12270 having landed; do not start this on the monolithic pipeline.rs

## Execution Summary

<details>
<summary>Click to expand</summary>

Extracted the parent-side worker lifecycle from `OrbitRuntime` into `PipelineWorkerSupervisor`, behavior-preserving, with isolated unit tests.

## What changed

New `crates/orbit-core/src/application/job/pipeline/worker/supervisor.rs`:
- `PipelineWorkerSupervisor` (Clone, 'static) owns `spawn`, `spawn_process`, `monitor_startup`, `record_cancellation_exit` (unix), `finalize_exit_failure`, `finalize_startup_failure`, `terminalize`, `record_diagnostic_step`, `record_worker_failure_audit`, `record_audit`, plus `worker_cancellation_signal_name` and the `worker_observer_read_counter` test hook.
- Explicit dependencies: `Arc<dyn JobRunStoreBackend>`, `Arc<dyn AuditEventStoreBackend>`, `WorkspacePaths`, `EventLog`, `WorkerCommandConfig`, `Arc<dyn PipelineRunHost>`. The observer thread now moves a supervisor clone instead of an `OrbitRuntime` clone (the host Arc still holds one, so runtime-owned temp state stays alive exactly as before).
- `PipelineRunHost` is the only seam back to the runtime: `reconciled_run` (= `show_job_run`, stale-run reconciliation) and `terminalize_run` (= `finalize_job_run_with_reservation_cleanup` with `RunTerminal`). Those two reach into reservation release and task coupling, which are runtime/task-domain concerns; everything else runs against stores alone.

New `worker/record.rs`: store-level writers for the diagnostic step and the pipeline audit row (`PipelineAuditRow`), shared verbatim by the runtime methods and the supervisor, so there is one implementation of each row shape and `record_pipeline_audit` keeps its cheap non-worker call path (no supervisor/runtime clone per audit).

`worker/command.rs`: `OrbitRuntime::pipeline_worker_command` became `WorkerCommandConfig::{for_paths, build}`, keeping both the `#[cfg(test)]` override branch and the production `current_exe`/`--root` branch unchanged. The observer read counter moved to `supervisor.rs` and is now keyed by the run-store instance instead of the runtime's audit-db path, so the supervisor can record without holding a runtime; `track`/`record(&runtime, ...)` signatures are unchanged and the isolation test passes as written.

`worker/mod.rs`: keeps the child-side work (`execute_pipeline_run_worker`, `execute_pipeline_run_now`, routine-dispatch guard, `read_pipeline_worker_log`) and thin delegations with unchanged signatures: `spawn_pipeline_worker`, `spawn_pipeline_worker_process`, `record_pipeline_worker_cancellation_exit`, `finalize_pipeline_worker_startup_failure`, `record_pipeline_audit`, `record_pipeline_diagnostic_step`, `record_pipeline_failure_step`. `monitor_pipeline_worker_startup` and `pipeline_worker_command` had no callers outside the moved code and were removed rather than kept as dead facades. `spawn_pipeline_worker_process`, `record_pipeline_worker_cancellation_exit`, and `OrbitRuntime::active_job_run_cancellation_request` now have only test callers and are `#[cfg(test)]`-gated to keep non-test builds warning-free.

Outside the declared worker directory (selectors appended to the task, with the reason recorded in a comment): `run/actions.rs` exposes the cancellation-request lookup as `active_cancellation_request(&dyn AuditEventStoreBackend, run_id)` (body moved verbatim; the runtime method delegates), `run/mod.rs` re-exports it, and `pipeline/mod.rs` re-export paths follow the moved observer counter. No cross-crate dependency edges added.

## Acceptance criteria

1. Supervisor type in `application/job/pipeline/worker/` owning spawn, startup monitoring, cancellation-exit recording, and both failure finalizations — met; runtime keeps delegations with unchanged signatures for every method that still has a caller.
2. Explicit dependencies + isolated tests — met: `worker/tests/supervisor.rs` builds a supervisor over a temp SQLite store, a recording `PipelineRunHost`, and an `EventLog`, with no `OrbitRuntime`. Four tests: startup failure (diagnostic step, `Interrupted` terminalization, `JobRunCompleted` event, failure audit with actor and message), claimed-run startup no-op, cancellation exit recorded without terminalizing (asserting `request_id`/`signal_name`/`exit_status` on the `pipeline.run.cancel.worker_exit` row), and unrequested-signal fallthrough.
3. No behavior change — audit names/payloads, event emission, terminal states, diagnostic ordering, log banner/tail semantics, and command-override/observer hooks are byte-for-byte the moved code; existing pipeline, cancellation-race, cli_runner, and MCP roundtrip tests pass unmodified (no test file outside the new one was touched).
4. `cargo test --workspace --no-fail-fast` green; clippy clean.
5. Dependency ORB-12270 (plus 12302/12306) landed; work started from the post-split worker module at HEAD ac0429ba5.

## Validation (all run in this worktree at ac0429ba5 + these changes)

- `cargo test --workspace --no-fail-fast` — passed (exit 0, no failing suites) on the final source.
- `make ci-lint` (workspace clippy, all targets, `-D warnings`) — passed on the final source.
- `cargo fmt --all --check` — clean. `make ci-fast` — passed.
- `make goldens` (CLI help/output goldens + `mcp_roundtrip` tools-list snapshot) — passed; no surface change, no golden regenerated.
- `cargo test -p orbit-core --lib pipeline` — 126 passed, including `observer_read_counts_isolate_identical_run_ids_in_independent_stores`, `claimed_sleeping_worker_does_not_keep_polling_the_run_store`, `worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic`, `routine_style_detached_worker_is_claimed_within_ownership_window`.
- `git diff --check` clean; `git status --short` shows only the five modified files and the three new source paths (`worker/supervisor.rs`, `worker/record.rs`, `worker/tests/`), no stray artifacts.

## Risks / notes

- One pre-existing flake surfaced on the first workspace run: `orbit-cli command::workspace::tests::init::checked_out_branch_keeps_main_as_the_default_for_main_checkouts` failed with `run git init: ENOENT`, a cwd-mutating `EnvGuard` race in that binary, unrelated to this diff; `cargo test -p orbit-cli --bin orbit` then passed 579/579 and the full re-run was green.
- Linux-only execution: the `#[cfg(unix)]` cancellation paths were exercised on Linux; Windows behavior is unchanged code but untested here.
- `PipelineRunHost` is a two-method seam, not a general policy interface; if the reservation/task-coupling half of terminalization later moves down, the trait should shrink rather than grow.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12271-6aa5328c`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra