### PR TITLE
Stabilize and document the friction.list JSON response contract

### DIFF
--- a/crates/orbit-cli/src/command/friction.rs
+++ b/crates/orbit-cli/src/command/friction.rs
@@ -11,7 +11,9 @@
 //! genuinely friction-specific: how to render a friction response as text.
 
 use clap::{ArgMatches, Args, Command, FromArgMatches, Subcommand};
-use orbit_common::governance::friction::{FRICTION_OPERATIONS, FrictionVerb, friction_operation};
+use orbit_common::governance::friction::{
+    FRICTION_LIST_RESPONSE_MODE_WITH_NOTES, FRICTION_OPERATIONS, FrictionVerb, friction_operation,
+};
 use orbit_common::governance::operation::CliRender;
 use orbit_core::OrbitRuntime;
 use serde_json::Value;
@@ -57,11 +59,23 @@ impl FromArgMatches for FrictionInvocation {
 
 impl Execute for FrictionCommand {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
-        let FrictionInvocation { spec, input, json } = self.command;
+        let FrictionInvocation {
+            spec,
+            mut input,
+            json,
+        } = self.command;
         // `--json` no longer picks a branch here: it resolves the sink's mode
         // in `main`, and the renderer projects whichever payload this builds.
         // The flag stays declared and accepted [ADR-0306].
         let _ = json;
+        if spec.verb == FrictionVerb::List
+            && let Some(object) = input.as_object_mut()
+        {
+            object.insert(
+                "response_mode".to_string(),
+                Value::String(FRICTION_LIST_RESPONSE_MODE_WITH_NOTES.to_string()),
+            );
+        }
         let value = runtime.run_tool(spec.tool_name, input)?;
         render(&value, spec.cli_render)
     }
@@ -112,11 +126,11 @@ fn records_table_payload(value: &Value) -> CommandOut {
         .map(|note| Block::text(format!("note: {note}")))
         .collect();
     blocks.push(Block::table(table));
-    Ok(Payload::blocks(value.clone(), blocks).into())
+    Ok(Payload::blocks(Value::Array(records), blocks).into())
 }
 
-/// Historical list JSON is a record array. An empty multi-word `--q` wraps as
-/// `{records, notes}` so the substring-needle diagnostic is visible.
+/// The tool's opt-in notes envelope is projected back to the historical record
+/// array for JSON output while retaining notes in the human rendering.
 fn split_list_payload(value: &Value) -> Option<(Vec<Value>, Vec<String>)> {
     match value {
         Value::Array(records) => Some((records.clone(), Vec::new())),

--- a/crates/orbit-cli/src/command/tests/friction.rs
+++ b/crates/orbit-cli/src/command/tests/friction.rs
@@ -10,7 +10,9 @@ use clap::Parser;
 use orbit_common::governance::friction::FrictionVerb;
 use serde_json::{Value, json};
 
-use super::super::{Cli, Commands, operation::RuntimeNeed};
+use super::super::{Cli, Commands, Execute, operation::RuntimeNeed};
+use crate::command::CommandOutput;
+use crate::output::payload::{Block, View};
 
 /// Parse an argv and return the friction invocation it produced.
 fn invocation(args: &[&str]) -> super::super::friction::FrictionInvocation {
@@ -77,6 +79,46 @@ fn cli_parses_friction_list() {
     assert_eq!(parsed.input, json!({ "status": "open" }));
     assert!(!parsed.json);
     assert_eq!(parsed.target_id(), None);
+}
+
+#[test]
+fn cli_keeps_array_json_while_rendering_multi_word_guidance() {
+    let runtime = orbit_core::OrbitRuntime::in_memory().expect("runtime");
+    runtime
+        .run_tool(
+            "orbit.friction.add",
+            json!({
+                "body": "workspace_init lost the parallel env snapshot while EnvGuard was armed.",
+                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+            }),
+        )
+        .expect("seed friction");
+    let command = super::super::friction::FrictionCommand {
+        command: invocation(&[
+            "orbit",
+            "friction",
+            "list",
+            "--q",
+            "EnvGuard workspace_init",
+        ]),
+    };
+
+    let CommandOutput::Payload(payload) = command.execute(&runtime).expect("list") else {
+        panic!("list returns a payload");
+    };
+    let (document, view) = payload.into_view();
+
+    assert_eq!(document, json!([]), "CLI JSON remains the legacy array");
+    let View::Blocks(blocks) = view else {
+        panic!("friction list has a human block view");
+    };
+    assert!(
+        blocks.iter().any(|block| matches!(
+            block,
+            Block::Text(text) if text.contains("single case-insensitive substring")
+        )),
+        "human output retains the multi-word guidance"
+    );
 }
 
 #[test]

--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -304,7 +304,7 @@
   {
     "active": true,
     "builtin": true,
-    "description": "List friction records",
+    "description": "List friction records. Returns a JSON record array by default. Set `response_mode` to `with_notes` for a stable `{records, notes}` object.",
     "enabled": true,
     "name": "orbit.friction.list",
     "parameters": [
@@ -360,6 +360,12 @@
         "description": "Optional number of records to skip",
         "name": "offset",
         "param_type": "integer",
+        "required": false
+      },
+      {
+        "description": "Optional response shape: `with_notes` returns `{records, notes}`; omit for the legacy record array",
+        "name": "response_mode",
+        "param_type": "string",
         "required": false
       }
     ],

--- a/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
@@ -8,7 +8,7 @@ orbit.auto_task.list	active	yes	-	List every auto-task definition in this worksp
 orbit.auto_task.mint	active	yes	name:string	Mint one task now from an auto-task definition. Unconditional: the schedule, dedupe policy, and enabled flag are ignored, and the scheduler's own cursor is left untouched.
 orbit.command.exec	active	yes	argv:string|string[], working_directory:string	Execute a command as an explicit argv array in an explicit working directory and return its stdout, stderr, and exit status. Requires operator capability and the workspace claim; withheld from managed runs.
 orbit.friction.add	active	yes	body:string, model:string	Append a friction report
-orbit.friction.list	active	yes	-	List friction records
+orbit.friction.list	active	yes	-	List friction records. Returns a JSON record array by default. Set `response_mode` to `with_notes` for a stable `{records, notes}` object.
 orbit.friction.update	active	yes	id:string	Update triage metadata for a friction record
 orbit.pipeline.invoke	active	yes	job_name:string, input:object	Submit a durable pipeline run and return immediately with its run ID.
 orbit.pipeline.wait	active	yes	run_ids:string|string[]	Block until the supplied pipeline runs reach terminal state or timeout.

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -205,7 +205,7 @@
     "name": "orbit_friction_add"
   },
   {
-    "description": "List friction records",
+    "description": "List friction records. Returns a JSON record array by default. Set `response_mode` to `with_notes` for a stable `{records, notes}` object.",
     "inputSchema": {
       "additionalProperties": true,
       "properties": {
@@ -237,6 +237,10 @@
         },
         "q": {
           "description": "Optional case-insensitive query over id, model, tags, status, task, and body",
+          "type": "string"
+        },
+        "response_mode": {
+          "description": "Optional response shape: `with_notes` returns `{records, notes}`; omit for the legacy record array",
           "type": "string"
         },
         "status": {

--- a/crates/orbit-common/src/governance/friction/mod.rs
+++ b/crates/orbit-common/src/governance/friction/mod.rs
@@ -8,7 +8,8 @@ pub mod operations;
 pub mod title;
 
 pub use operations::{
-    FRICTION_OPERATIONS, FrictionOperation, FrictionVerb, friction_operation, friction_operations,
+    FRICTION_LIST_RESPONSE_MODE_WITH_NOTES, FRICTION_OPERATIONS, FrictionOperation, FrictionVerb,
+    friction_operation, friction_operations,
 };
 pub use title::{FRICTION_TITLE_MAX_CHARS, derive_title, effective_title, normalize_title};
 

--- a/crates/orbit-common/src/governance/friction/operations.rs
+++ b/crates/orbit-common/src/governance/friction/operations.rs
@@ -43,6 +43,9 @@ pub enum FrictionVerb {
 /// A friction operation specification.
 pub type FrictionOperation = OperationSpec<FrictionVerb>;
 
+/// Opt-in `friction.list` response mode that returns records and guidance.
+pub const FRICTION_LIST_RESPONSE_MODE_WITH_NOTES: &str = "with_notes";
+
 impl FrictionVerb {
     /// This verb's specification.
     pub fn spec(self) -> &'static FrictionOperation {
@@ -154,7 +157,7 @@ const LIST: FrictionOperation = FrictionOperation {
     verb: FrictionVerb::List,
     name: "list",
     tool_name: "orbit.friction.list",
-    tool_description: "List friction records",
+    tool_description: "List friction records. Returns a JSON record array by default. Set `response_mode` to `with_notes` for a stable `{records, notes}` object.",
     cli_about: "List friction records",
     params: &[
         text_param("model", "Optional model filter"),
@@ -175,6 +178,15 @@ const LIST: FrictionOperation = FrictionOperation {
         text_param("to", "Optional RFC3339 upper bound for created_at"),
         count_param("limit", "Optional maximum number of records to return"),
         count_param("offset", "Optional number of records to skip"),
+        ParamSpec {
+            name: "response_mode",
+            param_type: ParamType::String,
+            required: false,
+            mcp_description: Some(Description::Static(
+                "Optional response shape: `with_notes` returns `{records, notes}`; omit for the legacy record array",
+            )),
+            cli: None,
+        },
     ],
     rejects_agent_field: false,
     mcp_scope: Some(McpToolScope::WorkspaceRequired),

--- a/crates/orbit-core/assets/skills/orbit/references/friction.md
+++ b/crates/orbit-core/assets/skills/orbit/references/friction.md
@@ -56,6 +56,24 @@ section heading gets whatever that section's first sentence says.
 `orbit friction update <ID> --title <title>` retitles an existing record
 without replacing its body.
 
+## Listing and JSON response contract
+
+`orbit.friction.list` returns a JSON array of friction records by default,
+including when any combination of filters produces no records. This is the
+legacy contract and is stable for array consumers.
+
+Callers that want search guidance can explicitly send
+`"response_mode": "with_notes"`. That mode always returns an object with the
+same two fields: `records` is the record array and `notes` is a string array.
+An empty multi-word substring search may include guidance in `notes`; matches,
+one-word misses, and other empty filtered results return an empty `notes`
+array. Other `response_mode` values are rejected.
+
+The human `orbit friction list` command and the dashboard opt into notes so
+they can show that guidance. `orbit friction list --json` remains a bare record
+array for compatibility; the notes envelope is available through the tool/MCP
+input above.
+
 ## Tags
 
 ```bash

--- a/crates/orbit-core/src/adapter/tool_host/friction_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/friction_tools.rs
@@ -11,7 +11,9 @@ use std::str::FromStr;
 
 use chrono::{DateTime, TimeZone, Utc};
 use orbit_common::OrbitError;
-use orbit_common::governance::friction::{FrictionVerb, effective_title, normalize_title};
+use orbit_common::governance::friction::{
+    FRICTION_LIST_RESPONSE_MODE_WITH_NOTES, FrictionVerb, effective_title, normalize_title,
+};
 use orbit_common::protocol::tool_input::{
     optional_csv_or_string_list_alias, optional_raw_string, optional_string, required_string,
 };
@@ -81,6 +83,16 @@ fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
 /// Translate the wire filter into the store filter, including the page, so
 /// SQLite decides which rows exist before any body is decoded.
 fn list_in(store: &dyn FrictionStoreBackend, input: Value) -> Result<Value, OrbitError> {
+    let response_mode = optional_string(&input, "response_mode")?;
+    let with_notes = match response_mode.as_deref() {
+        None => false,
+        Some(FRICTION_LIST_RESPONSE_MODE_WITH_NOTES) => true,
+        Some(value) => {
+            return Err(OrbitError::InvalidInput(format!(
+                "`response_mode` must be `{FRICTION_LIST_RESPONSE_MODE_WITH_NOTES}`, got '{value}'"
+            )));
+        }
+    };
     let month_bounds = optional_string(&input, "month")?
         .map(|raw| parse_month_bounds(&raw))
         .transpose()?;
@@ -110,21 +122,22 @@ fn list_in(store: &dyn FrictionStoreBackend, input: Value) -> Result<Value, Orbi
         .into_iter()
         .map(record_to_json)
         .collect::<Result<Vec<_>, _>>()?;
-    Ok(list_payload(records, filter.q.as_deref()))
+    Ok(list_payload(records, filter.q.as_deref(), with_notes))
 }
 
-/// Keep the historical JSON array when the page has hits or the needle is a
-/// single token. Wrap only the empty multi-word miss so a curator can see that
-/// the substring matcher — not an empty group — produced zero rows.
-fn list_payload(records: Vec<Value>, query: Option<&str>) -> Value {
-    if records.is_empty()
-        && let Some(query) = query
-        && let Some(note) = empty_whitespace_query_note(query)
-    {
-        return json!({
-            "records": [],
-            "notes": [note],
-        });
+/// Preserve the historical array unless the caller explicitly requests the
+/// stable notes envelope. The envelope shape does not depend on query results.
+fn list_payload(records: Vec<Value>, query: Option<&str>, with_notes: bool) -> Value {
+    if with_notes {
+        let notes = if records.is_empty() {
+            query
+                .and_then(empty_whitespace_query_note)
+                .into_iter()
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+        return json!({ "records": records, "notes": notes });
     }
     Value::Array(records)
 }

--- a/crates/orbit-core/src/adapter/tool_host/tests/friction_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/friction_tools.rs
@@ -148,7 +148,7 @@ fn an_empty_update_title_restores_derivation() {
 }
 
 #[test]
-fn list_notes_empty_multi_word_substring_miss() {
+fn list_default_is_always_the_legacy_array() {
     let (_temp, runtime, _repo) = test_runtime();
     let seeded = run_tool_as_operator(
         &runtime,
@@ -163,45 +163,94 @@ fn list_notes_empty_multi_word_substring_miss() {
     .expect("seed open friction");
     let id = seeded["id"].as_str().expect("record id");
 
-    let miss = run_tool_as_operator(
+    let month = seeded["created_at"]
+        .as_str()
+        .and_then(|created_at| created_at.get(..7))
+        .expect("record month");
+    let filtered_hit = run_tool_as_operator(
         &runtime,
         "orbit.friction.list",
-        json!({ "status": "open", "q": "EnvGuard workspace_init" }),
+        json!({
+            "model": TEST_CODEX_MODEL,
+            "status": "open",
+            "tag": "tooling",
+            "month": month,
+            "q": "EnvGuard",
+            "from": "2000-01-01T00:00:00Z",
+            "to": "2100-01-01T00:00:00Z",
+            "limit": 10,
+            "offset": 0,
+        }),
     )
-    .expect("multi-word list");
+    .expect("list with every filter");
+    let records = filtered_hit.as_array().expect("default record array");
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["id"], json!(id));
 
-    assert_eq!(miss["records"], json!([]));
-    let notes = miss["notes"].as_array().expect("notes array");
-    assert_eq!(notes.len(), 1);
-    let note = notes[0].as_str().expect("note text");
-    assert!(note.contains("single case-insensitive substring"), "{note}");
-    assert!(note.contains("not proof the corpus is empty"), "{note}");
-    assert!(note.contains("EnvGuard"), "{note}");
-    assert!(note.contains("workspace_init"), "{note}");
+    for input in [
+        json!({ "q": "EnvGuardUniqueMiss" }),
+        json!({ "q": "EnvGuard workspace_init" }),
+        json!({ "status": "resolved" }),
+    ] {
+        let result = run_tool_as_operator(&runtime, "orbit.friction.list", input)
+            .expect("default empty list");
+        assert_eq!(result, json!([]), "every default empty result is an array");
+    }
+}
+
+#[test]
+fn list_with_notes_is_one_stable_envelope_for_hits_and_misses() {
+    let (_temp, runtime, _repo) = test_runtime();
+    let seeded = run_tool_as_operator(
+        &runtime,
+        "orbit.friction.add",
+        json!({
+            "body": "workspace_init lost the parallel env snapshot while EnvGuard was armed.",
+            "model": TEST_CODEX_MODEL,
+        }),
+    )
+    .expect("seed friction");
 
     let hit = run_tool_as_operator(
         &runtime,
         "orbit.friction.list",
-        json!({ "status": "open", "q": "EnvGuard" }),
+        json!({ "q": "EnvGuard", "response_mode": "with_notes" }),
     )
-    .expect("single-term list");
+    .expect("notes-mode hit");
+    assert_eq!(hit["records"][0]["id"], seeded["id"]);
+    assert_eq!(hit["notes"], json!([]));
 
-    let records = hit.as_array().expect("historical array shape");
-    assert_eq!(records.len(), 1);
-    assert_eq!(records[0]["id"], json!(id));
-
-    let unmatched = run_tool_as_operator(
+    let one_word_miss = run_tool_as_operator(
         &runtime,
         "orbit.friction.list",
-        json!({ "status": "open", "q": "EnvGuardUniqueMiss" }),
+        json!({ "q": "UniqueMiss", "response_mode": "with_notes" }),
     )
-    .expect("single-term miss");
-    assert!(
-        unmatched
-            .as_array()
-            .is_some_and(|records| records.is_empty()),
-        "single-term empty pages keep the array shape: {unmatched}"
-    );
+    .expect("notes-mode one-word miss");
+    assert_eq!(one_word_miss, json!({ "records": [], "notes": [] }));
+
+    let multi_word_miss = run_tool_as_operator(
+        &runtime,
+        "orbit.friction.list",
+        json!({ "q": "EnvGuard workspace_init", "response_mode": "with_notes" }),
+    )
+    .expect("notes-mode multi-word miss");
+    assert_eq!(multi_word_miss["records"], json!([]));
+    let note = multi_word_miss["notes"][0].as_str().expect("note text");
+    assert!(note.contains("single case-insensitive substring"), "{note}");
+    assert!(note.contains("not proof the corpus is empty"), "{note}");
+}
+
+#[test]
+fn list_rejects_unknown_response_modes() {
+    let (_temp, runtime, _repo) = test_runtime();
+    let message = invalid_input_message(run_tool_as_operator(
+        &runtime,
+        "orbit.friction.list",
+        json!({ "response_mode": "sometimes" }),
+    ));
+
+    assert!(message.contains("`response_mode`"), "{message}");
+    assert!(message.contains("`with_notes`"), "{message}");
 }
 
 #[test]

--- a/crates/orbit-tools/src/builtin/orbit/friction/tests/derived_schema.rs
+++ b/crates/orbit-tools/src/builtin/orbit/friction/tests/derived_schema.rs
@@ -116,7 +116,8 @@ fn list_schema_matches_the_shipped_contract() {
     let schema = schema_for(FrictionVerb::List);
 
     assert_eq!(schema.name, "orbit.friction.list");
-    assert_eq!(schema.description, "List friction records");
+    assert!(schema.description.contains("JSON record array by default"));
+    assert!(schema.description.contains("`{records, notes}`"));
     assert_eq!(
         param_shape(&schema),
         vec![
@@ -129,7 +130,12 @@ fn list_schema_matches_the_shipped_contract() {
             ("to", "string", false),
             ("limit", "integer", false),
             ("offset", "integer", false),
+            ("response_mode", "string", false),
         ]
+    );
+    assert_eq!(
+        schema.parameters[9].description,
+        "Optional response shape: `with_notes` returns `{records, notes}`; omit for the legacy record array"
     );
 }
 

--- a/crates/orbit-web/src/api/frictions.rs
+++ b/crates/orbit-web/src/api/frictions.rs
@@ -13,7 +13,7 @@ use crate::state::Ws;
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{Path, Query};
 use axum::response::{IntoResponse, Json, Response};
-use orbit_common::governance::friction::FrictionVerb;
+use orbit_common::governance::friction::{FRICTION_LIST_RESPONSE_MODE_WITH_NOTES, FrictionVerb};
 use orbit_core::{OrbitError, OrbitRuntime};
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
@@ -158,7 +158,11 @@ pub(super) async fn list_frictions(
             "limit",
             Value::from(bounded_limit(query.limit, FRICTIONS_DEFAULT_LIMIT)),
         )?;
-        call.set("offset", Value::from(query.offset.unwrap_or(0)))
+        call.set("offset", Value::from(query.offset.unwrap_or(0)))?;
+        call.set(
+            "response_mode",
+            Value::String(FRICTION_LIST_RESPONSE_MODE_WITH_NOTES.to_string()),
+        )
     })();
     if let Err(e) = built {
         return map_runtime_error(e);

--- a/crates/orbit-web/src/api/tests/frictions.rs
+++ b/crates/orbit-web/src/api/tests/frictions.rs
@@ -399,7 +399,15 @@ fn dashboard_friction_parameters_are_declared_by_the_registry() {
     let used: &[(FrictionVerb, &[&str])] = &[
         (
             FrictionVerb::List,
-            &["status", "tag", "month", "q", "limit", "offset"],
+            &[
+                "status",
+                "tag",
+                "month",
+                "q",
+                "limit",
+                "offset",
+                "response_mode",
+            ],
         ),
         (FrictionVerb::Add, &["model", "body", "tags", "during_task"]),
         (FrictionVerb::Show, &["id"]),

--- a/docs/design/operations-as-data/2_design.md
+++ b/docs/design/operations-as-data/2_design.md
@@ -93,6 +93,14 @@ redaction policy for `Add`/`Update`, for example — pattern-match on the inner
 verb. Core's handler match remains exhaustive, so a new verb cannot omit runtime
 wiring.
 
+The `list` spec also declares the MCP-only `response_mode` parameter. Omitting
+it preserves the legacy record-array response for matches and every empty
+result. The explicit `with_notes` mode has one stable object shape,
+`{records, notes}`, so callers can request search guidance without making the
+default response conditional. The tool description and parameter description
+advertise both alternatives because the generic tool schema has no output
+schema field.
+
 ## 4. CLI adapter
 
 `orbit_cli::command::operation_args` builds a `clap::Command` subcommand per
@@ -121,6 +129,11 @@ Audit metadata is derived too. `command/operation.rs`'s friction arm reads
 `invocation.spec.name` and `invocation.target_id()` — the latter resolved by
 looking up the spec's positional parameter — instead of matching verb by verb.
 
+The friction CLI injects `response_mode: with_notes` for list calls so its
+human table can include search guidance. Its machine-readable document projects
+the envelope's `records` back to the historical array, keeping `--json`
+compatible.
+
 ## 5. Dashboard adapter
 
 The dashboard is the partial case, and deliberately so. `FrictionCall` takes tool
@@ -132,6 +145,9 @@ and dashboard-specific defaults (the `limit` cap, the human-actor fallback for
 `model`, the `tag_options` enrichment on GET). A REST path is an interface design
 choice, not a property of the verb, so deriving it was rejected rather than
 deferred.
+
+The dashboard list adapter explicitly requests `with_notes`, maps `records` to
+its `items` field, and forwards non-empty notes for the hint UI.
 
 ## 6. The touch-it-move-it ratchet
 

--- a/plugin/skills/orbit/references/friction.md
+++ b/plugin/skills/orbit/references/friction.md
@@ -56,6 +56,24 @@ section heading gets whatever that section's first sentence says.
 `orbit friction update <ID> --title <title>` retitles an existing record
 without replacing its body.
 
+## Listing and JSON response contract
+
+`orbit.friction.list` returns a JSON array of friction records by default,
+including when any combination of filters produces no records. This is the
+legacy contract and is stable for array consumers.
+
+Callers that want search guidance can explicitly send
+`"response_mode": "with_notes"`. That mode always returns an object with the
+same two fields: `records` is the record array and `notes` is a string array.
+An empty multi-word substring search may include guidance in `notes`; matches,
+one-word misses, and other empty filtered results return an empty `notes`
+array. Other `response_mode` values are rejected.
+
+The human `orbit friction list` command and the dashboard opt into notes so
+they can show that guidance. `orbit friction list --json` remains a bare record
+array for compatibility; the notes envelope is available through the tool/MCP
+input above.
+
 ## Tags
 
 ```bash


### PR DESCRIPTION
## Task

[ORB-12316](https://orbit-cli.com/tasks/ORB-12316) — Stabilize and document the friction.list JSON response contract

### Description

## Problem
At current source, `friction.list` returns the legacy JSON array for normal/default results, but only an empty multi-word miss returns `{records, notes}`. The tool metadata advertises no output schema or union, so an external array client fails conditionally in the one case meant to provide search guidance. In-repository CLI and web consumers already handle both forms. ORB-11565 introduced the useful empty-query guidance and is related to this compatibility risk; no open task owns the response contract.

## Required outcome
Preserve the legacy default array contract while exposing the guidance through an explicit opt-in or versioned notes envelope used by internal CLI/web callers that need it, or implement an equally compatible stable contract justified by current caller inspection. Do not silently change all default responses to an envelope and do not remove the useful guidance. Advertise the actual result shape/schema and document CLI/MCP JSON behavior. Add contract tests for normal matches, empty one-word queries, empty multi-word queries, all filters, legacy/default array consumers, and the explicit notes mode. Update internal callers so their hint UX remains intact. Keep scope to this response-contract compatibility defect; no optional style cleanup.

### Acceptance Criteria

- Default and legacy friction.list JSON consumers receive one stable documented response shape for matches and all empty-result cases.
- Empty multi-word search guidance remains available through an explicit, documented, stable mode without silently flipping every default response to an envelope.
- Tool metadata and CLI/MCP documentation describe the actual result schema or versioned alternatives.
- Contract tests cover matches, empty one-word and multi-word searches, filters, default array compatibility, explicit notes mode, and internal CLI/web hint behavior.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Stabilized orbit.friction.list so omitted response_mode always returns the legacy JSON record array for matches and every empty-result case.
- Added the explicit response_mode=with_notes contract, which always returns {records, notes}, validates unsupported values, and retains multi-word substring guidance.
- Opted the CLI and dashboard into notes mode while preserving the CLI --json array document; updated MCP/tool metadata, generated goldens, maintained skill copies, and the operations-as-data design.
- Added friction/mod.rs and generated tool-list golden selectors to task scope because they directly export or consume the new contract.
Criteria:
1. Default compatibility: core contract coverage verifies array results for a fully filtered match, one-word miss, multi-word miss, and filtered miss.
2. Explicit guidance: notes-mode coverage verifies stable envelopes for hits and one-word/multi-word misses, including the existing guidance on a multi-word miss.
3. Metadata/docs: the operation description and response_mode parameter advertise both shapes; MCP/tool snapshots and CLI/MCP documentation were regenerated and synchronized.
4. Internal behavior: CLI coverage verifies machine JSON stays an array while human blocks contain the hint; web coverage verifies the dashboard receives and forwards the hint.
Validation:
- cargo test -p orbit-core adapter::tool_host::tests::friction_tools -- --nocapture: passed (12 tests).
- cargo test -p orbit-cli command::tests::friction -- --nocapture: passed (14 tests); the final focused CLI behavior rerun also passed.
- cargo test -p orbit-tools builtin::orbit::friction::tests::derived_schema -- --nocapture: passed (8 tests).
- cargo test -p orbit-web api::tests::frictions -- --nocapture: passed (13 tests).
- make goldens UPDATE=1: passed and updated the three affected tool metadata goldens.
- make goldens: passed.
- make ci-fast: passed; its compiler-cache namespace probe reported the documented environment skip because unprivileged mount namespaces are unavailable, while the gate completed successfully.
- make ci-lint: passed with workspace/all-target warnings denied.
- git diff --check: passed.
- git status --short: 15 intended tracked modifications, no untracked files; initial checkout was clean at 0f2c53b43f970edeb135ce68622dcbfa48fd2b98.
Assessment: The response shape is now selected only by an explicit validated mode, with one shared wire constant and boundary-level coverage across tool host, CLI, web, metadata, and docs.
Remaining risks or deviations: None. Full make ci was not run per workspace policy.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12316-6aa53a18`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra