### PR TITLE
[qa-sweep] ORB-12292 gated the dashboard `archive` button on `status_transitions`, so `done` and `rejected` tasks — the only ones worth archiving — no longer offer archive in the UI

### DIFF
--- a/crates/orbit-web/assets/dashboard/tasks.js
+++ b/crates/orbit-web/assets/dashboard/tasks.js
@@ -1217,7 +1217,7 @@ function buildActionsRow(task, detail, context) {
     });
     actions.appendChild(btn);
   }
-  if (statusTransition(task, "archived")) {
+  if (task.status !== "archived") {
     const btn = el("button", { class: "action archive", text: "archive" });
     btn.addEventListener("click", (e) => {
       e.stopPropagation();

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -2052,8 +2052,114 @@ fn dashboard_inline_task_edits_report_pending_success_failure_and_offer_undo() {
         "the control must disable itself while its own change is pending"
     );
     assert!(
-        tasks.contains("if (statusTransition(task, \"archived\"))"),
-        "archive must be offered only when the canonical projection allows it"
+        tasks.contains("if (task.status !== \"archived\")"),
+        "archive must be offered for any non-archived task, including terminal statuses"
+    );
+}
+
+#[test]
+fn dashboard_task_detail_offers_archive_for_non_archived_tasks_and_omits_for_archived() {
+    run_dashboard_javascript_test(
+        r#"
+class Node {
+  constructor(tag = "") {
+    this.tag = tag;
+    this.children = [];
+    this.dataset = {};
+    this.style = {};
+    this.listeners = {};
+    this.className = "";
+    this._text = "";
+    this.parentNode = null;
+    this.disabled = false;
+  }
+  appendChild(child) { this.children.push(child); child.parentNode = this; return child; }
+  insertBefore(child, before) {
+    const old = child.parentNode;
+    if (old) old.children = old.children.filter((c) => c !== child);
+    const index = this.children.indexOf(before);
+    this.children.splice(index < 0 ? this.children.length : index, 0, child);
+    child.parentNode = this;
+    return child;
+  }
+  removeChild(child) {
+    this.children = this.children.filter((c) => c !== child);
+    child.parentNode = null;
+    return child;
+  }
+  replaceChildren(...next) { for (const child of this.children) child.parentNode = null; this.children = []; for (const child of next) this.appendChild(child); }
+  replaceWith(next) { const parent = this.parentNode; if (!parent) return; parent.children = parent.children.map((c) => c === this ? next : c); next.parentNode = parent; this.parentNode = null; }
+  addEventListener(name, callback) { this.listeners[name] = callback; }
+  setAttribute(name, value) { this[name] = String(value); }
+  focus() {}
+  get textContent() { return this._text + this.children.map((c) => c.textContent || "").join(""); }
+  set textContent(value) { this._text = String(value); this.children = []; }
+  get lastElementChild() { return this.children[this.children.length - 1]; }
+  get classList() {
+    return {
+      add: (...names) => { this.className = `${this.className} ${names.join(" ")}`.trim(); },
+      remove: () => {},
+      toggle: () => {},
+    };
+  }
+}
+const nodes = new Map();
+const get = (id) => nodes.get(id) || (nodes.set(id, new Node()), nodes.get(id));
+globalThis.document = {
+  getElementById: get,
+  createElement: (tag) => new Node(tag),
+  createTextNode: (text) => Object.assign(new Node(), { textContent: text }),
+  createDocumentFragment: () => new Node(),
+};
+const location = new URL("http://dashboard.test/#tasks");
+globalThis.window = { location, addEventListener: () => {}, confirm: () => false };
+Object.defineProperty(globalThis, "navigator", { value: { clipboard: { writeText: () => Promise.resolve() } }, configurable: true });
+globalThis.setTimeout = () => 0;
+
+const statuses = ["in-progress", "review", "blocked", "proposed", "backlog", "someday", "done", "rejected", "archived"];
+const { renderTasks } = await import("./tasks.js");
+
+function find(node, predicate) {
+  if (predicate(node)) return node;
+  for (const child of node.children || []) { const match = find(child, predicate); if (match) return match; }
+  return null;
+}
+
+for (const status of statuses) {
+  // Even when status_transitions is empty (as for done, archived) or excludes archived (as for rejected):
+  const task = {
+    id: `ORB-${status}`,
+    title: `${status} task`,
+    status,
+    history: [],
+    artifacts: [],
+    status_transitions: status === "done" || status === "archived" ? [] : [{ status: "backlog", required_field: null }],
+  };
+  renderTasks([task], {
+    getTasks: () => [task],
+    getTasksMeta: () => null,
+    getSearchQuery: () => "",
+    getActiveStatuses: () => new Set([status]),
+    statusOrder: statuses,
+    fmtAbsTime: (value) => value,
+    refreshDashboard: () => Promise.resolve(),
+  });
+
+  const row = find(get("tasks-body"), (node) => node.dataset.key === `task-ORB-${status}`);
+  if (!row || !row.listeners.click) throw new Error(`task row did not render for ${status}`);
+  row.listeners.click();
+
+  const detail = find(get("tasks-body"), (node) => node.dataset.key === `detail-ORB-${status}`);
+  if (!detail) throw new Error(`task detail did not render for ${status}`);
+
+  const archiveBtn = find(detail, (node) => node.className && node.className.includes("action archive"));
+  if (status === "archived") {
+    if (archiveBtn) throw new Error("archived task must not offer archive action");
+  } else {
+    if (!archiveBtn) throw new Error(`task with status '${status}' must offer archive action`);
+  }
+}
+"#,
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-12336](https://orbit-cli.com/tasks/ORB-12336) — [qa-sweep] ORB-12292 gated the dashboard `archive` button on `status_transitions`, so `done` and `rejected` tasks — the only ones worth archiving — no longer offer archive in the UI

### Description

## What happened

`4bcf446da` (ORB-12292, "Limit dashboard status choices and undo to valid task lifecycle transitions") changed the archive action's visibility condition in `crates/orbit-web/assets/dashboard/tasks.js` from

    if (task.status !== "archived") {

to

    if (statusTransition(task, "archived")) {

`statusTransition` reads the new server projection `status_transitions`, which `crates/orbit-web/src/projections.rs::dashboard_status_transitions` builds from `task_status_transition_allowed(task.status, target)`. The lifecycle table refuses `done -> archived` and `rejected -> archived` (delivered work "does not reopen"; a rejection is only reconsidered back to `backlog`/`in-progress`). Archiving is therefore *not* modeled as a status transition — it is a separate operation (`POST /api/tasks/:id/archive` -> `runtime.archive_task`, and `orbit task archive`).

Result: the dashboard now hides the `archive` button for exactly the terminal statuses an operator archives, while the underlying server capability still works. Before ORB-12292 the button was shown for every non-archived task.

## Evidence (HEAD 9e65efbd7094d46befec1bbf9450d441b949d228, Linux, disposable Orbit root under /tmp)

Built binary: `cargo build -p orbit-cli --bin orbit` ("Finished `dev` profile ... in 1m 00s"), run as `orbit --root /tmp/qa12333/root` from a scratch checkout.

`GET /api/tasks` projection:

    QAT-00003 done     status_transitions = []
    QAT-00004 rejected status_transitions = ["in-progress", "backlog"]
    QAT-00002 backlog  status_transitions = ["in-progress","blocked","proposed","someday","rejected","archived"]

Server-side archive still succeeds for both:

    curl -X POST -H 'Origin: http://127.0.0.1:17333' http://127.0.0.1:17333/api/tasks/QAT-00003/archive
    -> {"id":"QAT-00003","ok":true}      # task then reads status=archived
    curl -X POST -H 'Origin: http://127.0.0.1:17333' http://127.0.0.1:17333/api/tasks/QAT-00004/archive
    -> {"id":"QAT-00004","ok":true}
    orbit task archive QAT-00001  -> "Archived task 'QAT-00001'"   # was done

The shipped asset carries the new gate: `curl http://127.0.0.1:17333/static/tasks.js | grep -c 'statusTransition(task, "archived")'` -> 1.

## Reproduction

1. `orbit --root /tmp/s init --non-interactive --host-name h --task-prefix QAT`; from a scratch git checkout, `orbit --root /tmp/s workspace init`.
2. Create a task and drive it to `done` (`--approve`, `--status in-progress`, `--status review`, `--status done --execution-summary ...`), and reject a second task.
3. `orbit --root /tmp/s web serve --host 127.0.0.1 --port 17333 --no-open`.
4. `curl -s localhost:17333/api/tasks | jq '.items[] | {id,status,status_transitions}'` — the `done` row's `status_transitions` is `[]`, the `rejected` row's omits `archived`.
5. In the dashboard task list, neither row renders an `archive` button; the same tasks archive successfully via `POST /api/tasks/:id/archive` or `orbit task archive`.

## Scope

Dashboard UI only; the API, the CLI and the domain are unaffected, so this is lost UI reach, not data loss. The status dropdown restriction ORB-12292 added is otherwise correct and verified working (`review -> done` correctly advertises `required_field: "execution_summary"`, and `PATCH {"status":"done"}` without a summary is refused by the server with the matching message).

## Suggested direction

Archive is an operation, not a lifecycle status edge. Gate the button on something that models that (for example `task.status !== "archived"` as before, or an explicit `can_archive` flag in the projection) instead of on the status-transition table.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

### Summary of Changes
- **Fix dashboard archive action visibility**: In `crates/orbit-web/assets/dashboard/tasks.js`, reverted the archive action button visibility condition from `statusTransition(task, "archived")` back to `task.status !== "archived"`. Archiving is an independent operation (`POST /api/tasks/:id/archive` -> `runtime.archive_task`), not a lifecycle status edge, and must remain accessible for terminal tasks (`done`, `rejected`).
- **Test coverage**: Updated static source assertion in `crates/orbit-web/src/tests/dashboard_assets.rs` to check `task.status !== "archived"` and added the behavior test `dashboard_task_detail_offers_archive_for_non_archived_tasks_and_omits_for_archived` to ensure all non-archived task statuses (especially `done` and `rejected`) render the archive button when expanded, and `archived` tasks omit it.

### Validation
- `make ci-fast`: passed (fmt check + guardrail scripts).
- `make ci-lint`: passed (workspace-wide clippy pass with all warnings denied).
- `make goldens`: passed (orbit-cli snapshot tests).
- `cargo test -p orbit-web`: passed (392 tests passed including dashboard assets and unit tests).
- `git status --short` & `git diff --check`: verified clean diff and no untracked files.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12336-6aa586dc`
- Behind base: 0
- Ahead of base: 1