### PR TITLE
Guard orphan finalization with durable provider descendants

### DIFF
--- a/crates/orbit-core/src/application/job/run/reconcile.rs
+++ b/crates/orbit-core/src/application/job/run/reconcile.rs
@@ -2,6 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use orbit_common::OrbitError;
+use orbit_common::process::identity::{ProcessLiveness, is_stable_token, probe_process_liveness};
 use orbit_store::contracts::TaskReservationReleaseReason;
 use orbit_types::record::OrbitEvent;
 use orbit_types::workflow::{JobRun, JobRunState};
@@ -30,6 +31,13 @@ struct OwnerSnapshotKey {
     state: JobRunState,
     pid: Option<u32>,
     pid_start_time: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProviderFinalizationGuard {
+    Clear,
+    Alive,
+    Unknown,
 }
 
 impl ReconcilePass {
@@ -157,6 +165,25 @@ impl OrbitRuntime {
     where
         F: FnOnce(),
     {
+        self.reconcile_stale_job_run_before_revalidation_with_provider_probe(
+            run,
+            pass,
+            probe_process_liveness,
+            before_revalidation,
+        )
+    }
+
+    fn reconcile_stale_job_run_before_revalidation_with_provider_probe<F, P>(
+        &self,
+        run: &JobRun,
+        pass: &mut ReconcilePass,
+        provider_probe: P,
+        before_revalidation: F,
+    ) -> Result<bool, OrbitError>
+    where
+        F: FnOnce(),
+        P: Fn(u32, Option<&str>) -> ProcessLiveness,
+    {
         if terminal_run_timing_is_incomplete(run) {
             return self.repair_terminal_job_run_timing(run);
         }
@@ -169,9 +196,12 @@ impl OrbitRuntime {
             }
             return Ok(false);
         }
+        if !self.provider_evidence_allows_orphan_finalization(&run.run_id, &provider_probe) {
+            return Ok(false);
+        }
 
         before_revalidation();
-        self.finalize_orphaned_job_run(&run.run_id)
+        self.finalize_orphaned_job_run_with_provider_probe(&run.run_id, &provider_probe)
     }
 
     /// Deterministic seam for reproducing a terminal writer winning after the
@@ -192,11 +222,39 @@ impl OrbitRuntime {
         )
     }
 
+    /// Deterministic seam for provider evidence changing after the candidate
+    /// snapshot is classified but before the final write-boundary reread.
+    #[cfg(test)]
+    pub(super) fn reconcile_stale_job_run_with_provider_probe_after_classification<F, P>(
+        &self,
+        run: &JobRun,
+        provider_probe: P,
+        concurrent_provider_change: F,
+    ) -> Result<bool, OrbitError>
+    where
+        F: FnOnce(),
+        P: Fn(u32, Option<&str>) -> ProcessLiveness,
+    {
+        self.reconcile_stale_job_run_before_revalidation_with_provider_probe(
+            run,
+            &mut ReconcilePass::default(),
+            provider_probe,
+            concurrent_provider_change,
+        )
+    }
+
     /// [ORB-10002] Orphaned runs (owner process conclusively gone) become
     /// `interrupted`, not `failed`: the job did not fail, its worker died.
     /// Interrupted runs are resumable from their step checkpoints via
     /// `orbit job resume <run_id>`.
-    fn finalize_orphaned_job_run(&self, run_id: &str) -> Result<bool, OrbitError> {
+    fn finalize_orphaned_job_run_with_provider_probe<P>(
+        &self,
+        run_id: &str,
+        provider_probe: &P,
+    ) -> Result<bool, OrbitError>
+    where
+        P: Fn(u32, Option<&str>) -> ProcessLiveness,
+    {
         // [ORB-11116] The scan's candidate snapshot can go stale while a real
         // worker is terminalizing. Re-read at the interruption boundary and
         // re-run both state and owner classification so a completed run never
@@ -207,6 +265,9 @@ impl OrbitRuntime {
         let Some((error_code, message)) = stale_job_run_diagnostic(&current) else {
             return Ok(false);
         };
+        if !self.provider_evidence_allows_orphan_finalization(&current.run_id, provider_probe) {
+            return Ok(false);
+        }
 
         let finished_at = self.orphaned_run_finished_at(&current);
         let duration_ms = current.started_at.map(|started_at| {
@@ -248,6 +309,84 @@ impl OrbitRuntime {
             state: JobRunState::Interrupted.to_string(),
         })?;
         Ok(true)
+    }
+
+    /// A stale owner is not sufficient to condemn a run while any durable,
+    /// still-open provider child is alive or cannot be verified. The audit
+    /// collector reads the complete trail and process probing verifies the
+    /// recorded start token and PID namespace before returning `Alive`.
+    fn provider_evidence_allows_orphan_finalization<P>(
+        &self,
+        run_id: &str,
+        provider_probe: &P,
+    ) -> bool
+    where
+        P: Fn(u32, Option<&str>) -> ProcessLiveness,
+    {
+        let processes = match self.collect_run_provider_processes_with(run_id, provider_probe) {
+            Ok(processes) => processes,
+            Err(error) => {
+                tracing::warn!(
+                    target: "orbit.core.job_run",
+                    run_id,
+                    owner = "stale",
+                    error = %error,
+                    decision = "defer",
+                    reason = "provider_evidence_unreadable",
+                    "orphan finalization provider guard deferred",
+                );
+                return false;
+            }
+        };
+
+        let mut open = 0usize;
+        let mut alive = 0usize;
+        let mut unknown = 0usize;
+        for process in &processes {
+            if process.finished {
+                continue;
+            }
+            open += 1;
+            match process.liveness {
+                ProcessLiveness::Alive
+                    if process
+                        .pid_start_time
+                        .as_deref()
+                        .is_some_and(is_stable_token) =>
+                {
+                    alive += 1;
+                }
+                ProcessLiveness::Alive => unknown += 1,
+                ProcessLiveness::Unknown => unknown += 1,
+                ProcessLiveness::Exited => {}
+            }
+        }
+        let guard = if alive > 0 {
+            ProviderFinalizationGuard::Alive
+        } else if unknown > 0 {
+            ProviderFinalizationGuard::Unknown
+        } else {
+            ProviderFinalizationGuard::Clear
+        };
+        let (decision, reason) = match guard {
+            ProviderFinalizationGuard::Clear => ("finalize", "providers_closed_or_absent"),
+            ProviderFinalizationGuard::Alive => ("defer", "provider_alive"),
+            ProviderFinalizationGuard::Unknown => ("defer", "provider_liveness_unknown"),
+        };
+        tracing::debug!(
+            target: "orbit.core.job_run",
+            run_id,
+            owner = "stale",
+            providers = processes.len(),
+            open,
+            alive,
+            unknown,
+            decision,
+            reason,
+            "orphan finalization provider guard classified durable evidence",
+        );
+
+        guard == ProviderFinalizationGuard::Clear
     }
 
     /// When an orphaned run actually stopped doing work.

--- a/crates/orbit-core/src/application/job/run/tests/mod.rs
+++ b/crates/orbit-core/src/application/job/run/tests/mod.rs
@@ -9,6 +9,7 @@ mod conflict;
 mod owner;
 mod projection;
 mod reconcile;
+mod reconcile_provider;
 mod worker_limit;
 
 use chrono::{DateTime, Utc};

--- a/crates/orbit-core/src/application/job/run/tests/reconcile_provider.rs
+++ b/crates/orbit-core/src/application/job/run/tests/reconcile_provider.rs
@@ -1,0 +1,257 @@
+//! Provider-descendant guards for stale run reconciliation.
+
+use super::*;
+
+use crate::application::job::TERMINAL_OUTCOME_CONFLICT_CODE;
+use chrono::{Duration, Utc};
+use orbit_common::process::identity::ProcessLiveness;
+use orbit_store::V2AuditEventInsertParams;
+use orbit_types::workflow::JobRunState;
+
+#[test]
+fn live_provider_protects_stale_run_until_normal_completion() {
+    let (_root, runtime, run) = stale_run("qa_live_provider");
+    reserve_for_run(&runtime, &run.run_id, "file:src/live-provider.rs");
+    write_provider_spawn(
+        &runtime,
+        &run.run_id,
+        "provider-live",
+        4242,
+        "ps-lstart-utc-v1:token-live",
+    );
+
+    let reconciled = reconcile_with(&runtime, &run, |pid, token| {
+        assert_eq!((pid, token), (4242, Some("ps-lstart-utc-v1:token-live")));
+        ProcessLiveness::Alive
+    });
+
+    assert!(!reconciled);
+    assert_run_state(&runtime, &run, JobRunState::Running);
+    assert!(reservation_is_active(&runtime, &run.run_id));
+
+    write_provider_finish(&runtime, &run.run_id, "provider-live");
+    assert!(
+        runtime
+            .stores()
+            .jobs()
+            .finalize_job_run(&run.run_id, JobRunState::Success, Utc::now(), Some(3_000))
+            .expect("provider completes run normally")
+    );
+    let completed = runtime.show_job_run(&run.run_id).expect("show completion");
+    assert_eq!(completed.state, JobRunState::Success);
+    assert!(
+        completed
+            .steps
+            .iter()
+            .all(|step| { step.error_code.as_deref() != Some(TERMINAL_OUTCOME_CONFLICT_CODE) })
+    );
+}
+
+#[test]
+fn dead_and_reused_provider_pids_do_not_protect_stale_runs() {
+    for (job_id, token) in [
+        ("qa_dead_provider", "token-dead"),
+        ("qa_reused_provider_pid", "token-original-process"),
+    ] {
+        let (_root, runtime, run) = stale_run(job_id);
+        write_provider_spawn(&runtime, &run.run_id, "provider-dead", 5252, token);
+
+        let reconciled = reconcile_with(&runtime, &run, |pid, observed_token| {
+            assert_eq!((pid, observed_token), (5252, Some(token)));
+            ProcessLiveness::Exited
+        });
+
+        assert!(reconciled);
+        assert_run_state(&runtime, &run, JobRunState::Interrupted);
+    }
+}
+
+#[test]
+fn unknown_provider_liveness_defers_and_retains_reservation() {
+    let (_root, runtime, run) = stale_run("qa_unknown_provider");
+    reserve_for_run(&runtime, &run.run_id, "file:src/unknown-provider.rs");
+    write_provider_spawn(
+        &runtime,
+        &run.run_id,
+        "provider-unknown",
+        6262,
+        "token-unknown",
+    );
+
+    let reconciled = reconcile_with(&runtime, &run, |_, _| ProcessLiveness::Unknown);
+
+    assert!(!reconciled);
+    assert_run_state(&runtime, &run, JobRunState::Running);
+    assert!(reservation_is_active(&runtime, &run.run_id));
+}
+
+#[test]
+fn provider_spawn_during_write_boundary_revalidation_prevents_finalization() {
+    let (_root, runtime, run) = stale_run("qa_provider_spawn_race");
+    reserve_for_run(&runtime, &run.run_id, "file:src/provider-spawn-race.rs");
+    let stale = stored_run(&runtime, &run);
+
+    let reconciled = runtime
+        .reconcile_stale_job_run_with_provider_probe_after_classification(
+            &stale,
+            |pid, token| {
+                assert_eq!((pid, token), (7373, Some("ps-lstart-utc-v1:token-race")));
+                ProcessLiveness::Alive
+            },
+            || {
+                write_provider_spawn(
+                    &runtime,
+                    &run.run_id,
+                    "provider-race",
+                    7373,
+                    "ps-lstart-utc-v1:token-race",
+                );
+            },
+        )
+        .expect("reconcile provider spawn race");
+
+    assert!(!reconciled);
+    assert_run_state(&runtime, &run, JobRunState::Running);
+    assert!(reservation_is_active(&runtime, &run.run_id));
+}
+
+#[test]
+fn old_live_provider_beyond_display_limit_and_audit_page_protects_run() {
+    let (_root, runtime, run) = stale_run("qa_old_live_provider");
+    write_provider_spawn(
+        &runtime,
+        &run.run_id,
+        "provider-old-live",
+        8484,
+        "ps-lstart-utc-v1:token-old",
+    );
+    for index in 0..8 {
+        let event_id = format!("provider-newer-{index}");
+        write_provider_spawn(
+            &runtime,
+            &run.run_id,
+            &event_id,
+            9000 + index,
+            "token-finished",
+        );
+        write_provider_finish(&runtime, &run.run_id, &event_id);
+    }
+
+    let reconciled = reconcile_with(&runtime, &run, |pid, token| {
+        assert_eq!((pid, token), (8484, Some("ps-lstart-utc-v1:token-old")));
+        ProcessLiveness::Alive
+    });
+
+    assert!(!reconciled);
+    assert_run_state(&runtime, &run, JobRunState::Running);
+}
+
+fn stale_run(job_id: &str) -> (tempfile::TempDir, OrbitRuntime, JobRun) {
+    let (root, runtime) = test_runtime();
+    let run = insert_pending_run(&runtime, job_id);
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, Utc::now() - Duration::seconds(3), 999_999)
+        .expect("mark stale running");
+    (root, runtime, run)
+}
+
+fn reconcile_with<P>(runtime: &OrbitRuntime, run: &JobRun, probe: P) -> bool
+where
+    P: Fn(u32, Option<&str>) -> ProcessLiveness,
+{
+    runtime
+        .reconcile_stale_job_run_with_provider_probe_after_classification(
+            &stored_run(runtime, run),
+            probe,
+            || {},
+        )
+        .expect("reconcile stale run")
+}
+
+fn stored_run(runtime: &OrbitRuntime, run: &JobRun) -> JobRun {
+    runtime
+        .get_job_run_backend(&run.run_id)
+        .expect("read run")
+        .expect("run exists")
+}
+
+fn assert_run_state(runtime: &OrbitRuntime, run: &JobRun, expected: JobRunState) {
+    assert_eq!(stored_run(runtime, run).state, expected);
+}
+
+fn reservation_is_active(runtime: &OrbitRuntime, run_id: &str) -> bool {
+    active_reservation_owners(runtime)
+        .iter()
+        .any(|owner| owner == run_id)
+}
+
+fn write_provider_spawn(
+    runtime: &OrbitRuntime,
+    run_id: &str,
+    event_id: &str,
+    pid: u32,
+    pid_start_time: &str,
+) {
+    write_provider_event(
+        runtime,
+        run_id,
+        event_id,
+        serde_json::json!({
+            "body_kind": "cli_invocation_process",
+            "pid": pid,
+            "pid_start_time": pid_start_time,
+        }),
+    );
+}
+
+fn write_provider_finish(runtime: &OrbitRuntime, run_id: &str, process_event_id: &str) {
+    write_provider_event(
+        runtime,
+        run_id,
+        &format!("{process_event_id}-finished"),
+        serde_json::json!({
+            "body_kind": "cli_invocation_finished",
+            "exit_code": 0,
+            "timed_out": false,
+        }),
+    );
+}
+
+fn write_provider_event(
+    runtime: &OrbitRuntime,
+    run_id: &str,
+    event_id: &str,
+    fields: serde_json::Value,
+) {
+    let process_event_id = event_id.strip_suffix("-finished").unwrap_or(event_id);
+    let parent_event_id = format!("{process_event_id}-invocation");
+    let mut event = serde_json::json!({
+        "event_id": event_id,
+        "ts": Utc::now().to_rfc3339(),
+        "run_id": run_id,
+        "parent_event_id": parent_event_id,
+        "step_id": "agent_implement",
+        "provider": "codex",
+    });
+    event
+        .as_object_mut()
+        .expect("provider event object")
+        .extend(fields.as_object().expect("provider fields object").clone());
+    runtime
+        .insert_v2_audit_event(&V2AuditEventInsertParams {
+            workspace_id: runtime.workspace_id().expect("workspace id"),
+            event_id: event_id.to_string(),
+            source: "v2_envelope".to_string(),
+            schema_version: 1,
+            event_type: "activity.progress".to_string(),
+            ts: Utc::now(),
+            run_id: run_id.to_string(),
+            agent_identity: "test".to_string(),
+            parent_event_id: Some(parent_event_id),
+            workspace_path: None,
+            payload_json: event.to_string(),
+        })
+        .expect("write provider audit event");
+}

--- a/crates/orbit-core/src/runtime/run_audit.rs
+++ b/crates/orbit-core/src/runtime/run_audit.rs
@@ -211,6 +211,15 @@ impl RunExecutionProgress {
 /// Provider children carried on the progress projection. A run spawns a
 /// handful per step; the budget only bites on a long retry history.
 const MAX_PROVIDER_PROCESSES: usize = 8;
+/// Rows per store read while reconstructing a complete run audit trail.
+///
+/// This is a paging size, not an evidence limit. Safety decisions such as
+/// orphan reconciliation must see provider spawns even in unusually long
+/// trails, while each SQLite read should remain bounded.
+#[cfg(not(test))]
+const RUN_AUDIT_PAGE_SIZE: usize = 50_000;
+#[cfg(test)]
+const RUN_AUDIT_PAGE_SIZE: usize = 8;
 
 /// What one scan of a run's v2 audit trail says about its execution: every
 /// step it started, and every provider child those steps spawned.
@@ -339,13 +348,24 @@ impl OrbitRuntime {
     }
 
     pub fn collect_run_audit_events(&self, run_id: &str) -> Result<Vec<RunAuditEvent>, OrbitError> {
-        let rows = self.list_v2_audit_events(V2AuditEventFilter {
-            workspace_id: String::new(),
-            run_id: Some(run_id.to_string()),
-            source: Some("v2_envelope".to_string()),
-            limit: Some(50_000),
-            ..Default::default()
-        })?;
+        let mut rows = Vec::new();
+        let mut offset = 0;
+        loop {
+            let page = self.list_v2_audit_events(V2AuditEventFilter {
+                workspace_id: String::new(),
+                run_id: Some(run_id.to_string()),
+                source: Some("v2_envelope".to_string()),
+                limit: Some(RUN_AUDIT_PAGE_SIZE),
+                offset: Some(offset),
+                ..Default::default()
+            })?;
+            let page_len = page.len();
+            rows.extend(page);
+            if page_len < RUN_AUDIT_PAGE_SIZE {
+                break;
+            }
+            offset += page_len;
+        }
         let mut events_by_id = HashMap::new();
         let mut ordered_ids = Vec::new();
         for row in rows.into_iter().rev() {
@@ -392,7 +412,7 @@ impl OrbitRuntime {
         Ok(events)
     }
 
-    /// The newest valid timestamp carried by the bounded v2 envelope rows for
+    /// The newest valid timestamp carried by the newest v2 envelope rows for
     /// a run. This deliberately reads the envelope payload rather than the
     /// audit row ordering: imports and delayed writers can persist rows out of
     /// timestamp order.
@@ -404,7 +424,7 @@ impl OrbitRuntime {
             workspace_id: String::new(),
             run_id: Some(run_id.to_string()),
             source: Some("v2_envelope".to_string()),
-            limit: Some(50_000),
+            limit: Some(RUN_AUDIT_PAGE_SIZE),
             ..Default::default()
         })?;
 


### PR DESCRIPTION
## Task

[ORB-12323](https://orbit-cli.com/tasks/ORB-12323) — Guard orphan finalization with durable provider descendants

### Description

Run jrun-20260912-1152-t1 demonstrates an incomplete liveness fix. Owner PID 3232463 started 11:52:29 and provider PID 3232600 was durably recorded in spawn event v2evt-jrun-20260912-1152-t1-0000000d at 11:52:34; both identities record pid namespace 4026531836. The parent was finalized interrupted/process_not_found at 11:52:34.211 after 4.728s, yet the provider continued and applied ORB-12319's task-pilot assessment at 11:53:58.947 and the worker log resumed. A later operator retry was unnecessary in hindsight. A late database-disk-image-malformed message was observed, but a later doctor quick check passed; causality is unknown and database repair is out of scope.

Current classify_run_owner_with_probes checks only owner identity/namespace/ps/kill. finalize_orphaned_job_run rereads the run and rechecks its owner, then interrupts the run and releases reservations without consulting existing durable provider process spawn/exit evidence. ORB-10594 required owner-exits/provider-continues protection but implemented only the foreign-namespace guard; ORB-10557 and ORB-10646 are adjacent.

Before irreversible orphan finalization, inspect all durable provider-process spawn/exit evidence for the run, without relying on display-capped latest-eight projections. A matching conclusively alive provider must protect the run and its reservations. Unknown or unverifiable provider liveness must defer. Only conclusively closed/dead providers, or no provider evidence, together with a stale owner may permit interruption. Verify PID start token and namespace identity so PID reuse or an unrelated process cannot protect a run. Revalidate run state, owner, and provider evidence at the write boundary, including a provider-spawn race. Preserve declared timeout/cancellation semantics, structured process_not_found diagnostics, genuine orphan cleanup, and foreign-namespace protection. Emit bounded per-decision diagnostics describing the owner/provider guard.

Add deterministic tests: same-namespace dead owner plus live provider stays nonterminal and retains reservation, then provider completion/applied output succeeds without a terminal conflict; truly dead/no-provider interrupts; reused provider PID does not protect; unknown provider state defers; provider-spawn race is caught at the write boundary; an older live provider beyond eight recorded provider events still protects. Do not mutate live historical runs, reopen/backfill terminal records, broadly refactor run supervision, or present duplicate retry/admission as safe while execution remains unresolved. Independent review is required before deployment.

### Acceptance Criteria

- Orphan finalization queries all durable provider process evidence for the run, not a capped display projection, and a conclusively alive matching provider prevents terminalization and reservation release.
- Unknown/unverifiable provider state defers; PID start token and namespace checks prevent reused or unrelated processes from protecting the run.
- Run state, owner, and provider evidence are revalidated at the irreversible write boundary, including a deterministic provider-spawn race test.
- Tests cover live provider completion without terminal conflict, true dead/no-provider cleanup, PID reuse, unknown state, spawn race, and an older live provider beyond eight events.
- Declared timeout/cancellation behavior, structured process_not_found diagnostics, genuine orphan cleanup, and foreign-namespace protection remain intact.
- Bounded diagnostics record each owner/provider decision; no live run state repair, historical backfill, database repair, broad refactor, or retry-policy expansion is included.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Made complete run-audit reconstruction page through every durable v2 envelope row instead of stopping at 50,000; the operator-facing eight-provider projection remains bounded.
- Added a conservative provider-descendant guard before orphan finalization and repeated it after the authoritative run/owner reread at the write boundary. Matching stable-token providers defer as alive; missing/legacy-unverifiable or foreign-namespace evidence defers as unknown; closed, dead, or PID-reused descendants allow genuine orphan cleanup.
- Added one bounded structured owner/provider decision diagnostic with aggregate counts and reason per guard evaluation; unreadable durable evidence logs and defers.
- Added a dedicated 257-line sibling test module for provider liveness, reservation retention and normal completion, dead/reused PID cleanup, unknown state, deterministic spawn race, and an old live provider beyond both the display limit and test audit-page boundary. Expanded context to the module declaration and exact new test file to comply with the workspace source-size rule.

Acceptance criteria:
1. Complete paged durable evidence feeds reconciliation; live matching provider tests prove run and reservation retention.
2. Stable process token is required for a conclusive alive verdict; shared probes retain token-match and PID-namespace checks. Reused PID exits and unknown evidence defers are covered.
3. Fresh run state, owner, and complete provider evidence are checked immediately before the terminalization helper; deterministic provider-spawn race coverage passes.
4. The focused reconciliation suite covers live completion without conflict, existing no-provider cleanup, dead/reused/unknown provider states, spawn race, and evidence older than eight events.
5. Existing process_not_found, true orphan, foreign namespace, and cancellation race suites pass; timeout/finished provider fields and normal completion pairing remain unchanged.
6. Diagnostics are one bounded aggregate event per decision. No historical/live repair, database repair, retry policy, or supervision refactor was added.

Validation:
- PASSED: cargo test -p orbit-core application::job::run::tests::reconcile --no-fail-fast (22 tests).
- PASSED: cargo test -p orbit-core runtime::tests::run_audit --no-fail-fast (14 tests).
- PASSED: cargo test -p orbit-core application::job::run::tests::cancellation_race --no-fail-fast (5 tests).
- PASSED: cargo test -p orbit-core application::job::run::tests::owner --no-fail-fast (18 tests).
- PASSED: make ci-fast. Its optional compiler-cache namespace probe reported the documented bwrap/unprivileged-namespace skip; the make target completed successfully.
- PASSED: make ci-lint.
- PASSED: make goldens.
- PASSED: git diff --check.
- Final status accounts for three tracked modifications and the declared new reconcile_provider.rs test file.

Assessment: The change is narrowly scoped to durable audit collection and the orphan-finalization safety boundary, with a deterministic injected-probe seam limited to tests.
Remaining risk / deployment gate: Independent review was not performed inside this executor because the envelope explicitly forbids invoking another agent. The task requires independent review before deployment; the delivery pipeline/reviewer must satisfy that gate.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12323-6aa542e0`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra