### PR TITLE
[qa-sweep] `orbit clock tick --dry-run` reports `error — automation_deferred: evidence_unavailable` for disabled delivery auto-tasks that the real tick reports as `disabled`

### DIFF
--- a/crates/orbit-automation/src/delivery/mod.rs
+++ b/crates/orbit-automation/src/delivery/mod.rs
@@ -92,7 +92,10 @@ pub fn evaluate(
     let mut state = match store.automation_state(consumer)? {
         Some(state) => state,
         None => {
-            if !enabled && !dry_run {
+            // Disabled definitions never pin a baseline. Preview must match the
+            // real pass here: probing git would invent `would_baseline` or an
+            // `evidence_unavailable` error the scheduled tick never sees.
+            if !enabled {
                 return diagnostic(store, consumer, "disabled", None);
             }
 

--- a/crates/orbit-automation/src/delivery/tests/evidence.rs
+++ b/crates/orbit-automation/src/delivery/tests/evidence.rs
@@ -10,7 +10,7 @@ use std::{
     collections::BTreeMap,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
 
@@ -59,6 +59,8 @@ pub(super) struct Host {
     fail_admit: AtomicBool,
     pub(super) failed: AtomicBool,
     admission_deferred: AtomicBool,
+    fail_head: AtomicBool,
+    head_calls: AtomicUsize,
 }
 
 impl Host {
@@ -79,6 +81,8 @@ impl Host {
             fail_admit: AtomicBool::new(false),
             failed: AtomicBool::new(false),
             admission_deferred: AtomicBool::new(false),
+            fail_head: AtomicBool::new(false),
+            head_calls: AtomicUsize::new(0),
         }
     }
 
@@ -131,6 +135,10 @@ impl DeliveryHost for Host {
     }
 
     fn head(&self, _: &str) -> Result<(String, SourceRevision), AutomationError> {
+        self.head_calls.fetch_add(1, Ordering::SeqCst);
+        if self.fail_head.load(Ordering::SeqCst) {
+            return Err(AutomationError::Deferred("evidence_unavailable".into()));
+        }
         Ok(("owner/repo".into(), revision(0)))
     }
 
@@ -205,6 +213,113 @@ pub(super) fn setup() -> (Arc<dyn AutomationStoreBackend>, Host, DeliveryTrigger
         "baselined"
     );
     (store, host, trigger)
+}
+
+#[test]
+fn disabled_preview_without_state_matches_real_pass_and_does_not_probe_git() {
+    let store = compose::automation_store(Store::open_in_memory().unwrap()).unwrap();
+    let host = Host::new();
+    host.fail_head.store(true, Ordering::SeqCst);
+    let trigger = trigger();
+
+    let preview = delivery::evaluate(
+        store.as_ref(),
+        &host,
+        Evaluation {
+            consumer: "ws/qa",
+            epoch: "v1",
+            trigger: &trigger,
+            enabled: false,
+            dry_run: true,
+            now: now(),
+        },
+    )
+    .unwrap();
+    assert_eq!(preview.reason, "disabled");
+    assert!(preview.state.is_none());
+    assert_eq!(host.head_calls.load(Ordering::SeqCst), 0);
+    assert!(store.automation_state("ws/qa").unwrap().is_none());
+
+    let real = delivery::evaluate(
+        store.as_ref(),
+        &host,
+        Evaluation {
+            consumer: "ws/qa",
+            epoch: "v1",
+            trigger: &trigger,
+            enabled: false,
+            dry_run: false,
+            now: now(),
+        },
+    )
+    .unwrap();
+    assert_eq!(real.reason, "disabled");
+    assert!(real.state.is_none());
+    assert_eq!(host.head_calls.load(Ordering::SeqCst), 0);
+    assert!(store.automation_state("ws/qa").unwrap().is_none());
+
+    host.fail_head.store(false, Ordering::SeqCst);
+    let preview_with_head = delivery::evaluate(
+        store.as_ref(),
+        &host,
+        Evaluation {
+            consumer: "ws/qa",
+            epoch: "v1",
+            trigger: &trigger,
+            enabled: false,
+            dry_run: true,
+            now: now(),
+        },
+    )
+    .unwrap();
+    assert_eq!(preview_with_head.reason, "disabled");
+    assert_eq!(host.head_calls.load(Ordering::SeqCst), 0);
+    assert!(store.automation_state("ws/qa").unwrap().is_none());
+}
+
+#[test]
+fn enabled_preview_without_state_still_requires_branch_head() {
+    let store = compose::automation_store(Store::open_in_memory().unwrap()).unwrap();
+    let host = Host::new();
+    let trigger = trigger();
+
+    let would_baseline = delivery::evaluate(
+        store.as_ref(),
+        &host,
+        Evaluation {
+            consumer: "ws/qa",
+            epoch: "v1",
+            trigger: &trigger,
+            enabled: true,
+            dry_run: true,
+            now: now(),
+        },
+    )
+    .unwrap();
+    assert_eq!(would_baseline.reason, "would_baseline");
+    assert_eq!(host.head_calls.load(Ordering::SeqCst), 1);
+    assert!(store.automation_state("ws/qa").unwrap().is_none());
+
+    host.fail_head.store(true, Ordering::SeqCst);
+    let error = delivery::evaluate(
+        store.as_ref(),
+        &host,
+        Evaluation {
+            consumer: "ws/qa",
+            epoch: "v1",
+            trigger: &trigger,
+            enabled: true,
+            dry_run: true,
+            now: now(),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(
+        error,
+        AutomationError::Deferred(reason) if reason == "evidence_unavailable"
+    ));
+    assert_eq!(host.head_calls.load(Ordering::SeqCst), 2);
+    assert!(store.automation_state("ws/qa").unwrap().is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-12337](https://orbit-cli.com/tasks/ORB-12337) — [qa-sweep] `orbit clock tick --dry-run` reports `error — automation_deferred: evidence_unavailable` for disabled delivery auto-tasks that the real tick reports as `disabled`

### Description

## What happened

`81074be8e` (ORB-12237, clock consolidation 2/2) made `orbit clock tick` / `orbit sweep` evaluate auto-tasks in-process, so auto-task rows are now part of that command's user-facing output. In a freshly initialized workspace the preview (`--dry-run`) and the real pass disagree about the two shipped delivery auto-tasks, and the preview invents errors:

    $ orbit --root /tmp/s clock tick --dry-run
    ...
    delivery-code-review (repo, auto-task): error — execution failed: automation_deferred: evidence_unavailable
    delivery-qa (repo, auto-task): error — execution failed: automation_deferred: evidence_unavailable

    $ orbit --root /tmp/s clock tick
    clock tick[qa12333-host]: 6 routine(s), 6 auto-task(s), nothing due

JSON from the same two passes, same state, seconds apart:

    dry-run: ("delivery-code-review","error","execution failed: automation_deferred: evidence_unavailable")
    real:    ("delivery-code-review","delivery","disabled")

`error` is in `report_is_noteworthy` (`crates/orbit-cli/src/command/clock/tick.rs`), so these rows print by default — a fresh host's first `--dry-run` looks broken.

## Root cause

`crates/orbit-automation/src/delivery/mod.rs` (~line 95), in the "no automation state yet" branch:

    if !enabled && !dry_run {
        return diagnostic(store, consumer, "disabled", None);
    }
    let (repository, head) = host.head(&trigger.branch)?;

The real pass short-circuits on a disabled definition before touching git. The dry run skips that short-circuit and asks the source adapter for the declared branch head. The shipped `delivery-qa` / `delivery-code-review` definitions are `enabled: false` with `branch: agent-main`, so on any checkout that has no local `agent-main` the git probe fails and `source::Source::command` maps it to `AutomationError::Deferred("evidence_unavailable")` -> `automation_deferred: ...` -> an `error` report row (`crates/orbit-automation/src/auto_tasks/scheduler.rs::fire_definition` evaluates delivery definitions before the `enabled` check for both modes).

With the branch present the error disappears but the disagreement remains: the dry run then reports `would_baseline` for a definition the operator has disabled, while the real pass still reports `disabled`.

## Reproduction (HEAD 9e65efbd7094d46befec1bbf9450d441b949d228, Linux)

1. `cargo build -p orbit-cli --bin orbit`.
2. `orbit --root /tmp/s init --non-interactive --host-name h --task-prefix QAT`.
3. `git init` a scratch checkout with a single `main` branch (no `agent-main`); from it, `orbit --root /tmp/s workspace init`.
4. `orbit --root /tmp/s clock tick --dry-run` -> two `error — execution failed: automation_deferred: evidence_unavailable` rows for `delivery-code-review` and `delivery-qa`.
5. `orbit --root /tmp/s clock tick` -> `nothing due`; `--json` shows those definitions as `action: "delivery", reason: "disabled"`.
6. `git branch agent-main` in the scratch checkout, then `orbit --root /tmp/s clock tick --dry-run --json` -> the same two definitions now report `action: "delivery", reason: "would_baseline"` even though both are `enabled: false`.

## Scope

Validation/preview impact only: no run is dispatched, no task is minted, and no automation state is written in dry-run mode (`store.automation_initialize` stays behind `if !dry_run`). The real scheduled tick is correct. Production impact is the misleading operator preview — a new host's `orbit clock tick --dry-run` reports two errors that do not exist, which is exactly the command an operator uses to check a freshly installed clock.

## Suggested direction

Evaluate the definition's `enabled` state before reaching for git evidence in the no-state branch (apply the `disabled` short-circuit in dry-run too), or classify a deferral from the source adapter as a non-error report row (`deferred`/`skipped` with the reason) rather than `error`, so a preview cannot report a failure the real pass never encounters.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `delivery::evaluate` no-state branch now short-circuits `disabled` in dry-run as well as the real pass, before `host.head`. Preview no longer probes git for disabled definitions, so a missing `agent-main` cannot invent `automation_deferred: evidence_unavailable`, and a present branch cannot invent `would_baseline`.
- Tests: dry-run+disabled with failing or succeeding head reports `disabled`, calls head 0 times, writes no state; enabled dry-run still reports `would_baseline` or `Deferred(evidence_unavailable)`.
- Left `scheduler.rs` and `tick.rs` unchanged: delivery rows already use action `delivery` with the diagnostic reason; once that reason is `disabled`, `error` is no longer noteworthy. Existing-state evaluations still reconcile admitted work before the later `disabled` check.

Assessment: smallest compatible fix at the evaluator that owned the disagreement. Scheduler still maps real `evaluate_delivery` errors to `error` rows, which is correct for enabled definitions whose branch head is actually missing.

Criteria:
- Dry-run of a disabled no-state delivery definition reports `disabled`, not `error`/`evidence_unavailable`: covered by `disabled_preview_without_state_matches_real_pass_and_does_not_probe_git` (failing head never called).
- Dry-run of a disabled definition does not report `would_baseline` when the branch exists: same test, `fail_head=false` still `disabled` and 0 head calls.
- Real pass still reports `disabled` and writes no automation state: same test.
- Enabled dry-run still probes git: `enabled_preview_without_state_still_requires_branch_head` (`would_baseline` then `Deferred(evidence_unavailable)`).

Validation:
- `cargo test -p orbit-automation --lib delivery`: passed (29 tests, including the two new ones).
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `make goldens`: passed (no CLI surface change).
- `git diff --check`: passed.
- Live `orbit clock tick --dry-run` on a scratch host (reproduction steps 1–6): not run. Unit tests exercise the evaluator path that produced the CLI error; the CLI mapping is unchanged (`fire_definition` still surfaces the diagnostic reason).

Strategic decisions: apply the disabled short-circuit in dry-run rather than reclassifying source-adapter deferrals as non-errors, so preview and real pass agree on disabled definitions without hiding genuine probe failures for enabled ones.

Design weaknesses / risks:
- Severity: low. `members/mod.rs` still uses `if !enabled && !dry_run` in its no-state branch. Out of scope: shipped `delivery-qa` / `delivery-code-review` are delivery auto-tasks. An enabled delivery definition whose declared branch is missing still reports `error` in both modes.

Deviations from original plan: none.
Recommended follow-ups: none required for this bug. Optionally apply the same no-state short-circuit in the members evaluator if that preview is observed to disagree.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12337-6aa593d1`
- Behind base: 0
- Ahead of base: 1