### PR TITLE
feat(dashboard): lead the task detail side column with details

### DIFF
--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -1183,6 +1183,42 @@
         flex-wrap: wrap;
         gap: 6px;
       }
+      .property-list {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      .property-row {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 6px 16px;
+      }
+      /* The label lines up with a 28px control, and stays on the first line
+         when the tags editor opens beside it. */
+      .property-row .label {
+        color: var(--fg-dim);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        line-height: 28px;
+      }
+      .property-row .task-complexity-select {
+        width: 120px;
+        min-width: 0;
+      }
+      .property-row .field-editor-cell {
+        flex: 1 1 auto;
+        min-width: 0;
+        align-items: flex-end;
+      }
+      .property-row .field-editor {
+        width: 100%;
+        align-items: flex-end;
+      }
+      .property-row .detail-tag-row {
+        justify-content: flex-end;
+      }
       .detail-tag-row .chip {
         cursor: default;
       }
@@ -1327,14 +1363,29 @@
         border-bottom: 1px solid rgba(255, 255, 255, 0.05);
         padding-bottom: 8px;
         transition: color 0.2s ease;
+        display: flex;
+        align-items: center;
+        gap: 8px;
       }
+      /* The header holds the title, an optional count, and the field's own
+         action (its edit button) pushed to the far end. */
+      .field-block h4 .field-count {
+        color: var(--fg-mute);
+        font-family: var(--font-mono);
+        font-weight: 400;
+        letter-spacing: 0;
+      }
+      .field-block h4 .field-actions {
+        margin-left: auto;
+        display: flex;
+        align-items: center;
+      }
+      .field-block h4 .field-actions:empty { display: none; }
       
       .field-block.collapsible h4 {
         cursor: pointer;
         user-select: none;
-        display: flex;
         justify-content: space-between;
-        align-items: center;
       }
       
       .field-block.collapsible h4:hover {
@@ -1538,13 +1589,27 @@
         text-decoration: underline;
       }
 
-      .row-detail .ac-list,
-      .row-detail .file-list {
+      .row-detail .ac-list {
         margin: 0;
         padding-left: 24px;
         line-height: 1.6;
         overflow-wrap: anywhere;
         word-break: break-all;
+      }
+      .row-detail .file-list {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 11px;
+        line-height: 1.6;
+        overflow-wrap: anywhere;
+        word-break: break-all;
+      }
+      .row-detail .file-list .selector-dim {
+        color: var(--fg-mute);
       }
       
       .row-detail .history-line,

--- a/crates/orbit-web/assets/dashboard/field-editor.js
+++ b/crates/orbit-web/assets/dashboard/field-editor.js
@@ -27,6 +27,9 @@ export function buildInlineFieldEditor({
   hint = "",
   toggle = null,
   onEditingChange = () => {},
+  // Where given, the edit button renders into this node (a field header) rather
+  // than after the value; it is cleared while the editor is open.
+  editSlot = null,
 }) {
   const wrap = el("div", { class: "field-editor" });
   const accessibleName = editTitle || `Edit ${label}`;
@@ -49,7 +52,12 @@ export function buildInlineFieldEditor({
       // widget rather than a property of how it happens to be rendered.
       if (editable) showEditor();
     });
-    wrap.replaceChildren(renderView(), editButton);
+    if (editSlot) {
+      wrap.replaceChildren(renderView());
+      editSlot.replaceChildren(editButton);
+    } else {
+      wrap.replaceChildren(renderView(), editButton);
+    }
   };
 
   const showEditor = () => {
@@ -113,6 +121,7 @@ export function buildInlineFieldEditor({
     if (toggleRow) children.push(toggleRow);
     children.push(el("div", { class: "field-editor-controls" }, [saveButton, cancelButton, status]));
     children.push(error);
+    if (editSlot) editSlot.replaceChildren();
     wrap.replaceChildren(...children);
     onEditingChange(true);
     input.focus();

--- a/crates/orbit-web/assets/dashboard/tasks.js
+++ b/crates/orbit-web/assets/dashboard/tasks.js
@@ -295,12 +295,12 @@ const TASK_META_FIELDS = [
 ];
 
 const RELATION_GROUPS = [
-  ["blocked_by", "BlockedBy"],
-  ["child_of", "ChildOf"],
-  ["spawned_from", "SpawnedFrom"],
-  ["regression_from", "RegressionFrom"],
-  ["supersedes", "Supersedes"],
-  ["related_to", "RelatedTo"],
+  ["blocked_by", "blocked by"],
+  ["child_of", "child of"],
+  ["spawned_from", "spawned from"],
+  ["regression_from", "regression from"],
+  ["supersedes", "supersedes"],
+  ["related_to", "related to"],
 ];
 const RELATION_GROUP_LABELS = new Map(RELATION_GROUPS);
 
@@ -850,11 +850,22 @@ function buildCriteriaList(criteria) {
 }
 
 function buildFileList(paths) {
-  const ul = el("ul", { class: "file-list" });
+  const ul = el("ul", { class: "file-list mono" });
   for (const path of paths) {
-    ul.appendChild(el("li", { text: path }));
+    ul.appendChild(el("li", {}, selectorParts(path)));
   }
   return ul;
+}
+
+// A context selector is `kind:target`. The kind and, for path selectors, the
+// directory are dimmed so the basename — what an operator scans for — reads
+// first; the text content is still the whole selector.
+function selectorParts(selector) {
+  const match = /^([a-z]+):(.*)$/.exec(selector);
+  if (!match) return [selector];
+  const [, kind, target] = match;
+  const cut = kind === "file" || kind === "dir" ? target.lastIndexOf("/") + 1 : 0;
+  return [el("span", { class: "selector-dim", text: `${kind}:${target.slice(0, cut)}` }), target.slice(cut)];
 }
 
 function linesToText(values) {
@@ -899,7 +910,7 @@ function setDetailEditing(detail, field, open) {
   else delete detail.dataset.editing;
 }
 
-function buildTaskFieldEditor(task, field, detail, context) {
+function buildTaskFieldEditor(task, field, detail, context, editSlot = null) {
   const spec = TASK_FIELD_EDITORS[field];
   const mutable = canMutateTask(task);
   const editTitle = `Edit ${spec.label} for ${task.id}`;
@@ -919,6 +930,7 @@ function buildTaskFieldEditor(task, field, detail, context) {
       save: (text, options) => patchJson(taskMutationPath(task), spec.toPayload(text, options)),
       onSaved: (updatedTask) => completeFieldSave(task.id, field, updatedTask, context),
       onEditingChange: (open) => setDetailEditing(detail, field, open),
+      editSlot,
     }),
   );
   const feedback = fieldFeedback.get(fieldFeedbackKey(task.id, field));
@@ -1023,12 +1035,17 @@ function buildTaskDetail(task, context) {
   const leftCol = el("div", { class: "detail-main" });
   const rightCol = el("div", { class: "detail-side" });
 
-  const addField = (parent, title, child, collapsible = false, collapsed = false) => {
+  // The h4 carries the title in its own span so a header can also hold an
+  // action (the field's edit button) without the two reading as one label.
+  const addField = (parent, title, child, collapsible = false, collapsed = false, header = {}) => {
     let classes = "field-block";
     if (collapsible) classes += " collapsible";
     if (collapsed) classes += " collapsed";
     const block = el("div", { class: classes });
-    const h4 = el("h4", { text: title });
+    const heading = [el("span", { class: "field-title", text: title })];
+    if (header.count != null) heading.push(el("span", { class: "field-count", text: String(header.count) }));
+    if (header.actions) heading.push(header.actions);
+    const h4 = el("h4", {}, heading);
     if (collapsible) {
       makeToggleRow(h4, {
         expanded: !collapsed,
@@ -1043,12 +1060,13 @@ function buildTaskDetail(task, context) {
     block.appendChild(child);
     parent.appendChild(block);
   };
+  const actionSlot = () => el("span", { class: "field-actions" });
 
   // An editable field is shown even when it is empty — adding a missing
   // description is exactly the edit an operator comes here for — but only where
   // editing is actually allowed, so the read-only aggregate view stays as terse
   // as it was.
-  const editor = (field) => buildTaskFieldEditor(task, field, detail, context);
+  const editor = (field, editSlot = null) => buildTaskFieldEditor(task, field, detail, context, editSlot);
   const showsEditor = (field) =>
     canMutateTask(task) || taskFieldHasValue(task, TASK_FIELD_EDITORS[field]);
 
@@ -1076,14 +1094,11 @@ function buildTaskDetail(task, context) {
     addField(leftCol, "review gate", buildReviewGate(task.review), true, true);
   }
 
-  addField(rightCol, "complexity", buildComplexityUpdateControl(task, context));
-
-  if (showsEditor("tags")) {
-    addField(rightCol, "tags", editor("tags"));
-  }
+  // The side column leads with what identifies the task — who made it, which
+  // run, when — then the levers an operator sets, then the graph around it.
 
   // Provenance and timestamps: recorded by the pipeline, so read-only here even
-  // though the fields above are not.
+  // though the fields below are not.
   const meta = el("div", { class: "meta-list" });
   let metaCount = 0;
   for (const [key, label] of TASK_META_FIELDS) {
@@ -1115,6 +1130,20 @@ function buildTaskDetail(task, context) {
     addField(rightCol, "location", loc);
   }
 
+  // Complexity and tags are one card of properties: each is a label beside its
+  // control, and the tags edit button sits in the card header.
+  {
+    const properties = el("div", { class: "property-list" });
+    const property = (label, control) =>
+      el("div", { class: "property-row" }, [el("span", { class: "label", text: label }), control]);
+    properties.appendChild(property("complexity", buildComplexityUpdateControl(task, context)));
+    const actions = actionSlot();
+    if (showsEditor("tags")) {
+      properties.appendChild(property("tags", editor("tags", actions)));
+    }
+    addField(rightCol, "properties", properties, false, false, { actions });
+  }
+
   if (Array.isArray(task.external_refs) && task.external_refs.length > 0) {
     addField(rightCol, "external refs", buildExternalRefs(task.external_refs));
   }
@@ -1125,7 +1154,9 @@ function buildTaskDetail(task, context) {
   }
 
   if (showsEditor("context_files")) {
-    addField(rightCol, "context files", editor("context_files"));
+    const actions = actionSlot();
+    const count = Array.isArray(task.context_files) ? task.context_files.length : 0;
+    addField(rightCol, "context files", editor("context_files", actions), false, false, { actions, count });
   }
 
   if (Array.isArray(task.history) && task.history.length > 0) {

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -2199,7 +2199,7 @@ const complexitySelect = find(body, (node) => node.className === "task-complexit
 if (!complexitySelect.disabled) throw new Error("the complexity select must be disabled in aggregate view");
 if (!frame(complexitySelect.title)) throw new Error(`complexity refusal reads differently: ${complexitySelect.title}`);
 
-for (const title of ["description", "acceptance criteria", "tags", "context files"]) {
+for (const title of ["description", "acceptance criteria", "properties", "context files"]) {
   const block = fieldBlock(title);
   if (!block) throw new Error(`${title} is missing from the detail`);
   const edit = find(block, (node) => node.className === "field-edit");
@@ -2261,7 +2261,7 @@ if (!fieldBlock("description").textContent.includes("rewritten body")) {
   throw new Error(`the saved description was not re-rendered: ${fieldBlock("description").textContent}`);
 }
 await saveField("acceptance criteria", "first\nsecond\n\n", { acceptance_criteria: ["first", "second"] });
-await saveField("tags", "dashboard, orbit-web", { tags: ["dashboard", "orbit-web"] });
+await saveField("properties", "dashboard, orbit-web", { tags: ["dashboard", "orbit-web"] });
 
 // A rejected context-files save keeps the editor, the text, and the server's reason.
 const block = openEditor("context files");
@@ -2447,7 +2447,10 @@ const fieldBlock = (title) => {
   const blocks = [];
   const visit = (node) => { for (const child of node.children) { if (child.className.split(/\s+/).includes("field-block")) blocks.push(child); visit(child); } };
   visit(detailNode());
-  return blocks.find((block) => block.children[0] && block.children[0].textContent === title) || null;
+  // The header carries its title in a span so it can also hold a count and the
+  // field's edit button; tags live in the `properties` card beside complexity.
+  const heading = (block) => find(block.children[0], (node) => node.className === "field-title");
+  return blocks.find((block) => heading(block) && heading(block).textContent === title) || null;
 };
 const editorInput = (block) => find(block, (node) => node.className === "field-editor-input mono");
 const openEditor = (title) => {


### PR DESCRIPTION
## Summary

The expanded task's side column opened on a complexity select and a tags card, with provenance (who created it, which run, when) third. Every block carried identical card chrome, so a single select read as heavy as the details list, and each field's `edit` button dangled under its value.

- **Order**: details → location → properties → external refs → relations → context files → history → comments.
- **Properties card**: complexity and tags share one card, each a label beside its control; the tags `edit` button sits in the card header.
- **Header slot**: `addField` builds the `h4` from a title span plus an optional count and action slot; `buildInlineFieldEditor` takes an `editSlot` so the edit button renders into that header and is cleared while the editor is open.
- **Context files**: count in the header; entries render in mono with the selector kind and directory dimmed so the basename reads first.
- **Relation labels** read like the rest of the column (`regression from`, not `RegressionFrom`).

Design canvas (current vs. options): https://claude.ai/code/artifact/5f5347eb-a855-40d2-a590-1943a8d23a45 — this PR is Option A.

## Test plan

- [x] `cargo test -p orbit-web dashboard` — 70 passed (harness `fieldBlock` helper updated to read the title span; tags now live in `properties`).
- [x] Served `target/debug/orbit web serve` and opened DANI-10305 (ws_observatory): column order, header edit button, tags editor open/cancel from the header, dimmed selector paths, `blocked by` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
