### PR TITLE
[code-review] Lease the validated canonical SQLite path for in-root runtime aliases

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
@@ -406,25 +406,42 @@ pub(super) fn append_runtime_sidecar_grant(
     resolved: &mut ResolvedFsProfile,
     authority: &mut Vec<LinuxRuntimeWriteAuthority>,
 ) -> Result<(), DispatchError> {
-    append_runtime_sidecar_grant_with_lease(root, relative, resolved, authority, None)
+    append_runtime_sidecar_grant_with_lease(root, &root.join(relative), resolved, authority, None)
 }
 
+/// Grant a runtime SQLite database and the sidecars belonging to its accepted
+/// canonical path.
+///
+/// Containment must be decided before SQLite opens the lease: an authorized
+/// in-root alias is resolved away before `SQLITE_OPEN_NOFOLLOW` reaches the
+/// trust boundary, while an escaping alias is dropped without opening it.
+// pub(super) widened for the sibling tests/ layout.
 #[cfg(target_os = "linux")]
-fn append_runtime_sqlite_grants(
+pub(super) fn append_runtime_sqlite_grants(
     root: &Path,
     relative: &str,
     resolved: &mut ResolvedFsProfile,
     authority: &mut Vec<LinuxRuntimeWriteAuthority>,
 ) -> Result<(), DispatchError> {
-    let database = root.join(relative);
+    let Some(database) = validated_linux_runtime_descendant(root, relative)? else {
+        tracing::warn!(
+            runtime_root = %root.display(),
+            database = relative,
+            "skipping sandbox grants for a database that resolves outside its runtime root"
+        );
+        return Ok(());
+    };
+
     let lease = orbit_common::storage::sqlite::lease_wal_file_set(&database)
         .map_err(|error| DispatchError::CliInvocationPermanent(error.to_string()))?
         .map(std::sync::Arc::new);
 
     for suffix in ["", "-wal", "-shm"] {
+        let mut sidecar = database.as_os_str().to_os_string();
+        sidecar.push(suffix);
         append_runtime_sidecar_grant_with_lease(
             root,
-            &format!("{relative}{suffix}"),
+            Path::new(&sidecar),
             resolved,
             authority,
             lease.clone(),
@@ -436,15 +453,15 @@ fn append_runtime_sqlite_grants(
 #[cfg(target_os = "linux")]
 fn append_runtime_sidecar_grant_with_lease(
     root: &Path,
-    relative: &str,
+    candidate: &Path,
     resolved: &mut ResolvedFsProfile,
     authority: &mut Vec<LinuxRuntimeWriteAuthority>,
     wal_file_set_lease: Option<std::sync::Arc<orbit_common::storage::sqlite::WalFileSetLease>>,
 ) -> Result<(), DispatchError> {
-    let Some(file) = validated_linux_runtime_descendant(root, relative)? else {
+    let Some(file) = validated_linux_runtime_path(root, candidate)? else {
         tracing::warn!(
             runtime_root = %root.display(),
-            sidecar = relative,
+            sidecar = %candidate.display(),
             "skipping sandbox grant for a database sidecar that resolves outside its runtime root"
         );
         return Ok(());
@@ -586,7 +603,15 @@ pub(super) fn validated_linux_runtime_descendant(
     root: &Path,
     relative: &str,
 ) -> Result<Option<PathBuf>, DispatchError> {
-    let Some(resolved) = resolved_existing_ancestor(&root.join(relative))? else {
+    validated_linux_runtime_path(root, &root.join(relative))
+}
+
+#[cfg(target_os = "linux")]
+fn validated_linux_runtime_path(
+    root: &Path,
+    candidate: &Path,
+) -> Result<Option<PathBuf>, DispatchError> {
+    let Some(resolved) = resolved_existing_ancestor(candidate)? else {
         return Ok(None);
     };
     Ok(resolved.starts_with(root).then_some(resolved))

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
@@ -1384,9 +1384,10 @@ mod runtime_store_grants {
     use std::path::Path;
 
     use orbit_types::policy::ResolvedFsProfile;
+    use rusqlite::Connection;
 
     use crate::adapter::engine_host::v2_host::sandbox::{
-        append_runtime_directory_grant, append_runtime_sidecar_grant,
+        append_runtime_directory_grant, append_runtime_sidecar_grant, append_runtime_sqlite_grants,
         open_or_create_runtime_directory, validated_linux_runtime_descendant,
     };
 
@@ -1560,6 +1561,86 @@ mod runtime_store_grants {
             vec![root.join("orbit.db-wal").display().to_string()]
         );
         assert_eq!(authority[0].path, root.join("orbit.db-wal"));
+    }
+
+    #[test]
+    fn sqlite_grants_resolve_an_in_root_database_alias_before_leasing() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let root = canonical_root(root.path());
+        let database = root.join("real-orbit.db");
+        let writer = Connection::open(&database).expect("create database");
+        writer
+            .pragma_update(None, "journal_mode", "WAL")
+            .expect("enable WAL");
+        writer
+            .execute_batch("CREATE TABLE fixture(value INTEGER); INSERT INTO fixture VALUES (1);")
+            .expect("seed database");
+        symlink(&database, root.join("orbit.db")).expect("alias database inside root");
+        let mut profile = empty_profile();
+        let mut authority = Vec::new();
+
+        append_runtime_sqlite_grants(&root, "orbit.db", &mut profile, &mut authority)
+            .expect("grant canonical database file set");
+
+        let expected_paths = [
+            database.clone(),
+            root.join("real-orbit.db-wal"),
+            root.join("real-orbit.db-shm"),
+        ];
+        assert_eq!(
+            authority
+                .iter()
+                .map(|grant| grant.path.clone())
+                .collect::<Vec<_>>(),
+            expected_paths
+        );
+        assert_eq!(
+            profile.modify,
+            expected_paths
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+        );
+        let lease = authority[0]
+            .wal_file_set_lease
+            .as_ref()
+            .expect("database lease");
+        assert!(authority.iter().all(|grant| {
+            std::sync::Arc::ptr_eq(
+                lease,
+                grant.wal_file_set_lease.as_ref().expect("sidecar lease"),
+            )
+        }));
+
+        drop(writer);
+        assert!(
+            expected_paths[1..].iter().all(|path| path.exists()),
+            "the shared lease must keep both canonical sidecars linked"
+        );
+    }
+
+    #[test]
+    fn sqlite_grants_reject_an_escaping_alias_without_touching_its_target() {
+        let root = tempfile::tempdir().expect("runtime root");
+        let outside = tempfile::tempdir().expect("outside");
+        let root = canonical_root(root.path());
+        let target = canonical_root(outside.path()).join("external.db");
+        std::fs::write(&target, b"not an Orbit database").expect("create external target");
+        symlink(&target, root.join("orbit.db")).expect("redirect database outside root");
+        let mut profile = empty_profile();
+        let mut authority = Vec::new();
+
+        append_runtime_sqlite_grants(&root, "orbit.db", &mut profile, &mut authority)
+            .expect("an escaping database is skipped before SQLite opens it");
+
+        assert!(profile.modify.is_empty(), "grants: {:?}", profile.modify);
+        assert!(authority.is_empty());
+        assert_eq!(
+            std::fs::read(&target).expect("read external target"),
+            b"not an Orbit database"
+        );
+        assert!(!outside.path().join("external.db-wal").exists());
+        assert!(!outside.path().join("external.db-shm").exists());
     }
 
     /// SQLite writes its sidecars next to the database it opens, so a sidecar


### PR DESCRIPTION
## Task

[ORB-12329](https://orbit-cli.com/tasks/ORB-12329) — [code-review] Lease the validated canonical SQLite path for in-root runtime aliases

### Description

ORB-12327 introduced append_runtime_sqlite_grants, which opens the unresolved root/relative database with lease_wal_file_set before validated_linux_runtime_descendant performs containment validation and canonicalization. lease_wal_file_set uses SQLITE_OPEN_NOFOLLOW, so a supported symlink component that resolves inside the authorized root now aborts managed provider dispatch even though the existing resolves_an_alias_that_still_lands_inside_the_root contract permits it. Repair the grant builder so containment is validated first and the lease opens the accepted canonical database path. Preserve descriptor-backed race resistance, no-follow protections at the trust boundary, escaping-alias rejection, no external writes, and the WAL lease lifetime shared across DB/WAL/SHM grants. Do not broaden runtime grants or add path fallback/shadow storage.

### Acceptance Criteria

- Grant construction validates root containment before opening the WAL file-set lease and uses the accepted canonical database path for the lease.
- An in-root symlink alias accepted by the existing grant-builder contract produces DB/WAL/SHM descriptor-backed grants and a shared lease without dispatch failure.
- Aliases escaping the authorized root remain rejected and no external target is created or written.
- Descriptor identity/race protections and SQLITE_OPEN_NOFOLLOW trust-boundary behavior remain intact.
- The WAL lease remains alive across all three database grant authorities, with focused integration and regression tests passing.
- Focused tests plus ci-fast, ci-lint, goldens, fmt, and diff-check pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Validated and canonicalized the runtime database descendant before opening the WAL file-set lease.
- Derived DB/WAL/SHM candidates from the accepted canonical database path, while retaining per-file containment validation, descriptor-backed O_NOFOLLOW opens, and one shared Arc lease.
- Added Linux regressions proving an in-root database symlink yields canonical descriptor-backed grants and a live shared lease, while an escaping alias is skipped without modifying its external target or creating sidecars.

Acceptance criteria:
1. Containment now precedes lease construction, and the lease receives the accepted canonical database path.
2. The in-root alias regression produces canonical DB/WAL/SHM authorities and no dispatch error.
3. The escaping-alias regression produces no grant, preserves external bytes, and creates no external WAL/SHM.
4. Existing descriptor replacement, sidecar symlink, and SQLite NOFOLLOW paths remain unchanged and pass focused regressions.
5. All three authorities share the same Arc lease; dropping the fixture writer leaves WAL/SHM linked through that lease.
6. Focused tests and every required workspace gate passed.

Validation:
- PASSED: cargo test -p orbit-core sqlite_grants_ -- --nocapture (2 passed).
- PASSED: cargo test -p orbit-core runtime_store_grants -- --nocapture (14 passed).
- PASSED: cargo test -p orbit-core adapter::engine_host::v2_host::tests::sandbox -- --nocapture (51 passed).
- PASSED: cargo test -p orbit-common --features sqlite wal_file_set_lease -- --nocapture (2 passed).
- PASSED: cargo fmt --all --check.
- PASSED: make ci-fast. Its build-budget namespace fixture reported its documented environment skip because unprivileged Bubblewrap namespaces are unavailable; the gate exited successfully.
- PASSED: make ci-lint.
- PASSED: make goldens.
- PASSED: git diff --check.
- PASSED: final git status --short; only the two authorized tracked files are modified.

Assessment: The change is localized to the grant builder and focused tests, does not widen runtime roots, and adds no fallback or shadow storage.
Remaining risk: This host cannot exercise the ci-fast Bubblewrap namespace fixture, but the descriptor/containment behavior and full sandbox resolution suite were exercised directly.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12329-6aa56c2d`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra