### PR TITLE
Repair managed SQLite CannotOpen after WAL lease deployment using actual envelope evidence

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -463,6 +463,7 @@ pub fn run_cli_backend(
         on_spawn: Some(&on_spawn),
         wait: None,
         live_readers: None,
+        spawned_child: None,
         #[cfg(unix)]
         cancel_pair: None,
     });

--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -2,12 +2,14 @@ use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
 
 use orbit_common::OrbitError;
 use orbit_exec::{
-    BwrapProbeOutcome, LinuxBwrapMountAuthority, LinuxBwrapSpawnRequest, MacosLoginKeychainAccess,
-    MacosSandboxSpawnRequest, UnsatisfiedWriteGrant, compile_linux_bwrap_argv_with_authority,
-    compile_macos_sandbox_profile, linux_bwrap_write_grant_diagnostic, macos_login_keychain_access,
+    BwrapProbeOutcome, LinuxBwrapMountAuthority, LinuxBwrapPlan, LinuxBwrapSpawnRequest,
+    MacosLoginKeychainAccess, MacosSandboxSpawnRequest, UnsatisfiedWriteGrant,
+    compile_linux_bwrap_argv_with_authority, compile_macos_sandbox_profile,
+    linux_bwrap_write_grant_diagnostic, macos_login_keychain_access,
     prepare_linux_bwrap_write_grants, probe_bwrap, sandbox_exec_available,
     sandbox_exec_unavailable_message, spawn_under_linux_bwrap, spawn_under_macos_sandbox,
 };
@@ -447,6 +449,12 @@ pub(crate) struct SpawnedChild {
     /// Sandbox profile tempfile, if any. Held until the supervisor returns
     /// so the kernel can keep reading the SBPL profile while the child runs.
     pub(crate) _profile_temp: Option<NamedTempFile>,
+    /// Linux mount-source descriptors retained until the provider exits.
+    ///
+    /// Closing a duplicate SQLite database descriptor can release this
+    /// process's POSIX locks even while the host lease connection remains
+    /// open, so the complete plan shares the sandboxed child's lifetime.
+    pub(crate) _linux_mount_plan: Option<LinuxBwrapPlan>,
 }
 
 pub(crate) fn spawn_child_with_optional_sandbox(
@@ -503,25 +511,7 @@ fn spawn_linux_bwrap(
         }
         report_unsatisfied_grants(&prepared.unsatisfied);
     }
-    let authority = sandbox
-        .runtime_write_authority
-        .iter()
-        .map(|grant| {
-            grant
-                .handle
-                .try_clone()
-                .map(|source| LinuxBwrapMountAuthority {
-                    destination: grant.path.clone(),
-                    source,
-                })
-                .map_err(|error| {
-                    SpawnError::permanent(format!(
-                        "duplicate Linux runtime grant descriptor `{}`: {error}",
-                        grant.path.display()
-                    ))
-                })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let authority = linux_bwrap_mount_authority(sandbox);
     let plan = compile_linux_bwrap_argv_with_authority(
         &sandbox.fs_profile,
         program,
@@ -545,7 +535,24 @@ fn spawn_linux_bwrap(
     Ok(SpawnedChild {
         child,
         _profile_temp: None,
+        _linux_mount_plan: Some(plan),
     })
+}
+
+/// Borrow the runtime owner's exact descriptors for the mount plan. `File`
+/// duplication is forbidden here because closing any duplicate for a SQLite
+/// database can release unrelated POSIX locks owned by this process.
+pub(crate) fn linux_bwrap_mount_authority(
+    sandbox: &ResolvedSandbox,
+) -> Vec<LinuxBwrapMountAuthority> {
+    sandbox
+        .runtime_write_authority
+        .iter()
+        .map(|grant| LinuxBwrapMountAuthority {
+            destination: grant.path.clone(),
+            source: Arc::clone(&grant.handle),
+        })
+        .collect()
 }
 
 /// Inside a managed worktree, preparation should have satisfied every grant.
@@ -804,6 +811,7 @@ pub(crate) fn spawn_bare(
     Ok(SpawnedChild {
         child,
         _profile_temp: None,
+        _linux_mount_plan: None,
     })
 }
 
@@ -892,6 +900,7 @@ pub(crate) fn spawn_macos_sandboxed_with(
     Ok(SpawnedChild {
         child,
         _profile_temp: Some(profile_temp),
+        _linux_mount_plan: None,
     })
 }
 

--- a/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
@@ -207,6 +207,9 @@ pub(super) struct SpawnWithTimeoutRequest<'a> {
     /// lifetime of its thread so tests can observe finalization without
     /// sampling process-wide thread counts.
     pub(super) live_readers: Option<Arc<AtomicUsize>>,
+    /// Test seam for supervising an already-spawned child with its ownership
+    /// guards intact. Production always spawns from the request fields.
+    pub(super) spawned_child: Option<SpawnedChild>,
     /// Test seam for exercising output capture when the pollable cancellation
     /// channel cannot be constructed.
     #[cfg(unix)]
@@ -266,20 +269,28 @@ pub(super) fn spawn_with_timeout(
         on_spawn,
         wait,
         live_readers,
+        spawned_child,
         #[cfg(unix)]
         cancel_pair,
     } = request;
 
     let started = Instant::now();
+    let spawned = match spawned_child {
+        Some(spawned) => spawned,
+        None => spawn_child_with_optional_sandbox(program, args, env, cwd, sandbox, trace.provider)
+            .map_err(|err| SpawnError {
+                permanent: err.permanent,
+                message: format!("spawn {program}: {}", err.message),
+            })?,
+    };
     let SpawnedChild {
         mut child,
         // The temp profile must outlive the child — drop it after wait.
         _profile_temp,
-    } = spawn_child_with_optional_sandbox(program, args, env, cwd, sandbox, trace.provider)
-        .map_err(|err| SpawnError {
-            permanent: err.permanent,
-            message: format!("spawn {program}: {}", err.message),
-        })?;
+        // Linux mount descriptors also outlive the child. Dropping a cloned
+        // SQLite DB descriptor earlier can release the host's lease locks.
+        _linux_mount_plan,
+    } = spawned;
 
     // Report the PID before any blocking work: the whole point is to be
     // observable during a long invocation, and the child is already running.

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
@@ -1,15 +1,22 @@
 #![allow(missing_docs)]
 
 use std::ffi::OsString;
+#[cfg(target_os = "linux")]
+use std::fs::File;
+#[cfg(target_os = "linux")]
+use std::os::fd::AsRawFd;
 
 use orbit_exec::BwrapProbeOutcome;
+#[cfg(target_os = "linux")]
+use orbit_exec::{LinuxBwrapMountAuthority, compile_linux_bwrap_argv_with_authority, probe_bwrap};
 use orbit_types::workflow::ExecutorSandboxKind;
 use tempfile::tempdir;
 
 use super::super::super::dispatcher::ResolvedSandbox;
 use super::super::spawn::{
     SUPPORTED_SYSTEM_BIN_DIRS, SpawnError, SpawnedChild, copilot_model_unavailable_diagnostic,
-    linux_bwrap_failed_write_diagnostic, macos_keychain_auth_diagnostic_with, orbit_tool_env_with,
+    linux_bwrap_failed_write_diagnostic, linux_bwrap_mount_authority,
+    macos_keychain_auth_diagnostic_with, orbit_tool_env_with,
     prepare_linux_sandbox_for_dispatch_with_probe, prepare_macos_codex_ca_environment_with,
     reject_unsatisfiable_managed_grants, resolve_provider_launcher_with,
     resolve_provider_launcher_with_extra_dirs, spawn_bare, spawn_macos_sandboxed_with,
@@ -354,6 +361,7 @@ fn spawn_bare_runs_program_in_provided_cwd() {
     let SpawnedChild {
         child,
         _profile_temp,
+        _linux_mount_plan,
     } = spawn_bare("/bin/sh", &sh_args("pwd"), &[], Some(&cwd)).expect("spawn succeeds");
 
     let output = child.wait_with_output().expect("wait succeeds");
@@ -370,6 +378,7 @@ fn spawn_bare_does_not_inherit_ambient_sensitive_env() {
     let SpawnedChild {
         child,
         _profile_temp,
+        _linux_mount_plan,
     } = spawn_bare(
         "/bin/sh",
         &sh_args(
@@ -386,6 +395,154 @@ fn spawn_bare_does_not_inherit_ambient_sensitive_env() {
         String::from_utf8(output.stdout).expect("stdout utf8"),
         "unset"
     );
+}
+
+/// Regression for the engine ownership boundary behind the managed SQLite
+/// CannotOpen failure. The descriptor plan must remain alive after the child
+/// exits and until the supervisor drops the complete spawned-child guard.
+#[cfg(target_os = "linux")]
+#[test]
+fn spawned_child_guard_retains_linux_mount_descriptors() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path().canonicalize().expect("canonical root");
+    let target = root.join("orbit.db");
+    std::fs::write(&target, b"sqlite-object").expect("runtime object");
+    let profile = orbit_types::policy::ResolvedFsProfile {
+        name: "test".to_string(),
+        read: vec!["/**".to_string()],
+        modify: vec![target.display().to_string()],
+    };
+    let source =
+        std::sync::Arc::new(File::open(root.join("orbit.db")).expect("descriptor authority"));
+    let authority_fd = source.as_raw_fd();
+    let plan = compile_linux_bwrap_argv_with_authority(
+        &profile,
+        "/bin/true",
+        &[],
+        Some(&root),
+        false,
+        vec![LinuxBwrapMountAuthority {
+            destination: target,
+            source,
+        }],
+    )
+    .expect("descriptor plan");
+    let source_fd = plan.mount_evidence()[0].source_fd;
+    assert_eq!(
+        source_fd, authority_fd,
+        "plan compilation must share the authority handle, not duplicate its raw descriptor"
+    );
+    let SpawnedChild {
+        child,
+        _profile_temp,
+        _linux_mount_plan: _,
+    } = spawn_bare("/bin/sh", &sh_args("exit 0"), &[], Some(&root)).expect("child");
+    let mut spawned = SpawnedChild {
+        child,
+        _profile_temp,
+        _linux_mount_plan: Some(plan),
+    };
+
+    assert!(unsafe { libc::fcntl(source_fd, libc::F_GETFD) } >= 0);
+    assert!(spawned.child.wait().expect("wait").success());
+    assert!(
+        unsafe { libc::fcntl(source_fd, libc::F_GETFD) } >= 0,
+        "mount descriptor must survive child exit until supervision completes"
+    );
+
+    drop(spawned);
+    assert_eq!(unsafe { libc::fcntl(source_fd, libc::F_GETFD) }, -1);
+}
+
+/// Negative control for the proven fault: translating host runtime authority
+/// into mount authority must share the same raw descriptor, never `dup` it.
+#[cfg(target_os = "linux")]
+#[test]
+fn linux_runtime_mount_authority_shares_host_descriptor() {
+    let temp = tempdir().expect("tempdir");
+    let target = temp.path().join("orbit.db");
+    std::fs::write(&target, b"sqlite-object").expect("runtime object");
+    let source = std::sync::Arc::new(File::open(&target).expect("descriptor authority"));
+    let source_fd = source.as_raw_fd();
+    let sandbox = ResolvedSandbox {
+        kind: ExecutorSandboxKind::LinuxBwrap,
+        fs_profile: orbit_types::policy::ResolvedFsProfile {
+            name: "test".to_string(),
+            read: vec!["/**".to_string()],
+            modify: vec![target.display().to_string()],
+        },
+        allow_fallback: false,
+        managed_worktree: false,
+        runtime_write_authority: vec![
+            super::super::super::dispatcher::LinuxRuntimeWriteAuthority {
+                path: target,
+                handle: source,
+                wal_file_set_lease: None,
+            },
+        ],
+    };
+
+    let authority = linux_bwrap_mount_authority(&sandbox);
+    assert_eq!(authority.len(), 1);
+    assert_eq!(authority[0].source.as_raw_fd(), source_fd);
+    assert_eq!(std::sync::Arc::strong_count(&authority[0].source), 2);
+}
+
+/// Real-kernel counterpart: when Bubblewrap is available, exercise the actual
+/// engine spawn path and require it to return ownership of the descriptor plan.
+#[cfg(target_os = "linux")]
+#[test]
+#[ignore = "requires a Linux host with working Bubblewrap user/mount namespaces"]
+fn linux_bwrap_spawn_returns_mount_descriptor_ownership() {
+    let probe = probe_bwrap();
+    assert!(
+        probe.available,
+        "live boundary unvalidated: {}",
+        probe.detail
+    );
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path().canonicalize().expect("canonical root");
+    let target = root.join("orbit.db");
+    std::fs::write(&target, b"sqlite-object").expect("runtime object");
+    let sandbox = ResolvedSandbox {
+        kind: ExecutorSandboxKind::LinuxBwrap,
+        fs_profile: orbit_types::policy::ResolvedFsProfile {
+            name: "test".to_string(),
+            read: vec!["/**".to_string()],
+            modify: vec![target.display().to_string()],
+        },
+        allow_fallback: false,
+        managed_worktree: false,
+        runtime_write_authority: vec![
+            super::super::super::dispatcher::LinuxRuntimeWriteAuthority {
+                path: target.clone(),
+                handle: std::sync::Arc::new(File::open(&target).expect("descriptor authority")),
+                wal_file_set_lease: None,
+            },
+        ],
+    };
+    let mut spawned = super::super::spawn::spawn_child_with_optional_sandbox(
+        "/bin/sh",
+        &sh_args("exit 0"),
+        &[],
+        Some(&root),
+        Some(&sandbox),
+        "codex",
+    )
+    .expect("sandboxed spawn");
+
+    assert!(spawned._linux_mount_plan.is_some());
+    assert_eq!(
+        spawned
+            ._linux_mount_plan
+            .as_ref()
+            .expect("retained plan")
+            .mount_evidence()[0]
+            .source_fd,
+        sandbox.runtime_write_authority[0].handle.as_raw_fd(),
+        "engine spawn must not create a parent-side duplicate descriptor"
+    );
+    assert!(spawned.child.wait().expect("wait").success());
 }
 
 /// The failure an operator actually sees when a Keychain-backed login cannot be
@@ -1126,6 +1283,7 @@ fn spawn_macos_sandboxed_falls_back_to_bare_exec_when_allow_fallback_set() {
     // The fallback path returns a SpawnedChild with no profile tempfile
     // because the sandbox-exec wrapper was bypassed.
     assert!(spawned._profile_temp.is_none());
+    assert!(spawned._linux_mount_plan.is_none());
     let _ = spawned.child.wait();
 }
 

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/supervisor.rs
@@ -10,6 +10,13 @@ use std::time::Duration;
 
 use tempfile::tempdir;
 
+#[cfg(target_os = "linux")]
+use orbit_exec::{LinuxBwrapMountAuthority, compile_linux_bwrap_argv_with_authority};
+#[cfg(target_os = "linux")]
+use orbit_types::policy::ResolvedFsProfile;
+
+#[cfg(target_os = "linux")]
+use super::super::spawn::{SpawnedChild, spawn_bare};
 use super::super::supervisor::{SpawnTraceContext, SpawnWithTimeoutRequest, spawn_with_timeout};
 use super::test_support::{
     assert_event, capture_events, capture_events_live, capture_redacted_tracing_output, sh_args,
@@ -35,9 +42,81 @@ fn spawn_test_request<'a>(
         on_spawn: None,
         wait: None,
         live_readers: None,
+        spawned_child: None,
         #[cfg(unix)]
         cancel_pair: None,
     }
+}
+
+/// Execute the real supervisor with a descriptor-backed spawned-child guard.
+/// The plan must remain owned across its wait loop and be released only after
+/// supervision and process-tree cleanup return.
+#[cfg(target_os = "linux")]
+#[test]
+fn supervisor_retains_linux_mount_plan_through_wait_and_cleanup() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path().canonicalize().expect("canonical root");
+    let target = root.join("orbit.db");
+    std::fs::write(&target, b"sqlite-object").expect("runtime object");
+    let authority = Arc::new(std::fs::File::open(&target).expect("authority"));
+    let authority_lifetime = Arc::downgrade(&authority);
+    let plan = compile_linux_bwrap_argv_with_authority(
+        &ResolvedFsProfile {
+            name: "test".to_string(),
+            read: vec!["/**".to_string()],
+            modify: vec![target.display().to_string()],
+        },
+        "/bin/true",
+        &[],
+        Some(&root),
+        false,
+        vec![LinuxBwrapMountAuthority {
+            destination: target,
+            source: authority,
+        }],
+    )
+    .expect("descriptor plan");
+    let SpawnedChild {
+        child,
+        _profile_temp,
+        _linux_mount_plan: _,
+    } = spawn_bare("/bin/sh", &sh_args("exit 0"), &[], Some(&root)).expect("spawn");
+    let spawned = SpawnedChild {
+        child,
+        _profile_temp,
+        _linux_mount_plan: Some(plan),
+    };
+    let wait = |child: &mut std::process::Child| {
+        assert!(
+            authority_lifetime.upgrade().is_some(),
+            "supervisor dropped the mount plan before waiting for the child"
+        );
+        child.try_wait()
+    };
+    let args = sh_args("exit 0");
+    let cwd_label = root.display().to_string();
+    let mut request = spawn_test_request(
+        "/bin/sh",
+        &args,
+        Some(&root),
+        Duration::from_secs(5),
+        SpawnTraceContext {
+            provider: "codex",
+            job_run_id: "jrun-descriptor-lifetime",
+            task_id: Some("descriptor-lifetime"),
+            cwd: Some(&cwd_label),
+        },
+    );
+    request.spawned_child = Some(spawned);
+    request.wait = Some(&wait);
+
+    let (_, _, exit_code, _, timed_out) = spawn_with_timeout(request).expect("supervision");
+    assert_eq!(exit_code, Some(0));
+    assert!(!timed_out);
+    assert!(
+        authority_lifetime.upgrade().is_none(),
+        "supervisor must release the mount plan after cleanup"
+    );
 }
 
 #[test]

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -50,8 +50,8 @@ pub struct ResolvedShellExecutor {
 /// Open host object backing a Linux runtime convenience grant.
 ///
 /// The descriptor is acquired while the runtime path is validated and remains
-/// alive until Bubblewrap consumes the mount plan. The displayed path is only
-/// the namespace destination; it is never reopened as the mount source.
+/// alive until the sandboxed provider exits. The displayed path is only the
+/// namespace destination; it is never reopened as the mount source.
 #[derive(Clone, Debug)]
 pub struct LinuxRuntimeWriteAuthority {
     pub path: PathBuf,

--- a/crates/orbit-exec/src/linux_sandbox.rs
+++ b/crates/orbit-exec/src/linux_sandbox.rs
@@ -8,9 +8,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::fs::OpenOptions;
 #[cfg(unix)]
-use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
 
 use orbit_common::OrbitError;
 use orbit_types::policy::{ResolvedFsProfile, compile_glob_regex};
@@ -40,9 +41,9 @@ pub struct LinuxBwrapPlan {
     /// because their anchor does not exist. Never silently discarded: the
     /// caller reports each one against the rule that granted it.
     pub dropped_grants: Vec<UnsatisfiedWriteGrant>,
-    /// Mount-source descriptors retained until Bubblewrap has consumed argv.
-    /// Empty for ordinary path-based plans and audit rendering.
-    mount_sources: Vec<File>,
+    /// Mount-source descriptors retained by the caller until the sandboxed
+    /// child exits. Empty for ordinary path-based plans and audit rendering.
+    mount_sources: Vec<Arc<File>>,
     mount_evidence: Vec<LinuxBwrapMountEvidence>,
 }
 
@@ -72,11 +73,13 @@ pub struct LinuxBwrapMountEvidence {
     pub inode: u64,
 }
 
-/// A host object already validated and opened by the runtime owner.
+/// A host object already validated and opened by the runtime owner. Sharing
+/// the handle avoids a parent-side `dup`: closing such a duplicate can release
+/// unrelated POSIX locks held by SQLite in the same process.
 #[derive(Debug)]
 pub struct LinuxBwrapMountAuthority {
     pub destination: PathBuf,
-    pub source: File,
+    pub source: Arc<File>,
 }
 
 #[derive(Debug)]
@@ -780,31 +783,26 @@ pub fn compile_linux_bwrap_argv_with_authority(
 }
 
 #[cfg(unix)]
-fn prepare_mount_source(source: File) -> Result<File, OrbitError> {
+fn prepare_mount_source(source: Arc<File>) -> Result<Arc<File>, OrbitError> {
     if source.as_raw_fd() >= 3 {
         return Ok(source);
     }
 
-    let descriptor = unsafe { libc::fcntl(source.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 3) };
-    if descriptor < 0 {
-        return Err(OrbitError::Execution(format!(
-            "duplicate Linux runtime grant descriptor: {}",
-            std::io::Error::last_os_error()
-        )));
-    }
-
-    Ok(unsafe { File::from_raw_fd(descriptor) })
+    Err(OrbitError::Execution(format!(
+        "Linux runtime grant descriptor {} conflicts with child standard I/O",
+        source.as_raw_fd()
+    )))
 }
 
 #[cfg(not(unix))]
-fn prepare_mount_source(_source: File) -> Result<File, OrbitError> {
+fn prepare_mount_source(_source: Arc<File>) -> Result<Arc<File>, OrbitError> {
     Err(OrbitError::Execution(
         "descriptor-backed Linux runtime grants require Unix file descriptors".to_string(),
     ))
 }
 
 #[cfg(unix)]
-fn inherit_mount_sources(command: &mut Command, mount_sources: &[File]) {
+fn inherit_mount_sources(command: &mut Command, mount_sources: &[Arc<File>]) {
     use std::os::unix::process::CommandExt;
 
     let source_fds = mount_sources

--- a/crates/orbit-exec/src/tests/linux_sandbox.rs
+++ b/crates/orbit-exec/src/tests/linux_sandbox.rs
@@ -231,14 +231,14 @@ fn managed_aliases_replay_denies_and_pin_replaceable_parents() {
 
 #[cfg(target_os = "linux")]
 #[test]
-fn descriptor_mount_plan_holds_the_validated_object_and_closes_it_on_drop() {
+fn descriptor_mount_plan_shares_the_validated_authority_without_duplication() {
     use super::{LinuxBwrapMountAuthority, compile_linux_bwrap_argv_with_authority};
 
     let temp = tempfile::tempdir().expect("tempdir");
     let root = temp.path().canonicalize().expect("canonical root");
     let target = root.join("orbit.db-wal");
     fs::write(&target, b"validated").expect("sidecar");
-    let source = fs::File::open(&target).expect("open authority");
+    let source = std::sync::Arc::new(fs::File::open(&target).expect("open authority"));
     let source_fd = source.as_raw_fd();
     fs::rename(&target, root.join("validated-sidecar")).expect("replace name");
     fs::write(&target, b"replacement").expect("replacement");
@@ -252,11 +252,15 @@ fn descriptor_mount_plan_holds_the_validated_object_and_closes_it_on_drop() {
         false,
         vec![LinuxBwrapMountAuthority {
             destination: target.clone(),
-            source,
+            source: std::sync::Arc::clone(&source),
         }],
     )
     .expect("descriptor-backed plan");
     let retained_fd = plan.mount_sources[0].as_raw_fd();
+    assert_eq!(
+        retained_fd, source_fd,
+        "compilation must not create a parent-side duplicate descriptor"
+    );
     let evidence = &plan.mount_evidence()[0];
     let metadata = plan.mount_sources[0]
         .metadata()
@@ -274,6 +278,12 @@ fn descriptor_mount_plan_holds_the_validated_object_and_closes_it_on_drop() {
     assert!(unsafe { libc::fcntl(source_fd, libc::F_GETFD) } >= 0);
 
     drop(plan);
+    assert!(
+        unsafe { libc::fcntl(source_fd, libc::F_GETFD) } >= 0,
+        "dropping a mount plan must not close the runtime owner's authority"
+    );
+
+    drop(source);
     assert_eq!(unsafe { libc::fcntl(source_fd, libc::F_GETFD) }, -1);
     assert_eq!(
         std::io::Error::last_os_error().raw_os_error(),
@@ -328,7 +338,7 @@ fn descriptor_inheritance_preserves_the_command_exec_error_pipe() {
         modify.push(destination.display().to_string());
         authority.push(LinuxBwrapMountAuthority {
             destination,
-            source,
+            source: std::sync::Arc::new(source),
         });
     }
 
@@ -397,7 +407,7 @@ fn descriptor_mount_plan_rejects_an_external_symlink_replacement() {
         false,
         vec![LinuxBwrapMountAuthority {
             destination: target,
-            source,
+            source: std::sync::Arc::new(source),
         }],
     )
     .expect_err("replacement must fail closed");
@@ -466,7 +476,7 @@ fn descriptor_directory_mount_rejects_an_external_symlink_replacement() {
         false,
         vec![LinuxBwrapMountAuthority {
             destination: target,
-            source,
+            source: std::sync::Arc::new(source),
         }],
     )
     .expect_err("directory replacement must fail closed");

--- a/crates/orbit-exec/tests/linux_sandbox.rs
+++ b/crates/orbit-exec/tests/linux_sandbox.rs
@@ -113,7 +113,7 @@ fn kernel_descriptor_mount_never_writes_the_replacement_object() {
         false,
         vec![LinuxBwrapMountAuthority {
             destination: target.clone(),
-            source,
+            source: std::sync::Arc::new(source),
         }],
     )
     .expect("compile descriptor plan");

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -246,13 +246,20 @@ missing directory components with descriptor-relative `mkdirat`/`openat`
 operations that refuse symlinks, and opens the final directory or regular
 SQLite object. Engine retains those descriptors through dispatch. The actual
 Bubblewrap plan uses inherited `--bind-fd` mount sources; the mutable pathname
-is only the mount destination. Bubblewrap consumes and closes these setup
-descriptors rather than preserving them for the provider process. A path
+is only the mount destination. Bubblewrap consumes its inherited child copies
+of these setup descriptors rather than preserving them for the provider
+process. The engine shares the runtime owner's existing authority handle rather
+than creating a parent-side duplicate, and retains that shared handle until the
+provider exits: closing a duplicate main-database descriptor in the host
+process can release that process's POSIX SQLite locks and permit a second
+connection to unlink the leased WAL/SHM objects. A path
 replacement that prevents the descriptor grant from matching the final plan is
 rejected before spawn. This assumes the already-open runtime-root object and
 its ancestors cannot be remounted by an unprivileged concurrent writer; name
 renames and symlink replacement below that object do not change descriptor
-authority. Descriptor closure occurs when the plan is dropped after spawn.
+authority. The spawned-child guard releases its mount-plan ownership only
+after supervision and process-tree cleanup; the runtime owner controls final
+descriptor closure.
 
 This descriptor handoff is Linux-only. macOS continues to compile Seatbelt
 rules from canonical paths and other platforms reject a Linux Bubblewrap


### PR DESCRIPTION
## Task

[ORB-12332](https://orbit-cli.com/tasks/ORB-12332) — Repair managed SQLite CannotOpen after WAL lease deployment using actual envelope evidence

### Description

## Observed deployed failure
Fresh exact-target pilot jrun-20260912-1551-t1 for validation ORB-12331 ran on source c92c2297452cca0899084c1d1ca14251d2b2c18e after ORB-12326/27/28/29 deployment. Installed ~/.orbit/bin/orbit 0.21.0 SHA256 58a53060ac50e8b99c6dd8a38ec68645e0392768a534efe1bf710ee81cfa970d; authoritative host hm_9ca6004473492f06, workspace ws_orbit, MCP operator PID4144259 verified that exact executable/hash. Actual provider PID4145797, worker4145700; actual codex gpt-5.6-sol under linux-bwrap reviewer profile. /proc provider argv observed --bind-fd27/28/29 onto ~/.orbit/orbit.db, orbit.db-wal, orbit.db-shm; source-inspections-v1/0/checkout was read-only and pinned at c92.

Retained stdout blob8e2a04d94a44971515306dcd40376de50c0dbbdca64835eb63f4342e0fcee1e2 records actual managed MCP workspace_list failing audit-row persistence; orbit_task_show(id=ORB-12331,workspace=ws_orbit,model=codex) and orbit_search(query=ORB-12331,workspace=ws_orbit,kind=all,all=true) fail opening the store: failed to set synchronous=NORMAL for '~/.orbit/orbit.db': unable to open database file [code=CannotOpen, extended_code=14]. Search by design terms failed too. Registered CLI was NOT attempted in that pilot, so its failure is not established. Original run logs and events are operator-observable through registered authoritative surfaces; use the injected evidence if managed reads remain unavailable, never invent successful reads.

Provider exited0 and durable cli.invocation.finished0e at15:53:26.018280722Z, activity.finished0f .070271565 success, step.finished10 .071880481 success, run.finished1e .094169847 error were observed in correct order. Overall pilot failure was legitimate material_changed because the orchestrator added task relations after prepare; this sequencing mistake is not the SQLite defect and must not be repaired in code. No full pilot PASS is claimed.

## Bounded mandate
Before choosing a fix, reproduce the failed managed path and capture installed source/hash, effective fsProfile and descriptor-backed DB/WAL/SHM mounts/permissions/device/inode, actual child config and relevant nonsecret envelope environment/path, and exact SQLite stage/code. Distinguish initial store open from audit persistence, MCP from registered CLI. Diagnose the actual file-open/SQLite failure in that envelope; do not assume the historical sidecar-inode theory or add another lease/retry change based only on unit fixtures. Historical WAL identity replacement was inferred, not captured. Use source, process evidence and a failing control to establish the remaining cause, then fix only that boundary.

Keep implementation in the dedicated managed task worktree; preserve source-inspection read-only grants, descriptor race resistance, in-root aliases/escape rejection, authoritative global routing, corrupt/unreadable failures, and provider-return completion serialization. No shadow stores, production SQL, widened sandbox grants, error suppression, or forced terminal writes. Do not touch historical runs, ORB-12317/PR2070, ORB-12262, ORB-12219, clock/custom definitions/paused routines/disabled ship sweep, versions/tags/releases. Normal authorized candidate delivery is allowed; release publication is not. Operator owns any host-level diagnostic execution, deployment, and the independent postdeploy ORB-12331 revalidation; managed leaf cannot dispatch other workers.

## Completion boundary
Before the source candidate is considered valid, evidence must show the actual failing managed path and candidate passing that same MCP plus registered CLI path, or an explicit precise operator handoff if the leaf cannot create the necessary real namespace. A synthetic fixture alone is not a live pass. Keep negative controls. The operator will independently rerun stable exact-plural-target validation after deployment and require provider exit0 followed by complete ordered durable success. Do not manufacture repository changes just to satisfy pipeline shape.

### Acceptance Criteria

- Capture a concrete failed managed-envelope reproduction on the deployed candidate, with exact SQLite path/stage/code and DB/WAL/SHM descriptor/mount/identity evidence; separate observed facts from hypotheses.
- Demonstrate real managed MCP explicit ws_orbit task.show and search and registered CLI counterparts on the same authoritative envelope; preserve exact failure evidence before repair and show passing results after candidate repair, with explicit operator handoff for unavailable host namespace capabilities.
- Fix only the proven remaining read boundary; retain descriptor-backed security, source-inspection read-only protection, alias containment, visible corrupt/unreadable failures, and normal provider/audit completion ordering.
- Add meaningful regression coverage that fails on the proven prior behavior and passes after repair, plus relevant negative controls; run focused checks and required repository gates.
- Record exact source candidate and reproducible operator deployment/ORB-12331 revalidation handoff. Do not claim full deployed success until the operator observes both transport reads and ordered successful provider/activity/step/run completion.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced parent-side File::try_clone conversion with shared Arc<File> mount authority, eliminating the raw DB/WAL/SHM descriptor closes that can release SQLite POSIX locks.
- Retained the Linux mount plan in SpawnedChild through the supervisor wait, timeout, wait-error, reader-drain, and process-tree cleanup paths.
- Made descriptors below fd 3 fail closed instead of duplicating them into the child-safe range.
- Updated the maintained Linux sandbox contract and added ownership, supervisor-lifetime, replacement/escape, and real-Bubblewrap coverage.
- Filed friction F2026-09-149 for the non-obvious POSIX-lock/descriptor interaction.

Criterion evidence:
1. Pre-repair deployed evidence is preserved in task comments: source c92c2297452cca0899084c1d1ca14251d2b2c18e, installed binary SHA256 58a53060ac50e8b99c6dd8a38ec68645e0392768a534efe1bf710ee81cfa970d, ~/.orbit/orbit.db synchronous=NORMAL failure with CannotOpen/extended 14, DB dev/inode 64512/834622, linked WAL 64512/812061, linked SHM 64512/814995, old worker-deleted WAL 64512/792248 and SHM 64512/806491, child mount namespace 4026532525 and mount 401 for the DB while WAL/SHM mount IDs 402/403 were absent. Observed facts are separated from the causal conclusion: the captured old descriptors alone did not identify the unlink actor. The independent bundled-SQLite two-process controls then showed retained duplicates preserve locks/sidecars, DB-duplicate drop loses the DB read lock and permits WAL/SHM unlink, SHM-only drop loses DMS without sidecar retirement, and WAL-only drop preserves locks/files.
2. Before repair, retained blob 8e2a04d94a44971515306dcd40376de50c0dbbdca64835eb63f4342e0fcee1e2 records managed MCP workspace discovery failing only at audit persistence and explicit ws_orbit task.show/search failing while runtime construction opened persistence.audit_db at synchronous=NORMAL. Registered CLI was not executed in that old pilot and is not claimed failed. On the locally built candidate, explicit registered CLI task.show and search both passed, and an actual target/debug/orbit MCP stdio session bound to ws_orbit returned isError=false for orbit_task_show ORB-12332 and orbit_search ORB-12332. Those reads ran in this managed envelope, but the outer namespace was created by the pre-repair deployed worker; they are smoke evidence, not the required postdeployment proof.
3. The implementation changes only descriptor ownership at the engine/exec spawn boundary. It does not widen grants, change routing or SQLite flags, suppress corrupt/unreadable failures, alter alias/escape checks, weaken source-inspection read-only mounts, or change provider/audit event ordering.
4. Executed regressions prove the mount plan shares the runtime owner's exact raw descriptor (no dup), survives the real supervisor wait/cleanup lifecycle, and is released after supervision. Existing Linux sandbox negative controls for symlink replacement, directory escape, path-only replacement, ordered denies, and inherited exec-error pipe passed. The real nested-Bubblewrap test was attempted and failed solely because this worker cannot create a user/mount namespace.
5. Source candidate: starting HEAD c92c2297452cca0899084c1d1ca14251d2b2c18e plus uncommitted binary diff SHA256 3ac10b05f445c67838893eca3f3d2a848cc561033aa7483b4e9b721877a94a8a. Locally built target/debug/orbit SHA256 f6b18c54b460dac8be9c6fbeb38ffc1a8447a89273d503e88229d6c30114fc02. The pipeline owns the final commit and deployable artifact identity.

Validation:
- PASSED: cargo fmt --all -- --check.
- PASSED: cargo test -p orbit-exec linux_sandbox::tests -- --nocapture (11 passed).
- PASSED: cargo test -p orbit-engine activity_job::cli_runner::tests::spawn -- --nocapture (38 passed, 1 ignored real-host test).
- PASSED: cargo test -p orbit-engine activity_job::cli_runner::tests::supervisor -- --nocapture (10 passed, including executed descriptor lifetime).
- PASSED: cargo test -p orbit-core reviewer_runtime_database_grants_hold_one_wal_file_set_lease -- --exact --nocapture on the earlier unchanged core state (1 passed); the final combined command used an incomplete exact filter and ran 0, so it is not counted as a second pass.
- PASSED: cargo test -p orbit-exec --test linux_sandbox -- --nocapture (20 passed, 2 ignored real-host tests; namespace-dependent bodies reported unavailable).
- PASSED: make ci-fast (compiler-cache namespace probe explicitly skipped for namespace denial; gate exited 0).
- PASSED: make ci-lint.
- PASSED: make goldens.
- PASSED: candidate registered CLI task.show/search and candidate MCP stdio orbit_task_show/orbit_search with explicit ws_orbit.
- PASSED: git diff --check; git status contains only the ten declared task-scoped tracked modifications.
- NOT RUN/PENDING OPERATOR: deployed candidate through a newly repaired linux-bwrap spawn and independent ORB-12331 end-to-end completion.
- FAILED DUE ENVIRONMENT CAPABILITY, not product behavior: cargo test -p orbit-engine activity_job::cli_runner::tests::spawn::linux_bwrap_spawn_returns_mount_descriptor_ownership -- --ignored --exact --nocapture; Bubblewrap reported No permissions to create new namespace.

Operator handoff:
1. After pipeline commit, record the exact commit, build the candidate, record its SHA256, deploy that exact binary to ~/.orbit/bin/orbit, and restart the authoritative ws_orbit MCP/worker services.
2. Run cargo test -p orbit-engine activity_job::cli_runner::tests::spawn::linux_bwrap_spawn_returns_mount_descriptor_ownership -- --ignored --exact --nocapture on the namespace-capable host.
3. Dispatch the stable exact-target ORB-12331 validation. While its provider is active, capture worker/provider/managed-MCP PIDs and mount namespace IDs; full child mountinfo; DB/WAL/SHM host, provider-root, and child stat mode/uid/dev/inode; worker fd targets plus fdinfo flags; and relevant /proc/locks snapshots before and after nested reads.
4. In that actual managed child, execute configured MCP orbit_task_show(id=ORB-12331, workspace=ws_orbit, model=codex) and orbit_search(query=ORB-12331, workspace=ws_orbit, kind=all, all=true, model=codex), then registered CLI orbit tool run orbit.task.show and orbit.search with the same explicit workspace and inputs.
5. Require both transports to read the authoritative store without CannotOpen and independently observe provider exit 0 followed by ordered successful cli.invocation.finished, activity.finished, step.finished, and run.finished events. Full deployed success is intentionally not claimed before this observation.

Assessment: The proven boundary is repaired without changing sandbox authority or SQLite policy. Remaining risk is confined to the unavailable real host namespace/postdeployment validation described above.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12332-6aa577ae`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra