### PR TITLE
[qa-sweep] `orbit config show --scope effective --json` lists `execution.env.inherit` under `settings`, but `orbit config get execution.env.inherit` rejects it as an unknown config key

### DIFF
--- a/crates/orbit-cli/src/command/config/show.rs
+++ b/crates/orbit-cli/src/command/config/show.rs
@@ -139,6 +139,7 @@ pub(super) fn effective_text(runtime: &OrbitRuntime, values: &[EffectiveConfigVa
     let _ = writeln!(out);
 
     let _ = writeln!(out, "derived:");
+    let _ = writeln!(out, "  {:<36} false", "execution_env_inherit");
     let _ = writeln!(
         out,
         "  {:<36} {}",

--- a/crates/orbit-cli/src/command/config/tests/show.rs
+++ b/crates/orbit-cli/src/command/config/tests/show.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use orbit_config::{ConfigRoots, load_effective_config};
+use orbit_config::{ConfigRoots, admit_config_key, load_effective_config};
 
 use super::super::show::{effective_json, effective_text, scoped_json, scoped_text};
 use super::super::support::{ConfigScopeArg, open_store_for_scope};
@@ -185,4 +185,39 @@ fn config_show_marks_absent_workspace_layer_and_lists_every_settable_key() {
     assert_eq!(s_json["source"]["exists"], false);
     assert!(s_text.contains("(absent)"));
     assert!(s_text.contains("[unset]"));
+}
+
+#[test]
+fn every_effective_settings_key_is_readable_by_config_get() {
+    let (_root, runtime, global_root, workspace_root) = test_runtime();
+
+    let effective = load_effective_config(&ConfigRoots::new(&global_root, &workspace_root))
+        .expect("load effective layered config");
+    let json = effective_json(&runtime, effective.values());
+    let text = effective_text(&runtime, effective.values());
+
+    let settings = json["settings"].as_object().expect("settings object");
+    assert!(
+        !settings.is_empty(),
+        "expected at least one settings key to check"
+    );
+    for key in settings.keys() {
+        admit_config_key(key).unwrap_or_else(|err| {
+            panic!("settings key {key} must be readable by config get: {err}")
+        });
+    }
+
+    // `execution.env.inherit` is a derived invariant, not an admitted config
+    // key: it must not appear in `settings` (ORB-12339), and it must still
+    // surface as the top-level `execution_env_inherit` field and in the
+    // text `derived:` section, matching the scoped views.
+    assert!(
+        !settings.contains_key("execution.env.inherit"),
+        "settings must not list the non-admitted execution.env.inherit key: {settings:?}"
+    );
+    assert_eq!(json["execution_env_inherit"], false);
+    assert!(
+        text.contains("derived:") && text.contains("execution_env_inherit"),
+        "text output must surface execution_env_inherit under derived: {text}"
+    );
 }

--- a/crates/orbit-config/src/layering.rs
+++ b/crates/orbit-config/src/layering.rs
@@ -368,11 +368,13 @@ fn effective_values(
             source: source_for_key(key, global, workspace),
         })
         .collect::<Vec<_>>();
-    values.push(EffectiveConfigValue {
-        key: "execution.env.inherit".to_string(),
-        value: serde_json::json!(resolved.snapshot.execution_env_inherit),
-        source: built_in_source(),
-    });
+
+    // `execution.env.inherit` is a derived invariant, not an admitted config
+    // key (see `resolved::ExecutionEnvPolicy`), so it does not belong in the
+    // `settings`-shaped values here: `config get` rejects it via
+    // `admit_config_key`, and a settings-only listing must stay readable by
+    // `config get`/`config set`. `orbit config show`'s JSON/text rendering
+    // surfaces it separately as a derived field.
 
     for (name, crew) in &resolved.crews {
         let mut fields = vec![


### PR DESCRIPTION
## Task

[ORB-12339](https://orbit-cli.com/tasks/ORB-12339) — [qa-sweep] `orbit config show --scope effective --json` lists `execution.env.inherit` under `settings`, but `orbit config get execution.env.inherit` rejects it as an unknown config key

### Description

## What happened

While checking the ORB-12276 (`39eeae6bc`) get/show parity fix, a key-by-key sweep of every `settings` entry found one key that cannot be read back:

    $ orbit config show --scope effective --json | jq '.settings["execution.env.inherit"]'
    false

    $ orbit config get execution.env.inherit --scope effective --json
    {"code":"invalid_input","did_you_mean":[... 31 real keys ...],
     "error":"invalid input: unknown config key 'execution.env.inherit'"}
    exit 1

The other 31 `settings` keys agree exactly between `config show` and `config get` in all three scopes (`effective`, `global`, `workspace`) — the ORB-12276 fix itself checks out. `execution.env.inherit` is the single outlier, and it appears only in `--scope effective`: the scoped views (31 keys) omit it, and the scoped *text* output renders it under `derived:` rather than `settings:` (`crates/orbit-cli/src/command/config/show.rs`). The effective view instead pushes it into the settings list in `crates/orbit-config/src/layering.rs::effective_values`:

    values.push(EffectiveConfigValue {
        key: "execution.env.inherit".to_string(),
        value: serde_json::json!(resolved.snapshot.execution_env_inherit),
        source: built_in_source(),
    });

`docs/CONFIG.md` already states that `execution.env.inherit` "is not a configurable key", and `crates/orbit-config/src/resolved.rs` documents it as a derived invariant pinned to `false` since ORB-00365. So `config get`'s rejection is correct and the effective `settings` map is the surface that misrepresents it. The effective JSON already exposes the same fact as the top-level `execution_env_inherit` field, so the settings entry is redundant as well as unreadable.

## Impact

Low. Any caller that enumerates `settings` keys from `config show --json` and reads each one back with `config get` gets one `invalid_input` and a non-zero exit for a key that is not settable at all. Nothing is misconfigured; there is no wrong value.

## Reproduction (HEAD 9e65efbd7094d46befec1bbf9450d441b949d228, Linux)

1. `cargo build -p orbit-cli --bin orbit`.
2. `orbit --root /tmp/s init --non-interactive --host-name h --task-prefix QAT`; `orbit --root /tmp/s workspace init` from a scratch checkout.
3. `orbit --root /tmp/s config show --scope effective --json | jq -r '.settings | keys[]' | while read k; do orbit --root /tmp/s config get "$k" --scope effective --json >/dev/null || echo "unreadable: $k"; done`
   -> `unreadable: execution.env.inherit` (and nothing else).

## Suggested direction

Render the derived invariant the same way the scoped views do — outside the `settings` map (the effective JSON's existing top-level `execution_env_inherit` field already carries it) — so every `settings` key is a key `config get`/`config set` accept.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

## Fix

`config show --scope effective --json` listed `execution.env.inherit` inside `settings`, but `config get`/`admit_config_key` correctly reject it — it's a derived invariant (pinned `false` since ORB-00365), not an admitted config key. The scoped (global/workspace) views already rendered it outside `settings` (JSON top-level `execution_env_inherit` field, text `derived:` section); the effective view was the outlier.

Changes:
- `crates/orbit-config/src/layering.rs::effective_values` — removed the manual `values.push(...)` that injected `execution.env.inherit` into the settings-shaped `EffectiveConfigValue` list. `values`/`settings`/`provenance` are now driven purely by `ConfigSnapshot::all_values()` (i.e. `CONFIG_KEY_REGISTRY`), so every `settings` key is `config get`/`config set`-admitted by construction.
- `crates/orbit-cli/src/command/config/show.rs::effective_text` — added `execution_env_inherit` under the existing `derived:` section (hardcoded `false`, matching the existing hardcoded top-level JSON field and the always-`false` invariant), so the effective text view keeps parity with the scoped text view instead of silently dropping the fact.
- `effective_json`'s existing top-level `"execution_env_inherit": false` field required no change — it already carried this fact outside `settings`.

## Acceptance criteria
No explicit acceptance criteria were listed on the task; the description's reproduction and "suggested direction" served as the spec. Both are satisfied:
- `settings` no longer contains `execution.env.inherit` (verified: `jq '.settings | has("execution.env.inherit")'` → `false`).
- The fact is still exposed via the existing top-level `execution_env_inherit` JSON field and now also via the text `derived:` section.
- Every key that `config show --scope effective --json .settings` now emits is provably `config get`-readable (new test asserts `admit_config_key` succeeds for every settings key).

## Validation
- `cargo test -p orbit-config --lib` — 122 passed.
- `cargo test -p orbit-cli --bin orbit command::config` — 29 passed (28 pre-existing + 1 new regression test `every_effective_settings_key_is_readable_by_config_get`).
- `make ci-fast` — passed (fmt-check + guardrails).
- `make ci-lint` — passed (workspace clippy, `-D warnings`; required a follow-up literal-format fix in `show.rs` for `clippy::write_literal`).
- `make goldens` — passed (no CLI help/MCP surface changed, so no golden diffs).
- Manual repro of the exact bug-report reproduction against a built `orbit` binary in scratch dirs (`orbit init` + `orbit workspace init` + the `jq`/`config get` loop from the report): zero `unreadable:` lines, confirming the fix; scratch dirs were removed afterward.
- `git status --short` / `git diff --check`: clean; only the three scoped files changed, no stray artifacts.

No blockers, no scope deviations, no friction filed (straightforward, well-localized fix under 10 minutes of investigation once the two context files were read).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12339-6aa586db`
- Behind base: 0
- Ahead of base: 1