### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design-patterns/error_translation.md
+++ b/docs/design-patterns/error_translation.md
@@ -1,7 +1,7 @@
 ---
 type: pattern
 summary: "Crate-Boundary Error Translation"
-last_validated: 2026-08-23
+last_validated: 2026-09-12
 ---
 # Crate-Boundary Error Translation
 
@@ -55,8 +55,8 @@ pub enum DispatchError {
 }
 ```
 
-The translator lives next to the error and preserves validation failures while
-collapsing the remaining dispatch failures:
+The translator lives next to the error and preserves validation failures and
+recoverable VCS conflicts while collapsing the remaining dispatch failures:
 
 ```rust
 pub fn dispatch_error_to_orbit(error: DispatchError) -> OrbitError {
@@ -68,6 +68,9 @@ pub fn dispatch_error_to_orbit(error: DispatchError) -> OrbitError {
     }
 }
 ```
+
+The live translator additionally preserves `DispatchError::RecoverableVcsConflict`
+as `OrbitError::RecoverableVcsConflict`.
 
 Other live translators in the same shape are `selector_error_to_orbit`
 (`orbit-common::fs::selector`) and `rpc_error_to_orbit`

--- a/docs/design-patterns/newtype.md
+++ b/docs/design-patterns/newtype.md
@@ -1,7 +1,7 @@
 ---
 type: pattern
 summary: "Newtype Wrapper"
-last_validated: 2026-08-23
+last_validated: 2026-09-12
 ---
 # Newtype Wrapper
 
@@ -37,4 +37,4 @@ The former `RefName` example was removed with the `orbit-knowledge` crate; no cu
 
 ---
 
-**Related: parsed sum-type form.** `Selector` (`crates/orbit-common/src/fs/selector.rs:40`) applies the same principle to a structured input string: `FromStr` parses `dir:`/`file:`/`symbol:` prefixes into an enum with a typed `SelectorParseError`. The enum variants have `pub` fields (a deliberate ergonomics trade for pattern matching at use sites), so the invariant is enforced by convention — every callsite uses `parse()` — rather than by visibility. Reach for this when the input has multiple legitimate shapes and pattern-matching the parsed result outweighs airtight construction.
+**Related: parsed sum-type form.** `Selector` (`crates/orbit-common/src/fs/selector.rs`) applies the same principle to a structured input string: `FromStr` parses `dir:`/`file:`/`symbol:` prefixes into an enum with a typed `SelectorParseError`. The enum variants have `pub` fields (a deliberate ergonomics trade for pattern matching at use sites), so the invariant is enforced by convention — every callsite uses `parse()` — rather than by visibility. Reach for this when the input has multiple legitimate shapes and pattern-matching the parsed result outweighs airtight construction.

--- a/docs/design-patterns/test_layout.md
+++ b/docs/design-patterns/test_layout.md
@@ -1,7 +1,7 @@
 ---
 type: pattern
 summary: "Per-Module Sibling tests/ Directory"
-last_validated: 2026-08-23
+last_validated: 2026-09-12
 ---
 # Per-Module Sibling tests/ Directory
 

--- a/docs/design/_templates/references/glossary.md
+++ b/docs/design/_templates/references/glossary.md
@@ -1,7 +1,7 @@
 ---
 type: design
 summary: "Glossary: <Feature>"
-last_validated: 2026-08-23
+last_validated: 2026-09-12
 ---
 
 # Glossary: <Feature>

--- a/docs/runbooks/logging.md
+++ b/docs/runbooks/logging.md
@@ -5,7 +5,7 @@ tags: [operations, logs, tracing, rotation, routines]
 paths: ["crates/orbit-common/src/observability/log_rotation.rs", "crates/orbit-core/src/application/routines/sweep.rs"]
 related_features: [auditability, routines]
 related_artifacts: [ORB-00423]
-last_validated: 2026-08-22
+last_validated: 2026-09-12
 ---
 
 # Inspect and Retain Logs
@@ -19,8 +19,10 @@ All Orbit processes—the CLI, `orbit web serve`, and the MCP server—append st
 events to one global JSONL sink:
 
 ```text
-~/.orbit/state/logs/orbit.jsonl        # override: $ORBIT_LOG_PATH
+~/.orbit/state/logs/orbit.jsonl        # default writer and reader path
 ```
+
+`orbit log tail` can read another sink with `--path` or `$ORBIT_LOG_PATH`.
 
 One JSON object is written per line:
 `{"timestamp", "level", "target", "fields": {..., "message"}}`. Secret-looking values
@@ -28,8 +30,8 @@ One JSON object is written per line:
 `Authorization` or `x-api-key` headers; and `sk-…` keys) are redacted before reaching the
 sink.
 
-Before diagnosing a missing or unexpected log, confirm the actual binary, effective
-`ORBIT_LOG_PATH`, `RUST_LOG`, root, and config file used by the process.
+Before diagnosing a missing or unexpected log, confirm the actual binary, reader path
+(`--path` or `$ORBIT_LOG_PATH`), `RUST_LOG`, root, and config file used by the process.
 
 ## Read and filter logs
 
@@ -64,7 +66,7 @@ log_max_total_mb = 500
 log_max_file_mb = 100
 ```
 
-Rotation is implemented in `orbit-common/src/utility/log_rotation.rs`.
+Rotation is implemented in `crates/orbit-common/src/observability/log_rotation.rs`.
 
 ## Routine sweep log on macOS
 

--- a/docs/runbooks/stuck-job-runs.md
+++ b/docs/runbooks/stuck-job-runs.md
@@ -5,7 +5,7 @@ tags: [operations, jobs, runs, recovery, debugging]
 paths: ["crates/orbit-core/src/application/job/**", "crates/orbit-cli/src/command/run/**", "crates/orbit-core/src/runtime/run_audit.rs"]
 related_features: [activity-job, auditability]
 related_artifacts: [ORB-10070, ORB-10496, ORB-10801]
-last_validated: 2026-08-22
+last_validated: 2026-09-12
 ---
 
 # Recover Stuck Job Runs
@@ -58,7 +58,8 @@ Agent: provider=codex pid=154953 step=agent_implement liveness=alive started_at=
 - `liveness=unknown` — the host cannot probe liveness. Never read this as dead.
 
 Liveness is probed when you ask, against the local process table, so it is only meaningful on
-the host that ran the child; a historical run inspected elsewhere reports `exited`. Use
+the host that ran the child; a historical run inspected elsewhere may report `exited` or
+`unknown` depending on what that host can observe. Use
 `orbit run show --json` for the full records (`pid`, `pid_start_time`, `step_id`, `finished`),
 or `orbit run events <run_id> --type cli.invocation.process` for the raw audit events.
 
@@ -89,13 +90,13 @@ or reboot without finalizing the run. A job that genuinely failed is `failed`;
 
 ## Understand orphan reconciliation
 
-Every run records its owner `pid` plus a pid-start-time token. Pipeline workers claim their
-queued run at startup, so `pending` runs carry an owner too [ORB-10070]. A reconcile pass
-probes liveness and finalizes conclusively orphaned runs to `interrupted`, releasing their
-task reservations:
+Newly submitted runs record their owner `pid` plus a pid-start-time token. Pipeline workers
+claim their queued run at startup, so `pending` runs may carry an owner too [ORB-10070]. A
+reconcile pass probes the owner and any recorded provider child, then finalizes conclusively
+orphaned runs to `interrupted`, releasing their task reservations:
 
-- `running` runs with a dead owner;
-- `pending` runs whose claimed worker died; and
+- `running` runs with a dead owner and no live or unverifiable provider child;
+- `pending` runs whose claimed worker died and have no live or unverifiable provider child; and
 - `pending` runs never claimed within a 30-minute grace window, such as queued children
   stranded when their parent run was interrupted by a reboot.
 
@@ -132,7 +133,7 @@ names each child it dispatched, to establish their lineage.
 After verifying that the owner is gone or that the run should no longer continue:
 
 ```sh
-orbit run cancel <run_id>
+orbit run cancel <run_id> --confirm
 ```
 
 This terminalizes the run on demand. Do not cancel solely because a legitimate step has
@@ -159,7 +160,7 @@ Three differences matter when triaging one:
   destination-resolved caller machine ID, invocation mode, and actual identity proof:
   strict grants are `key-bound`; explicitly cooperative same-OS-account SSH grants are
   `cooperative` and `self-asserted`.
-- **Cancel it the ordinary way.** `orbit run cancel <run_id>` signals the owner process
+- **Cancel it the ordinary way.** `orbit run cancel <run_id> --confirm` signals the owner process
   (TERM then KILL) and terminates the process tree, exactly as for any other run.
 - **It cannot be resumed.** `orbit job resume` and `submit_resume_run` refuse a run that
   carries an admission, because that admission covered one invocation and a resume would


### PR DESCRIPTION
## Task

[ORB-12345](https://orbit-cli.com/tasks/ORB-12345) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: completed the bounded documentation rotation for 2026-09-12.

Batch selection and scope:
- Inventory command: `rg --files docs -g '*.md' | sort`, followed by frontmatter extraction and stable path sorting. The six oldest editable in-scope Markdown docs were exactly:
  1. `docs/runbooks/logging.md` (last_validated 2026-08-22)
  2. `docs/runbooks/stuck-job-runs.md` (2026-08-22)
  3. `docs/design-patterns/error_translation.md` (2026-08-23)
  4. `docs/design-patterns/newtype.md` (2026-08-23)
  5. `docs/design-patterns/test_layout.md` (2026-08-23)
  6. `docs/design/_templates/references/glossary.md` (2026-08-23)
- Missing last_validated values would sort first; the inventory found no frontmatter-less Markdown docs. The design template is eligible because the default docs walker includes it, its existing type/summary are schema-valid, and its template structure was checked against docs/design/CONVENTIONS.md. No frontmatter migration was needed.
- docs/design/activity-job/1_overview.md and 3_vision.md were the next dated documents and were deliberately not part of this six-document batch. docs/INDEX.md was inventory-only/generated and remained untouched.

Document results and verification evidence:
- logging.md: corrected the stale rotation path from orbit-common/src/utility to crates/orbit-common/src/observability/log_rotation.rs, and clarified that ORBIT_LOG_PATH is a log-tail reader override rather than the process writer path. Verified with `rg -n "ORBIT_LOG_PATH|log_max_|sweep_log_path"` across logging, rotation, config, and routine sources; `orbit log tail --help`; and `orbit sweep --help`.
- stuck-job-runs.md: added the required `--confirm` flag to cancellation commands, corrected remote historical liveness wording to allow exited/unknown, and documented the provider-child guard used by orphan reconciliation. Verified with `orbit run cancel --help`, `orbit job run --help`, `orbit activity --help`, and `rg -n "reconcile_stale_job_runs|provider_evidence_allows_orphan_finalization|PENDING_RUN_UNCLAIMED_GRACE_MINUTES|claim_pending_job_run_owner"` across the run, owner, query, and worker sources.
- error_translation.md: corrected the live translator description to include RecoverableVcsConflict preservation and named the corresponding OrbitError mapping. Verified with `rg -n "RecoverableVcsConflict|dispatch_error_to_orbit|selector_error_to_orbit|rpc_error_to_orbit"` across dispatcher, selector, and RPC sources; the error-translation guard also passed.
- newtype.md: removed a brittle stale line-number anchor while retaining the verified Selector path and API claim. Verified with `rg -n "pub enum Selector|SelectorParseError|impl FromStr for Selector"` in crates/orbit-common/src/fs/selector.rs and a workspace search confirming no current orbit-knowledge crate or RefName implementation.
- test_layout.md: no prose change was needed after checking the sibling test declarations and layouts in orbit-mcp and orbit-registry. Verified with `rg -n "mod tests;|tests/(name_map|schema|dispatch|structured)|remote/tests|workspace_registry"`.
- docs/design/_templates/references/glossary.md: no content change was needed; the existing type: design, summary, placeholder glossary structure, and template role were verified with `nl -ba docs/design/_templates/references/glossary.md` and the template references in docs/design/CONVENTIONS.md. It was stamped only after that check.

Unvalidated items:
- No selected document or selected claim was left unvalidated. No selected document had uncertain classification. No frontmatter-less document was selected, so no inferred type/summary or migration was performed. Historical task references were retained as provenance.
- No document outside the six-document batch was modified; no new document, section, metadata field, sidecar, or validation-marker system was introduced.

Acceptance mapping:
1-2. Exactly six were selected by missing-then-oldest date with stable path tie-break, and every stamped document has the verification evidence above.
3, 6-7. Nothing selected was left unvalidated; all existing frontmatter was retained and only last_validated was updated after verification.
4. Final diff contains only the six selected docs; no .orbit/adrs, CHANGELOG.md, docs/changelogs, docs/design/_archive, docs/INDEX.md, or other generated state changed.
5. The inventory honored the never-validated-first rule; none were frontmatter-less.
8-10. Only existing frontmatter dates and narrowly justified stale-claim/path/command corrections changed; no new prose section or prose reflow was made.
11. `make ci-fast` passed.

Validation:
- `make ci-fast`: passed. Its compiler-cache namespace subcheck reported an environment skip because bubblewrap could not create a mount namespace (`No permissions to create new namespace`); all other fast guardrails passed. Namespace-specific behavior remains unexercised on this host.
- `git diff --check`: passed.
- `git status --short`: passed; expected six modified Markdown files and no untracked paths.
- Final diff review: 6 files, 28 insertions, 22 deletions.
- Friction checkpoint: filed F2026-09-153 documenting the non-obvious inclusion of authoring templates versus generated docs/INDEX.md.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12345-6aa5ae86`
- Behind base: 0
- Ahead of base: 1