### PR TITLE
workspace teardown: require an explicit <workspace_id> argument instead of resolving the target from cwd

### DIFF
--- a/crates/orbit-cli/src/command/workspace/command.rs
+++ b/crates/orbit-cli/src/command/workspace/command.rs
@@ -38,7 +38,7 @@ pub enum WorkspaceSubcommand {
     Publication(WorkspacePublicationCommand),
     /// Remove a workspace from the registry (does not delete .orbit)
     Remove(WorkspaceRemoveArgs),
-    /// Remove all Orbit artifacts from this workspace
+    /// Remove all Orbit artifacts from a named workspace
     Teardown(WorkspaceTeardownArgs),
 }
 

--- a/crates/orbit-cli/src/command/workspace/teardown.rs
+++ b/crates/orbit-cli/src/command/workspace/teardown.rs
@@ -1,7 +1,10 @@
+use std::path::{Path, PathBuf};
+
 use clap::Args;
-use orbit_cmd::remove_checkout_task_stores;
+use orbit_cmd::{bound_partition_id, remove_checkout_task_stores, task_store_partition_path};
 use orbit_core::{OrbitError, OrbitRuntime};
 use orbit_registry::workspace_registry;
+use orbit_types::workspace::{Workspace, WorkspaceCheckout, WorkspaceRegistry};
 
 use crate::command::{CommandOut, CommandOutput, Execute};
 
@@ -9,6 +12,10 @@ use super::support::{is_dir_empty, remove_symlinks_in};
 
 #[derive(Args)]
 pub struct WorkspaceTeardownArgs {
+    /// Registered workspace name, logical id (`ws_*`), or absolute checkout path
+    #[arg(value_name = "WORKSPACE", id = "workspace_selector")]
+    pub workspace: String,
+
     /// Required flag to confirm destructive operation
     #[arg(long)]
     pub confirm: bool,
@@ -16,27 +23,26 @@ pub struct WorkspaceTeardownArgs {
 
 impl Execute for WorkspaceTeardownArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
-        if !self.confirm {
-            return Err(OrbitError::InvalidInput(
-                "teardown is destructive. Pass --confirm to proceed.".to_string(),
-            ));
-        }
+        let global_root = runtime.global_root();
+        let registry_path = workspace_registry::registry_path_for(&global_root);
+        let registry = workspace_registry::load_registry_from(&registry_path)?;
+        let (workspace, checkout) = resolve_teardown_target(&registry, &self.workspace)?;
+        refuse_if_cwd_belongs_to_another_checkout(&registry, &checkout)?;
 
-        let orbit_dir = runtime.data_root();
-        let global_dir = runtime.global_root();
+        let orbit_dir = checkout.orbit_dir.clone();
+        let repo_root = checkout.repo_root.clone();
+        let workspace_id = workspace.id.clone();
+        let workspace_name = workspace.name.clone();
 
-        // Safety: never delete the global ~/.orbit/ directory
         let orbit_canonical =
             std::fs::canonicalize(&orbit_dir).unwrap_or_else(|_| orbit_dir.clone());
         let global_canonical =
-            std::fs::canonicalize(&global_dir).unwrap_or_else(|_| global_dir.clone());
+            std::fs::canonicalize(&global_root).unwrap_or_else(|_| global_root.clone());
         if orbit_canonical == global_canonical {
             return Err(OrbitError::InvalidInput(
                 "refusing to teardown the global ~/.orbit/ directory".to_string(),
             ));
         }
-
-        // Safety: orbit_dir must end with ".orbit"
         if orbit_dir.file_name().and_then(|n| n.to_str()) != Some(".orbit") {
             return Err(OrbitError::InvalidInput(format!(
                 "data root '{}' does not end with .orbit — aborting teardown",
@@ -44,31 +50,31 @@ impl Execute for WorkspaceTeardownArgs {
             )));
         }
 
-        let repo_root = orbit_dir
-            .parent()
-            .ok_or_else(|| OrbitError::InvalidInput("cannot determine repo root".to_string()))?;
+        let partitions =
+            planned_task_store_partitions(&global_root, &orbit_dir, Some(workspace_id.as_str()))?;
+        let plan = format_teardown_plan(&workspace, &checkout, &partitions);
+        if !self.confirm {
+            return Err(OrbitError::InvalidInput(format!(
+                "teardown is destructive. Resolved target:\n{plan}\nPass --confirm to proceed."
+            )));
+        }
+
+        println!("teardown plan:\n{plan}");
 
         let mut removed: Vec<String> = Vec::new();
 
         // 1. Deregister from workspace registry (before deleting .orbit/)
-        let global_root = runtime.global_root();
-        let registry_path = workspace_registry::registry_path_for(&global_root);
         let mut catalog_workspace_id = None;
         if registry_path.exists() {
             let mut registry = workspace_registry::load_registry_from(&registry_path)?;
-            let checkout = registry.checkouts.iter().find(|checkout| {
-                let ws_canonical = std::fs::canonicalize(&checkout.orbit_dir)
-                    .unwrap_or_else(|_| checkout.orbit_dir.clone());
-                ws_canonical == orbit_canonical
-            });
-            if let Some(ws_id) = checkout.map(|checkout| checkout.workspace_id.clone()) {
-                let ws = workspace_registry::remove_workspace(&mut registry, &ws_id)?;
+            if workspace_registry::find_workspace_by_id(&registry, &workspace_id).is_some() {
+                let ws = workspace_registry::remove_workspace(&mut registry, &workspace_id)?;
                 workspace_registry::save_registry_to(&registry, &registry_path)?;
                 removed.push(format!(
                     "deregistered workspace '{}' from registry",
                     ws.name
                 ));
-                catalog_workspace_id = Some(ws_id);
+                catalog_workspace_id = Some(workspace_id.clone());
             }
         }
 
@@ -79,7 +85,7 @@ impl Execute for WorkspaceTeardownArgs {
         for partition in
             remove_checkout_task_stores(&global_root, &orbit_dir, catalog_workspace_id.as_deref())?
         {
-            removed.push(format!("deleted task store {}", partition.display()));
+            removed.push(format_deleted_partition(&partition, &workspace_name));
         }
 
         // 3. Remove legacy repo-local skill symlinks from .agents/skills/ and .claude/skills/
@@ -89,11 +95,9 @@ impl Execute for WorkspaceTeardownArgs {
                 remove_symlinks_in(&skills_dir)?;
                 removed.push(format!("removed symlinks from {}/skills/", dir_name));
 
-                // Remove skills dir if empty
                 if is_dir_empty(&skills_dir) {
                     std::fs::remove_dir(&skills_dir).map_err(|e| OrbitError::Io(e.to_string()))?;
                 }
-                // Remove parent dir if empty
                 let parent = repo_root.join(dir_name);
                 if parent.is_dir() && is_dir_empty(&parent) {
                     std::fs::remove_dir(&parent).map_err(|e| OrbitError::Io(e.to_string()))?;
@@ -108,7 +112,6 @@ impl Execute for WorkspaceTeardownArgs {
             removed.push(format!("deleted {}", orbit_dir.display()));
         }
 
-        // 5. Print summary
         println!("teardown complete:");
         for item in &removed {
             println!("  - {item}");
@@ -119,4 +122,132 @@ impl Execute for WorkspaceTeardownArgs {
 
         Ok(CommandOutput::Silent)
     }
+}
+
+fn resolve_teardown_target(
+    registry: &WorkspaceRegistry,
+    selector: &str,
+) -> Result<(Workspace, WorkspaceCheckout), OrbitError> {
+    let workspace_id = workspace_id_for_selector(registry, selector)?
+        .ok_or_else(|| unknown_teardown_selector(selector))?;
+    let workspace = workspace_registry::find_workspace_by_id(registry, &workspace_id)
+        .cloned()
+        .ok_or_else(|| unknown_teardown_selector(selector))?;
+    let checkout = workspace_registry::find_checkout_by_id(registry, &workspace.id)
+        .cloned()
+        .ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "workspace '{}' ({}) has no registered checkout on this machine",
+                workspace.name, workspace.id
+            ))
+        })?;
+    Ok((workspace, checkout))
+}
+
+fn unknown_teardown_selector(selector: &str) -> OrbitError {
+    OrbitError::InvalidInput(format!(
+        "unknown workspace selector '{selector}'; pass a registered workspace name, a logical workspace ID, or an absolute local checkout path"
+    ))
+}
+
+fn workspace_id_for_selector(
+    registry: &WorkspaceRegistry,
+    selector: &str,
+) -> Result<Option<String>, OrbitError> {
+    if let Some(workspace) = workspace_registry::find_workspace(registry, selector)? {
+        return Ok(Some(workspace.id.clone()));
+    }
+
+    if Path::new(selector).is_absolute() {
+        return Ok(
+            workspace_registry::find_checkout_by_path(registry, Path::new(selector))
+                .map(|checkout| checkout.workspace_id.clone()),
+        );
+    }
+
+    Ok(None)
+}
+
+fn refuse_if_cwd_belongs_to_another_checkout(
+    registry: &WorkspaceRegistry,
+    selected: &WorkspaceCheckout,
+) -> Result<(), OrbitError> {
+    let cwd = std::env::current_dir().map_err(|e| OrbitError::Io(e.to_string()))?;
+    let Some(cwd_checkout) = workspace_registry::find_checkout_by_path(registry, &cwd) else {
+        return Ok(());
+    };
+    if cwd_checkout.workspace_id == selected.workspace_id {
+        return Ok(());
+    }
+
+    let cwd_name = workspace_registry::find_workspace_by_id(registry, &cwd_checkout.workspace_id)
+        .map(|workspace| workspace.name.as_str())
+        .unwrap_or(cwd_checkout.workspace_id.as_str());
+    Err(OrbitError::InvalidInput(format!(
+        "workspace selector does not match the checkout containing the current directory ('{cwd_name}'); cd into the target checkout or pass that workspace's name, id, or absolute path"
+    )))
+}
+
+fn planned_task_store_partitions(
+    global_root: &Path,
+    orbit_dir: &Path,
+    catalog_workspace_id: Option<&str>,
+) -> Result<Vec<PathBuf>, OrbitError> {
+    let mut paths = Vec::new();
+    if let Some(bound) = bound_partition_id(global_root, orbit_dir)? {
+        let path = task_store_partition_path(global_root, &bound);
+        if path.is_dir() {
+            paths.push(path);
+        }
+    }
+    if let Some(catalog_id) = catalog_workspace_id {
+        let path = task_store_partition_path(global_root, catalog_id);
+        if path.is_dir() && !paths.iter().any(|existing| existing == &path) {
+            paths.push(path);
+        }
+    }
+    Ok(paths)
+}
+
+pub(super) fn format_teardown_plan(
+    workspace: &Workspace,
+    checkout: &WorkspaceCheckout,
+    partitions: &[PathBuf],
+) -> String {
+    let mut lines = vec![
+        format!("workspace: {} ({})", workspace.name, workspace.id),
+        format!("checkout: {}", checkout.repo_root.display()),
+    ];
+    if partitions.is_empty() {
+        lines.push("task-store partition: (none)".to_string());
+    } else {
+        for path in partitions {
+            let bundles = partition_bundle_count(path);
+            lines.push(format!(
+                "task-store partition: {} ({bundles} bundle{})",
+                path.display(),
+                if bundles == 1 { "" } else { "s" }
+            ));
+        }
+    }
+    lines.join("\n")
+}
+
+pub(super) fn format_deleted_partition(path: &Path, workspace_name: &str) -> String {
+    let id = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("?");
+    format!("deleted task store partition {id} (workspace '{workspace_name}')")
+}
+
+fn partition_bundle_count(path: &Path) -> usize {
+    std::fs::read_dir(path)
+        .map(|entries| {
+            entries
+                .flatten()
+                .filter(|entry| entry.path().is_dir())
+                .count()
+        })
+        .unwrap_or(0)
 }

--- a/crates/orbit-cli/src/command/workspace/tests/teardown.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/teardown.rs
@@ -5,19 +5,25 @@
 //! [ORB-12119] The partition to delete is the one the *task registry* binds to
 //! the checkout, not the one named for its workspace-catalog id, and its
 //! registry bindings must be retired with it.
+//!
+//! [ORB-12347] The target is an explicit selector, never cwd inference.
 
 use std::path::Path;
 
 use chrono::Utc;
+use clap::{Parser, error::ErrorKind};
 use orbit_cmd::DoctorCommands;
 use orbit_cmd::task_store::{bound_partition_id, partition_is_bound, task_workspaces_dir};
 use orbit_core::{OrbitError, OrbitRuntime};
 use orbit_registry::workspace_registry;
 use orbit_types::workspace::{Workspace, WorkspaceCheckout, WorkspaceStatus};
 
-use crate::command::Execute;
+use crate::command::{Cli, Execute};
+use crate::tests::env_isolation::EnvGuard;
 
-use super::super::teardown::WorkspaceTeardownArgs;
+use super::super::teardown::{
+    WorkspaceTeardownArgs, format_deleted_partition, format_teardown_plan,
+};
 
 fn write_task_bundle(global_root: &Path, workspace_id: &str, task_id: &str) {
     let bundle = task_workspaces_dir(global_root)
@@ -27,7 +33,13 @@ fn write_task_bundle(global_root: &Path, workspace_id: &str, task_id: &str) {
     std::fs::write(bundle.join("task.yaml"), b"id: dummy\n").expect("write bundle file");
 }
 
-fn register(global_root: &Path, workspace_id: &str, repo_root: &Path, orbit_dir: &Path) {
+fn register(
+    global_root: &Path,
+    workspace_id: &str,
+    name: &str,
+    repo_root: &Path,
+    orbit_dir: &Path,
+) {
     let registry_path = workspace_registry::registry_path_for(global_root);
     let mut registry =
         workspace_registry::load_registry_from(&registry_path).expect("load registry");
@@ -36,7 +48,7 @@ fn register(global_root: &Path, workspace_id: &str, repo_root: &Path, orbit_dir:
         &mut registry,
         Workspace {
             id: workspace_id.to_string(),
-            name: workspace_id.to_string(),
+            name: name.to_string(),
             owner_machine_id: None,
             git_remote: None,
             ship_mode: None,
@@ -59,6 +71,203 @@ fn register(global_root: &Path, workspace_id: &str, repo_root: &Path, orbit_dir:
     workspace_registry::save_registry_to(&registry, &registry_path).expect("save registry");
 }
 
+fn teardown(workspace: &str, confirm: bool) -> WorkspaceTeardownArgs {
+    WorkspaceTeardownArgs {
+        workspace: workspace.to_string(),
+        confirm,
+    }
+}
+
+#[test]
+fn teardown_without_a_workspace_selector_is_usage_not_cwd_inference() {
+    for args in [
+        &["orbit", "workspace", "teardown"] as &[&str],
+        &["orbit", "workspace", "teardown", "--confirm"],
+    ] {
+        let error = match Cli::try_parse_from(args.iter().copied()) {
+            Ok(_) => panic!("{args:?} must not parse without a workspace selector"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument, "{error}");
+        let message = error.to_string();
+        assert!(
+            message.contains("Usage:"),
+            "missing selector must print usage, got: {message}"
+        );
+        assert!(
+            message.contains("<WORKSPACE>"),
+            "usage must name the required selector, got: {message}"
+        );
+    }
+}
+
+#[test]
+fn teardown_rejects_a_selector_that_is_not_registered() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let repo_root = temp.path().join("repo");
+    let orbit_dir = repo_root.join(".orbit");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::create_dir_all(&orbit_dir).expect("create workspace root");
+    register(&global_root, "ws_known", "known", &repo_root, &orbit_dir);
+
+    let runtime = OrbitRuntime::from_roots(&global_root, &orbit_dir).expect("build runtime");
+    let error = teardown("not-registered", true)
+        .execute(&runtime)
+        .expect_err("unregistered selector must fail");
+    let message = error.to_string();
+    assert!(
+        matches!(error, OrbitError::InvalidInput(_)),
+        "unregistered selector must be invalid input: {error:?}"
+    );
+    assert!(
+        message.contains("unknown workspace selector 'not-registered'"),
+        "{message}"
+    );
+    assert!(
+        workspace_registry::find_workspace_by_id(
+            &workspace_registry::load_registry_from(&workspace_registry::registry_path_for(
+                &global_root,
+            ))
+            .expect("load registry"),
+            "ws_known",
+        )
+        .is_some(),
+        "a rejected selector must not deregister another workspace"
+    );
+}
+
+#[test]
+fn teardown_rejects_a_selector_that_does_not_match_the_cwd_checkout() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let here = temp.path().join("here");
+    let here_orbit = here.join(".orbit");
+    let other = temp.path().join("other");
+    let other_orbit = other.join(".orbit");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::create_dir_all(&here_orbit).expect("create here workspace root");
+    std::fs::create_dir_all(&other_orbit).expect("create other workspace root");
+    register(&global_root, "ws_here", "here", &here, &here_orbit);
+    register(&global_root, "ws_other", "other", &other, &other_orbit);
+    write_task_bundle(&global_root, "ws_here", "ORB-1");
+    write_task_bundle(&global_root, "ws_other", "ORB-2");
+
+    let _env = EnvGuard::acquire().cwd(&here);
+    let runtime = OrbitRuntime::from_roots(&global_root, &here_orbit).expect("build runtime");
+    let error = teardown("other", true)
+        .execute(&runtime)
+        .expect_err("selector for a different checkout must fail");
+    let message = error.to_string();
+    assert!(
+        matches!(error, OrbitError::InvalidInput(_)),
+        "cwd mismatch must be invalid input: {error:?}"
+    );
+    assert!(
+        message.contains("does not match the checkout containing the current directory ('here')"),
+        "{message}"
+    );
+    assert!(
+        here_orbit.is_dir() && other_orbit.is_dir(),
+        "a mismatched selector must not delete either checkout"
+    );
+    assert!(
+        task_workspaces_dir(&global_root).join("ws_here").exists()
+            && task_workspaces_dir(&global_root).join("ws_other").exists(),
+        "a mismatched selector must not delete either task store"
+    );
+}
+
+#[test]
+fn teardown_without_confirm_prints_the_resolved_plan_and_does_not_delete() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let repo_root = temp.path().join("constellation");
+    let orbit_dir = repo_root.join(".orbit");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::create_dir_all(&orbit_dir).expect("create workspace root");
+    register(
+        &global_root,
+        "ws_orbit",
+        "constellation",
+        &repo_root,
+        &orbit_dir,
+    );
+    write_task_bundle(&global_root, "ws_orbit", "ORB-1");
+
+    let runtime = OrbitRuntime::from_roots(&global_root, &orbit_dir).expect("build runtime");
+    let bound = bound_partition_id(&global_root, &orbit_dir)
+        .expect("read checkout binding")
+        .expect("checkout is bound");
+    write_task_bundle(&global_root, &bound, "ORB-2");
+    let partition = task_workspaces_dir(&global_root).join(&bound);
+
+    let error = teardown("constellation", false)
+        .execute(&runtime)
+        .expect_err("unconfirmed teardown must refuse");
+    let message = error.to_string();
+    assert!(
+        message.contains("workspace: constellation (ws_orbit)"),
+        "plan must name catalog workspace and id: {message}"
+    );
+    assert!(
+        message.contains(&format!("checkout: {}", repo_root.display())),
+        "plan must name checkout root: {message}"
+    );
+    assert!(
+        message.contains(&format!("task-store partition: {}", partition.display())),
+        "plan must name the task-store partition path: {message}"
+    );
+    assert!(
+        partition.exists() && orbit_dir.is_dir(),
+        "unconfirmed teardown must not delete"
+    );
+}
+
+#[test]
+fn partition_summary_names_the_workspace_it_belonged_to() {
+    let path = Path::new("/tmp/tasks/workspaces/ws_orbit");
+    assert_eq!(
+        format_deleted_partition(path, "constellation"),
+        "deleted task store partition ws_orbit (workspace 'constellation')"
+    );
+}
+
+#[test]
+fn teardown_plan_names_workspace_checkout_and_partition() {
+    let now = Utc::now();
+    let workspace = Workspace {
+        id: "ws_orbit".to_string(),
+        name: "constellation".to_string(),
+        owner_machine_id: None,
+        git_remote: None,
+        ship_mode: None,
+        base_branch: "main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: now,
+        updated_at: now,
+    };
+    let checkout = WorkspaceCheckout::owner(
+        "ws_orbit".to_string(),
+        "/repos/constellation".into(),
+        "/repos/constellation/.orbit".into(),
+    );
+    let plan = format_teardown_plan(
+        &workspace,
+        &checkout,
+        &[Path::new("/tmp/tasks/workspaces/ws_orbit").to_path_buf()],
+    );
+    assert!(
+        plan.contains("workspace: constellation (ws_orbit)"),
+        "{plan}"
+    );
+    assert!(plan.contains("checkout: /repos/constellation"), "{plan}");
+    assert!(
+        plan.contains("task-store partition: /tmp/tasks/workspaces/ws_orbit"),
+        "{plan}"
+    );
+}
+
 #[test]
 fn teardown_deletes_the_bound_task_store_partition_and_retires_its_bindings() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -77,12 +286,19 @@ fn teardown_deletes_the_bound_task_store_partition_and_retires_its_bindings() {
     register(
         &global_root,
         "ws_survivor",
+        "ws_survivor",
         &survivor_root,
         &survivor_orbit_dir,
     );
     write_task_bundle(&global_root, "ws_survivor", "ORB-1");
 
-    register(&global_root, "ws_teardown", &repo_root, &orbit_dir);
+    register(
+        &global_root,
+        "ws_teardown",
+        "ws_teardown",
+        &repo_root,
+        &orbit_dir,
+    );
     let runtime = OrbitRuntime::from_roots(&global_root, &orbit_dir).expect("build runtime");
 
     // Opening the runtime bound this checkout in the task registry. That
@@ -106,7 +322,7 @@ fn teardown_deletes_the_bound_task_store_partition_and_retires_its_bindings() {
         "fixture task store must exist before teardown"
     );
 
-    WorkspaceTeardownArgs { confirm: true }
+    teardown("ws_teardown", true)
         .execute(&runtime)
         .expect("teardown");
 
@@ -167,11 +383,17 @@ fn teardown_without_confirm_leaves_the_task_store_and_registration_untouched() {
     let orbit_dir = repo_root.join(".orbit");
     std::fs::create_dir_all(&global_root).expect("create global root");
     std::fs::create_dir_all(&orbit_dir).expect("create workspace root");
-    register(&global_root, "ws_unconfirmed", &repo_root, &orbit_dir);
+    register(
+        &global_root,
+        "ws_unconfirmed",
+        "ws_unconfirmed",
+        &repo_root,
+        &orbit_dir,
+    );
     write_task_bundle(&global_root, "ws_unconfirmed", "ORB-1");
 
     let runtime = OrbitRuntime::from_roots(&global_root, &orbit_dir).expect("build runtime");
-    let result = WorkspaceTeardownArgs { confirm: false }.execute(&runtime);
+    let result = teardown("ws_unconfirmed", false).execute(&runtime);
     assert!(matches!(result, Err(OrbitError::InvalidInput(_))));
 
     assert!(

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -100,9 +100,12 @@ individual flag; neither command upgrades the binary or pulls a remote repositor
 
 ### Reclaim orphaned task stores
 
-`orbit workspace teardown --confirm` deregisters the workspace and deletes both the checkout's
-`.orbit/` and the global task-store partition its task state is bound to, retiring that
-partition's rows in `~/.orbit/tasks/index.sqlite` in the same step.
+`orbit workspace teardown <workspace> --confirm` requires an explicit registered name,
+`ws_*` id, or absolute checkout path — it never infers the target from cwd. It prints the
+resolved catalog name and id, checkout root, and task-store partition path, then deregisters
+the workspace and deletes both the checkout's `.orbit/` and the global task-store partition
+its task state is bound to, retiring that partition's rows in `~/.orbit/tasks/index.sqlite`
+in the same step. The summary names the catalog workspace the deleted partition belonged to.
 
 A partition directory is named for a **task-store partition id**
 (`workspace_bindings.workspace_id` in `~/.orbit/tasks/index.sqlite`), minted as `<slug>-<hash>`


### PR DESCRIPTION
## Task

[ORB-12347](https://orbit-cli.com/tasks/ORB-12347) — workspace teardown: require an explicit <workspace_id> argument instead of resolving the target from cwd

### Description

## What happened
`orbit workspace teardown --confirm` run from `codebases/parallax` (a checkout whose own `.orbit/` is not registered) walked up to the umbrella root and tore down the **constellation** workspace instead: deregistered it from the catalog, deleted its task-store partition (`~/.orbit/tasks/workspaces/ws_orbit`, 12 task bundles: ORB-11353 11368 11396 11422 11423 11424 11425 11428 11433 11466 11510 12027), and removed `constellation/.orbit/`. There is no undo path; the bundles are gone (git-tracked `.orbit/resources`+`routines`+`adrs`+`config.toml` were restored with `git checkout`, the bundles were not).

## Why the current UX is unsafe
1. The target is implicit: it is whatever `.orbit/` the runtime resolves for cwd (ancestor walk). `--confirm` confirms *the operation*, not *the target*, and the command never echoes the resolved workspace name before acting.
2. The summary names the task-store partition id (`ws_orbit`, from `.orbit/config.yaml` `workspace_id`) which lives in a different id namespace from the catalog id, so it read as if the *orbit* workspace had been destroyed. The catalog name was correct; the partition id was misleading.

## Proposed change
- `orbit workspace teardown <workspace_id|name>` takes a required positional selector (same `--workspace` selector semantics: registered name, `ws_*` id, or absolute checkout path). Refuse when omitted; no cwd inference for a destructive op.
- Fail if the selector does not resolve to a registered checkout, or resolves to a checkout that does not contain cwd when cwd is inside some other `.orbit` checkout (defensive cross-check).
- Before deleting, print the resolved plan (catalog name + id, checkout root, task-store partition path, bundle count) and require `--confirm`; `--confirm` should ideally carry the name (`--confirm <name>`), like `gh repo delete`.
- In the summary, label the partition line as the task-store partition of the named workspace (e.g. `deleted task store partition ws_orbit (workspace 'constellation')`).
- Consider moving the partition to `~/.orbit/quarantine/` instead of `remove_dir_all` so a teardown is recoverable for a while.

Code: `crates/orbit-cli/src/command/workspace/teardown.rs`, `crates/orbit-cmd/src/task_store.rs::remove_checkout_task_stores`.

### Acceptance Criteria

- teardown without a workspace selector exits non-zero with usage, never inferring the target from cwd
- teardown prints the resolved workspace name/id, checkout root and task-store partition path before deleting anything
- summary line for the partition names the workspace it belonged to
- unit tests cover: missing selector, selector not registered, selector mismatching cwd checkout

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- `orbit workspace teardown` now requires a positional `<WORKSPACE>` selector (registered name, `ws_*` id, or absolute checkout path). Omitting it is a clap usage error; the command no longer infers the target from cwd or `runtime.data_root()`.
- Selector resolution is fail-closed: unknown/unregistered selectors error; a selector for a different registered checkout than the one containing cwd is refused.
- After resolution and before any mutation, teardown prints catalog name+id, checkout root, and task-store partition path (with bundle count). `--confirm` is still required; without it the same plan is in the error and nothing is deleted.
- Partition summary lines now read `deleted task store partition <id> (workspace '<name>')`.
- Help text and the health-checks runbook use the explicit-selector form.

Assessment: Acceptance criteria are covered by unit tests at the CLI parse and execute boundaries. Existing bound-partition deletion and unconfirmed-no-op tests still pass.

Criteria:
1. teardown without a workspace selector exits non-zero with usage, never inferring the target from cwd — pass (`teardown_without_a_workspace_selector_is_usage_not_cwd_inference`; clap MissingRequiredArgument + Usage/`<WORKSPACE>` for both bare and `--confirm` forms).
2. teardown prints the resolved workspace name/id, checkout root and task-store partition path before deleting anything — pass (`teardown_without_confirm_prints_the_resolved_plan_and_does_not_delete`; confirmed path prints the same plan then mutates).
3. summary line for the partition names the workspace it belonged to — pass (`partition_summary_names_the_workspace_it_belonged_to` plus live confirmed teardown output).
4. unit tests cover missing selector, selector not registered, selector mismatching cwd checkout — pass (three dedicated tests).

Validation:
- `cargo test -p orbit-cli --bin orbit -- workspace::tests::teardown` — passed (8 tests)
- `make ci-fast` — passed
- `make ci-lint` — passed
- `make goldens` — passed
- `git diff --check` — passed

Strategic decisions: `--confirm <name>` and quarantine-instead-of-delete were proposed but not in acceptance criteria; left out.

Deviations from original plan: none material. `crates/orbit-cmd/src/task_store.rs::remove_checkout_task_stores` is unchanged; targeting still uses that function after the CLI resolves an explicit checkout.

Remaining risks: cwd cross-check uses the workspace catalog's longest-prefix checkout match, so a nested unregistered `.orbit` under a registered parent can still name that parent if the operator explicitly selects it. That is the remaining operator-confirmation path, not silent cwd inference.

Friction: none filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12347-6aa5ab25`
- Behind base: 0
- Ahead of base: 1