### PR TITLE
Make clock pause refuse an unavailable native manager

### DIFF
--- a/crates/orbit-core/src/application/routines/clock.rs
+++ b/crates/orbit-core/src/application/routines/clock.rs
@@ -773,9 +773,15 @@ pub(super) fn set_clock_enabled_with(
     home: &Path,
 ) -> Result<ClockStatus, OrbitError> {
     let settings = load_clock_settings(global_root)?;
-    let current = runner
-        .run(&manager_status_command(platform))
-        .unwrap_or(false);
+    let current = if enabled {
+        // Preserve the enable/rearm path: systemd always repairs and verifies
+        // the unit below, while launchd keeps its existing idempotent load.
+        runner
+            .run(&manager_status_command(platform))
+            .unwrap_or(false)
+    } else {
+        observe_clock_enabled_for_pause(platform, runner)?
+    };
     if platform == ClockPlatform::Systemd && enabled {
         migrate_stale_systemd_service(home)?;
         migrate_stale_systemd_timer(home, settings)?;
@@ -820,6 +826,51 @@ pub(super) fn set_clock_enabled_with(
     Ok(clock_status_from(
         settings, enabled, enabled, platform, None, None,
     ))
+}
+
+/// Observe enough native-manager state to make pause safe and idempotent.
+/// A failed status command is inactive only when the manager's diagnostic is
+/// a recognized disabled/not-loaded state; transport and ambiguous failures
+/// must stop before the control path can mutate the manager.
+fn observe_clock_enabled_for_pause(
+    platform: ClockPlatform,
+    runner: &dyn ClockCommandRunner,
+) -> Result<bool, OrbitError> {
+    let status_command = manager_status_command(platform);
+    let status_output = runner
+        .probe(&status_command)
+        .map_err(|error| clock_manager_probe_error(platform, &status_command, &error))?;
+    if status_output.success {
+        return Ok(true);
+    }
+
+    match platform {
+        ClockPlatform::Systemd if systemd_reports_disabled_or_missing(&status_output) => Ok(false),
+        ClockPlatform::Systemd => Err(clock_manager_unavailable_error(
+            platform,
+            [(&status_command, &status_output)],
+            None,
+        )),
+        ClockPlatform::Launchd if launchd_reports_not_loaded(&status_output) => Ok(false),
+        ClockPlatform::Launchd => {
+            let manager_command = launchd_manager_probe_command();
+            let manager_output = runner
+                .probe(&manager_command)
+                .map_err(|error| clock_manager_probe_error(platform, &manager_command, &error))?;
+            if manager_output.success {
+                Ok(false)
+            } else {
+                Err(clock_manager_unavailable_error(
+                    platform,
+                    [
+                        (&status_command, &status_output),
+                        (&manager_command, &manager_output),
+                    ],
+                    None,
+                ))
+            }
+        }
+    }
 }
 
 pub fn clock_status(global_root: &Path) -> Result<ClockStatus, OrbitError> {

--- a/crates/orbit-core/src/application/routines/tests/clock.rs
+++ b/crates/orbit-core/src/application/routines/tests/clock.rs
@@ -886,14 +886,18 @@ fn launchd_not_loaded_is_disabled_but_transport_failure_is_unavailable() {
 fn pause_and_enable_are_idempotent_for_launchd() {
     let root = tempdir().expect("create global root");
     let home = tempdir().expect("create home");
-    let runner = MockRunner::new(vec![
-        Ok(true),
-        Ok(true),
-        Ok(false),
-        Ok(false),
-        Ok(true),
-        Ok(true),
-    ]);
+    let runner = MockRunner::with_probes(
+        vec![Ok(true), Ok(false), Ok(true), Ok(true)],
+        Vec::new(),
+        vec![
+            Ok(manager_output(true, "", "")),
+            Ok(manager_output(
+                false,
+                "",
+                "Could not find service com.orbit.sweep in domain for user",
+            )),
+        ],
+    );
     assert!(
         !set_clock_enabled_with(
             root.path(),
@@ -939,6 +943,188 @@ fn pause_and_enable_are_idempotent_for_launchd() {
         .enabled
     );
     assert_eq!(runner.commands().len(), 6);
+}
+
+#[test]
+fn unavailable_or_unknown_systemd_state_refuses_pause_before_mutation() {
+    let root = tempdir().expect("create global root");
+    let home = tempdir().expect("create home");
+    save_clock_settings(
+        root.path(),
+        ClockSettings {
+            cadence_seconds: 300,
+        },
+    )
+    .expect("write clock settings");
+    let settings_before = fs::read_to_string(root.path().join("clock.toml"))
+        .expect("read clock settings before pause");
+    let unit_dir = home.path().join(".config/systemd/user");
+    fs::create_dir_all(&unit_dir).expect("create systemd unit directory");
+    let timer_path = unit_dir.join("orbit-sweep.timer");
+    fs::write(&timer_path, "sentinel timer\n").expect("write sentinel timer");
+
+    let unavailable = MockRunner::with_probes(
+        Vec::new(),
+        Vec::new(),
+        vec![Err(OrbitError::Execution(
+            "systemctl transport unavailable".to_string(),
+        ))],
+    );
+    let error = set_clock_enabled_with(
+        root.path(),
+        false,
+        ClockPlatform::Systemd,
+        &unavailable,
+        home.path(),
+    )
+    .expect_err("unavailable systemd manager must refuse pause");
+    assert!(
+        error
+            .to_string()
+            .contains("systemd clock manager is unavailable")
+    );
+    assert_eq!(
+        unavailable.commands(),
+        vec!["systemctl --user is-enabled orbit-sweep.timer"]
+    );
+
+    let unknown = MockRunner::with_probes(
+        Vec::new(),
+        Vec::new(),
+        vec![Ok(manager_output(false, "", "Access denied"))],
+    );
+    let error = set_clock_enabled_with(
+        root.path(),
+        false,
+        ClockPlatform::Systemd,
+        &unknown,
+        home.path(),
+    )
+    .expect_err("unknown systemd state must refuse pause");
+    assert!(
+        error
+            .to_string()
+            .contains("systemd clock manager is unavailable")
+    );
+    assert!(error.to_string().contains("Access denied"));
+    assert_eq!(
+        unknown.commands(),
+        vec!["systemctl --user is-enabled orbit-sweep.timer"]
+    );
+    assert_eq!(
+        fs::read_to_string(root.path().join("clock.toml"))
+            .expect("read clock settings after pause"),
+        settings_before
+    );
+    assert_eq!(
+        fs::read_to_string(timer_path).expect("read timer after pause"),
+        "sentinel timer\n"
+    );
+}
+
+#[test]
+fn unavailable_launchd_state_refuses_pause_before_mutation() {
+    let root = tempdir().expect("create global root");
+    let home = tempdir().expect("create home");
+    save_clock_settings(
+        root.path(),
+        ClockSettings {
+            cadence_seconds: 300,
+        },
+    )
+    .expect("write clock settings");
+    let settings_before = fs::read_to_string(root.path().join("clock.toml"))
+        .expect("read clock settings before pause");
+    let agents_dir = home.path().join("Library/LaunchAgents");
+    fs::create_dir_all(&agents_dir).expect("create launchd agent directory");
+    let plist_path = agents_dir.join("com.orbit.sweep.plist");
+    fs::write(&plist_path, "sentinel plist\n").expect("write sentinel plist");
+    let runner = MockRunner::with_probes(
+        Vec::new(),
+        Vec::new(),
+        vec![
+            Ok(manager_output(false, "", "Operation not permitted")),
+            Ok(manager_output(false, "", "Operation not permitted")),
+        ],
+    );
+
+    let error = set_clock_enabled_with(
+        root.path(),
+        false,
+        ClockPlatform::Launchd,
+        &runner,
+        home.path(),
+    )
+    .expect_err("unavailable launchd manager must refuse pause");
+
+    assert!(
+        error
+            .to_string()
+            .contains("launchd clock manager is unavailable")
+    );
+    assert_eq!(
+        runner.commands(),
+        vec!["launchctl list com.orbit.sweep", "launchctl list"]
+    );
+    assert_eq!(
+        fs::read_to_string(root.path().join("clock.toml"))
+            .expect("read clock settings after pause"),
+        settings_before
+    );
+    assert_eq!(
+        fs::read_to_string(plist_path).expect("read plist after pause"),
+        "sentinel plist\n"
+    );
+}
+
+#[test]
+fn recognized_inactive_manager_states_keep_pause_idempotent() {
+    let root = tempdir().expect("create global root");
+    let home = tempdir().expect("create home");
+
+    for diagnostic in [
+        "disabled",
+        "Failed to get unit file state: No such file or directory",
+    ] {
+        let runner = MockRunner::with_probes(
+            Vec::new(),
+            Vec::new(),
+            vec![Ok(manager_output(false, "", diagnostic))],
+        );
+        let status = set_clock_enabled_with(
+            root.path(),
+            false,
+            ClockPlatform::Systemd,
+            &runner,
+            home.path(),
+        )
+        .expect("recognized inactive systemd state is idempotent");
+        assert!(!status.enabled);
+        assert_eq!(
+            runner.commands(),
+            vec!["systemctl --user is-enabled orbit-sweep.timer"]
+        );
+    }
+
+    let launchd = MockRunner::with_probes(
+        Vec::new(),
+        Vec::new(),
+        vec![Ok(manager_output(
+            false,
+            "",
+            "Could not find service com.orbit.sweep in domain for user",
+        ))],
+    );
+    let status = set_clock_enabled_with(
+        root.path(),
+        false,
+        ClockPlatform::Launchd,
+        &launchd,
+        home.path(),
+    )
+    .expect("recognized not-loaded launchd state is idempotent");
+    assert!(!status.enabled);
+    assert_eq!(launchd.commands(), vec!["launchctl list com.orbit.sweep"]);
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-12319](https://orbit-cli.com/tasks/ORB-12319) — Make clock pause refuse an unavailable native manager

### Description

The ORB-12314 deploy gate passed: CLI status plus web GET and POST preflight correctly reject an unavailable native clock manager without fabricating a status payload or allowing control mutation. A separate pre-existing CLI control gap remains in set_clock_enabled_with. It still treats runner.run(is-enabled) failure as false; a requested pause with current=false shortcuts to success, so direct `orbit clock pause` can report paused while the timer remains running when the user service manager is unavailable.

Reuse ORB-12314's typed native-manager observation/preflight as appropriate. Unknown or unavailable manager state must return an actionable error before any manager mutation or unit rewrite and must never print false paused success. Preserve idempotent pause when systemd is genuinely disabled/missing or launchd genuinely not loaded, ordinary enabled pause, and existing enable/rearm/unschedulable repair behavior. Cover systemd and launchd unavailable-manager results, recognized disabled/not-loaded results, enabled normal pause, and existing enable/rearm semantics with the bounded fake runner. Assert from the fake command log that an unavailable observation causes no mutation command. Do not invoke live pause/stop/control operations or change persistent host configuration; the runbook's timer-always-alive policy remains unchanged. Keep scope in the existing clock source and tests; no broad clock refactor.

### Acceptance Criteria

- Direct clock pause returns an actionable error when native manager state is unavailable or unknown and emits no false paused success.
- Unavailable systemd and launchd observations cause no manager mutation, unit rewrite, or persistent configuration write, proven by fake-runner command logs.
- Recognized systemd disabled/missing and launchd not-loaded states retain idempotent pause behavior.
- Enabled normal pause and existing enable/rearm/unschedulable repair behavior remain unchanged.
- Focused fake-runner tests and repository-required checks pass without live service-manager control.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Direct pause now probes native manager state with typed command output and returns the existing actionable manager-unavailable error for execution failures or ambiguous systemd results before any control mutation.
- Recognized systemd disabled or missing states and launchd not-loaded states remain idempotent; launchd confirms an ambiguous label failure against the manager before treating it as inactive.
- Added bounded fake-runner coverage for unavailable and unknown systemd state, unavailable launchd state, unchanged clock settings and unit files, exact non-mutating command logs, recognized inactive states, normal pause, and existing enable/rearm behavior.
Acceptance criteria:
1. Satisfied: unavailable or unknown observations return OrbitError containing the platform-specific actionable manager-unavailable guidance, so no paused ClockStatus can be emitted.
2. Satisfied: fake logs contain only systemctl is-enabled or launchctl list probes for unavailable cases; sentinel timer/plist and clock.toml contents remain unchanged.
3. Satisfied: focused tests cover systemd disabled/missing and launchd not-loaded idempotent pause with no mutation command.
4. Satisfied: existing launchd idempotent pause/enable, systemd enabled pause, stale-unit migration, enable/restart/rearm, and unschedulable-repair tests pass unchanged apart from supplying typed launchd probe output.
5. Satisfied: all focused and repository-required checks passed without live service-manager control.
Validation:
- passed: cargo test -p orbit-core application::routines::tests::clock (38 passed, 0 failed)
- passed: make ci-fast (exit 0; its environment capability probe reported the expected non-fatal user-namespace skip)
- passed: make ci-lint (exit 0)
- passed: make goldens (exit 0)
- passed: git diff --check
- passed: git status --short; exactly the two authorized clock files are modified.
Assessment: The change is bounded to the control boundary and its fake-runner tests, preserves the enable path, and performs no live native-manager or persistent host operation.
Remaining risks: macOS behavior is represented by the bounded launchd fake rather than a live launchd environment, as required by the task.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12319-6aa53f48`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra