### PR TITLE
Record successful provider completion before post-exit run reconciliation

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
@@ -276,6 +276,11 @@ impl RuntimeHost for OrbitRuntime {
             .map(ToOwned::to_owned)
     }
 
+    fn refresh_persistence_after_cli_provider(&self) -> Result<(), OrbitError> {
+        self.sqlite_store()?
+            .refresh_file_connections(&self.context.persistence().audit_db)
+    }
+
     fn missing_required_environment_vars(&self, required_env_vars: &[&str]) -> Vec<String> {
         self.execution_env_policy()
             .missing_required(required_env_vars)

--- a/crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs
+++ b/crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs
@@ -1,13 +1,17 @@
 //! Shipped task-pilot job boundary regressions [ORB-11411].
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 
+use chrono::Utc;
 use orbit_engine::{DispatchError, JobOutcome, ResolvedCliExecutor, RuntimeHost};
+use orbit_store::V2AuditEventFilter;
 use orbit_tools::{FsAuditLogger, ToolContext};
 use orbit_types::task::{TaskPriority, TaskStatus, TaskType};
+use orbit_types::workflow::{ExecutorDef, ExecutorType, JobRunState, JobRunTrigger};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
@@ -368,4 +372,234 @@ spec:
             Some(orbit_types::task::TaskComplexity::Medium)
         );
     }
+}
+
+#[cfg(unix)]
+fn task_pilot_provider_stdout(task_id: &str) -> String {
+    let response = json!({
+        "schemaVersion": 1,
+        "status": "success",
+        "result": {
+            "partition_index": 0,
+            "task_ids": [task_id],
+            "tasks": [{
+                "task_id": task_id,
+                "context_files_before": [],
+                "context_files_after": ["file:src/remote.rs"],
+                "disposition": "selectors",
+                "recommended_crew": "system",
+                "recommended_complexity": "medium",
+                "assessment_rationale": "The real CLI fixture identified one existing source file.",
+                "confidence": "high",
+                "evidence_gaps": [],
+                "validation_approach": "Assert the worker terminal audit trail.",
+                "reassessment_triggers": ["the source revision changes"],
+                "blocked_by": [],
+                "duplicate_of": null,
+                "already_landed": null,
+                "release_action_required": null,
+                "adr_conflicts": [],
+                "utility_warnings": [],
+                "surface_warnings": [],
+            }],
+            "summary": "real CLI fixture",
+        },
+        "error": null,
+    });
+    [
+        json!({"type": "thread.started", "thread_id": "task-pilot-fixture"}).to_string(),
+        json!({
+            "type": "item.completed",
+            "item": {
+                "id": "answer",
+                "type": "agent_message",
+                "text": response.to_string(),
+            },
+        })
+        .to_string(),
+        json!({
+            "type": "turn.completed",
+            "usage": {"input_tokens": 17, "cached_input_tokens": 0, "output_tokens": 5},
+        })
+        .to_string(),
+    ]
+    .join("\n")
+        + "\n"
+}
+
+#[cfg(unix)]
+fn install_store_replacing_provider(fixture: &TaskPilotJobFixture, stdout: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let fake_provider = fixture.repo_root.join("claude");
+    fs::write(fake_provider.with_extension("stdout"), stdout).expect("write provider stdout");
+    let database = fixture.global_root.join("orbit.db");
+    fs::write(
+        &fake_provider,
+        format!(
+            "#!/bin/sh\n\
+             cat >/dev/null\n\
+             database='{}'\n\
+             cp \"$database\" \"$database.rebound\"\n\
+             cp \"$database-wal\" \"$database.rebound-wal\"\n\
+             cp \"$database-shm\" \"$database.rebound-shm\"\n\
+             mv \"$database\" \"$database.retired\"\n\
+             mv \"$database-wal\" \"$database.retired-wal\"\n\
+             mv \"$database-shm\" \"$database.retired-shm\"\n\
+             mv \"$database.rebound\" \"$database\"\n\
+             mv \"$database.rebound-wal\" \"$database-wal\"\n\
+             mv \"$database.rebound-shm\" \"$database-shm\"\n\
+             cat \"$0.stdout\"\n",
+            database.display(),
+        ),
+    )
+    .expect("write provider executable");
+    let mut permissions = fs::metadata(&fake_provider)
+        .expect("provider metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_provider, permissions).expect("make provider executable");
+
+    let now = Utc::now();
+    fixture
+        .runtime
+        .upsert_executor_def(&ExecutorDef {
+            name: "claude".to_string(),
+            executor_type: ExecutorType::DirectAgent,
+            command: Some(fake_provider.display().to_string()),
+            args: Vec::new(),
+            stdout_format: None,
+            model_pair_override: None,
+            model_flag: None,
+            timeout_seconds: None,
+            env: HashMap::new(),
+            sandbox: None,
+            allow_fallback: false,
+            created_at: Some(now),
+            updated_at: Some(now),
+        })
+        .expect("seed real CLI provider");
+}
+
+#[cfg(unix)]
+#[test]
+fn real_cli_task_pilot_worker_persists_apply_and_terminal_completion_audit() {
+    let fixture = task_pilot_job_fixture("agent-main", "agent-main");
+    let task = fixture
+        .runtime
+        .add_task(TaskAddParams {
+            title: "Real CLI task-pilot completion fixture".to_string(),
+            description: "Exercise provider completion through the detached worker path."
+                .to_string(),
+            acceptance_criteria: vec!["pilot result is applied durably".to_string()],
+            priority: TaskPriority::High,
+            task_type: Some(TaskType::Bug),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed task-pilot target");
+    let stdout = task_pilot_provider_stdout(&task.id);
+    install_store_replacing_provider(&fixture, &stdout);
+
+    let input = json!({"task_ids": [task.id], "base_branch": "agent-main"});
+    let run = fixture
+        .runtime
+        .stores()
+        .jobs()
+        .insert_job_run(
+            "task_pilot_pipeline",
+            1,
+            Utc::now(),
+            Some(input.clone()),
+            None,
+        )
+        .expect("insert task-pilot run");
+    fixture
+        .runtime
+        .seed_v2_pipeline_run(&run, &input, None, JobRunTrigger::cli())
+        .expect("seed task-pilot run state");
+    fixture
+        .runtime
+        .execute_pipeline_run_worker(&run.run_id)
+        .expect("real CLI task-pilot worker succeeds");
+
+    // Reopen from the authoritative paths instead of trusting the worker's
+    // cached handles. Without the provider-return rebind, the old connection
+    // can report a self-consistent success that no post-exit observer sees.
+    let reopened =
+        OrbitRuntime::from_roots(&fixture.global_root, &fixture.repo_root.join(".orbit"))
+            .expect("reopen authoritative runtime");
+    let stored = reopened.show_job_run(&run.run_id).expect("show run");
+    assert_eq!(stored.state, JobRunState::Success);
+    assert!(!stored.steps.is_empty(), "terminal steps must be durable");
+    let state = reopened
+        .read_run_state(&run.run_id)
+        .expect("read completed pipeline state")
+        .expect("completed pipeline state exists");
+    let applied = reopened.get_task(&task.id).expect("read applied task");
+    assert_eq!(
+        applied.context_files,
+        vec!["file:src/remote.rs"],
+        "pipeline: {}",
+        state.pipeline
+    );
+    assert!(
+        reopened
+            .get_task_history(&task.id)
+            .expect("read task history")
+            .iter()
+            .any(|entry| entry.event == "task_pilot_applied"),
+        "successful provider output must cross the real apply boundary"
+    );
+
+    let mut events = reopened
+        .list_v2_audit_events(V2AuditEventFilter {
+            workspace_id: String::new(),
+            run_id: Some(run.run_id.clone()),
+            ..Default::default()
+        })
+        .expect("read terminal audit trail");
+    events.sort_by_key(|event| event.ts);
+    let event_types = events
+        .iter()
+        .map(|event| event.event_type.as_str())
+        .collect::<Vec<_>>();
+    let provider_finished = event_types
+        .iter()
+        .position(|event| *event == "cli.invocation.finished")
+        .expect("provider-finished audit");
+    let activity_finished = event_types[provider_finished + 1..]
+        .iter()
+        .position(|event| *event == "activity.finished")
+        .map(|offset| provider_finished + 1 + offset)
+        .expect("activity-finished audit after provider exit");
+    let step_finished = event_types[activity_finished + 1..]
+        .iter()
+        .position(|event| *event == "step.finished")
+        .map(|offset| activity_finished + 1 + offset)
+        .expect("step-finished audit after activity completion");
+    assert!(
+        event_types[step_finished + 1..].contains(&"run.finished"),
+        "run-finished audit must follow the provider/activity/step completion chain"
+    );
+
+    let finished: Value = serde_json::from_str(&events[provider_finished].payload_json)
+        .expect("parse provider-finished audit");
+    assert_eq!(finished["exit_code"], 0);
+    assert_eq!(finished["timed_out"], false);
+    let stdout_ref = finished["stdout_blob_ref"]
+        .as_str()
+        .expect("stdout blob reference");
+    let stderr_ref = finished["stderr_blob_ref"]
+        .as_str()
+        .expect("stderr blob reference");
+    let blobs = fixture.runtime.paths().audit_dir.join("blobs");
+    assert_eq!(
+        fs::read(blobs.join(&stdout_ref[..2]).join(stdout_ref)).expect("read stdout blob"),
+        stdout.as_bytes()
+    );
+    assert_eq!(
+        fs::read(blobs.join(&stderr_ref[..2]).join(stderr_ref)).expect("read stderr blob"),
+        b""
+    );
 }

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -503,6 +503,18 @@ pub fn run_cli_backend(
     let stdout_blob_ref = audit.write_blob(stdout.bytes());
     let stderr_blob_ref = audit.write_blob(stderr.bytes());
 
+    // The provider has exited and the supervisor owns its exact status,
+    // captured response, and durable blob evidence. Rebind before the first
+    // completion event: a sandboxed provider may have opened the explicitly
+    // granted SQLite/WAL files while this long-lived worker retained handles
+    // from before spawn.
+    host.refresh_persistence_after_cli_provider()
+        .map_err(|error| {
+            DispatchError::CliInvocationPermanent(format!(
+                "refresh durable store after provider `{provider}` exited: {error}"
+            ))
+        })?;
+
     audit.emit_lossy(V2AuditEventKind::CliInvocationFinished {
         provider: provider.clone(),
         exit_code,

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -110,7 +110,11 @@ fn run_cli_backend_finished_audit_event_keeps_stdout_stderr_blob_refs() {
         "codex:gpt-5.5",
         sink_for_writer,
     ));
-    let host = TestHost::with_command(script.display().to_string());
+    let refresh_marker = temp.path().join("persistence-refreshed");
+    let mut host = TestHost::with_command(script.display().to_string());
+    host.task_context = Some(serde_json::json!({
+        "persistence_refresh_marker": refresh_marker,
+    }));
     let spec = test_agent_loop_spec(Duration::from_secs(5));
     let input = serde_json::json!({
         "prompt": "do it",
@@ -129,6 +133,10 @@ fn run_cli_backend_finished_audit_event_keeps_stdout_stderr_blob_refs() {
     .expect("run succeeds");
 
     assert!(outcome.success);
+    assert!(
+        refresh_marker.exists(),
+        "the provider exit boundary must refresh persistence before completion audit"
+    );
     let stdout = "{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}\n";
     assert_eq!(outcome.output["stdout_text"], stdout);
     assert_eq!(outcome.output["stdout_text_truncated"], false);
@@ -162,6 +170,61 @@ fn run_cli_backend_finished_audit_event_keeps_stdout_stderr_blob_refs() {
     assert!(!finished.4);
     assert_eq!(sink.blob("blob-2"), Some(stdout.as_bytes().to_vec()));
     assert_eq!(sink.blob("blob-3"), Some(b"plain stderr\n".to_vec()));
+}
+
+#[test]
+fn run_cli_backend_fails_closed_when_post_provider_persistence_cannot_rebind() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("codex");
+    write_executable(
+        &script,
+        "#!/bin/sh\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\nprintf '%s\\n' 'captured stderr' >&2\n",
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink.clone();
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-refresh-failure",
+        "codex:gpt-5.5",
+        sink_for_writer,
+    ));
+    let mut host = TestHost::with_command(script.display().to_string());
+    host.task_context = Some(serde_json::json!({
+        "persistence_refresh_error": "authoritative database unavailable",
+    }));
+
+    let error = run_cli_backend(
+        &host,
+        &test_agent_loop_spec(Duration::from_secs(5)),
+        "test_activity",
+        "job-refresh-failure",
+        audit.clone(),
+        &serde_json::json!({"prompt": "do it"}),
+        None,
+    )
+    .expect_err("a successful envelope cannot bypass a failed durable rebind");
+
+    assert!(
+        matches!(error, DispatchError::CliInvocationPermanent(_)),
+        "{error:?}"
+    );
+    assert!(
+        error
+            .to_string()
+            .contains("authoritative database unavailable")
+    );
+    assert!(
+        audit
+            .events_snapshot()
+            .expect("events")
+            .iter()
+            .all(|event| !matches!(&event.kind, V2AuditEventKind::CliInvocationFinished { .. })),
+        "provider-finished must not be claimed through an unavailable authoritative store"
+    );
+    assert!(
+        sink.blob("blob-2").is_some() && sink.blob("blob-3").is_some(),
+        "exact stdout/stderr evidence is captured before persistence rebind"
+    );
 }
 
 #[test]

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -450,6 +450,26 @@ impl RuntimeHost for TestHost {
     fn orbit_workspace_selector(&self) -> Option<String> {
         self.orbit_workspace_selector.clone()
     }
+
+    fn refresh_persistence_after_cli_provider(&self) -> Result<(), OrbitError> {
+        if let Some(marker) = self
+            .task_context
+            .as_ref()
+            .and_then(|context| context.get("persistence_refresh_marker"))
+            .and_then(Value::as_str)
+        {
+            fs::write(marker, b"refreshed").map_err(|error| OrbitError::Io(error.to_string()))?;
+        }
+        match self
+            .task_context
+            .as_ref()
+            .and_then(|context| context.get("persistence_refresh_error"))
+            .and_then(Value::as_str)
+        {
+            Some(message) => Err(OrbitError::Store(message.to_string())),
+            None => Ok(()),
+        }
+    }
 }
 
 pub(in crate::activity_job::cli_runner) fn test_agent_loop_spec(

--- a/crates/orbit-engine/src/context/hosts.rs
+++ b/crates/orbit-engine/src/context/hosts.rs
@@ -332,6 +332,14 @@ pub trait RuntimeHost: Send + Sync {
     fn orbit_workspace_selector(&self) -> Option<String> {
         None
     }
+    /// Rebind durable runtime handles after an external CLI provider exits.
+    ///
+    /// Provider sandboxes may receive explicit access to a SQLite database and
+    /// its WAL sidecars. A host with cached connections refreshes them here so
+    /// completion audit and checkpoints target the authoritative files.
+    fn refresh_persistence_after_cli_provider(&self) -> Result<(), OrbitError> {
+        Ok(())
+    }
     fn missing_required_environment_vars(&self, _required_env_vars: &[&str]) -> Vec<String> {
         Vec::new()
     }

--- a/crates/orbit-store/src/driver/sqlite/connection.rs
+++ b/crates/orbit-store/src/driver/sqlite/connection.rs
@@ -118,6 +118,38 @@ impl Store {
         })
     }
 
+    /// Rebind this handle and all of its writer clones to the current files at
+    /// `path`, then discard idle readers that may retain retired WAL identity.
+    ///
+    /// The runtime uses this at the external-provider return boundary. Those
+    /// children can legitimately open the granted database and its sidecars;
+    /// after they exit, completion accounting must use the authoritative path
+    /// rather than a connection retained from before the child ran.
+    pub fn refresh_file_connections(&self, path: &Path) -> Result<(), OrbitError> {
+        let readers = self.readers.as_ref().ok_or_else(|| {
+            OrbitError::Store(
+                "connection refresh requires a writable file-backed store".to_string(),
+            )
+        })?;
+        let fresh = Self::open(path)?;
+        fresh.check_writable()?;
+
+        {
+            let mut current = self
+                .conn
+                .lock()
+                .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+            let mut replacement = fresh
+                .conn
+                .lock()
+                .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+            std::mem::swap(&mut *current, &mut *replacement);
+        }
+
+        readers.clear_idle()?;
+        Ok(())
+    }
+
     /// Open an existing database for an observational probe, without creating
     /// the database, applying migrations, or changing database pragmas. Use a fresh
     /// connection so a cached runtime handle cannot hide a replaced path.
@@ -184,7 +216,10 @@ impl Store {
     /// deadlock, exactly as the old direct `conn.lock()` did.
     pub(crate) fn read(&self) -> Result<ReadGuard<'_>, OrbitError> {
         match &self.readers {
-            Some(pool) => Ok(ReadGuard::pooled(pool.checkout()?, pool)),
+            Some(pool) => {
+                let (generation, connection) = pool.checkout()?;
+                Ok(ReadGuard::pooled(generation, connection, pool))
+            }
             None => {
                 let guard = self
                     .conn

--- a/crates/orbit-store/src/driver/sqlite/read_pool.rs
+++ b/crates/orbit-store/src/driver/sqlite/read_pool.rs
@@ -19,6 +19,7 @@
 
 use std::ops::Deref;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, MutexGuard};
 
 use orbit_common::OrbitError;
@@ -33,6 +34,7 @@ const MAX_IDLE_READERS: usize = 4;
 pub(crate) struct ReadPool {
     path: PathBuf,
     idle: Mutex<Vec<Connection>>,
+    generation: AtomicU64,
 }
 
 impl ReadPool {
@@ -40,26 +42,44 @@ impl ReadPool {
         Self {
             path,
             idle: Mutex::new(Vec::new()),
+            generation: AtomicU64::new(0),
         }
     }
 
     /// Pop an idle reader or open a fresh one. Never waits on other readers.
-    pub(crate) fn checkout(&self) -> Result<Connection, OrbitError> {
+    pub(crate) fn checkout(&self) -> Result<(u64, Connection), OrbitError> {
+        let generation = self.generation.load(Ordering::Acquire);
         let idle = self
             .idle
             .lock()
             .map_err(|e| OrbitError::Store(format!("read pool mutex poisoned: {e}")))?
             .pop();
-        match idle {
+        let connection = match idle {
             Some(conn) => Ok(conn),
             None => self.open_reader(),
-        }
+        }?;
+        Ok((generation, connection))
+    }
+
+    /// Drop every idle reader so the next checkout resolves the database path
+    /// again. A long-lived process uses this after an external child that was
+    /// allowed to open the SQLite files has exited: WAL sidecars may have been
+    /// retired and recreated while those cached readers were idle.
+    pub(crate) fn clear_idle(&self) -> Result<(), OrbitError> {
+        let mut idle = self
+            .idle
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("read pool mutex poisoned: {e}")))?;
+        self.generation.fetch_add(1, Ordering::Release);
+        idle.clear();
+        Ok(())
     }
 
     /// Return a reader to the idle list, dropping it when the list is full
     /// (or when the pool mutex is poisoned — losing a connection is fine).
-    fn checkin(&self, conn: Connection) {
+    fn checkin(&self, generation: u64, conn: Connection) {
         if let Ok(mut idle) = self.idle.lock()
+            && generation == self.generation.load(Ordering::Acquire)
             && idle.len() < MAX_IDLE_READERS
         {
             idle.push(conn);
@@ -88,15 +108,17 @@ pub(crate) enum ReadGuard<'a> {
     Pooled {
         conn: Option<Connection>,
         pool: &'a ReadPool,
+        generation: u64,
     },
     Writer(MutexGuard<'a, Connection>),
 }
 
 impl<'a> ReadGuard<'a> {
-    pub(crate) fn pooled(conn: Connection, pool: &'a ReadPool) -> Self {
+    pub(crate) fn pooled(generation: u64, conn: Connection, pool: &'a ReadPool) -> Self {
         Self::Pooled {
             conn: Some(conn),
             pool,
+            generation,
         }
     }
 }
@@ -119,10 +141,14 @@ impl Deref for ReadGuard<'_> {
 
 impl Drop for ReadGuard<'_> {
     fn drop(&mut self) {
-        if let ReadGuard::Pooled { conn, pool } = self
+        if let ReadGuard::Pooled {
+            conn,
+            pool,
+            generation,
+        } = self
             && let Some(conn) = conn.take()
         {
-            pool.checkin(conn);
+            pool.checkin(*generation, conn);
         }
     }
 }

--- a/crates/orbit-store/src/driver/sqlite/tests/connection.rs
+++ b/crates/orbit-store/src/driver/sqlite/tests/connection.rs
@@ -34,6 +34,143 @@ fn check_writable_acquires_and_releases_write_lock() {
         .expect("store still accepts transactions after the probe");
 }
 
+#[cfg(unix)]
+#[test]
+fn refresh_file_connections_rebinds_clones_after_database_replacement() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("store.db");
+    let replacement_path = dir.path().join("replacement.db");
+    let store = Store::open(&path).expect("open original store");
+    let clone = store.clone();
+
+    store
+        .with_transaction(|tx| {
+            tx.connection()
+                .execute_batch(
+                    "CREATE TABLE refresh_fixture(value TEXT NOT NULL);
+                     INSERT INTO refresh_fixture VALUES ('original');",
+                )
+                .map_err(|error| OrbitError::Store(error.to_string()))
+        })
+        .expect("seed original database");
+    store
+        .conn
+        .lock()
+        .expect("original writer")
+        .execute_batch("PRAGMA wal_checkpoint(TRUNCATE); PRAGMA journal_mode=DELETE;")
+        .expect("detach original WAL sidecars");
+    {
+        let replacement = Store::open(&replacement_path).expect("open replacement store");
+        replacement
+            .with_transaction(|tx| {
+                tx.connection()
+                    .execute_batch(
+                        "CREATE TABLE refresh_fixture(value TEXT NOT NULL);
+                         INSERT INTO refresh_fixture VALUES ('replacement');",
+                    )
+                    .map_err(|error| OrbitError::Store(error.to_string()))
+            })
+            .expect("seed replacement database");
+        replacement
+            .conn
+            .lock()
+            .expect("replacement writer")
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE); PRAGMA journal_mode=DELETE;")
+            .expect("detach replacement WAL sidecars");
+    }
+    let checked_out_before_refresh = store.read().expect("check out pre-refresh reader");
+    std::fs::rename(&replacement_path, &path).expect("replace database path");
+
+    store
+        .refresh_file_connections(&path)
+        .expect("refresh authoritative connections");
+    drop(checked_out_before_refresh);
+    assert_eq!(
+        store
+            .reader_pool_for_test()
+            .expect("file store has reader pool")
+            .idle_len(),
+        0,
+        "a reader checked out before refresh must not return to the new generation"
+    );
+    clone
+        .with_transaction(|tx| {
+            tx.connection()
+                .execute("INSERT INTO refresh_fixture VALUES ('durable')", [])
+                .map(|_| ())
+                .map_err(|error| OrbitError::Store(error.to_string()))
+        })
+        .expect("clone shares the rebound writer");
+    let after_refresh = rusqlite::Connection::open(&path).expect("reopen authoritative path");
+    let values = after_refresh
+        .prepare("SELECT value FROM refresh_fixture ORDER BY rowid")
+        .expect("prepare values")
+        .query_map([], |row| row.get::<_, String>(0))
+        .expect("query values")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect values");
+    assert_eq!(values, vec!["replacement", "durable"]);
+}
+
+#[test]
+fn refresh_file_connections_fails_closed_during_a_writer_transaction() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("store.db");
+    let store = Store::open(&path).expect("open store");
+    let (started_tx, started_rx) = std::sync::mpsc::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let writer_store = store.clone();
+    let writer = std::thread::spawn(move || {
+        writer_store.with_transaction_behavior(rusqlite::TransactionBehavior::Immediate, |tx| {
+            tx.connection()
+                .execute_batch("CREATE TABLE refresh_writer(value INTEGER);")
+                .map_err(|error| OrbitError::Store(error.to_string()))?;
+            started_tx
+                .send(())
+                .map_err(|error| OrbitError::Store(error.to_string()))?;
+            release_rx
+                .recv()
+                .map_err(|error| OrbitError::Store(error.to_string()))?;
+            Ok(())
+        })
+    });
+    started_rx.recv().expect("writer transaction started");
+
+    let error = store
+        .refresh_file_connections(&path)
+        .expect_err("refresh cannot bypass an active writer transaction");
+    assert!(error.to_string().contains("write probe failed"), "{error}");
+
+    release_tx.send(()).expect("release writer transaction");
+    writer
+        .join()
+        .expect("join writer")
+        .expect("writer transaction commits");
+    store
+        .refresh_file_connections(&path)
+        .expect("refresh succeeds after transaction completion");
+}
+
+#[test]
+fn refresh_file_connections_refuses_read_only_and_in_memory_handles() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("store.db");
+    drop(Store::open(&path).expect("initialize store"));
+
+    for store in [
+        Store::open_read_only(&path).expect("open read-only store"),
+        Store::open_in_memory().expect("open in-memory store"),
+    ] {
+        let error = store
+            .refresh_file_connections(&path)
+            .expect_err("only writable file stores may refresh");
+        assert!(
+            error.to_string().contains("writable file-backed store"),
+            "{error}"
+        );
+    }
+}
+
 #[test]
 fn path_write_probe_does_not_create_or_migrate_databases() {
     let dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Task

[ORB-12326](https://orbit-cli.com/tasks/ORB-12326) — Record successful provider completion before post-exit run reconciliation

### Description

Fresh deployed run jrun-20260912-1333-t1 on source c94d0fb1d2099cfa1239d719ba800827ef6f202e exposed a narrower completion-accounting defect after ORB-12323. The task-pilot worker owner PID 3771867 and provider PID 3771992 (same pid namespace 4026531836) were directly observed alive while run.show reported running. Durable run audit stops at provider spawn event v2evt-jrun-20260912-1333-t1-0000000d at 13:33:31.445651064Z: there is no provider-finished, activity-finished, step-finished, or run-finished event. Nevertheless, ORB-12317 records task_pilot_applied at 13:37:11.472427329Z (operation e1af4e902f9b43effe139834ae903a533f7d59f501d8a7942d323c2c67d8663c). The first operator observation of terminal interrupted/process_not_found was approximately 13:37:25–13:37:30, after apply and after the processes exited; stored finished_at 13:33:31 is only backdated to the last durable event. Worker log is ~/workspace/constellation/codebases/orbit/.orbit/state/logs/jrun-20260912-1333-t1.worker.log; run logs project no records and no finalizer audit error.

Trace the real worker/provider exit and completion path, the actual reconciler observer and wall-clock ordering, and the database/audit identity and filesystem paths used by the provider sandbox, worker, and reconciler. Determine why a successful task-pilot apply was not followed by durable provider/activity/step/run completion and why post-exit reconciliation consequently recorded interruption. Fix the narrow proven cause so a normal real task-pilot self-claim that applies successfully reaches terminal success with complete audit evidence. Preserve ORB-12323's conservative live-descendant guard, genuine orphan cleanup, cancellation/timeout semantics, and structured failures.

Do not force or backfill the historical run, add blanket retries, expand into a diagnostic framework, or assume SQLite/CAS is causal without proof. The pilot assessment separately observed in-sandbox orbit.task.show/search failing to set synchronous=NORMAL with unable to open database file; treat that as separate evidence unless the trace proves it shares this root cause. Do not retry jrun-20260912-1333-t1.

### Acceptance Criteria

- A deterministic regression reproduces the proven sequence: real task-pilot/provider self-claim and successful apply are followed by missing completion audit and post-exit interruption, with the responsible boundary identified from concrete exit status, observer timing, and store/audit path identity.
- The narrow fix makes a successful real task-pilot run persist provider-finished, activity/step completion, and terminal success without forced lifecycle writes, historical backfill, or blanket retry.
- Provider exit status/envelope handling and worker propagation remain fail-closed for genuine provider failure, incomplete envelope, timeout, and cancellation.
- Post-exit reconciliation still interrupts true orphans and ORB-12323 continues to protect conclusively live or unverifiable descendants and their reservations.
- Tests exercise the successful pilot self-claim→apply→terminal-success path plus the identified failure boundary and relevant negative outcomes without arbitrary sleeps.
- A deployed-binary live task-pilot validation confirms normal terminal success and durable completion audit; the historical 1333 run remains untouched.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented the narrow provider-return persistence rebind immediately after exact stdout/stderr capture and before cli.invocation.finished. OrbitRuntime now reopens the authoritative writable file-backed SQLite store, swaps the shared writer connection used by all store clones, and advances a read-pool generation while clearing idle readers. Readers checked out before refresh are dropped on return rather than re-entering the new generation. Refresh refuses read-only/in-memory stores and fails closed if the authoritative write probe cannot proceed, including an active writer transaction. No sandbox grant, lifecycle backfill, forced terminal write, or blanket retry was added.

Criteria evidence:
1. Historical evidence identifies the first missing boundary. For runs 1333 and 1344, provider stdout audit blobs contain valid terminal response envelopes and turn.completed, and those blobs are only written after spawn_with_timeout returns with concrete process status. ORB-12317 then records task_pilot_applied while cli.invocation.finished, activity.finished, step.finished, and run.finished remain absent. The worker/provider and reconciler resolved the same global database and workspace identity; the provider activity retired/recreated database, WAL, and SHM path identities while the worker retained pre-spawn handles. The deterministic real-CLI fixture reproduces that identity replacement. With the production rebind temporarily removed, the fresh authoritative observer saw Running rather than Success; restored code passes. Existing dead-orphan reconciliation coverage establishes the subsequent interruption boundary without sleeps.
2. The real CLI task-pilot worker regression exercises the shipped pipeline, real provider subprocess, self-claim/apply path, and authoritative-path reopen. It asserts task_pilot_applied, exit_code 0, timed_out false, exact stdout and empty stderr blobs, ordered cli.invocation.finished/activity.finished/step.finished/run.finished, durable steps, and terminal Success.
3. Existing orchestrator and worker suites retain fail-closed handling for nonzero provider exit, missing/invalid/failed/timeout envelopes, process timeout, cancellation, signal exit, wait and worktree failures. A focused test proves a successful envelope cannot emit provider-finished when persistence rebind fails.
4. ORB-12323 reconciliation behavior is unchanged. All five descendant tests pass, including protection for live and unverifiable descendants/reservations and interruption eligibility for dead/reused PIDs.
5. Tests use process completion, channels, connection ownership, and fresh authoritative reopen rather than arbitrary sleeps. Store coverage includes identity replacement across clones, a reader borrowed before refresh and returned afterward, idle-reader generation invalidation, concurrent writer transaction failure, and read-only/in-memory refusal.
6. Historical jrun-20260912-1333-t1 remains untouched; its persisted row was rechecked as interrupted with PID 3771867 and finished_at 2026-09-12T13:33:31.445651064Z. A changed installed binary was not deployed and a governed live task-pilot was not launched because commit/install/deployment and that operation are pipeline/operator-owned. This remains the explicit post-delivery validation gate.

Validation:
- cargo test -p orbit-engine activity_job::cli_runner::tests::orchestrator:: — passed: 82 passed, 2 environment-gated nested-bwrap tests ignored.
- cargo test -p orbit-core application::job::tests::task_pilot_pipeline — passed: 5 passed.
- cargo test -p orbit-core application::job::run::tests::reconcile_provider — passed: 5 passed.
- cargo test -p orbit-core application::job::pipeline::worker::tests — passed: 4 passed.
- cargo test -p orbit-store driver::sqlite::tests::read_pool — passed: 6 passed, 1 benchmark ignored.
- cargo test -p orbit-store driver::sqlite::tests::connection — passed: 17 passed.
- Red/green regression with the production rebind temporarily removed — failed as expected at authoritative reopened state Running versus Success; restored implementation passes.
- cargo fmt --all -- --check — passed.
- make ci-fast — passed; its nested-bwrap capability probe reported the documented environment skip.
- make ci-lint — passed.
- make goldens — passed.
- git diff --check — passed.
- git status --short — 9 intended modified tracked files and no untracked files.

Scope expanded to the RuntimeHost persistence hook, OrbitRuntime adapter, shared SQLite writer/read-pool implementation, and focused tests because concrete path-identity evidence showed provider-return accounting continued through cached handles used by audit, checkpoints, and finalization. No crate dependency edge and no provider write permission were added.

Remaining risk/deviation: the acceptance criterion requiring post-change installed-binary live task-pilot validation cannot be completed inside this managed implementation checkout and remains an operator/pipeline gate after delivery. The hermetic real-process regression exercises the same database/WAL/SHM identity replacement and durable observer boundary.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12326-6aa558c9`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*

Orchestrated-By: astra