### PR TITLE
[code-review] Systemd bus-unavailable diagnostic is misclassified as a disabled clock, reintroducing the false "paused" report

### DIFF
--- a/crates/orbit-core/src/application/routines/clock.rs
+++ b/crates/orbit-core/src/application/routines/clock.rs
@@ -963,8 +963,18 @@ pub(super) fn clock_status_with(
     ))
 }
 
+/// A failed `is-enabled` probe is a recognized disabled or missing unit only
+/// when the diagnostic names a unit state. A manager transport failure is
+/// ruled out first because systemd reuses the same errno text for both: a
+/// missing unit file reports `Failed to get unit file state: No such file or
+/// directory`, while an unreachable user bus reports `Failed to connect to
+/// bus: No such file or directory`. Only the former is a disabled clock.
 fn systemd_reports_disabled_or_missing(output: &ManagerCommandOutput) -> bool {
     let diagnostic = format!("{}\n{}", output.stdout, output.stderr).to_ascii_lowercase();
+    if systemd_reports_transport_failure(&diagnostic) {
+        return false;
+    }
+
     [
         "disabled",
         "masked",
@@ -974,11 +984,19 @@ fn systemd_reports_disabled_or_missing(output: &ManagerCommandOutput) -> bool {
         "transient",
         "not-found",
         "not found",
-        "no such file or directory",
+        "failed to get unit file state",
         "could not be found",
     ]
     .iter()
     .any(|marker| diagnostic.contains(marker))
+}
+
+/// systemctl prefixes every bus-connection failure with `Failed to connect to`
+/// (`... bus: No medium found`, `... bus: No such file or directory`,
+/// `... user scope bus via local transport: ...`), regardless of the errno
+/// that follows.
+fn systemd_reports_transport_failure(lowercase_diagnostic: &str) -> bool {
+    lowercase_diagnostic.contains("failed to connect to")
 }
 
 fn launchd_reports_not_loaded(output: &ManagerCommandOutput) -> bool {

--- a/crates/orbit-core/src/application/routines/tests/clock.rs
+++ b/crates/orbit-core/src/application/routines/tests/clock.rs
@@ -818,6 +818,30 @@ fn missing_systemd_unit_is_disabled_but_manager_transport_failure_is_unavailable
 }
 
 #[test]
+fn systemd_bus_missing_socket_is_unavailable_not_disabled() {
+    let root = tempdir().expect("create global root");
+    let runner = MockRunner::with_probes(
+        Vec::new(),
+        vec![Err(OrbitError::Execution(
+            "show failed: Failed to connect to bus: No such file or directory".to_string(),
+        ))],
+        vec![Ok(manager_output(
+            false,
+            "",
+            "Failed to connect to bus: No such file or directory",
+        ))],
+    );
+
+    let error = clock_status_with(root.path(), ClockPlatform::Systemd, &runner)
+        .expect_err("a missing user bus socket must fail status, not report a paused clock");
+    let message = error.to_string();
+
+    assert!(message.contains("systemd clock manager is unavailable"));
+    assert!(message.contains("Failed to connect to bus: No such file or directory"));
+    assert!(!message.contains("paused"));
+}
+
+#[test]
 fn enabled_systemd_with_unavailable_details_remains_enabled_but_unverifiable() {
     let root = tempdir().expect("create global root");
     let runner = MockRunner::with_outputs(
@@ -1078,6 +1102,47 @@ fn unavailable_launchd_state_refuses_pause_before_mutation() {
 }
 
 #[test]
+fn systemd_bus_missing_socket_refuses_pause() {
+    let root = tempdir().expect("create global root");
+    let home = tempdir().expect("create home");
+    let settings_before = fs::read_to_string(root.path().join("clock.toml")).ok();
+    let runner = MockRunner::with_probes(
+        Vec::new(),
+        Vec::new(),
+        vec![Ok(manager_output(
+            false,
+            "",
+            "Failed to connect to bus: No such file or directory",
+        ))],
+    );
+
+    let error = set_clock_enabled_with(
+        root.path(),
+        false,
+        ClockPlatform::Systemd,
+        &runner,
+        home.path(),
+    )
+    .expect_err("an unreachable user bus must refuse pause instead of claiming it succeeded");
+
+    assert!(
+        error
+            .to_string()
+            .contains("systemd clock manager is unavailable")
+    );
+    assert_eq!(
+        runner.commands(),
+        vec!["systemctl --user is-enabled orbit-sweep.timer"],
+        "no manager mutation is issued when the timer state is unobservable"
+    );
+    assert_eq!(
+        fs::read_to_string(root.path().join("clock.toml")).ok(),
+        settings_before,
+        "clock settings are untouched by a refused pause"
+    );
+}
+
+#[test]
 fn recognized_inactive_manager_states_keep_pause_idempotent() {
     let root = tempdir().expect("create global root");
     let home = tempdir().expect("create home");
@@ -1085,6 +1150,7 @@ fn recognized_inactive_manager_states_keep_pause_idempotent() {
     for diagnostic in [
         "disabled",
         "Failed to get unit file state: No such file or directory",
+        "Unit orbit-sweep.timer could not be found.",
     ] {
         let runner = MockRunner::with_probes(
             Vec::new(),


### PR DESCRIPTION
## Task

[ORB-12335](https://orbit-cli.com/tasks/ORB-12335) — [code-review] Systemd bus-unavailable diagnostic is misclassified as a disabled clock, reintroducing the false "paused" report

### Description

## Summary

`systemd_reports_disabled_or_missing` classifies a native-manager transport failure as a
recognized "disabled or missing unit" whenever the diagnostic contains the substring
`no such file or directory`. systemd's own bus-connection failure message is literally
`Failed to connect to bus: No such file or directory`, so the exact condition ORB-12314 and
ORB-12319 were filed to distinguish collapses back into `enabled=false` — the misleading
"paused" report — on one of the two most common ways a user manager is unreachable.

## Evidence

`crates/orbit-core/src/application/routines/clock.rs:966-982` matches markers against the
combined, lowercased stdout+stderr of the status probe with no regard for which diagnostic
produced them:

```rust
fn systemd_reports_disabled_or_missing(output: &ManagerCommandOutput) -> bool {
    let diagnostic = format!("{}\n{}", output.stdout, output.stderr).to_ascii_lowercase();
    [ ..., "not found", "no such file or directory", "could not be found" ]
        .iter().any(|marker| diagnostic.contains(marker))
}
```

The marker is there for the missing-unit case — `Failed to get unit file state: No such file
or directory` — which the test at
`crates/orbit-core/src/application/routines/tests/clock.rs:786-800` asserts. But the
manager-unavailable tests only ever exercise the *other* bus message,
`Failed to connect to bus: No medium found`
(`crates/orbit-core/src/application/routines/tests/clock.rs:765`), which contains no marker
and therefore correctly fails closed. The `No such file or directory` variant of the same bus
failure is never covered and takes the disabled path.

Both live consumers are affected:

- `crates/orbit-core/src/application/routines/clock.rs:848` —
  `observe_clock_enabled_for_pause` returns `Ok(false)`.
- `crates/orbit-core/src/application/routines/clock.rs:944` — `clock_status_with` yields
  `(schedulable = false, health_issue = None)`.

## Failure scenario

On a host where `systemctl --user` cannot reach the user bus because the socket path does not
exist (headless server without lingering, `su`/SSH session with no user manager, container),
`systemctl --user is-enabled orbit-sweep.timer` exits 1 with
`Failed to connect to bus: No such file or directory`.

1. `orbit clock status` reports `enabled = false`, `schedulable = false`, and **no health
   issue**. `crates/orbit-cli/src/command/clock/command.rs:56` renders this as `paused` and
   `:82` advises that "manual `orbit clock tick` remains available".
2. The dashboard projection at `crates/orbit-web/src/api/routines.rs:389` maps `!clock.enabled`
   to health `"paused"`, and the same read feeds `expected_enabled = false` into the clock
   mutation controls — the fabricated-control path ORB-12314 explicitly required be avoided.
3. `orbit clock pause` reads `current = false`, hits the `current == enabled` short circuit at
   `crates/orbit-core/src/application/routines/clock.rs:815-819`, and returns success claiming
   the clock is paused. No manager command was ever issued and the timer's real state is
   unknown — it may still be armed and firing.

The operator is told the scheduler is deliberately paused when Orbit in fact could not observe
it at all.

## Suggested direction

Classify on the specific diagnostic rather than a substring union: a `Failed to connect to
bus` / transport prefix should be recognized as unavailable *before* the missing-unit markers
are consulted, or the unit-state markers should be anchored to their own message
(`failed to get unit file state`, `unit ... could not be found`) instead of matching a bare
errno string anywhere in the output.

Filed by the ORB-12334 code-review sweep over
`7062d3a303ead90520bcddf86725439b7a4129d1..9e65efbd7094d46befec1bbf9450d441b949d228`.

### Acceptance Criteria

- `systemd_reports_disabled_or_missing` (or its replacement) classifies a status probe whose stderr is `Failed to connect to bus: No such file or directory` as an unavailable manager, not as a disabled or missing unit.
- `clock_status_with` returns the typed manager-unavailable error for that probe output instead of `enabled=false` with no health issue, and `observe_clock_enabled_for_pause` refuses the pause instead of returning `Ok(false)`.
- The existing missing-unit behavior still holds: `Failed to get unit file state: No such file or directory` and `Unit orbit-sweep.timer could not be found` continue to report a disabled clock, and the `No medium found` bus failure continues to report unavailable.
- A regression test covers the `Failed to connect to bus: No such file or directory` variant for both the status read and the pause control path.

## Execution Summary

<details>
<summary>Click to expand</summary>

Classify systemd status-probe diagnostics on the specific message rather than a bare errno substring, so an unreachable user bus is no longer reported as a deliberately paused clock.

## Change

`crates/orbit-core/src/application/routines/clock.rs`
- `systemd_reports_disabled_or_missing` now rules out a manager transport failure before consulting unit-state markers, via a new `systemd_reports_transport_failure` helper that matches systemctl's `Failed to connect to` bus-failure prefix (covers `... bus: No medium found`, `... bus: No such file or directory`, and the `user scope bus via local transport` variants regardless of the trailing errno).
- Replaced the bare `"no such file or directory"` marker with the anchored `"failed to get unit file state"` message, so the missing-unit case is recognized by its own diagnostic instead of an errno string that can appear anywhere in the output.
- Added a doc comment on the classifier stating why the transport check must run first (systemd reuses the same errno text for a missing unit file and an unreachable bus).

Both live consumers pick the fix up unchanged: `observe_clock_enabled_for_pause` (clock.rs:848) now takes the `Err(clock_manager_unavailable_error(..))` arm, and `clock_status_with` (clock.rs:944) falls through to returning the manager-unavailable error instead of `(enabled=false, health_issue=None)`.

## Criteria

1. **Bus failure classified as unavailable, not disabled/missing** — met. `systemd_reports_disabled_or_missing` returns false for a probe whose stderr is `Failed to connect to bus: No such file or directory`; the transport guard short-circuits before the marker list.
2. **`clock_status_with` returns the typed error; pause refuses** — met and tested. `systemd_bus_missing_socket_is_unavailable_not_disabled` asserts the status read fails with `systemd clock manager is unavailable`, echoes the bus diagnostic, and does not contain "paused". `systemd_bus_missing_socket_refuses_pause` asserts `set_clock_enabled_with(.., false, Systemd, ..)` errors, that only the `is-enabled` probe ran (no manager mutation), and that `clock.toml` is unchanged.
3. **Existing missing-unit and `No medium found` behavior preserved** — met. `missing_systemd_unit_is_disabled_but_manager_transport_failure_is_unavailable` (both `Failed to get unit file state: No such file or directory` and `Unit orbit-sweep.timer could not be found`) and `unavailable_systemd_manager_fails_status_with_bounded_diagnostics` (`No medium found`) still pass unmodified. `recognized_inactive_manager_states_keep_pause_idempotent` was extended with the `Unit orbit-sweep.timer could not be found.` variant on the pause path, which the `could not be found` marker still covers.
4. **Regression test for both paths** — met, and confirmed fault-detecting: with the classifier reverted to its original form (transport guard removed, anchored marker restored to the bare errno string), both new tests FAIL (`2 failed`); with the fix they pass. The 38 other clock tests pass in both states, confirming the new coverage is what isolates this defect.

## Validation

- `cargo test -p orbit-core --lib routines::tests::clock` — passed (40 passed, 0 failed), including the two new tests.
- Fault-detection check: same command against the pre-fix classifier — 2 failed / 38 passed, as expected; fix restored afterwards.
- `make ci-fast` — passed (fmt-check + guardrails). `test-compiler-cache-namespaces` self-reported `skip: cannot create a mount namespace` (unprivileged user namespaces disabled on this host); that is a runner capability limit, not a failure of this change.
- `make ci-lint` — passed (workspace-wide all-target clippy, warnings denied).
- `make goldens` — passed; no CLI help, output-golden, or MCP snapshot text changed.
- `git diff --check` clean; `git status --short` shows only the two in-scope modified files. No untracked or scratch files in the worktree (the pre-fix comparison copy was written to `/tmp`).

## Scope and risk

No files outside the declared `context_files` were touched; no new context selectors needed. Behavior change is narrow and fail-closed: diagnostics containing `Failed to connect to` are now unavailable rather than disabled. A hypothetical systemd build that emitted `Failed to connect to` alongside a genuinely disabled unit would now surface a manager-unavailable error instead of `enabled=false` — the safe direction, and the one ORB-12314/ORB-12319 require. The anchored unit-state markers are strictly narrower than the old bare errno match, so no previously-unavailable diagnostic becomes disabled. All evidence is from mocked `ClockCommandRunner` probes on Linux; no live host without a user bus was exercised, so the end-to-end CLI/dashboard rendering of the new error is verified only at the core boundary that owns the classification.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12335-6aa591c5`
- Behind base: 0
- Ahead of base: 1