### PR TITLE
Distinguish unavailable native clock manager from a paused clock

### DIFF
--- a/crates/orbit-core/src/application/routines/clock.rs
+++ b/crates/orbit-core/src/application/routines/clock.rs
@@ -267,6 +267,24 @@ impl ManagerCommand {
 pub(super) trait ClockCommandRunner {
     fn run(&self, command: &ManagerCommand) -> Result<bool, OrbitError>;
     fn stdout(&self, command: &ManagerCommand) -> Result<Option<String>, OrbitError>;
+
+    fn probe(&self, command: &ManagerCommand) -> Result<ManagerCommandOutput, OrbitError> {
+        let success = self.run(command)?;
+        Ok(ManagerCommandOutput {
+            success,
+            exit_code: Some(if success { 0 } else { 1 }),
+            stdout: String::new(),
+            stderr: String::new(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ManagerCommandOutput {
+    pub(super) success: bool,
+    pub(super) exit_code: Option<i32>,
+    pub(super) stdout: String,
+    pub(super) stderr: String,
 }
 
 struct NativeClockCommandRunner;
@@ -281,14 +299,23 @@ impl ClockCommandRunner for NativeClockCommandRunner {
     }
 
     fn stdout(&self, command: &ManagerCommand) -> Result<Option<String>, OrbitError> {
+        let output = self.probe(command)?;
+        if output.success {
+            Ok(Some(output.stdout))
+        } else {
+            Err(manager_probe_failure(command, &output))
+        }
+    }
+
+    fn probe(&self, command: &ManagerCommand) -> Result<ManagerCommandOutput, OrbitError> {
         Command::new(command.program)
             .args(&command.args)
             .output()
-            .map(|output| {
-                output
-                    .status
-                    .success()
-                    .then(|| String::from_utf8_lossy(&output.stdout).into_owned())
+            .map(|output| ManagerCommandOutput {
+                success: output.status.success(),
+                exit_code: output.status.code(),
+                stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
             })
             .map_err(|error| OrbitError::Execution(format!("run {}: {error}", command.display())))
     }
@@ -670,6 +697,13 @@ fn manager_status_command(platform: ClockPlatform) -> ManagerCommand {
     }
 }
 
+fn launchd_manager_probe_command() -> ManagerCommand {
+    ManagerCommand {
+        program: "launchctl",
+        args: vec!["list".into()],
+    }
+}
+
 fn systemd_next_trigger_command() -> ManagerCommand {
     ManagerCommand {
         program: "systemctl",
@@ -802,9 +836,34 @@ pub(super) fn clock_status_with(
     runner: &dyn ClockCommandRunner,
 ) -> Result<ClockStatus, OrbitError> {
     let settings = load_clock_settings(global_root)?;
-    let enabled = runner
-        .run(&manager_status_command(platform))
-        .unwrap_or(false);
+    let status_command = manager_status_command(platform);
+    let status_output = runner
+        .probe(&status_command)
+        .map_err(|error| clock_manager_probe_error(platform, &status_command, &error))?;
+    let enabled = match platform {
+        ClockPlatform::Launchd if !status_output.success => {
+            if launchd_reports_not_loaded(&status_output) {
+                false
+            } else {
+                let manager_command = launchd_manager_probe_command();
+                let manager_output = runner.probe(&manager_command).map_err(|error| {
+                    clock_manager_probe_error(platform, &manager_command, &error)
+                })?;
+                if !manager_output.success {
+                    return Err(clock_manager_unavailable_error(
+                        platform,
+                        [
+                            (&status_command, &status_output),
+                            (&manager_command, &manager_output),
+                        ],
+                        None,
+                    ));
+                }
+                false
+            }
+        }
+        _ => status_output.success,
+    };
     let mut manager_details = None;
     let (schedulable, health_issue) = if platform == ClockPlatform::Systemd {
         match query_systemd_clock_details(runner) {
@@ -825,14 +884,20 @@ pub(super) fn clock_status_with(
                     )
                 }
             }
-            Err(_) if enabled => (
+            Err(error) if enabled => (
                 false,
-                Some(
-                    "systemd timer is enabled but its next trigger could not be verified; recovery: inspect `systemctl --user status orbit-sweep.timer`, then run `orbit clock enable` to rewrite a stale unit if needed, re-arm, and verify it"
-                        .to_string(),
-                ),
+                Some(format!(
+                    "systemd timer is enabled but its next trigger could not be verified ({error}); recovery: inspect `systemctl --user status orbit-sweep.timer`, then run `orbit clock enable` to rewrite a stale unit if needed, re-arm, and verify it"
+                )),
             ),
-            Err(_) => (false, None),
+            Err(_) if systemd_reports_disabled_or_missing(&status_output) => (false, None),
+            Err(error) => {
+                return Err(clock_manager_unavailable_error(
+                    platform,
+                    [(&status_command, &status_output)],
+                    Some(&error),
+                ));
+            }
         }
     } else {
         (enabled, None)
@@ -845,6 +910,114 @@ pub(super) fn clock_status_with(
         health_issue,
         manager_details,
     ))
+}
+
+fn systemd_reports_disabled_or_missing(output: &ManagerCommandOutput) -> bool {
+    let diagnostic = format!("{}\n{}", output.stdout, output.stderr).to_ascii_lowercase();
+    [
+        "disabled",
+        "masked",
+        "static",
+        "indirect",
+        "generated",
+        "transient",
+        "not-found",
+        "not found",
+        "no such file or directory",
+        "could not be found",
+    ]
+    .iter()
+    .any(|marker| diagnostic.contains(marker))
+}
+
+fn launchd_reports_not_loaded(output: &ManagerCommandOutput) -> bool {
+    let diagnostic = format!("{}\n{}", output.stdout, output.stderr).to_ascii_lowercase();
+    [
+        "could not find service",
+        "service not found",
+        "no such process",
+    ]
+    .iter()
+    .any(|marker| diagnostic.contains(marker))
+}
+
+fn clock_manager_unavailable_error<'a, const N: usize>(
+    platform: ClockPlatform,
+    attempts: [(&'a ManagerCommand, &'a ManagerCommandOutput); N],
+    detail_error: Option<&OrbitError>,
+) -> OrbitError {
+    let mut diagnostics = attempts
+        .into_iter()
+        .map(|(command, output)| manager_probe_diagnostic(command, output))
+        .collect::<Vec<_>>();
+    if let Some(error) = detail_error {
+        diagnostics.push(bounded_manager_text(&error.to_string()));
+    }
+    OrbitError::Execution(format!(
+        "{} clock manager is unavailable; {}. Check that the per-user {} manager is running and that this process can query it",
+        platform.name(),
+        diagnostics.join("; "),
+        platform.name(),
+    ))
+}
+
+fn manager_probe_failure(command: &ManagerCommand, output: &ManagerCommandOutput) -> OrbitError {
+    OrbitError::Execution(manager_probe_diagnostic(command, output))
+}
+
+fn clock_manager_probe_error(
+    platform: ClockPlatform,
+    command: &ManagerCommand,
+    error: &OrbitError,
+) -> OrbitError {
+    OrbitError::Execution(format!(
+        "{} clock manager is unavailable; `{}` could not run: {}. Check that the per-user {} manager is installed and running and that this process can query it",
+        platform.name(),
+        command.display(),
+        bounded_manager_text(&error.to_string()),
+        platform.name(),
+    ))
+}
+
+fn manager_probe_diagnostic(command: &ManagerCommand, output: &ManagerCommandOutput) -> String {
+    let exit = output.exit_code.map_or_else(
+        || "by signal".to_string(),
+        |code| format!("with exit code {code}"),
+    );
+    let stdout = bounded_manager_text(&output.stdout);
+    let stderr = bounded_manager_text(&output.stderr);
+    let mut detail = Vec::new();
+    if !stdout.is_empty() {
+        detail.push(format!("stdout: {stdout}"));
+    }
+    if !stderr.is_empty() {
+        detail.push(format!("stderr: {stderr}"));
+    }
+    if detail.is_empty() {
+        format!("`{}` failed {exit} without output", command.display())
+    } else {
+        format!(
+            "`{}` failed {exit} ({})",
+            command.display(),
+            detail.join(", ")
+        )
+    }
+}
+
+fn bounded_manager_text(value: &str) -> String {
+    const MAX_DIAGNOSTIC_CHARS: usize = 512;
+
+    let collapsed = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    let mut chars = collapsed.chars();
+    let bounded = chars
+        .by_ref()
+        .take(MAX_DIAGNOSTIC_CHARS)
+        .collect::<String>();
+    if chars.next().is_some() {
+        format!("{bounded}…")
+    } else {
+        bounded
+    }
 }
 
 #[derive(Debug, Default)]

--- a/crates/orbit-core/src/application/routines/tests/clock.rs
+++ b/crates/orbit-core/src/application/routines/tests/clock.rs
@@ -7,14 +7,16 @@ use tempfile::tempdir;
 use orbit_common::OrbitError;
 
 use super::super::clock::{
-    ClockCommandRunner, ClockPlatform, ClockSettings, ManagerCommand, clock_status_with,
-    install_clock_with, load_clock_settings, render_systemd_service, render_systemd_timer,
-    save_clock_settings, set_clock_cadence_with, set_clock_enabled_with, validated_sweep_log_path,
+    ClockCommandRunner, ClockPlatform, ClockSettings, ManagerCommand, ManagerCommandOutput,
+    clock_status_with, install_clock_with, load_clock_settings, render_systemd_service,
+    render_systemd_timer, save_clock_settings, set_clock_cadence_with, set_clock_enabled_with,
+    validated_sweep_log_path,
 };
 
 struct MockRunner {
     results: Mutex<Vec<Result<bool, OrbitError>>>,
     outputs: Mutex<Vec<Result<Option<String>, OrbitError>>>,
+    probes: Mutex<Vec<Result<ManagerCommandOutput, OrbitError>>>,
     commands: Mutex<Vec<String>>,
 }
 
@@ -23,6 +25,7 @@ impl MockRunner {
         Self {
             results: Mutex::new(results.into_iter().rev().collect()),
             outputs: Mutex::new(Vec::new()),
+            probes: Mutex::new(Vec::new()),
             commands: Mutex::new(Vec::new()),
         }
     }
@@ -34,6 +37,20 @@ impl MockRunner {
         Self {
             results: Mutex::new(results.into_iter().rev().collect()),
             outputs: Mutex::new(outputs.into_iter().rev().collect()),
+            probes: Mutex::new(Vec::new()),
+            commands: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn with_probes(
+        results: Vec<Result<bool, OrbitError>>,
+        outputs: Vec<Result<Option<String>, OrbitError>>,
+        probes: Vec<Result<ManagerCommandOutput, OrbitError>>,
+    ) -> Self {
+        Self {
+            results: Mutex::new(results.into_iter().rev().collect()),
+            outputs: Mutex::new(outputs.into_iter().rev().collect()),
+            probes: Mutex::new(probes.into_iter().rev().collect()),
             commands: Mutex::new(Vec::new()),
         }
     }
@@ -66,6 +83,37 @@ impl ClockCommandRunner for MockRunner {
             .expect("test output queue lock")
             .pop()
             .expect("test configured output for every manager query")
+    }
+
+    fn probe(&self, command: &ManagerCommand) -> Result<ManagerCommandOutput, OrbitError> {
+        self.commands
+            .lock()
+            .expect("test command log lock")
+            .push(command.display());
+        if let Some(output) = self.probes.lock().expect("test probe queue lock").pop() {
+            return output;
+        }
+        let success = self
+            .results
+            .lock()
+            .expect("test result queue lock")
+            .pop()
+            .expect("test configured a result for every manager command")?;
+        Ok(ManagerCommandOutput {
+            success,
+            exit_code: Some(if success { 0 } else { 1 }),
+            stdout: String::new(),
+            stderr: String::new(),
+        })
+    }
+}
+
+fn manager_output(success: bool, stdout: &str, stderr: &str) -> ManagerCommandOutput {
+    ManagerCommandOutput {
+        success,
+        exit_code: Some(if success { 0 } else { 1 }),
+        stdout: stdout.to_string(),
+        stderr: stderr.to_string(),
     }
 }
 
@@ -700,6 +748,138 @@ fn disabled_systemd_timer_reports_loaded_state_without_becoming_schedulable() {
     assert!(!status.schedulable);
     assert_eq!(status.effective_cadence_seconds, None);
     assert!(status.health_issue.is_none());
+}
+
+#[test]
+fn unavailable_systemd_manager_fails_status_with_bounded_diagnostics() {
+    let root = tempdir().expect("create global root");
+    let repeated = "manager transport unavailable ".repeat(100);
+    let runner = MockRunner::with_probes(
+        Vec::new(),
+        vec![Err(OrbitError::Execution(format!(
+            "systemctl show failed: {repeated}"
+        )))],
+        vec![Ok(manager_output(
+            false,
+            "",
+            "Failed to connect to bus: No medium found",
+        ))],
+    );
+
+    let error = clock_status_with(root.path(), ClockPlatform::Systemd, &runner)
+        .expect_err("unavailable user manager must fail status");
+    let message = error.to_string();
+
+    assert!(message.contains("systemd clock manager is unavailable"));
+    assert!(message.contains("Failed to connect to bus: No medium found"));
+    assert!(message.contains("systemctl show failed"));
+    assert!(message.len() < 1_500, "manager diagnostics stay bounded");
+    for misleading in [
+        "paused",
+        "effectively inactive",
+        "orbit clock enable",
+        "pause",
+    ] {
+        assert!(!message.contains(misleading));
+    }
+}
+
+#[test]
+fn missing_systemd_unit_is_disabled_but_manager_transport_failure_is_unavailable() {
+    let root = tempdir().expect("create global root");
+    let missing = MockRunner::with_probes(
+        Vec::new(),
+        vec![Err(OrbitError::Execution(
+            "show failed: Unit orbit-sweep.timer could not be found".to_string(),
+        ))],
+        vec![Ok(manager_output(
+            false,
+            "",
+            "Failed to get unit file state: No such file or directory",
+        ))],
+    );
+
+    let status = clock_status_with(root.path(), ClockPlatform::Systemd, &missing)
+        .expect("a missing unit is a recognized disabled clock");
+    assert!(!status.enabled);
+    assert!(!status.loaded);
+    assert!(!status.schedulable);
+
+    let unavailable = MockRunner::with_probes(
+        Vec::new(),
+        vec![Err(OrbitError::Execution(
+            "show failed: Access denied".to_string(),
+        ))],
+        vec![Ok(manager_output(false, "", "Access denied"))],
+    );
+    let error = clock_status_with(root.path(), ClockPlatform::Systemd, &unavailable)
+        .expect_err("permission failure is not a disabled clock");
+    assert!(error.to_string().contains("manager is unavailable"));
+}
+
+#[test]
+fn enabled_systemd_with_unavailable_details_remains_enabled_but_unverifiable() {
+    let root = tempdir().expect("create global root");
+    let runner = MockRunner::with_outputs(
+        vec![Ok(true)],
+        vec![Err(OrbitError::Execution(
+            "systemctl show failed: temporary manager error".to_string(),
+        ))],
+    );
+
+    let status = clock_status_with(root.path(), ClockPlatform::Systemd, &runner)
+        .expect("enabled state remains authoritative when only details fail");
+
+    assert!(status.enabled);
+    assert!(!status.schedulable);
+    assert_eq!(status.effective_cadence_seconds, None);
+    assert!(status.health_issue.as_deref().is_some_and(|issue| {
+        issue.contains("could not be verified") && issue.contains("temporary manager error")
+    }));
+}
+
+#[test]
+fn launchd_not_loaded_is_disabled_but_transport_failure_is_unavailable() {
+    let root = tempdir().expect("create global root");
+    let not_loaded = MockRunner::with_probes(
+        Vec::new(),
+        Vec::new(),
+        vec![Ok(manager_output(
+            false,
+            "",
+            "Could not find service com.orbit.sweep in domain for user",
+        ))],
+    );
+
+    let status = clock_status_with(root.path(), ClockPlatform::Launchd, &not_loaded)
+        .expect("a recognized not-loaded agent is disabled");
+    assert!(!status.enabled);
+    assert!(!status.loaded);
+    assert!(!status.schedulable);
+    assert_eq!(
+        not_loaded.commands(),
+        vec!["launchctl list com.orbit.sweep"]
+    );
+
+    let unavailable = MockRunner::with_probes(
+        Vec::new(),
+        Vec::new(),
+        vec![
+            Ok(manager_output(false, "", "Operation not permitted")),
+            Ok(manager_output(false, "", "Operation not permitted")),
+        ],
+    );
+    let error = clock_status_with(root.path(), ClockPlatform::Launchd, &unavailable)
+        .expect_err("failure at the label and manager probes is unavailable");
+    let message = error.to_string();
+    assert!(message.contains("launchd clock manager is unavailable"));
+    assert!(message.contains("launchctl list com.orbit.sweep"));
+    assert!(message.contains("launchctl list`"));
+    assert!(!message.contains("pause"));
+    assert_eq!(
+        unavailable.commands(),
+        vec!["launchctl list com.orbit.sweep", "launchctl list"]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-12314](https://orbit-cli.com/tasks/ORB-12314) — Distinguish unavailable native clock manager from a paused clock

### Description

## Problem
When the native service manager cannot be queried, Orbit currently collapses transport or permission failure into `enabled=false`. A concrete Linux reproduction is an environment without `XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS`: both `systemctl --user is-enabled` and `systemctl --user show` exit 1 with `Failed to connect to bus: No medium found`, while installed `orbit clock status` exits 0 and reports the clock as paused/effectively inactive. With the user-bus environment present, the same timer is enabled, active, and scheduled at 300 seconds.

The current path in `crates/orbit-core/src/application/routines/clock.rs` uses `runner.run(...).unwrap_or(false)` for enabled state; the native runner reduces `is-enabled` to `status.success()` and only exposes detail errors after enabled is true. CLI presentation maps `!enabled` to paused, and the web projection reports paused health / `expected_enabled=false`, which can expose inappropriate clock controls or mutations.

## Required outcome
Represent native clock-manager unavailability separately from a recognized disabled/not-loaded unit. Preserve bounded command and error diagnostics, for both systemd and launchd. An unavailable manager must not be described as paused/effectively inactive, must not advise enable/pause, and must not feed fabricated `expected_enabled=false` into dashboard mutation controls; withhold controls or fail the status read clearly. Preserve existing behavior for enabled+active clocks with a finite next trigger, genuinely disabled/paused clocks, enabled but unschedulable/unverifiable clocks, enabled with detail query unavailable, and missing unit versus unavailable manager.

Use the smallest appropriate process-result or second-probe seam; do not broadly refactor clock management or change persistent configuration. Worker execution must use fake commands and isolated tests only and must not pause or enable the live clock. The root operator will separately verify unset-env versus user-bus-env behavior on an installed candidate.

### Acceptance Criteria

- Clock status distinguishes service-manager transport/permission unavailability from a recognized disabled or not-loaded clock on both systemd and launchd.
- Unavailable-manager output includes bounded actionable diagnostics and never claims paused/effectively inactive or recommends enable/pause.
- CLI, API, and dashboard rendering expose unavailable status honestly and withhold mutation controls or otherwise fail the status read without fabricating expected_enabled=false.
- Tests cover unavailable at both probes, recognized disabled with readable details, enabled healthy, enabled unschedulable, enabled with detail unavailable, systemd missing-unit versus manager unavailable, and launchd not-loaded versus transport/permission failure.
- No live clock state or persistent clock configuration is changed by implementation or tests.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a native manager probe result that retains exit code, stdout, and stderr, with whitespace-normalized 512-character diagnostic bounds.
- Classified systemd disabled/missing units and launchd not-loaded agents separately from transport, permission, and process-spawn failures.
- Made unavailable clock-manager reads return actionable errors before any ClockStatus is fabricated; existing CLI and web/API callers propagate the failure, so the dashboard receives no clock payload or mutation controls.
- Expanded isolated fake-runner coverage without invoking live service-manager mutations or writing persistent host configuration.

Acceptance criteria:
1. Systemd and launchd now distinguish recognized disabled/not-loaded results from unavailable manager queries.
2. Unavailable errors name failed probes, exit information, bounded output, and manager-access remediation; tests reject paused/effectively inactive and enable/pause advice.
3. clock_status returns an error on unavailability. The inspected CLI uses ? before state rendering, and the routines API maps the error before building dashboard JSON, so expected_enabled is not fabricated.
4. Focused tests cover unavailable probes on both platforms, readable disabled details, healthy enabled, enabled unschedulable, enabled detail failure, systemd missing unit versus unavailable, and launchd not-loaded versus permission failure.
5. All new tests use MockRunner and temporary directories only; no live clock or persistent settings were changed.

Validation:
- cargo test -p orbit-core application::routines::tests::clock — passed (35 passed, 0 failed).
- make ci-fast — passed; the existing unprivileged namespace capability probe reported its documented skip.
- make ci-lint — passed.
- make goldens — passed.
- git diff --check — passed.
- git status --short — passed inspection; only the two authorized task files are modified.

Assessment: The change stays within the authoritative clock-status boundary and preserves enabled healthy, enabled unschedulable, enabled detail-unavailable, and recognized paused behavior. CLI/API/dashboard integration needed no edits because those callers already fail the request before rendering status or controls.

Remaining risk:
- Native launchd behavior is covered with deterministic command outputs; the root operator retains the planned installed-candidate verification on macOS.
- Native systemd unset-bus versus user-bus verification is intentionally deferred to the root operator per the task mandate.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12314-6aa53840`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra