### PR TITLE
Preserve unresolved orphan debt when replaying equivalent delivery history

### DIFF
--- a/crates/orbit-automation/src/delivery/recovery.rs
+++ b/crates/orbit-automation/src/delivery/recovery.rs
@@ -422,7 +422,18 @@ fn replay_plan(
             .ok_or_else(|| AutomationError::Refused(refusal::COVERAGE_UNVERIFIABLE.into()))?,
         DateTime::<Utc>::UNIX_EPOCH,
     )?;
-    if !canonical.unresolved.is_empty() {
+    let mapped_unresolved = input
+        .record
+        .mappings
+        .iter()
+        .filter_map(|mapping| {
+            state
+                .unresolved
+                .get(&mapping.orphan.commit)
+                .map(|reason| (mapping.canonical.commit.clone(), reason.clone()))
+        })
+        .collect::<std::collections::BTreeMap<_, _>>();
+    if canonical.unresolved != mapped_unresolved {
         return Err(AutomationError::Refused(
             refusal::PROVIDER_PROOF_UNAVAILABLE.into(),
         ));
@@ -505,6 +516,7 @@ fn replay_plan(
     });
     next.unresolved
         .retain(|commit, _| !mapped.contains(commit.as_str()));
+    next.unresolved.extend(mapped_unresolved);
     next.associations
         .retain(|commit, _| !mapped.contains(commit.as_str()));
     next.associations.extend(canonical.associations);

--- a/crates/orbit-automation/src/delivery/tests/recovery.rs
+++ b/crates/orbit-automation/src/delivery/tests/recovery.rs
@@ -471,8 +471,20 @@ fn an_unknown_consumer_and_a_host_refusal_stop_before_any_write() {
 #[test]
 fn history_replay_preserves_frozen_coverage_and_adds_canonical_debt() {
     let (store, _host, trigger, frozen_batch) = stalled();
-    let before = store.automation_state(CONSUMER).unwrap().unwrap();
-    let orphan = before.observed.clone();
+    let previous = store.automation_state(CONSUMER).unwrap().unwrap();
+    let orphan = SourceRevision {
+        commit: "52d691ba".into(),
+        tree: "orphan-tree".into(),
+    };
+    let mut before = previous.clone();
+    before.generation += 1;
+    before.observed = orphan.clone();
+    before.pending_commits.push(orphan.commit.clone());
+    before
+        .unresolved
+        .insert(orphan.commit.clone(), "evidence_pending".into());
+    assert!(store.automation_commit(&previous, &before, None).unwrap());
+
     let inserted = SourceRevision {
         commit: "69555b04".into(),
         tree: "inserted-tree".into(),
@@ -481,11 +493,6 @@ fn history_replay_preserves_frozen_coverage_and_adds_canonical_debt() {
         commit: "50798789".into(),
         tree: orphan.tree.clone(),
     };
-    let mut replacement = landing(2);
-    replacement.before = inserted.clone();
-    replacement.after = canonical.clone();
-    replacement.commits = vec![canonical.commit.clone()];
-    replacement.evidence_digest = "canonical-proof".into();
     let added = Delivery {
         key: "pr:owner/repo:agent-main:1586".into(),
         repository: before.repository.clone(),
@@ -502,8 +509,10 @@ fn history_replay_preserves_frozen_coverage_and_adds_canonical_debt() {
         from: before.covered.clone(),
         through: canonical.clone(),
         commits: vec![inserted.commit.clone(), canonical.commit.clone()],
-        deliveries: vec![added.clone(), replacement],
-        unresolved: Default::default(),
+        deliveries: vec![added.clone()],
+        unresolved: [(canonical.commit.clone(), "evidence_pending".into())]
+            .into_iter()
+            .collect(),
         associations: Default::default(),
         exclusions: Default::default(),
         complete: true,
@@ -518,7 +527,7 @@ fn history_replay_preserves_frozen_coverage_and_adds_canonical_debt() {
         old_observed: orphan.clone(),
         new_observed: canonical.clone(),
         mappings: vec![HistoryMapping {
-            orphan,
+            orphan: orphan.clone(),
             canonical: canonical.clone(),
             proof_digest: "orbit-tree-and-binary-patch".into(),
         }],
@@ -532,6 +541,38 @@ fn history_replay_preserves_frozen_coverage_and_adds_canonical_debt() {
         reason: "reconcile the verified Sep 8 rebase".into(),
         ..Default::default()
     };
+
+    let mut unavailable_page = page.clone();
+    unavailable_page
+        .deliveries
+        .retain(|delivery| delivery.key != added.key);
+    unavailable_page
+        .unresolved
+        .insert(inserted.commit.clone(), "evidence_unavailable".into());
+    let unavailable_record = record.clone();
+    let unavailable = recovery::Recovery {
+        consumer: CONSUMER,
+        epoch: "v1",
+        trigger: &trigger,
+        repository: "owner/repo",
+        host_refusal: None,
+        request: &request,
+        by: "operator",
+        now: now(),
+        replay: Some(recovery::HistoryReplayInput {
+            page: unavailable_page,
+            record: unavailable_record,
+        }),
+    };
+    assert!(matches!(
+        recovery::preview(store.as_ref(), &unavailable),
+        Err(AutomationError::Refused(reason)) if reason == refusal::PROVIDER_PROOF_UNAVAILABLE
+    ));
+    assert_eq!(
+        store.automation_state(CONSUMER).unwrap(),
+        Some(before.clone())
+    );
+
     let operation = recovery::Recovery {
         consumer: CONSUMER,
         epoch: "v1",
@@ -564,6 +605,12 @@ fn history_replay_preserves_frozen_coverage_and_adds_canonical_debt() {
     assert_eq!(after.active, before.active);
     assert_eq!(after.active.unwrap().batch, frozen_batch);
     assert_eq!(after.observed, canonical);
+    assert_eq!(
+        after.unresolved.get("50798789").map(String::as_str),
+        Some("evidence_pending")
+    );
+    assert!(!after.unresolved.contains_key(&orphan.commit));
+    assert_eq!(after.pending[0..2], before.pending);
     assert!(
         after
             .pending

--- a/crates/orbit-core/src/application/automation/recovery.rs
+++ b/crates/orbit-core/src/application/automation/recovery.rs
@@ -84,15 +84,23 @@ pub fn recover_auto_task(
     runtime.ensure_coordination_task_write_permitted()?;
 
     if let Some(replay) = &operation.replay {
-        let (_, current_head) = source
-            .head(&trigger.branch)
-            .map_err(automation_error_to_orbit)?;
-        if current_head != replay.record.captured_head {
-            return Err(OrbitError::InvalidInput(
-                orbit_types::workflow::automation::recovery::refusal::HISTORY_HEAD_CHANGED.into(),
-            ));
-        }
+        ensure_replay_head(&source, &trigger.branch, &replay.record.captured_head)?;
     }
 
     recovery::apply(store.as_ref(), &operation).map_err(automation_error_to_orbit)
+}
+
+pub(super) fn ensure_replay_head(
+    source: &Source<'_>,
+    branch: &str,
+    captured_head: &orbit_types::workflow::automation::SourceRevision,
+) -> Result<(), OrbitError> {
+    let (_, current_head) = source.head(branch).map_err(automation_error_to_orbit)?;
+    if &current_head != captured_head {
+        return Err(OrbitError::InvalidInput(
+            orbit_types::workflow::automation::recovery::refusal::HISTORY_HEAD_CHANGED.into(),
+        ));
+    }
+
+    Ok(())
 }

--- a/crates/orbit-core/src/application/automation/source.rs
+++ b/crates/orbit-core/src/application/automation/source.rs
@@ -424,11 +424,7 @@ impl<'a> Source<'a> {
         let common_base = self.revision(&base_commit)?;
         let old_commits = self.first_parent_range(&base_commit, &old_observed.commit)?;
         let canonical_commits = self.first_parent_range(&base_commit, &head.commit)?;
-        if old_commits.is_empty() || old_commits.len() > 1000 || canonical_commits.len() > 1000 {
-            return Err(AutomationError::Refused(
-                refusal::HISTORY_TRAVERSAL_LIMIT.into(),
-            ));
-        }
+        validate_replay_range_lengths(old_commits.len(), canonical_commits.len())?;
 
         let mut candidates_by_proof = BTreeMap::<String, Vec<(usize, String)>>::new();
         for (position, canonical) in canonical_commits.iter().enumerate() {
@@ -448,17 +444,8 @@ impl<'a> Source<'a> {
                 .get(&proof_digest)
                 .map(Vec::as_slice)
                 .unwrap_or_default();
-            let [(position, canonical)] = candidates else {
-                return Err(AutomationError::Refused(
-                    refusal::HISTORY_MAPPING_AMBIGUOUS.into(),
-                ));
-            };
-            if last_position.is_some_and(|last| *position <= last) {
-                return Err(AutomationError::Refused(
-                    refusal::HISTORY_MAPPING_AMBIGUOUS.into(),
-                ));
-            }
-            last_position = Some(*position);
+            let (position, canonical) = unique_mapping_candidate(candidates, last_position)?;
+            last_position = Some(position);
             mappings.push(HistoryMapping {
                 orphan: self.revision(orphan)?,
                 canonical: self.revision(canonical)?,
@@ -496,6 +483,19 @@ impl<'a> Source<'a> {
                         landed_at: delivery.landed_at,
                     }),
                 );
+                continue;
+            }
+
+            // A strongly mapped unresolved commit is already an identified
+            // obligation even though no provider owns it. Mark its canonical
+            // replacement as known so ordinary observation does not demand
+            // fresh provider proof for the same debt. The exact reason is
+            // restored on the page below; inserted commits still take the
+            // normal provider lookup path.
+            if state.unresolved.contains_key(&mapping.orphan.commit) {
+                probe
+                    .associations
+                    .insert(mapping.canonical.commit.clone(), None);
             }
         }
         probe.active = None;
@@ -503,7 +503,7 @@ impl<'a> Source<'a> {
             .last()
             .map(|mapping| mapping.canonical.clone())
             .ok_or_else(|| AutomationError::Refused(refusal::HISTORY_MAPPING_AMBIGUOUS.into()))?;
-        let page = self
+        let mut page = self
             .observe_with_lookup_limit(
                 branch,
                 &probe,
@@ -513,6 +513,18 @@ impl<'a> Source<'a> {
                 true,
             )
             .map_err(|_| AutomationError::Refused(refusal::PROVIDER_PROOF_UNAVAILABLE.into()))?;
+
+        for mapping in &mappings {
+            let Some(reason) = state.unresolved.get(&mapping.orphan.commit) else {
+                continue;
+            };
+
+            page.unresolved
+                .insert(mapping.canonical.commit.clone(), reason.clone());
+            if !state.associations.contains_key(&mapping.orphan.commit) {
+                page.associations.remove(&mapping.canonical.commit);
+            }
+        }
 
         Ok((
             page,
@@ -650,4 +662,35 @@ impl<'a> Source<'a> {
 
         Ok(())
     }
+}
+
+pub(super) fn validate_replay_range_lengths(
+    orphan_count: usize,
+    canonical_count: usize,
+) -> Result<(), AutomationError> {
+    if orphan_count == 0 || orphan_count > 1000 || canonical_count > 1000 {
+        return Err(AutomationError::Refused(
+            refusal::HISTORY_TRAVERSAL_LIMIT.into(),
+        ));
+    }
+
+    Ok(())
+}
+
+pub(super) fn unique_mapping_candidate(
+    candidates: &[(usize, String)],
+    last_position: Option<usize>,
+) -> Result<(usize, &str), AutomationError> {
+    let [(position, canonical)] = candidates else {
+        return Err(AutomationError::Refused(
+            refusal::HISTORY_MAPPING_AMBIGUOUS.into(),
+        ));
+    };
+    if last_position.is_some_and(|last| *position <= last) {
+        return Err(AutomationError::Refused(
+            refusal::HISTORY_MAPPING_AMBIGUOUS.into(),
+        ));
+    }
+
+    Ok((*position, canonical))
 }

--- a/crates/orbit-core/src/application/automation/tests/consumer.rs
+++ b/crates/orbit-core/src/application/automation/tests/consumer.rs
@@ -130,18 +130,6 @@ fn replay_proves_the_exact_sep_8_double_rebase_mapping() {
     let source = super::super::source::Source::new(&fixture_root);
     let old = source.revision(&orphan).unwrap();
     let covered = source.revision(&base).unwrap();
-    let old_delivery = Delivery {
-        key: "direct:sep-8-settings".into(),
-        repository: "constellation-works/orbit".into(),
-        branch: "agent-main".into(),
-        before: covered.clone(),
-        after: old.clone(),
-        commits: vec![orphan.clone()],
-        task_ids: vec![],
-        evidence_reference: "incident:sep-8-settings".into(),
-        evidence_digest: "persisted-proof".into(),
-        landed_at: Utc::now(),
-    };
     let state = AutomationState {
         members: None,
         consumer: "ws/qa".into(),
@@ -154,17 +142,19 @@ fn replay_proves_the_exact_sep_8_double_rebase_mapping() {
         observed: old,
         covered: covered.clone(),
         pending_commits: vec![orphan.clone()],
-        pending: vec![old_delivery],
+        pending: vec![],
         waived: vec![],
         excluded: vec![],
-        unresolved: Default::default(),
+        unresolved: [(orphan.clone(), "evidence_pending".into())]
+            .into_iter()
+            .collect(),
         associations: Default::default(),
         active: None,
     };
     let provider_lookups = std::cell::RefCell::new(Vec::new());
     let provider = |_: &str, sha: &str| {
         provider_lookups.borrow_mut().push(sha.to_owned());
-        assert_eq!(sha, inserted, "mapped commit reuses persisted identity");
+        assert_eq!(sha, inserted, "the inserted commit needs provider proof");
         Ok(json!([{
             "number": 1586,
             "html_url": "https://github.com/constellation-works/orbit/pull/1586",
@@ -193,32 +183,30 @@ fn replay_proves_the_exact_sep_8_double_rebase_mapping() {
         provider_lookups.borrow().as_slice(),
         [inserted.clone()].as_slice()
     );
-    assert_eq!(page.deliveries.len(), 2);
+    assert_eq!(page.deliveries.len(), 1);
     assert!(page.deliveries.iter().any(|delivery| {
         delivery.key == "pr:constellation-works/orbit:agent-main:1586"
             && delivery.commits == vec![inserted.clone()]
     }));
-    assert!(page.deliveries.iter().any(|delivery| {
-        delivery.key == "direct:sep-8-settings"
-            && delivery.commits == vec![canonical.clone()]
-            && delivery.task_ids.is_empty()
-            && delivery.evidence_reference == "incident:sep-8-settings"
-    }));
     assert_eq!(
-        page.unresolved,
-        [(inserted.clone(), "landing_span_pending".into())]
-            .into_iter()
-            .collect(),
-        "the provider-resolved inserted span retains its ordinary pending reason"
+        page.unresolved.get(&canonical).map(String::as_str),
+        Some("evidence_pending")
     );
+    assert!(!page.associations.contains_key(&canonical));
 
     git(&fixture_root, &["checkout", "--detach", &canonical]);
     git(&fixture_root, &["branch", "-f", "agent-main", &inserted]);
-    let (_, changed_head) = source.head("agent-main").unwrap();
-    assert_ne!(
-        changed_head, proof.captured_head,
-        "a moved configured head is detected by the replay apply fence"
-    );
+    let error = super::super::recovery::ensure_replay_head(
+        &super::super::source::Source::new(&fixture_root),
+        "agent-main",
+        &proof.captured_head,
+    )
+    .expect_err("a configured-head change must refuse apply");
+    assert!(matches!(
+        error,
+        orbit_common::OrbitError::InvalidInput(reason)
+            if reason == orbit_types::workflow::automation::recovery::refusal::HISTORY_HEAD_CHANGED
+    ));
     git(&fixture_root, &["branch", "-f", "agent-main", &canonical]);
 
     let mut missing = state.clone();
@@ -242,6 +230,26 @@ fn replay_proves_the_exact_sep_8_double_rebase_mapping() {
         error,
         orbit_automation::AutomationError::Refused(reason)
             if reason == orbit_types::workflow::automation::recovery::refusal::HISTORY_BOUNDARY_UNREACHABLE
+    ));
+}
+
+#[test]
+fn replay_refuses_ambiguous_mapping_and_bounded_traversal_exhaustion() {
+    use orbit_automation::AutomationError;
+    use orbit_types::workflow::automation::recovery::refusal;
+
+    let ambiguous = vec![(1, "canonical-a".into()), (2, "canonical-b".into())];
+    assert!(matches!(
+        super::super::source::unique_mapping_candidate(&ambiguous, None),
+        Err(AutomationError::Refused(reason)) if reason == refusal::HISTORY_MAPPING_AMBIGUOUS
+    ));
+    assert!(matches!(
+        super::super::source::validate_replay_range_lengths(1001, 1),
+        Err(AutomationError::Refused(reason)) if reason == refusal::HISTORY_TRAVERSAL_LIMIT
+    ));
+    assert!(matches!(
+        super::super::source::validate_replay_range_lengths(1, 1001),
+        Err(AutomationError::Refused(reason)) if reason == refusal::HISTORY_TRAVERSAL_LIMIT
     ));
 }
 

--- a/crates/orbit-store/src/driver/sqlite/automation/recovery.rs
+++ b/crates/orbit-store/src/driver/sqlite/automation/recovery.rs
@@ -219,7 +219,34 @@ fn validate_history_replay(
         .iter()
         .map(String::as_str)
         .collect::<std::collections::BTreeSet<_>>();
+    let mut expected_unresolved = previous.unresolved.clone();
+    for mapping in &replay.mappings {
+        let Some(reason) = expected_unresolved.remove(&mapping.orphan.commit) else {
+            continue;
+        };
+        if expected_unresolved
+            .insert(mapping.canonical.commit.clone(), reason)
+            .is_some()
+        {
+            return Err(invalid());
+        }
+    }
+
+    let mapped_orphans = replay
+        .mappings
+        .iter()
+        .map(|mapping| mapping.orphan.commit.as_str())
+        .collect::<std::collections::HashSet<_>>();
+    let retained_commits = previous
+        .pending_commits
+        .iter()
+        .filter(|commit| !mapped_orphans.contains(commit.as_str()));
+
     if added != recorded
+        || next.unresolved != expected_unresolved
+        || !retained_commits
+            .into_iter()
+            .all(|commit| next.pending_commits.contains(commit))
         || next.pending_commits.len() > 5000
         || next.pending.len() > 1000
         || next

--- a/crates/orbit-store/src/driver/sqlite/automation/tests/checkpoints.rs
+++ b/crates/orbit-store/src/driver/sqlite/automation/tests/checkpoints.rs
@@ -1,7 +1,9 @@
 use crate::contracts::AutomationStoreBackend;
 use crate::{Store, compose};
 use chrono::{TimeZone, Utc};
-use orbit_types::workflow::automation::recovery::{RecoveryRecord, ReissuedAction};
+use orbit_types::workflow::automation::recovery::{
+    HistoryMapping, HistoryReplayRecord, RecoveryRecord, ReissuedAction,
+};
 use orbit_types::workflow::automation::*;
 
 fn state() -> AutomationState {
@@ -274,6 +276,115 @@ fn adopted(previous: &AutomationState) -> AutomationState {
     next.epoch = "retuned".into();
     next.trigger = Some(retuned(previous));
     next
+}
+
+fn replay_fixture() -> (AutomationState, AutomationState, RecoveryRecord) {
+    let mut previous = state();
+    previous.generation = 1;
+    previous.observed = SourceRevision {
+        commit: "orphan".into(),
+        tree: "shared-tree".into(),
+    };
+    previous.pending_commits = vec!["orphan".into()];
+    previous
+        .unresolved
+        .insert("orphan".into(), "evidence_pending".into());
+
+    let canonical = SourceRevision {
+        commit: "canonical".into(),
+        tree: "shared-tree".into(),
+    };
+    let mut next = previous.clone();
+    next.generation = 2;
+    next.observed = canonical.clone();
+    next.pending_commits = vec![canonical.commit.clone()];
+    next.unresolved.clear();
+    next.unresolved
+        .insert(canonical.commit.clone(), "evidence_pending".into());
+
+    let replay = HistoryReplayRecord {
+        captured_generation: previous.generation,
+        captured_head: SourceRevision {
+            commit: "configured-head".into(),
+            tree: "head-tree".into(),
+        },
+        common_base: previous.covered.clone(),
+        old_observed: previous.observed.clone(),
+        new_observed: canonical.clone(),
+        mappings: vec![HistoryMapping {
+            orphan: previous.observed.clone(),
+            canonical,
+            proof_digest: "exact-proof".into(),
+        }],
+        added_obligations: vec![],
+        unchanged_baseline: previous.baseline.clone(),
+        unchanged_covered: previous.covered.clone(),
+        accepted_receipts: 0,
+    };
+    let record = RecoveryRecord {
+        consumer: previous.consumer.clone(),
+        previous_epoch: previous.epoch.clone(),
+        epoch: previous.epoch.clone(),
+        previous_trigger: previous.trigger.clone(),
+        trigger: previous.trigger.clone(),
+        adopted_settings: false,
+        reissued: None,
+        replayed_history: Some(replay),
+        reason: "reconcile proven history".into(),
+        by: "operator".into(),
+        at: at(),
+    };
+
+    (previous, next, record)
+}
+
+#[test]
+fn history_replay_migrates_the_exact_unresolved_reason_and_fences_generation() {
+    let store = compose::automation_store(Store::open_in_memory().unwrap()).unwrap();
+    let baseline = state();
+    let (previous, next, record) = replay_fixture();
+    assert!(store.automation_initialize(&baseline).unwrap());
+    assert!(store.automation_commit(&baseline, &previous, None).unwrap());
+
+    let mut changed_reason = next.clone();
+    changed_reason
+        .unresolved
+        .insert("canonical".into(), "different_reason".into());
+    assert!(
+        store
+            .automation_recover(&previous, &changed_reason, &record)
+            .is_err()
+    );
+    assert_eq!(
+        store.automation_state(&previous.consumer).unwrap(),
+        Some(previous.clone())
+    );
+
+    assert!(store.automation_recover(&previous, &next, &record).unwrap());
+    let audit = store.automation_recoveries(&previous.consumer, 10).unwrap();
+    let replay = audit[0].replayed_history.as_ref().unwrap();
+    assert_eq!(replay.old_observed, previous.observed);
+    assert_eq!(replay.new_observed, next.observed);
+    assert_eq!(replay.unchanged_covered, previous.covered);
+    assert_eq!(replay.mappings[0].proof_digest, "exact-proof");
+
+    let raced = compose::automation_store(Store::open_in_memory().unwrap()).unwrap();
+    assert!(raced.automation_initialize(&baseline).unwrap());
+    assert!(raced.automation_commit(&baseline, &previous, None).unwrap());
+    let mut concurrent = previous.clone();
+    concurrent.generation += 1;
+    assert!(
+        raced
+            .automation_commit(&previous, &concurrent, None)
+            .unwrap()
+    );
+    assert!(!raced.automation_recover(&previous, &next, &record).unwrap());
+    assert!(
+        raced
+            .automation_recoveries(&previous.consumer, 10)
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[test]

--- a/docs/design/automation-triggers/2_design.md
+++ b/docs/design/automation-triggers/2_design.md
@@ -152,6 +152,12 @@ Missing objects, ambiguous content, unreachable covered/frozen boundaries,
 provider gaps, contract drift, or a changed head/generation fail closed. Never
 silently replace the baseline with current HEAD.
 
+An unresolved orphan with no delivery or provider association is itself unpaid
+debt. When the exact mapping proof uniquely identifies its canonical replacement,
+replay moves the same unresolved reason to that replacement without inventing a
+provider identity. This exception applies only to the mapped pre-existing debt;
+every inserted canonical commit still requires ordinary provider proof.
+
 Batch input contains batch/consumer/epoch IDs, ordered delivery IDs and evidence
 digests, exact `from_exclusive`/`through_inclusive` revisions and trees, full
 commit membership, required examination class, exclusion certificates, effective

--- a/docs/design/automation-triggers/5_operations.md
+++ b/docs/design/automation-triggers/5_operations.md
@@ -302,7 +302,9 @@ Replay never rewrites Git. It preserves the baseline, covered cursor, accepted
 receipts, waivers, exclusions, and the complete active batch/action/input digest.
 Pending deliveries, unresolved commits, and provider associations are replaced
 only through stable delivery keys and exact commit mapping; inserted commits use
-the normal provider association path. State and its immutable recovery record
+the normal provider association path. A mapped unresolved-only orphan keeps its
+exact reason on the canonical commit without acquiring a fabricated provider
+association. State and its immutable recovery record
 commit in one generation-fenced transaction. The command also compares the
 captured branch head immediately before that transaction and refuses a moved
 head. Restore unavailable objects or provider evidence and retry; do not reset


### PR DESCRIPTION
## Task

[ORB-12317](https://orbit-cli.com/tasks/ORB-12317) — Preserve unresolved orphan debt when replaying equivalent delivery history

### Description

ORB-12312's replay-history implementation models the live incident incorrectly. The authoritative post-receipt state has observed orphan 52d691ba6c58457cc472e181b1fee14f9276d274 with unresolved[52d]=evidence_pending, and no pending delivery or provider association for that commit. replay_history_with_lookup currently seeds mapped canonical 50798789 only when the orphan has an association or a pending/waived delivery whose after revision is the orphan. It therefore leaves 507 unresolved, and replay_plan rejects every canonical unresolved entry as provider_proof_unavailable. The positive test fabricates a direct:sep-8-settings association absent from live state.

Correct only this replay path. When the existing unresolved, non-delivery orphan is proven strictly equivalent to canonical 50798789 by the existing strong proof, migrate that exact logical obligation and reason from 52d to 507 without requiring new PR/provider proof for the same old debt. Retain provider-proof requirements for newly inserted canonical commit 69555b04 (PR 1586), and continue refusing inserted commits with unavailable or ambiguous provider proof.

Preserve the existing bounded full-index/binary-parent-diff/.orbit-tree/uniqueness mapping proof and traversal bound. Preserve baseline, covered revision, accepted receipts, active frozen action payload, waivers, exclusions, and every other pending/unresolved obligation. Apply through the existing atomic CAS and audit old/new observed revisions, mapping proof, added obligations, and unchanged coverage. Do not reset, waive, exclude, drop debt, change git history, or write live consumer state in the worker.

Add a fixture matching live state: no direct delivery or association for 52d, unresolved reason evidence_pending. Preview is inert; apply maps that reason to 507, adds the normal PR1586 obligation, and loses nothing. Add meaningful negative coverage for unavailable provider proof on the inserted commit, ambiguous mapping, traversal limit, changed configured head, and concurrent store generation. Keep existing adopt/reissue behavior unchanged and tests bounded without arbitrary delays. Keep scope within delivery history replay; no automation-port extraction or broad refactor. Independent postfix review and a newly installed binary preview are required before any operator applies recovery.

### Acceptance Criteria

- A live-shaped fixture with unresolved 52d=evidence_pending and no delivery/provider association previews inertly and applies by moving the same reason to strictly proven equivalent 507 while adding PR1586 through normal provider association.
- Existing strong exact-mapping proof and bounded traversal remain intact; an inserted canonical commit without provider proof, ambiguous mapping, or traversal exhaustion refuses closed.
- Baseline, covered revision, accepted receipts, active frozen action payload, waivers, exclusions, and every unrelated pending/unresolved obligation remain unchanged; no debt is reset, waived, excluded, or dropped.
- Apply uses configured-head and store-generation concurrency controls and writes an audit record with old/new observed revisions, mapping proof, added obligations, and unchanged coverage.
- Tests cover the live-shaped positive preview/apply path plus inserted-provider-unavailable, ambiguity, traversal-bound, configured-head-change, and concurrent-generation failures without live consumer writes or arbitrary delays.
- Existing adopt-settings and reissue-action behavior remains unchanged.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Core replay carries an unresolved-only orphan through the existing exact mapping proof, suppresses provider lookup only for that mapped pre-existing obligation, restores its exact reason on the canonical commit, and leaves inserted commits on the normal provider-proof path.
- Automation reconciliation accepts only the exact mapped unresolved set, migrates those reasons, retains unrelated pending state, and still refuses any additional unresolved canonical commit as provider_proof_unavailable.
- SQLite recovery validation independently reconstructs the required unresolved migration, retains every unmapped pending commit, preserves generation CAS behavior, and audits old/new observed revisions, mapping proof, added obligations, and unchanged coverage.
- The merged hermetic Git fixture now models unresolved orphan debt with no delivery/provider association; tests cover inert replay construction, PR1586 insertion, inserted-provider-unavailable, mapping ambiguity, traversal bounds, configured-head change, exact-reason validation, and concurrent store generation.
- Design and operations docs describe the narrow unresolved-only replay rule and retain the pre-live-apply safety gates.

Acceptance criteria:
1. Passed: the real-Git fixture performs no provider lookup for the mapped canonical replacement, produces the replay page without a write, migrates evidence_pending, and adds only the normal PR1586 delivery.
2. Passed: the existing full binary parent-diff plus stable .orbit-tree and uniqueness proof remains intact; tests refuse ambiguous mapping, both traversal bounds, and inserted provider unavailability.
3. Passed: replay assertions preserve baseline, covered, frozen action/batch, waivers, exclusions, prior pending deliveries, and the exact unresolved reason; store validation rejects a changed reason and dropped unmapped commits.
4. Passed: configured-head comparison is directly tested; SQLite CAS rejects a stale generation without an audit write; the successful audit asserts old/new observed revisions, proof digest, and unchanged coverage.
5. Passed: focused Core, Automation, and Store tests cover the requested positive and negative paths without sleeps or live consumer writes.
6. Passed: the complete automation recovery test module passes, including adopt-settings and reissue-action behavior.

Validation:
- cargo test -p orbit-core application::automation::tests::consumer::replay --no-fail-fast: passed, 2 tests using the merged hermetic Git fixture.
- cargo test -p orbit-automation delivery::tests::recovery --no-fail-fast: passed, 9 tests.
- cargo test -p orbit-store driver::sqlite::automation::tests::checkpoints --no-fail-fast: passed, 10 tests.
- make ci-fast: passed; its mount-namespace cache probe reported its documented sandbox skip while the command exited successfully.
- make ci-lint: passed.
- make goldens: passed.
- cargo fmt --all -- --check: passed.
- git diff --check: passed.

Assessment: The change is narrow to delivery-history replay and enforces debt conservation at the store boundary. No live consumer state or Git history was changed.

Remaining pre-live-apply gates:
- A fresh independent postfix review of the delivered candidate and inert preview with the newly installed binary remain required before any operator apply. The earlier candidate received an independent PASS, but this retry integrates the subsequently merged hermetic fixture and leaves final review/delivery to the pipeline as required.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12317-6aa555d0`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*

Orchestrated-By: astra