### PR TITLE
[friction-curation] Make test-build-budget hermetic when nested under build-budget.py

### DIFF
--- a/scripts/test-build-budget.sh
+++ b/scripts/test-build-budget.sh
@@ -8,6 +8,14 @@ TMP="$(mktemp -d)"
 BACKGROUND_PIDS=()
 TEST_COMPLETE=0
 
+# Clear any build-budget environment inherited from an outer wrapper (e.g. `make ci`).
+# Fixtures manage their own slots, lock directory, and admission hermetically [ORB-12350].
+unset ORBIT_BUILD_BUDGET ORBIT_BUILD_BUDGET_DIR ORBIT_BUILD_BUDGET_HELD \
+  ORBIT_BUILD_BUDGET_SLOT ORBIT_BUILD_SLOTS ORBIT_CARGO_JOBS CARGO_BUILD_JOBS
+for var in $(compgen -v ORBIT_BUILD_ 2>/dev/null || true); do
+  unset "$var"
+done
+
 cleanup() {
   local status=$?
   local pid


### PR DESCRIPTION
## Task

[ORB-12350](https://orbit-cli.com/tasks/ORB-12350) — [friction-curation] Make test-build-budget hermetic when nested under build-budget.py

### Description

## Problem
`scripts/test-build-budget.sh` asserts that four overlapping helpers with `ORBIT_BUILD_SLOTS=2` reach **exactly** two concurrent slots (`scripts/test-build-budget.sh:140`). Standalone that check passes. When the same script runs *inside* `scripts/build-budget.py` — which is how `make ci` invokes it (`Makefile:152-153` wraps `./scripts/ci-guardrails.sh`, and `scripts/ci-guardrails.sh:75` always runs `test-build-budget.sh`) — the inherited outer `ORBIT_BUILD_*` environment makes the inner fixtures share the outer wrapper's slot, so observed max concurrency is not 2.

Reproduced on HEAD `1ca6416e0` (2026-09-12, worktree `orbit-jrun-20260912-1955-c2`):

```
$ ./scripts/test-build-budget.sh
test-build-budget: ok
$ ./scripts/build-budget.py -- ./scripts/test-build-budget.sh
test-build-budget: FAIL: cross-worktree concurrency was not exactly two
```

`make ci-fast` stays green because it calls `ci-guardrails.sh --fast` without the outer wrapper (`Makefile:156-157`). Agents told to make `make ci` green therefore burn a full workspace run on this self-test rather than on their change. F2026-09-140.

## Why It Matters
The check is not about the change under test: it fails on an unmodified `scripts/` tree whenever it is reached through `make ci`. That turns the canonical merge-gate into a 17-minute false red and a bisect of an unrelated self-test.

## Constraints / Notes
- Smallest fix: have `test-build-budget.sh` clear inherited `ORBIT_BUILD_*` (it already supplies its own `ORBIT_BUILD_BUDGET_DIR` / `ORBIT_BUILD_SLOTS`) before spawning fixtures. Alternatively run this one self-test outside the outer budget wrapper.
- Do not disable the check, skip it under `make ci`, or weaken slot enforcement so a missing budget still passes.
- If the assertion is relaxed from "exactly two" to "at most two and more than one", still prove that two slots are actually used.
- No fail-closed product guard is being widened.

### Acceptance Criteria

- `./scripts/build-budget.py -- ./scripts/test-build-budget.sh` exits 0 on a quiet machine (the nested path `make ci` actually runs).
- `./scripts/test-build-budget.sh` still exits 0 standalone (the `make ci-fast` path).
- Cross-worktree slot enforcement remains proven: with `ORBIT_BUILD_SLOTS=2`, observed max concurrency is 2, or at most 2 and more than 1 if the assertion is intentionally relaxed.
- The self-test still sets its own `ORBIT_BUILD_BUDGET_DIR` and `ORBIT_BUILD_SLOTS` and does not inherit the outer wrapper's slot or lock directory.
- `make ci-fast` still invokes `ci-guardrails.sh --fast` without skipping this check.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Outcome
Updated `scripts/test-build-budget.sh` to clear inherited build budget and job limit environment variables (`ORBIT_BUILD_BUDGET`, `ORBIT_BUILD_BUDGET_DIR`, `ORBIT_BUILD_BUDGET_HELD`, `ORBIT_BUILD_BUDGET_SLOT`, `ORBIT_BUILD_SLOTS`, `ORBIT_CARGO_JOBS`, `CARGO_BUILD_JOBS`, and any ambient `ORBIT_BUILD_*` variables) upon startup. This ensures fixture runs remain hermetic when nested under an outer `build-budget.py` wrapper (such as in `make ci`), preventing false slot bypasses from inherited `ORBIT_BUILD_BUDGET_HELD`.

## Acceptance Criteria Mapping
- `./scripts/build-budget.py -- ./scripts/test-build-budget.sh` exits 0 on a quiet machine: Passed (confirmed exit code 0).
- `./scripts/test-build-budget.sh` still exits 0 standalone: Passed (confirmed exit code 0).
- Cross-worktree slot enforcement remains proven: with `ORBIT_BUILD_SLOTS=2`, observed max concurrency is 2: Passed (`cat $TMP/state/max` is exactly 2).
- The self-test still sets its own `ORBIT_BUILD_BUDGET_DIR` and `ORBIT_BUILD_SLOTS` and does not inherit outer wrapper's slot or lock directory: Passed (outer variables cleared before fixtures run).
- `make ci-fast` still invokes `ci-guardrails.sh --fast` without skipping this check: Passed (`test-build-budget: ok` runs and succeeds during `make ci-fast`).

## Validation Commands
- `./scripts/build-budget.py -- ./scripts/test-build-budget.sh`: Passed
- `./scripts/test-build-budget.sh`: Passed
- `ORBIT_BUILD_SLOTS=1 ORBIT_BUILD_BUDGET_DIR=/tmp/fake-dir ORBIT_CARGO_JOBS=99 ./scripts/build-budget.py -- ./scripts/test-build-budget.sh`: Passed
- `make ci-fast`: Passed
- `make ci-lint`: Passed
- `make goldens`: Passed
- `git diff --check`: Passed

## Remaining Risks or Deviations
None.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12350-6aa5b169`
- Behind base: 0
- Ahead of base: 1