### PR TITLE
Serialize provider-return SQLite refresh behind the shared writer mutex

### DIFF
--- a/crates/orbit-store/src/driver/sqlite/connection.rs
+++ b/crates/orbit-store/src/driver/sqlite/connection.rs
@@ -131,14 +131,17 @@ impl Store {
                 "connection refresh requires a writable file-backed store".to_string(),
             )
         })?;
-        let fresh = Self::open(path)?;
-        fresh.check_writable()?;
 
         {
+            // Serialize before the fresh handle's write probe. Otherwise a
+            // sibling transaction can exhaust SQLite's independent busy
+            // timeout even though the shared writer would safely wait for it.
             let mut current = self
                 .conn
                 .lock()
                 .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+            let fresh = Self::open(path)?;
+            fresh.check_writable()?;
             let mut replacement = fresh
                 .conn
                 .lock()

--- a/crates/orbit-store/src/driver/sqlite/tests/connection.rs
+++ b/crates/orbit-store/src/driver/sqlite/tests/connection.rs
@@ -1,6 +1,9 @@
 //! Sibling tests for `sqlite/connection.rs` health probes [ORB-10005].
 
+use std::time::Duration;
+
 use orbit_common::OrbitError;
+use orbit_common::storage::sqlite::DEFAULT_BUSY_TIMEOUT_MS;
 
 use crate::Store;
 use crate::driver::sqlite::migration::SUPPORTED_SCHEMA_VERSION;
@@ -113,7 +116,7 @@ fn refresh_file_connections_rebinds_clones_after_database_replacement() {
 }
 
 #[test]
-fn refresh_file_connections_fails_closed_during_a_writer_transaction() {
+fn refresh_file_connections_waits_for_the_shared_writer_transaction() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("store.db");
     let store = Store::open(&path).expect("open store");
@@ -123,7 +126,7 @@ fn refresh_file_connections_fails_closed_during_a_writer_transaction() {
     let writer = std::thread::spawn(move || {
         writer_store.with_transaction_behavior(rusqlite::TransactionBehavior::Immediate, |tx| {
             tx.connection()
-                .execute_batch("CREATE TABLE refresh_writer(value INTEGER);")
+                .execute_batch("CREATE TABLE completion_audit(value TEXT NOT NULL);")
                 .map_err(|error| OrbitError::Store(error.to_string()))?;
             started_tx
                 .send(())
@@ -136,19 +139,51 @@ fn refresh_file_connections_fails_closed_during_a_writer_transaction() {
     });
     started_rx.recv().expect("writer transaction started");
 
-    let error = store
-        .refresh_file_connections(&path)
-        .expect_err("refresh cannot bypass an active writer transaction");
-    assert!(error.to_string().contains("write probe failed"), "{error}");
+    let (refresh_started_tx, refresh_started_rx) = std::sync::mpsc::channel();
+    let (refreshed_tx, refreshed_rx) = std::sync::mpsc::channel();
+    let refresh_store = store.clone();
+    let refresh_path = path.clone();
+    let refresh = std::thread::spawn(move || {
+        refresh_started_tx.send(()).expect("start refresh");
+        refreshed_tx
+            .send(refresh_store.refresh_file_connections(&refresh_path))
+            .expect("report refresh result");
+    });
+    refresh_started_rx.recv().expect("refresh started");
+
+    let independent_busy_timeout = Duration::from_millis(u64::from(DEFAULT_BUSY_TIMEOUT_MS));
+    assert!(
+        matches!(
+            refreshed_rx.recv_timeout(independent_busy_timeout + Duration::from_secs(1)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ),
+        "refresh must wait on the shared writer mutex beyond SQLite's independent busy timeout"
+    );
 
     release_tx.send(()).expect("release writer transaction");
     writer
         .join()
         .expect("join writer")
         .expect("writer transaction commits");
+    refreshed_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("refresh completes after writer transaction")
+        .expect("refresh succeeds after established serialization");
+    refresh.join().expect("join refresh");
+
     store
-        .refresh_file_connections(&path)
-        .expect("refresh succeeds after transaction completion");
+        .with_transaction(|tx| {
+            tx.connection()
+                .execute("INSERT INTO completion_audit VALUES ('finished')", [])
+                .map(|_| ())
+                .map_err(|error| OrbitError::Store(error.to_string()))
+        })
+        .expect("completion audit persists after refresh");
+    let persisted: String = rusqlite::Connection::open(&path)
+        .expect("reopen authoritative database")
+        .query_row("SELECT value FROM completion_audit", [], |row| row.get(0))
+        .expect("read completion audit");
+    assert_eq!(persisted, "finished");
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-12328](https://orbit-cli.com/tasks/ORB-12328) — Serialize provider-return SQLite refresh behind the shared writer mutex

### Description

PR #2071 / ORB-12326 added refresh_file_connections after provider return. Exact-head review found that it opens a fresh store and calls check_writable (BEGIN IMMEDIATE) before acquiring the existing shared writer mutex. If a sibling Store clone holds a transaction through that mutex longer than SQLite's busy timeout, the independent admission probe returns SQLITE_BUSY and is promoted to a permanent provider dispatch failure, even though the next real audit insert would have waited on the same shared mutex and succeeded. Repair the ordering so refresh uses the established writer serialization boundary and does not add an unnecessary pre-lock contention failure. Preserve fail-closed genuine open/rebind errors, read-only/in-memory refusal, writer ownership, reader-generation invalidation including borrowed readers, and all provider error/timeout/cancel semantics. Do not weaken SQLite locking or broaden sandbox grants.

### Acceptance Criteria

- A deterministic sibling-Store transaction contention regression holds the shared writer mutex beyond the independent SQLite busy timeout and proves provider-return refresh waits on established serialization rather than returning a false permanent dispatch failure.
- Refresh respects the shared writer mutex before any write-capability admission probe that can contend with sibling clones; the subsequent real completion audit persists successfully.
- Genuine open, read-only, in-memory, corrupt, and rebind failures remain visible and fail closed.
- Reader-generation invalidation, including a reader borrowed before refresh and returned afterward, remains correct.
- Focused store/provider-return tests plus ci-fast, ci-lint, goldens, fmt, and diff-check pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Acquired the existing shared writer mutex before opening and write-probing the replacement SQLite connection, so sibling Store transactions use established serialization instead of exhausting the replacement connection busy timeout.
- Replaced the prior expected SQLITE_BUSY regression with a synchronized test that holds a sibling transaction for six seconds, verifies refresh remains queued beyond the 5,000 ms busy timeout, releases the writer, and proves a completion-audit-shaped insert is durable afterward.
Assessment: The repair is limited to the two authorized store files. Existing error propagation, writable file-backed admission, connection swap ownership, and read-pool generation invalidation are unchanged.

Acceptance criteria:
1. The new sibling-Store regression holds the shared mutex beyond DEFAULT_BUSY_TIMEOUT_MS and observes no early refresh result.
2. Refresh now obtains Store.conn before Self::open/check_writable; its post-refresh completion row persists through a separately reopened authoritative connection.
3. The complete connection suite preserved missing/open, read-only, in-memory, malformed/corrupt, migration contention, and replacement behavior; the provider runner suite preserved permanent rebind failure handling.
4. The replacement test still checks that a reader borrowed before refresh is discarded when returned after the generation advances; the read-pool suite passed.
5. All required focused and repository gates passed.

Validation:
- cargo fmt --all -- --check — passed.
- cargo test -p orbit-store driver::sqlite::tests::connection — passed, 17 tests.
- cargo test -p orbit-store driver::sqlite::tests::read_pool — passed, 6 tests; 1 pre-existing slow benchmark ignored.
- cargo test -p orbit-engine activity_job::cli_runner::tests::orchestrator — passed, 82 tests; 2 sandbox-environment tests ignored by their existing cfg/runtime guards.
- cargo test -p orbit-core real_cli_task_pilot_worker_persists_apply_and_terminal_completion_audit — passed.
- make ci-fast — passed.
- make ci-lint — passed.
- make goldens — passed.
- git diff --check — passed.
- git status --short — only the two authorized tracked modifications.

Deviations from original plan: None.
Remaining risks: The contention regression was exercised on Linux; no OS-specific SQLite behavior was changed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12328-6aa5669a`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra