### PR TITLE
Restore managed read-only task and search access to the authoritative SQLite store

### DIFF
--- a/crates/orbit-common/src/storage/sqlite.rs
+++ b/crates/orbit-common/src/storage/sqlite.rs
@@ -12,6 +12,7 @@ use std::fs;
 use std::io;
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
+use std::sync::Mutex;
 
 use rusqlite::{Connection, OpenFlags};
 
@@ -49,6 +50,76 @@ pub struct OpenedConnection {
     pub currency: ObservationCurrency,
 }
 
+/// A live SQLite connection that keeps one WAL file set linked.
+///
+/// Linux runtime sandboxes bind the database, WAL, and shared-memory files by
+/// descriptor so a pathname replacement cannot redirect a grant. SQLite may
+/// normally unlink those sidecars when its last connection closes. Keeping a
+/// connection alive until the sandboxed provider exits prevents the bound
+/// descriptors from becoming a coherent but obsolete file set.
+pub struct WalFileSetLease {
+    path: PathBuf,
+    _connection: Mutex<Connection>,
+}
+
+impl std::fmt::Debug for WalFileSetLease {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WalFileSetLease")
+            .field("path", &self.path)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Keep an existing WAL database's sidecars linked until this lease is dropped.
+///
+/// Returns `None` for a missing database or a database that is not in WAL mode.
+/// The connection does not hold a transaction, so it does not pin a read
+/// snapshot or prevent ordinary checkpoints; it only prevents last-close WAL
+/// cleanup from replacing the descriptor-backed sandbox file set.
+pub fn lease_wal_file_set(path: &Path) -> Result<Option<WalFileSetLease>, OrbitError> {
+    if !path
+        .try_exists()
+        .map_err(|error| sqlite_path_error("inspect", path, error))?
+    {
+        return Ok(None);
+    }
+
+    let connection = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_WRITE
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX
+            | OpenFlags::SQLITE_OPEN_NOFOLLOW,
+    )
+    .map_err(|error| sqlite_operation_error(Some(path), "open WAL file-set lease", &error))?;
+    connection
+        .busy_timeout(std::time::Duration::from_millis(u64::from(
+            DEFAULT_BUSY_TIMEOUT_MS,
+        )))
+        .map_err(|error| sqlite_operation_error(Some(path), "set lease busy_timeout", &error))?;
+    let journal_mode = connection
+        .pragma_query_value(None, "journal_mode", |row| row.get::<_, String>(0))
+        .map_err(|error| {
+            sqlite_operation_error(Some(path), "inspect lease journal mode", &error)
+        })?;
+    if !journal_mode.eq_ignore_ascii_case("wal") {
+        return Ok(None);
+    }
+
+    connection
+        .query_row("SELECT count(*) FROM sqlite_schema", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .map_err(|error| {
+            sqlite_operation_error(Some(path), "initialize WAL file-set lease", &error)
+        })?;
+
+    Ok(Some(WalFileSetLease {
+        path: path.to_path_buf(),
+        _connection: Mutex::new(connection),
+    }))
+}
+
 /// Open an Orbit SQLite database without exposing its persisted state.
 ///
 /// Writable databases are created or repaired to owner-only access on Unix.
@@ -83,12 +154,7 @@ pub fn open_private(path: &Path) -> Result<OpenedConnection, OrbitError> {
             | OpenFlags::SQLITE_OPEN_NO_MUTEX
             | OpenFlags::SQLITE_OPEN_NOFOLLOW,
     )
-    .map_err(|error| {
-        OrbitError::Store(format!(
-            "cannot open SQLite database '{}': {error}",
-            path.display()
-        ))
-    })?;
+    .map_err(|error| sqlite_operation_error(Some(&path), "cannot open SQLite database", &error))?;
     let pragmas = apply_default_pragmas_for_path(&connection, &path)?;
     if pragmas.write_denied || filesystem_is_read_only(&path)? {
         drop(connection);
@@ -365,7 +431,7 @@ fn apply_default_pragmas_inner(
     conn: &Connection,
     path: Option<&Path>,
 ) -> Result<PragmaOutcome, OrbitError> {
-    let (journal_mode, mut write_denied) = request_wal_journal_mode(conn);
+    let (journal_mode, mut write_denied) = request_wal_journal_mode(conn, path);
     conn.pragma_update(None, "busy_timeout", DEFAULT_BUSY_TIMEOUT_MS)
         .map_err(|error| sqlite_operation_error(path, "set busy_timeout", &error))?;
     conn.pragma_update(None, "foreign_keys", "ON")
@@ -396,21 +462,33 @@ fn sqlite_operation_error(path: Option<&Path>, phase: &str, error: &rusqlite::Er
         error.sqlite_error_code(),
         Some(ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked)
     );
+    let detail = sqlite_error_detail(error);
     if contention && let Some(path) = path {
         return OrbitError::SqliteContention(Box::new(SqliteContention {
             path: path.display().to_string(),
             phase: phase.to_string(),
-            detail: error.to_string(),
+            detail,
         }));
     }
 
-    let message = match phase {
-        "set busy_timeout" => format!("failed to set busy_timeout: {error}"),
-        "enable foreign keys" => format!("failed to enable foreign keys: {error}"),
-        "set synchronous=NORMAL" => format!("failed to set synchronous=NORMAL: {error}"),
-        _ => error.to_string(),
+    let operation = match phase {
+        "set busy_timeout" => "failed to set busy_timeout",
+        "enable foreign keys" => "failed to enable foreign keys",
+        "set synchronous=NORMAL" => "failed to set synchronous=NORMAL",
+        _ => phase,
     };
-    OrbitError::Store(message)
+    let path = path.map_or_else(String::new, |path| format!(" for '{}'", path.display()));
+    OrbitError::Store(format!("{operation}{path}: {detail}"))
+}
+
+fn sqlite_error_detail(error: &rusqlite::Error) -> String {
+    match error.sqlite_error() {
+        Some(sqlite) => format!(
+            "{} [code={:?}, extended_code={}]",
+            error, sqlite.code, sqlite.extended_code
+        ),
+        None => error.to_string(),
+    }
 }
 
 /// What a caller needs from an observational open.
@@ -482,7 +560,10 @@ pub fn open_observational(
             row.get::<_, i64>(0)
         })
         .map_err(|error| {
-            observational_unavailable(path, &format!("its first read failed: {error}"))
+            observational_unavailable(
+                path,
+                &format!("its first read failed: {}", sqlite_error_detail(&error)),
+            )
         })?;
 
     if currency == ObservationCurrency::MainFileOnly {
@@ -600,18 +681,19 @@ fn open_read_only_connection(
             | OpenFlags::SQLITE_OPEN_URI,
     )
     .map_err(|error| {
-        OrbitError::Store(format!(
-            "cannot open SQLite database '{}' for observational reads: {error}",
-            path.display()
-        ))
+        sqlite_operation_error(
+            Some(path),
+            "cannot open SQLite database for observational reads",
+            &error,
+        )
     })?;
 
     conn.pragma_update(None, "query_only", "ON")
-        .map_err(|error| OrbitError::Store(format!("failed to set query_only: {error}")))?;
+        .map_err(|error| sqlite_operation_error(Some(path), "set query_only", &error))?;
     conn.pragma_update(None, "busy_timeout", DEFAULT_BUSY_TIMEOUT_MS)
-        .map_err(|error| OrbitError::Store(format!("failed to set busy_timeout: {error}")))?;
+        .map_err(|error| sqlite_operation_error(Some(path), "set busy_timeout", &error))?;
     conn.pragma_update(None, "foreign_keys", "ON")
-        .map_err(|error| OrbitError::Store(format!("failed to enable foreign keys: {error}")))?;
+        .map_err(|error| sqlite_operation_error(Some(path), "enable foreign keys", &error))?;
     Ok(conn)
 }
 
@@ -670,7 +752,7 @@ pub fn filesystem_is_read_only(_path: &Path) -> Result<bool, OrbitError> {
 /// Request WAL and report the journal mode SQLite settled on. Never fails:
 /// WAL is a performance/concurrency upgrade, not a correctness requirement,
 /// so refusals degrade to a warning plus the active mode.
-fn request_wal_journal_mode(conn: &Connection) -> (String, bool) {
+fn request_wal_journal_mode(conn: &Connection, path: Option<&Path>) -> (String, bool) {
     match conn.pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get::<_, String>(0)) {
         Ok(mode) => {
             if !mode.eq_ignore_ascii_case("wal") && !mode.eq_ignore_ascii_case("memory") {
@@ -683,9 +765,11 @@ fn request_wal_journal_mode(conn: &Connection) -> (String, bool) {
             (mode, false)
         }
         Err(error) => {
+            let detail = sqlite_error_detail(&error);
             tracing::warn!(
                 target: "orbit.common.sqlite",
-                error = %error,
+                path = path.map(|path| path.display().to_string()),
+                error = detail,
                 "could not set WAL mode; continuing with the active journal mode",
             );
             let write_denied = OrbitError::Store(error.to_string()).is_readonly_or_access_failure();

--- a/crates/orbit-common/src/storage/tests/sqlite.rs
+++ b/crates/orbit-common/src/storage/tests/sqlite.rs
@@ -60,6 +60,102 @@ fn defaults_are_idempotent() {
     assert!(outcome.wal_active());
 }
 
+#[cfg(unix)]
+#[test]
+fn wal_file_set_lease_keeps_sidecar_identity_stable() {
+    use std::os::unix::fs::MetadataExt;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("leased.db");
+    let connection = Connection::open(&path).expect("create database");
+    connection
+        .pragma_update(None, "journal_mode", "WAL")
+        .expect("enable WAL");
+    connection
+        .execute_batch("CREATE TABLE fixture(value INTEGER); INSERT INTO fixture VALUES (1);")
+        .expect("seed database");
+    drop(connection);
+    assert!(
+        ["-wal", "-shm"]
+            .iter()
+            .all(
+                |suffix| !std::path::PathBuf::from(format!("{}{suffix}", path.display())).exists()
+            ),
+        "the pre-repair lifecycle gap requires SQLite last-close cleanup"
+    );
+
+    let lease = super::super::sqlite::lease_wal_file_set(&path)
+        .expect("open WAL lease")
+        .expect("WAL database needs a lease");
+    let identities = ["-wal", "-shm"].map(|suffix| {
+        std::fs::metadata(format!("{}{suffix}", path.display()))
+            .expect("lease materialized sidecar")
+            .ino()
+    });
+
+    let writer = Connection::open(&path).expect("open concurrent writer");
+    writer
+        .execute("INSERT INTO fixture VALUES (2)", [])
+        .expect("write through leased file set");
+    drop(writer);
+
+    assert_eq!(
+        ["-wal", "-shm"].map(|suffix| {
+            std::fs::metadata(format!("{}{suffix}", path.display()))
+                .expect("leased sidecar remains linked")
+                .ino()
+        }),
+        identities,
+        "last-close cleanup must not replace descriptor-backed sidecars"
+    );
+    drop(lease);
+}
+
+#[test]
+fn wal_file_set_lease_keeps_missing_and_corrupt_failures_attributable() {
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing = dir.path().join("missing.db");
+    assert!(
+        super::super::sqlite::lease_wal_file_set(&missing)
+            .expect("missing database is not a lease error")
+            .is_none()
+    );
+
+    let corrupt = dir.path().join("corrupt.db");
+    std::fs::write(&corrupt, b"not a SQLite database").expect("write corrupt database");
+    let error = super::super::sqlite::lease_wal_file_set(&corrupt)
+        .expect_err("corrupt database must fail closed");
+    let message = error.to_string();
+    assert!(
+        message.contains(&corrupt.display().to_string()),
+        "{message}"
+    );
+    assert!(message.contains("code=NotADatabase"), "{message}");
+    assert!(message.contains("extended_code=26"), "{message}");
+
+    #[cfg(unix)]
+    {
+        let unreadable = dir.path().join("unreadable.db");
+        Connection::open(&unreadable).expect("create unreadable fixture");
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000))
+            .expect("remove database access");
+        let error = super::super::sqlite::lease_wal_file_set(&unreadable)
+            .expect_err("unreadable database must fail closed");
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o600))
+            .expect("restore database access");
+        let message = error.to_string();
+        assert!(
+            message.contains(&unreadable.display().to_string()),
+            "{message}"
+        );
+        assert!(message.contains("code=CannotOpen"), "{message}");
+        assert!(message.contains("extended_code=14"), "{message}");
+    }
+}
+
 #[test]
 fn private_open_rejects_parent_directory_traversal() {
     let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
@@ -331,9 +331,7 @@ fn append_linux_runtime_write_roots(
     for relative in ["state/logs", "state/audit", "tasks"] {
         append_runtime_directory_grant(&global, relative, resolved, authority)?;
     }
-    for relative in ["orbit.db", "orbit.db-wal", "orbit.db-shm"] {
-        append_runtime_sidecar_grant(&global, relative, resolved, authority)?;
-    }
+    append_runtime_sqlite_grants(&global, "orbit.db", resolved, authority)?;
 
     if !grants_workspace_modify {
         return Ok(());
@@ -348,13 +346,7 @@ fn append_linux_runtime_write_roots(
     ] {
         append_runtime_directory_grant(&workspace, relative, resolved, authority)?;
     }
-    for relative in [
-        "state/semantic.db",
-        "state/semantic.db-wal",
-        "state/semantic.db-shm",
-    ] {
-        append_runtime_sidecar_grant(&workspace, relative, resolved, authority)?;
-    }
+    append_runtime_sqlite_grants(&workspace, "state/semantic.db", resolved, authority)?;
 
     // Language-neutral host cache for toolchain artifacts shared across
     // worktrees (compiler caches, etc.). Implementer-only so read-only
@@ -394,6 +386,7 @@ pub(super) fn append_runtime_directory_grant(
     authority.push(LinuxRuntimeWriteAuthority {
         path: directory,
         handle: std::sync::Arc::new(File::from(handle)),
+        wal_file_set_lease: None,
     });
     Ok(())
 }
@@ -406,12 +399,47 @@ pub(super) fn append_runtime_directory_grant(
 /// symlink would otherwise hand the sandbox a writable bind on whatever the
 /// link names.
 // pub(super) widened for the sibling tests/ layout.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", test))]
 pub(super) fn append_runtime_sidecar_grant(
     root: &Path,
     relative: &str,
     resolved: &mut ResolvedFsProfile,
     authority: &mut Vec<LinuxRuntimeWriteAuthority>,
+) -> Result<(), DispatchError> {
+    append_runtime_sidecar_grant_with_lease(root, relative, resolved, authority, None)
+}
+
+#[cfg(target_os = "linux")]
+fn append_runtime_sqlite_grants(
+    root: &Path,
+    relative: &str,
+    resolved: &mut ResolvedFsProfile,
+    authority: &mut Vec<LinuxRuntimeWriteAuthority>,
+) -> Result<(), DispatchError> {
+    let database = root.join(relative);
+    let lease = orbit_common::storage::sqlite::lease_wal_file_set(&database)
+        .map_err(|error| DispatchError::CliInvocationPermanent(error.to_string()))?
+        .map(std::sync::Arc::new);
+
+    for suffix in ["", "-wal", "-shm"] {
+        append_runtime_sidecar_grant_with_lease(
+            root,
+            &format!("{relative}{suffix}"),
+            resolved,
+            authority,
+            lease.clone(),
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn append_runtime_sidecar_grant_with_lease(
+    root: &Path,
+    relative: &str,
+    resolved: &mut ResolvedFsProfile,
+    authority: &mut Vec<LinuxRuntimeWriteAuthority>,
+    wal_file_set_lease: Option<std::sync::Arc<orbit_common::storage::sqlite::WalFileSetLease>>,
 ) -> Result<(), DispatchError> {
     let Some(file) = validated_linux_runtime_descendant(root, relative)? else {
         tracing::warn!(
@@ -429,6 +457,7 @@ pub(super) fn append_runtime_sidecar_grant(
             authority.push(LinuxRuntimeWriteAuthority {
                 path: file,
                 handle: std::sync::Arc::new(File::from(handle)),
+                wal_file_set_lease,
             });
             Ok(())
         }

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
@@ -56,6 +56,61 @@ fn reviewer_read_rules_follow_inspection_cwd_without_primary_write_grants() {
 
 #[cfg(target_os = "linux")]
 #[test]
+fn reviewer_runtime_database_grants_hold_one_wal_file_set_lease() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let inspection = tempfile::tempdir().expect("inspection checkout");
+    seed_executor(
+        &runtime,
+        "codex",
+        Some(orbit_types::workflow::ExecutorSandboxKind::LinuxBwrap),
+    );
+
+    let sandbox = runtime
+        .resolve_executor_sandbox("codex", Some("reviewer"), Some(inspection.path()))
+        .expect("resolve reviewer sandbox")
+        .expect("Linux sandbox");
+    let database_grants = sandbox
+        .runtime_write_authority
+        .iter()
+        .filter(|grant| {
+            grant.path.file_name().is_some_and(|name| {
+                matches!(
+                    name.to_str(),
+                    Some("orbit.db" | "orbit.db-wal" | "orbit.db-shm")
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(database_grants.len(), 3);
+    assert!(
+        database_grants
+            .iter()
+            .all(|grant| grant.wal_file_set_lease.is_some()),
+        "the DB, WAL, and SHM descriptors must share a live SQLite lease"
+    );
+    let first = database_grants[0]
+        .wal_file_set_lease
+        .as_ref()
+        .expect("database lease");
+    assert!(database_grants.iter().all(|grant| {
+        std::sync::Arc::ptr_eq(
+            first,
+            grant.wal_file_set_lease.as_ref().expect("sidecar lease"),
+        )
+    }));
+    assert!(
+        sandbox
+            .fs_profile
+            .modify
+            .iter()
+            .all(|grant| !grant.starts_with(inspection.path().to_string_lossy().as_ref())),
+        "the runtime lease must not grant source-inspection writes"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
 fn resolve_executor_sandbox_returns_linux_descriptor_with_absolute_mounts() {
     let runtime =
         seeded_runtime_with_executor(Some(orbit_types::workflow::ExecutorSandboxKind::LinuxBwrap));

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -56,6 +56,9 @@ pub struct ResolvedShellExecutor {
 pub struct LinuxRuntimeWriteAuthority {
     pub path: PathBuf,
     pub handle: Arc<File>,
+    /// Shared connection that prevents SQLite last-close cleanup from
+    /// replacing a descriptor-backed WAL/SHM file set while the provider runs.
+    pub wal_file_set_lease: Option<Arc<orbit_common::storage::sqlite::WalFileSetLease>>,
 }
 
 impl PartialEq for LinuxRuntimeWriteAuthority {

--- a/crates/orbit-exec/src/lib.rs
+++ b/crates/orbit-exec/src/lib.rs
@@ -54,12 +54,12 @@ pub use linux_landlock::{
 };
 pub use linux_sandbox::{
     BwrapProbeOutcome, LINUX_STABLE_BUILD_MOUNT, LINUX_STABLE_WORKSPACE_MOUNT,
-    LinuxBwrapMountAuthority, LinuxBwrapPlan, LinuxBwrapPostRunGuard, LinuxBwrapSpawnRequest,
-    PreparedWriteGrants, UnsatisfiedWriteGrant, WriteAnchorKind, WriteGrant, bwrap_path,
-    bwrap_program_for_audit, bwrap_unavailable_message, compile_linux_bwrap_argv,
-    compile_linux_bwrap_argv_with_authority, linux_bwrap_write_grant_diagnostic,
-    linux_bwrap_write_grants, prepare_linux_bwrap_write_grants, probe_bwrap,
-    spawn_under_linux_bwrap,
+    LinuxBwrapMountAuthority, LinuxBwrapMountEvidence, LinuxBwrapPlan, LinuxBwrapPostRunGuard,
+    LinuxBwrapSpawnRequest, PreparedWriteGrants, UnsatisfiedWriteGrant, WriteAnchorKind,
+    WriteGrant, bwrap_path, bwrap_program_for_audit, bwrap_unavailable_message,
+    compile_linux_bwrap_argv, compile_linux_bwrap_argv_with_authority,
+    linux_bwrap_write_grant_diagnostic, linux_bwrap_write_grants, prepare_linux_bwrap_write_grants,
+    probe_bwrap, spawn_under_linux_bwrap,
 };
 pub use macos_sandbox::{
     MacosLoginKeychainAccess, MacosSandboxSpawnRequest, claude_state_dir_from_env,

--- a/crates/orbit-exec/src/linux_sandbox.rs
+++ b/crates/orbit-exec/src/linux_sandbox.rs
@@ -43,6 +43,7 @@ pub struct LinuxBwrapPlan {
     /// Mount-source descriptors retained until Bubblewrap has consumed argv.
     /// Empty for ordinary path-based plans and audit rendering.
     mount_sources: Vec<File>,
+    mount_evidence: Vec<LinuxBwrapMountEvidence>,
 }
 
 impl PartialEq for LinuxBwrapPlan {
@@ -54,6 +55,22 @@ impl PartialEq for LinuxBwrapPlan {
 }
 
 impl Eq for LinuxBwrapPlan {}
+
+impl LinuxBwrapPlan {
+    /// Descriptor and object identity used by each effective `--bind-fd` grant.
+    pub fn mount_evidence(&self) -> &[LinuxBwrapMountEvidence] {
+        &self.mount_evidence
+    }
+}
+
+/// Bounded evidence tying a writable sandbox destination to its open object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinuxBwrapMountEvidence {
+    pub destination: PathBuf,
+    pub source_fd: i32,
+    pub device: u64,
+    pub inode: u64,
+}
 
 /// A host object already validated and opened by the runtime owner.
 #[derive(Debug)]
@@ -692,6 +709,7 @@ pub fn compile_linux_bwrap_argv(
         args: out,
         dropped_grants,
         mount_sources: Vec::new(),
+        mount_evidence: Vec::new(),
     })
 }
 
@@ -714,6 +732,13 @@ pub fn compile_linux_bwrap_argv_with_authority(
         let source = prepare_mount_source(grant.source)?;
         #[cfg(unix)]
         let source_fd = source.as_raw_fd();
+        #[cfg(unix)]
+        let metadata = source.metadata().map_err(|error| {
+            OrbitError::Execution(format!(
+                "inspect Linux runtime grant descriptor for `{}`: {error}",
+                grant.destination.display()
+            ))
+        })?;
         let rendered = grant.destination.display().to_string();
         let mut replaced = false;
         for index in 0..plan.args.len().saturating_sub(2) {
@@ -737,6 +762,17 @@ pub fn compile_linux_bwrap_argv_with_authority(
                 "validated Linux runtime grant `{}` had no writable mount in the final sandbox plan",
                 grant.destination.display()
             )));
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+
+            plan.mount_evidence.push(LinuxBwrapMountEvidence {
+                destination: grant.destination,
+                source_fd,
+                device: metadata.dev(),
+                inode: metadata.ino(),
+            });
         }
         plan.mount_sources.push(source);
     }

--- a/crates/orbit-exec/src/tests/linux_sandbox.rs
+++ b/crates/orbit-exec/src/tests/linux_sandbox.rs
@@ -257,6 +257,15 @@ fn descriptor_mount_plan_holds_the_validated_object_and_closes_it_on_drop() {
     )
     .expect("descriptor-backed plan");
     let retained_fd = plan.mount_sources[0].as_raw_fd();
+    let evidence = &plan.mount_evidence()[0];
+    let metadata = plan.mount_sources[0]
+        .metadata()
+        .expect("mounted object metadata");
+    use std::os::unix::fs::MetadataExt;
+    assert_eq!(evidence.destination, target);
+    assert_eq!(evidence.source_fd, retained_fd);
+    assert_eq!(evidence.device, metadata.dev());
+    assert_eq!(evidence.inode, metadata.ino());
     assert!(plan.args.windows(3).any(|args| {
         args[0] == "--bind-fd"
             && args[1] == retained_fd.to_string()


### PR DESCRIPTION
## Task

[ORB-12327](https://orbit-cli.com/tasks/ORB-12327) — Restore managed read-only task and search access to the authoritative SQLite store

### Description

Two fresh deployed task-pilot providers on source c94d0fb1/879f09bb applied their assessments but could not use the assigned managed tool surface to read tasks or search. In jrun-20260912-1333-t1, the retained Codex transcript `~/.codex/sessions/2026/09/12/rollout-2026-09-12T13-33-31-01a095d2-be26-7342-b7ef-aeb0972f83d4.jsonl` records orbit.task.show ORB-12317 failing at 13:33:59 with `store_error: failed to set synchronous=NORMAL: unable to open database file`; at 13:34:10, registered CLI show plus two scoped searches fail through the same WAL/open path. The durable provider transcript is audit blob e42bd4975dd806383f3737757560736b7fd923869cc4d6b4f0658ef7fe6374ab. A second pilot jrun-20260912-1344-t1 reproduced the same inability and fell back to its injected task snapshot plus pinned source inspection.

Diagnose this read path before choosing a repair. Capture the exact database path, extended SQLite error code, database/WAL/SHM inode and open-descriptor identity, and effective bwrap mount grants as seen by the managed provider and tool host. The common SQLite helper currently drops path and extended-code context; retain enough bounded diagnostics to distinguish mount/descriptor/identity/permission failure without exposing secrets. Preserve ORB-12042's descriptor-held grant model and all existing task/search read contracts. Do not use a shadow store, blanket-suppress read-only/permission errors, weaken source-checkout read-only protection, assume this shares ORB-12326's provider-completion cause, or treat missing-workspace-selector MCP errors as part of this defect.

Repair only the proven boundary so an actual managed task-pilot envelope can read its assigned task and perform a scoped search through the advertised registered tools while its source inspection remains read-only. Keep corrupt/unreadable database failures visible and attributable. If concrete tracing proves ORB-12326 has the same root cause, consolidate rather than overlapping implementation.

### Acceptance Criteria

- A deterministic regression reproduces the managed-envelope task.show/search failure and captures the exact database path, extended SQLite code, DB/WAL/SHM inode or descriptor identity, and effective mount/grant evidence needed to establish the cause.
- The repair lets a real managed read-only task-pilot envelope read its assigned task and perform a workspace-scoped search through advertised tools without granting repository or source-inspection writes.
- ORB-12042's descriptor-held database/WAL/SHM grant behavior, current authoritative-store routing, and normal external task/search reads remain intact; no shadow store or path-based fallback is introduced.
- Negative tests keep genuinely unreadable, missing, or corrupt database failures visible with bounded path/code attribution rather than suppressing or rewriting them as success.
- Missing-workspace-selector MCP errors remain their existing expected contract and are not conflated with this mounted SQLite failure.
- Focused store/tool/sandbox tests plus ci-fast, ci-lint, goldens, and a deployed managed-envelope live probe pass; ORB-12326 is consolidated only if evidence proves a shared cause.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Diagnosed the managed reviewer failure as a descriptor-lifetime gap: the effective Bubblewrap plan granted the authoritative global DB/WAL/SHM through descriptor-backed writable mounts and kept the inspection checkout read-only, but SQLite last-close cleanup could unlink/recreate WAL/SHM after grant acquisition, leaving the sandbox pinned to obsolete sidecar objects.
- Added a shared WAL file-set lease that keeps a host SQLite connection alive for the lifetime of all three runtime grant descriptors. It holds no transaction, introduces no shadow store or path fallback, and preserves current authoritative routing and ORB-12042 descriptor identity.
- Added bounded SQLite diagnostics with the exact database path, primary code, and extended code across writable, observational, and lease opens.
- Added mount evidence exposing the effective bind-fd destination, source descriptor, device, and inode, plus regressions proving last-close sidecar removal before the repair, stable WAL/SHM inode identity under the lease, one shared reviewer lease, unchanged source-inspection write denial, and corrupt/unreadable/missing behavior.
- Added file:crates/orbit-exec/src/lib.rs to task scope because the public plan evidence type must be re-exported from the crate API.

Acceptance evidence:
1. The common regression demonstrates the pre-repair last-close sidecar disappearance and stable post-repair WAL/SHM inodes; the orbit-exec regression matches destination/fd/device/inode to the final --bind-fd argv; diagnostics assert exact corrupt code=NotADatabase and extended_code=26 and unreadable code=CannotOpen and extended_code=14 with exact paths.
2. The reviewer sandbox regression confirms the DB/WAL/SHM share one lease and grants no source-inspection modification. The built candidate successfully ran orbit.task.show for ORB-12327 and workspace-scoped orbit.search through registered tools.
3. The existing descriptor-backed mounts and authoritative paths remain; no new store, fallback, routing branch, or repository grant was added. Existing sandbox and task-show/read-only regressions pass.
4. Missing grant targets remain absent without creation; corrupt and unreadable databases fail with bounded exact path/code attribution. Existing incomplete WAL/SHM observational failures pass.
5. cargo test -p orbit-cli --test mcp_roundtrip unmanaged_orbit_workspace_env_does_not_bind_mcp -- --exact --nocapture passed, preserving the explicit-selector error contract.
6. Focused common/core/engine/exec/CLI tests, make ci-fast, make ci-lint, and make goldens passed. The deployed task-pilot probe was not run because deployment and dispatch are operator-owned and unavailable to this managed implementation envelope. The existing live mount test returned success by its documented nested-namespace skip; direct cargo test -p orbit-exec kernel_descriptor_mount_never_writes_the_replacement_object -- --ignored --exact --nocapture was denied with: bwrap: No permissions to create new namespace. A built-binary managed task.show/search probe passed, but it is not a deployed reviewer-profile substitute.

Validation:
- PASS: cargo test -p orbit-common --features sqlite --lib storage::tests::sqlite -- --nocapture (17 passed, 1 fixture helper ignored).
- PASS: cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::sandbox -- --nocapture (49 passed).
- PASS: cargo test -p orbit-engine activity_job::cli_runner::tests::spawn -- --nocapture (36 passed).
- PASS: cargo test -p orbit-exec --lib linux_sandbox::tests -- --nocapture (11 passed; isolated child also passed).
- PASS: focused descriptor evidence test.
- PASS: focused MCP missing-selector, global task-show, and read-only mount test commands.
- PASS: built target/debug/orbit task.show and workspace-scoped search probe.
- PASS: make ci-fast.
- PASS: make ci-lint.
- PASS: make goldens.
- PASS: git diff --check.
- PASS: final git status accounted for exactly eight task-scoped modified files and no untracked paths.
- NOT RUN: deployed managed task-pilot live probe; requires operator deployment/dispatch authority.
- NOT RUN: nested live Bubblewrap kernel body; current sandbox denies a second user/mount namespace.

Assessment: The repair is limited to the proven SQLite sidecar lifetime and diagnostic/mount-evidence boundaries. The open lease does not retain a transaction, so normal checkpoints remain possible while last-close unlink/replacement is prevented. Remaining risk is the required post-deployment task-pilot probe on a host able to create the real Bubblewrap namespace.

ORB-12326: not consolidated. Its provider-completion ordering fix is already at starting HEAD f453bc741d722a962febdd70c4d7337c14abf7e0; evidence here identifies a separate SQLite WAL/SHM lifetime cause.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12327-6aa56411`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra