### PR TITLE
Isolate web routine tests from native clock manager availability

### DIFF
--- a/crates/orbit-web/src/api/routines.rs
+++ b/crates/orbit-web/src/api/routines.rs
@@ -14,7 +14,7 @@ use orbit_common::governance::authorization::{
 use orbit_common::observability::audit_id::audit_execution_id;
 use orbit_core::application::routines::{
     ClockStatus, RoutineStatus, RoutineStatusReport, RoutineToggleOutcome, ScheduleDisplayState,
-    clock_status, set_clock_cadence, set_clock_enabled, set_routine_enabled,
+    set_clock_cadence, set_clock_enabled, set_routine_enabled,
 };
 use orbit_core::{AuditEventInsertParams, OrbitRuntime, RoutineFireRecord, RoutineFireState};
 use orbit_types::telemetry::AuditEventStatus;
@@ -66,7 +66,7 @@ pub(super) async fn list_routine_health(State(state): State<DashboardState>) -> 
         Ok(report) => report,
         Err(error) => return map_runtime_error(error),
     };
-    let clock = match clock_status(state.global_root()) {
+    let clock = match state.clock_status() {
         Ok(clock) => clock,
         Err(error) => return map_runtime_error(error),
     };
@@ -226,7 +226,7 @@ pub(super) async fn control_clock(
         }
     };
     let started = Instant::now();
-    let before = match clock_status(state.global_root()) {
+    let before = match state.clock_status() {
         Ok(status) => status,
         Err(error) => return map_runtime_error(error),
     };
@@ -283,7 +283,7 @@ pub(super) async fn control_clock(
         );
         return map_runtime_error(error);
     }
-    let after = match clock_status(state.global_root()) {
+    let after = match state.clock_status() {
         Ok(status) => status,
         Err(error) => return map_runtime_error(error),
     };

--- a/crates/orbit-web/src/api/tests/routines.rs
+++ b/crates/orbit-web/src/api/tests/routines.rs
@@ -1,12 +1,13 @@
 //! Tests for the routine-health JSON API [ORB-10138].
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode};
 use orbit_common::governance::authorization::OPERATOR_OVERRIDE_ENV;
 use orbit_core::application::routines::{ClockStatus, ScheduleDisplayState};
-use orbit_core::{OrbitRuntime, RoutineFireRecord, RoutineFireState};
+use orbit_core::{OrbitError, OrbitRuntime, RoutineFireRecord, RoutineFireState};
 use orbit_registry::{NewHostIdentity, ensure_host_identity};
 use tower::ServiceExt;
 
@@ -14,6 +15,25 @@ use super::super::router;
 use super::super::routines::{clock_json, duration_ms, fire_json, fire_ok, next_evaluation_json};
 use super::test_support::body_json;
 use crate::state::DashboardState;
+
+fn clock_status(enabled: bool) -> ClockStatus {
+    ClockStatus {
+        configured_cadence_seconds: 300,
+        effective_cadence_seconds: enabled.then_some(300),
+        enabled,
+        loaded: true,
+        running: Some(enabled),
+        schedulable: enabled,
+        health_issue: None,
+        last_tick_at: None,
+        next_tick_at: enabled.then(|| "2026-09-12T13:00:00+00:00".to_string()),
+        platform: "systemd",
+    }
+}
+
+fn with_clock_status(state: DashboardState, status: ClockStatus) -> DashboardState {
+    state.with_clock_status_observer(Arc::new(move |_| Ok(status.clone())))
+}
 
 fn fire(state: RoutineFireState, created_at: &str, updated_at: &str) -> RoutineFireRecord {
     RoutineFireRecord {
@@ -152,7 +172,13 @@ async fn routines_endpoint_returns_envelope_for_empty_host() {
         })
     })
     .expect("seed host identity");
-    let state = DashboardState::global(temp.path().to_path_buf(), Vec::new(), None);
+    let observations = Arc::new(AtomicUsize::new(0));
+    let observed = observations.clone();
+    let state = DashboardState::global(temp.path().to_path_buf(), Vec::new(), None)
+        .with_clock_status_observer(Arc::new(move |_| {
+            observed.fetch_add(1, Ordering::Relaxed);
+            Ok(clock_status(true))
+        }));
 
     let response = router()
         .with_state(state)
@@ -173,8 +199,64 @@ async fn routines_endpoint_returns_envelope_for_empty_host() {
     assert!(json["clock"]["provider"].is_string());
     assert!(json["clock"]["configured_cadence_seconds"].is_number());
     assert!(json["clock"]["enabled"].is_boolean());
+    assert_eq!(json["clock"]["enabled"], true);
     assert_eq!(json["routines"], serde_json::json!([]));
     assert_eq!(json["load_errors"], serde_json::json!([]));
+    assert_eq!(observations.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn routines_endpoint_preserves_disabled_clock_observation() {
+    let temp = tempfile::tempdir().expect("temp global root");
+    ensure_host_identity(temp.path(), || {
+        Ok(NewHostIdentity {
+            host_id: "dashboard-test".to_string(),
+            task_prefix: "DA".to_string(),
+        })
+    })
+    .expect("seed host identity");
+    let state = with_clock_status(
+        DashboardState::global(temp.path().to_path_buf(), Vec::new(), None),
+        clock_status(false),
+    );
+
+    let response = routine_request(state, "/routines", None).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["clock"]["enabled"], false);
+    assert_eq!(json["clock"]["health"], "paused");
+    assert_eq!(
+        json["clock"]["effective_cadence_seconds"],
+        serde_json::Value::Null
+    );
+}
+
+#[tokio::test]
+async fn routines_endpoint_preserves_unavailable_clock_manager_error() {
+    let temp = tempfile::tempdir().expect("temp global root");
+    ensure_host_identity(temp.path(), || {
+        Ok(NewHostIdentity {
+            host_id: "dashboard-test".to_string(),
+            task_prefix: "DA".to_string(),
+        })
+    })
+    .expect("seed host identity");
+    let state = DashboardState::global(temp.path().to_path_buf(), Vec::new(), None)
+        .with_clock_status_observer(Arc::new(|_| {
+            Err(OrbitError::Execution(
+                "systemd clock manager is unavailable; fixture transport failure".to_string(),
+            ))
+        }));
+
+    let response = routine_request(state, "/routines", None).await;
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let json = body_json(response).await;
+    assert_eq!(
+        json["error"],
+        "execution failed: systemd clock manager is unavailable; fixture transport failure"
+    );
 }
 
 /// Pin the process signals `CallerCapabilities::resolve` reads, for the whole
@@ -368,10 +450,13 @@ async fn authorized_routine_toggle_reads_back_and_rejects_stale_or_wrong_selecti
         &workspace_registry::registry_path_for(&global),
     )
     .expect("registry");
-    let state = DashboardState::global(
-        global,
-        vec![workspace_entry("alpha", repo, orbit_dir, true)],
-        Some("alpha".to_string()),
+    let state = with_clock_status(
+        DashboardState::global(
+            global,
+            vec![workspace_entry("alpha", repo, orbit_dir, true)],
+            Some("alpha".to_string()),
+        ),
+        clock_status(true),
     );
 
     with_caller_env([(OPERATOR_OVERRIDE_ENV, Some("1"))], async {

--- a/crates/orbit-web/src/state.rs
+++ b/crates/orbit-web/src/state.rs
@@ -39,6 +39,9 @@ use axum::http::StatusCode;
 use axum::http::request::Parts;
 use axum::response::{IntoResponse, Json, Response};
 use orbit_cmd::registry_runtime::{RegisteredRuntimeFactory, workspace_runtime_binding};
+use orbit_core::application::routines::ClockStatus;
+#[cfg(test)]
+use orbit_core::application::routines::clock_status;
 use orbit_core::runtime::{HostLifetime, WorkspaceRuntimeBinding};
 use orbit_core::{OrbitError, OrbitRuntime, ShipMode};
 use orbit_registry::workspace_registry;
@@ -58,6 +61,12 @@ const INITIAL_GENERATION: u64 = 0;
 /// prove an older-snapshot runtime cannot republish as current.
 #[cfg(test)]
 pub(crate) type PrePublishHook = Arc<dyn Fn(&str) + Send + Sync>;
+
+/// Test-only replacement for native host-clock observations. Production builds
+/// call `clock_status` directly and do not carry this indirection.
+#[cfg(test)]
+pub(crate) type ClockStatusObserver =
+    Arc<dyn Fn(&Path) -> Result<ClockStatus, OrbitError> + Send + Sync>;
 
 /// One registered workspace the dashboard can serve.
 ///
@@ -251,6 +260,9 @@ struct StateInner {
     /// Test seam: paused just before a freshly-built runtime is published.
     #[cfg(test)]
     on_pre_publish: Mutex<Option<PrePublishHook>>,
+    /// Test seam for deterministic host-clock reads in global API fixtures.
+    #[cfg(test)]
+    clock_status_observer: Mutex<ClockStatusObserver>,
 }
 
 impl StateInner {
@@ -540,6 +552,8 @@ impl DashboardState {
                 generation_counter: AtomicU64::new(INITIAL_GENERATION + 1),
                 #[cfg(test)]
                 on_pre_publish: Mutex::new(None),
+                #[cfg(test)]
+                clock_status_observer: Mutex::new(Arc::new(clock_status)),
             }),
         }
     }
@@ -558,6 +572,25 @@ impl DashboardState {
     /// because routine fires live in the global store.
     pub(crate) fn global_root(&self) -> &std::path::Path {
         &self.inner.global_root
+    }
+
+    /// Observe the native host clock. Production retains the direct native
+    /// call; unit tests may replace only this read boundary.
+    pub(crate) fn clock_status(&self) -> Result<ClockStatus, OrbitError> {
+        #[cfg(test)]
+        {
+            let observer = self
+                .inner
+                .clock_status_observer
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .clone();
+            observer(&self.inner.global_root)
+        }
+        #[cfg(not(test))]
+        {
+            orbit_core::application::routines::clock_status(&self.inner.global_root)
+        }
     }
 
     /// Test-only convenience: the live default selection. Production reads the
@@ -674,6 +707,18 @@ impl DashboardState {
             .on_pre_publish
             .lock()
             .unwrap_or_else(PoisonError::into_inner) = Some(hook);
+    }
+
+    /// Replace host-clock observations before this state is cloned into a
+    /// router. Clock control still uses the native mutation functions.
+    #[cfg(test)]
+    pub(crate) fn with_clock_status_observer(self, observer: ClockStatusObserver) -> Self {
+        *self
+            .inner
+            .clock_status_observer
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = observer;
+        self
     }
 }
 


### PR DESCRIPTION
## Task

[ORB-12325](https://orbit-cli.com/tasks/ORB-12325) — Isolate web routine tests from native clock manager availability

### Description

ORB-12318 full-workspace validation at PR2066 head 6ffcede0 reproduced two orbit-web routine test failures with XDG_RUNTIME_DIR and DBUS_SESSION_BUS_ADDRESS unset: `routines_endpoint_returns_envelope_for_empty_host` returns HTTP 500 instead of 200, and `authorized_routine_toggle_reads_back_and_rejects_stale_or_wrong_selection` receives the typed manager-unavailable payload so `routines[0].enabled` is null. Both call `DashboardState::global` and the production `clock_status` path; `systemctl --user is-enabled` and `show` exit 1 with `Failed to connect to bus: No medium found`. ORB-12314 correctly made unavailable manager state fail closed, exposing fixture dependence on the ambient host. F2026-09-148 records the validation blocker.

Add a bounded deterministic native-clock observation seam/fake for global routine API fixtures. Cover healthy enabled and disabled observations plus typed unavailable-manager behavior. Keep production status/error/control behavior unchanged. Tests must make no live clock calls or mutations and must not depend on a host user-bus environment. Repair the fixtures rather than restoring a boolean fallback, skipping tests, or supplying ambient bus variables. Validate the focused orbit-web routines suite with the bus variables explicitly unset and run the full workspace suite under appropriate concurrency. Keep scope to the test seam and affected fixtures.

### Acceptance Criteria

- Global routine API fixtures inject deterministic native-clock observations and do not invoke the host service manager.
- Focused tests cover healthy enabled and disabled manager observations and preserve the typed unavailable-manager distinction introduced by ORB-12314.
- Production routine endpoint and clock control error handling remain unchanged; no boolean fallback, skip, live clock mutation, or host user-bus dependency is introduced.
- With XDG_RUNTIME_DIR and DBUS_SESSION_BUS_ADDRESS unset, the focused orbit-web routines suite passes and the two prior failures return their intended fixture assertions.
- The full workspace suite and repository-required gates pass under appropriate concurrency, with exact evidence recorded.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a DashboardState-owned host-clock observation boundary. In production builds it directly invokes the existing native clock_status function; only test builds carry an injectable observer, defaulting to the same native function.
- Routed all three routine API clock reads (list and control pre/post observations) through that boundary while leaving set_clock_enabled, set_clock_cadence, error mapping, and routine mutation behavior unchanged.
- Made every global routine API fixture inject deterministic clock observations. Added endpoint coverage for healthy enabled, healthy disabled/paused, and OrbitError::Execution manager-unavailable results; the empty-host fixture counts exactly one injected observation, proving its request does not reach the host manager.
- Kept changes within the three declared context files; no new files, dependency edges, fallback booleans, skips, bus variables, or live clock mutations were added.

Acceptance criteria evidence:
1. Global fixtures: all DashboardState::global uses in api/tests/routines.rs now install an observer. The empty-host fixture asserts the fake was called exactly once, and the final focused run passed with both user-bus variables removed.
2. Observation states: routines_endpoint_returns_envelope_for_empty_host asserts enabled=true; routines_endpoint_preserves_disabled_clock_observation asserts enabled=false, paused health, and no effective cadence; routines_endpoint_preserves_unavailable_clock_manager_error injects the typed Result error and asserts the unchanged HTTP 500/error payload.
3. Production/control invariants: the observer field and setter are cfg(test); the non-test DashboardState::clock_status branch directly calls orbit_core::application::routines::clock_status. Native set_clock_enabled/set_clock_cadence calls and all existing map_runtime_error paths are unchanged.
4. Unset-bus regression: env -u XDG_RUNTIME_DIR -u DBUS_SESSION_BUS_ADDRESS cargo test -p orbit-web api::tests::routines -- --nocapture passed 14 tests, including routines_endpoint_returns_envelope_for_empty_host and authorized_routine_toggle_reads_back_and_rejects_stale_or_wrong_selection.
5. Workspace/gates: all final required commands below passed under the repository build-budget concurrency policy.

Validation:
- PASSED: env -u XDG_RUNTIME_DIR -u DBUS_SESSION_BUS_ADDRESS cargo test -p orbit-web api::tests::routines -- --nocapture — 14 passed, 0 failed.
- PASSED: make ci-fast — exit 0. Its nested compiler-cache namespace probe reported its documented sandbox skip because unprivileged user namespaces are unavailable; the gate itself passed.
- PASSED: make ci-lint — final rerun exit 0 for cargo clippy --workspace --all-targets -- -D warnings. The first run correctly failed on a test-only expect(); the seam was changed to poison-recovering mutex access and the exact gate then passed.
- PASSED: make goldens — 2 help tests, 8 output golden tests, and 1 MCP snapshot test passed.
- PASSED: make test — exit 0 for build-budgeted cargo test --workspace, including all workspace unit, integration, and doc-test binaries; repository-declared ignored tests remained ignored.
- PASSED: git diff --check — no whitespace errors.
- PASSED: git status --short — only crates/orbit-web/src/state.rs, crates/orbit-web/src/api/routines.rs, and crates/orbit-web/src/api/tests/routines.rs are modified.

Assessment: The seam is bounded to test compilation and read observations, so it removes ambient service-manager dependence without weakening the production fail-closed behavior ORB-12314 introduced.

Remaining risks: Native systemd/launchd behavior is intentionally not exercised by these web fixtures; it remains covered at the owning orbit-core fake-runner boundary. No live manager query or mutation was performed by the final focused fixtures.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12325-6aa5493b`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra