### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/mcp-session-context/4_decisions.md
+++ b/docs/design/mcp-session-context/4_decisions.md
@@ -4,12 +4,12 @@ type: design
 title: "MCP Session Context — Decisions"
 owner: codex
 last_updated: 2026-08-22
-last_validated: 2026-08-22
+last_validated: 2026-09-12
 status: Accepted
 feature: mcp-session-context
 doc_role: decisions
 tags: ["mcp-session-context", "mcp", "workspace", "audit"]
-paths: ["crates/orbit-common/src/types/tool.rs", "crates/orbit-mcp/src/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-core/src/command/tool/**"]
+paths: ["crates/orbit-types/src/tool/definition.rs", "crates/orbit-mcp/src/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-core/src/adapter/tool_host/**", "crates/orbit-core/src/runtime/**"]
 related_features: ["mcp-session-context"]
 related_artifacts: []
 ---
@@ -60,10 +60,10 @@ These are the current implementation choices for MCP v1.
 
 **Consequences.** Successes and failures can be correlated end to end. Cost: trace creation and propagation are mandatory for every MCP call.
 
-## V1 defers policy authorization
+## V1 centralizes policy at the runtime chokepoint
 
-**Context.** Identity transport and execution plumbing are useful before an Orbit authorization model is chosen.
+**Context.** Identity transport and execution plumbing need one authoritative authorization boundary, while caller-provided labels remain untrusted.
 
-**Decision.** MCP definitions carry only global-versus-workspace-required scope. MCP v1 does not authorize by capability, placement, lease, IP address, SSH label, or machine label. The kernel exposes the authoritative host's complete supported surface; Core remains the future policy seam.
+**Decision.** MCP definitions still distinguish global-versus-workspace-required scope, but governed tool calls pass through `OrbitRuntime::authorize_tool_operation`. MCP session capabilities and destination-granted remote-agent capability are checked there; on federated destination calls, the catalog-role gate also runs before the tool body. Caller and process machine labels, host labels, and IP addresses remain audit metadata rather than authenticated principals.
 
-**Consequences.** The skeleton stays small and avoids treating audit metadata as authority. Cost: deployments rely on access to the local process or SSH account until explicit Core authorization is designed.
+**Consequences.** The kernel advertises the canonical surface and Core/runtime owns the policy checks, so all entry surfaces share the same authorization seam. Cost: each adapter must preserve the trusted session/process context that the seam evaluates.

--- a/docs/design/worktree-artifacts/3_vision.md
+++ b/docs/design/worktree-artifacts/3_vision.md
@@ -11,7 +11,7 @@ tags: ["worktree-artifacts"]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-cli/**"]
 related_features: ["worktree-artifacts"]
 related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201"]
-last_validated: 2026-08-22
+last_validated: 2026-09-12
 ---
 
 # Worktree Artifacts - Vision

--- a/docs/design/worktree-artifacts/4_decisions.md
+++ b/docs/design/worktree-artifacts/4_decisions.md
@@ -11,7 +11,7 @@ tags: ["worktree-artifacts"]
 paths: ["crates/orbit-core/**", "crates/orbit-store/**", "crates/orbit-engine/**", "crates/orbit-cli/**"]
 related_features: ["worktree-artifacts", "host-registry", "mcp-bridge"]
 related_artifacts: ["ORB-00199", "ORB-00200", "ORB-00201", "ORB-10272", "ORB-10297", "ORB-10330", "ORB-10501", "ORB-10535", "ORB-10545", "ORB-10668", "ORB-10669", "ORB-10725"]
-last_validated: 2026-08-22
+last_validated: 2026-09-12
 ---
 
 # Worktree Artifacts - Decisions
@@ -256,7 +256,7 @@ Add a second benign case, `primary_dirt_only_delta_is_benign`, that is deliberat
 3. no mutated path intersects `run_changed_paths` (the same gate ORB-10471 introduced);
 4. **every** mutated path lives under `.orbit/`, Orbit's own record store.
 
-Clause 4 is the load-bearing addition. `.orbit/` holds tasks, ADRs, learnings, frictions, and routines: content the engine driving the pipeline rewrites as a matter of course, and content that is never a run's code candidate. A primary mutation anywhere else — source, manifests, CI config — remains `primary_checkout_drift` regardless of disjointness, preserving ORB-10134 escape detection intact.
+Clause 4 is the load-bearing addition. `.orbit/` holds tasks, frictions, auto-tasks, and routines: content the engine driving the pipeline rewrites as a matter of course, and content that is never a run's code candidate. A primary mutation anywhere else — source, manifests, CI config — remains `primary_checkout_drift` regardless of disjointness, preserving ORB-10134 escape detection intact.
 
 Acceptance is logged at `info` on `orbit.engine.cli_runner` with the ignored paths, matching the fast-forward case. The guard never cleans or reconciles the dirt it ignores.
 

--- a/docs/runbooks/CONVENTIONS.md
+++ b/docs/runbooks/CONVENTIONS.md
@@ -5,7 +5,7 @@ tags: [docs, operations, runbooks]
 paths: ["docs/runbooks/**"]
 related_features: [orbit-docs]
 related_artifacts: []
-last_validated: 2026-08-22
+last_validated: 2026-09-12
 ---
 
 # Runbook Conventions
@@ -52,7 +52,7 @@ related_artifacts: ["<task-id>"]
 ```
 
 Use `paths` only for source areas to which the procedure genuinely applies. Use
-`related_artifacts` for the tasks, ADRs, learnings, or frictions that establish the behavior;
+`related_artifacts` for the tasks, retained ADR references, or frictions that establish the behavior;
 do not invent IDs for documentation-only edits.
 
 ## 3. Recommended structure

--- a/docs/runbooks/audit-trail.md
+++ b/docs/runbooks/audit-trail.md
@@ -5,7 +5,7 @@ tags: [operations, audit, observability, debugging]
 paths: ["crates/orbit-core/src/runtime/run_audit.rs", "crates/orbit-types/src/telemetry/audit_event.rs"]
 related_features: [auditability, activity-job]
 related_artifacts: [ORB-10014, ORB-10227, ORB-10228]
-last_validated: 2026-08-22
+last_validated: 2026-09-12
 ---
 
 # Inspect the Audit Trail

--- a/docs/runbooks/database-recovery.md
+++ b/docs/runbooks/database-recovery.md
@@ -5,7 +5,7 @@ tags: [operations, sqlite, corruption, recovery]
 paths: ["crates/orbit-store/**", "crates/orbit-cmd/src/doctor.rs"]
 related_features: [orbit-core]
 related_artifacts: [ORB-10014, ORB-10473]
-last_validated: 2026-08-22
+last_validated: 2026-09-12
 ---
 
 # Recover a Corrupted Database


### PR DESCRIPTION
## Task

[ORB-12342](https://orbit-cli.com/tasks/ORB-12342) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Completed the exact six-document batch selected from the HEAD corpus by missing-then-oldest last_validated, with stable path tie-break:
1. docs/design/mcp-session-context/4_decisions.md (2026-08-22)
2. docs/design/worktree-artifacts/3_vision.md (2026-08-22)
3. docs/design/worktree-artifacts/4_decisions.md (2026-08-22)
4. docs/runbooks/CONVENTIONS.md (2026-08-22)
5. docs/runbooks/audit-trail.md (2026-08-22)
6. docs/runbooks/database-recovery.md (2026-08-22)
The selection command enumerated all eligible Markdown files from HEAD, excluded docs/design/_archive/** and docs/changelogs/**, and reported frontmatter-less: 0. No selected document was skipped.

Changes and verification evidence:
- docs/design/mcp-session-context/4_decisions.md: stamped 2026-09-12; corrected stale paths to crates/orbit-types/src/tool/definition.rs, crates/orbit-core/src/adapter/tool_host/**, and crates/orbit-core/src/runtime/**; replaced the obsolete deferred-authorization wording with the current OrbitRuntime::authorize_tool_operation, MCP capability, remote-agent grant, and federated catalog-role behavior. Verified with test -e, sed, and rg against crates/orbit-types/src/tool/definition.rs, crates/orbit-mcp/src/adapter/dispatch.rs, crates/orbit-cli/src/command/mcp/server.rs, and crates/orbit-core/src/runtime/authorization.rs.
- docs/design/worktree-artifacts/3_vision.md: stamped 2026-09-12 with no prose change. Verified its current-feature framing and relative links with test -e; retired task/ADR/learning references were retained as historical provenance, not treated as current implementation claims.
- docs/design/worktree-artifacts/4_decisions.md: stamped 2026-09-12; corrected the current stationary-primary description from retired ADR/learning records to the current tasks, frictions, auto-tasks, and routines record store. Verified the helper and current record-store comment in crates/orbit-engine/src/activity_job/workspace.rs, the named tests, and the delivery-summary implementation under crates/orbit-engine/src/executor/automation/vcs/commit/**. Historical sections were left intact.
- docs/runbooks/CONVENTIONS.md: stamped 2026-09-12; removed the obsolete native-learning reference from related_artifacts guidance, retaining tasks, retained ADR references, and frictions. Verified the linked schema/design paths and generated index contract with scripts/generate-doc-indexes.sh --check.
- docs/runbooks/audit-trail.md: stamped 2026-09-12 with no prose change. Verified the SQLite audit tables/fields in crates/orbit-store/src/driver/sqlite/audit_event_store/** and the documented audit subcommands/flags with orbit audit list/show/stats/export/prune --help.
- docs/runbooks/database-recovery.md: stamped 2026-09-12 with no prose change. Verified the doctor, graph-removal, task-reindex, and semantic-index CLI surfaces with orbit doctor --help, orbit task reindex --help, and orbit semantic index --help, plus the referenced store paths.

Frontmatter migration: none; every selected document already had schema-compatible frontmatter. No new metadata field, sidecar, document, or section was created. No selected document had uncertain classification. Destructive recovery actions were not executed; their documented commands were checked against the read-only CLI/source surfaces and the text was left unchanged. Historical provenance was not rewritten.

Criteria mapping:
- Exact bounded batch and ordering: passed.
- Every stamped document verified and evidence named above: passed.
- Unverifiable selected documents/claims: none identified that affected the current documented behavior; historical provenance and destructive recovery examples were left unchanged and called out above.
- Forbidden/generated paths: passed; git diff names only the six selected docs.
- Frontmatter-less ordering/inference and migration: passed; corpus reported zero frontmatter-less docs, so no migration was needed.
- No new marker system, docs, sections, or prose reflow: passed.
- make ci-fast: passed (exit 0). Its nested compiler-cache namespace check reported an environment skip because unprivileged bubblewrap namespaces are unavailable; all remaining guardrails passed.
Validation commands:
- scripts/generate-doc-indexes.sh --check: passed.
- CLI help checks for audit list/show/stats/export/prune, task reindex, doctor, and semantic index: passed.
- source/path/link verification rg and test -e checks: passed.
- git diff --check: passed.
- GIT_OPTIONAL_LOCKS=0 git status --short: passed; only the six intended documentation files are modified.
- make ci-fast: passed.
The worktree remains intentionally uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12342-6aa59a41`
- Behind base: 0
- Ahead of base: 1