### PR TITLE
Prepare v0.22.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,21 @@
 # Changelog
 
-## Unreleased
+## 0.22.0
+
+### Breaking Changes
+
+- **Task start and approve tools consolidated**: `orbit task start` CLI command and `orbit.task.start` / `orbit.task.approve` MCP tools are removed in favor of `orbit.task.update`. ([ORB-12268])
+- **Operation tools withdrawn from MCP**: all five `orbit.operation.*` tools are removed from the MCP surface; operations are managed via the Orbit CLI. ([ORB-12267])
+- **MCP task listing response shape updated**: `orbit.task.list` returns `{ tasks, total, truncated }` instead of `{ items }`; update MCP callers to consume the `tasks` array. ([ORB-12195])
+- **Routine hosts and source role configuration removed**: routine `hosts:` pins and `[routines] role = "source"` configuration schemas are removed in favor of host clock consolidation. ([ORB-12236])
 
 ### Highlights
 
 - **Dashboard inline task editors**: the expanded task detail edits complexity, description, tags, acceptance criteria, and context files in place, each saved as a single-field `PATCH /api/tasks/:id` with inline errors and an allow-missing-context escape. ([ORB-12235])
+- **Unified host clock consolidation**: `orbit clock tick` evaluates routines and auto-tasks in a single host loop, retiring separate auto-task schedulers and simplifying multi-host execution. ([ORB-12237])
+- **Owner-wins cross-host task sync**: cross-host synchronization safely imports foreign-prefix task bundles while preserving local task state and preventing overwrites. ([ORB-12126])
+- **Delivery auto-task reset and self-healing**: added `auto-task reset` and automated replay proof for diverged history recovery instead of silent per-tick deferrals. ([ORB-12346])
+- **Effective provider sandbox visibility**: `orbit.agent.invoke` surfaces the active execution sandbox and warns when running under full-access mode. ([ORB-12249])
 
 ## 0.21.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,7 +2094,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbit-agent"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-automation"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cli"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cmd"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "chrono",
  "flate2",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-common"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-config"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "orbit-common",
  "orbit-types",
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-core"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -2264,7 +2264,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-engine"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-exec"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "libc",
  "orbit-common",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-mcp"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2323,7 +2323,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-policy"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-registry"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "chrono",
  "hostname",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-search"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-store"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-tools"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-types"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2429,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-web"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.21.0"
+version = "0.22.0"
 edition = "2024"
 license = "MIT"
 # MSRV [ORB-10010]: edition 2024 requires >= 1.85; the highest `rust-version`

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbit-tools/cli",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "mcpName": "io.github.constellation-works/orbit",
   "description": "npm proxy for the Orbit CLI. Downloads the matching native binary from GitHub Releases on install and forwards all invocations.",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface, skills, and orchestration subagents to Claude Code.",
   "author": {
     "name": "constellation-works",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP task and knowledge surface plus workflow skills to Codex.",
   "author": {
     "name": "constellation-works",
@@ -20,7 +20,7 @@
   "mcpServers": {
     "orbit": {
       "command": "npx",
-      "args": ["-y", "@orbit-tools/cli@0.21.0", "mcp", "serve"]
+      "args": ["-y", "@orbit-tools/cli@0.22.0", "mcp", "serve"]
     }
   },
   "interface": {

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "orbit": {
       "command": "npx",
-      "args": ["-y", "@orbit-tools/cli@0.21.0", "mcp", "serve"]
+      "args": ["-y", "@orbit-tools/cli@0.22.0", "mcp", "serve"]
     }
   }
 }

--- a/plugin/mcp.json
+++ b/plugin/mcp.json
@@ -4,7 +4,7 @@
     "orbit": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@orbit-tools/cli@0.21.0", "mcp", "serve"]
+      "args": ["-y", "@orbit-tools/cli@0.22.0", "mcp", "serve"]
     }
   }
 }

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "orbit",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface and shared workflow skills to compatible clients.",
   "author": {
     "name": "constellation-works",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/constellation-works/orbit",
     "source": "github"
   },
-  "version": "0.21.0",
+  "version": "0.22.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@orbit-tools/cli",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Task

[ORB-12399](https://orbit-cli.com/tasks/ORB-12399) — Prepare v0.22.0 release

### Description

Prepare the candidate release for v0.22.0 following RELEASING.md and docs/runbooks/release.md.

## Release Context
- Previous reachable release tag: `v0.21.0`
- Candidate version: `0.22.0` (pre-1.0 semver minor bump due to breaking changes)
- Surveyed range: `v0.21.0..HEAD` (165 commits)

## Breaking Change Candidates Flagged in Survey
1. **ORB-12268** (commit `c26f6bb00`): Removed CLI command `orbit task start`. Removed MCP tools `orbit.task.approve` and `orbit.task.start` in favor of `orbit.task.update`.
2. **ORB-12267** (commit `432a8f1ff`): Withdrew all 5 `orbit.operation.*` verbs (`enable`, `explain`, `list`, `revoke`, `stop`) from the MCP surface.
3. **ORB-12195** (commit `58f7295d4`): Changed MCP `orbit.task.list` response shape from `{ items: [...] }` to `{ tasks: [...], total, truncated }`.
4. **ORB-12236** (commit `9365d1f46`): Clock consolidation (1/2): removed routine `hosts:` pins and `[routines] role = "source"` configuration/YAML schema.

## Instructions
Follow the runbook in RELEASING.md and docs/runbooks/release.md:
- Confirm breaking changes with the human before drafting the final CHANGELOG.md entry.
- Update version-bearing files (Cargo.toml, npm/package.json, server.json, plugin manifests, MCP pins) and refresh Cargo.lock with `cargo update --workspace`.
- Run `scripts/sync-plugin-skills.sh` and verify mirror sync.
- Run verification checks: `make release-check`, `./scripts/smoke-plugin-install.sh`, `./scripts/smoke-npm-install.sh --dry-run-version-assertion`, `make ci-fast`, `make ci-lint`.
- The task stops before commits, tags, pushes, publishing, branch promotion, version bumps, or CHANGELOG edits, and points to RELEASING.md for final procedures.

### Acceptance Criteria

- Cargo.toml, Cargo.lock, npm/package.json, server.json, and all plugin manifests consistently identify version 0.22.0 without third-party dependency drift in Cargo.lock.
- CHANGELOG.md includes a compiled ## 0.22.0 section covering breaking changes and highlights since v0.21.0 per RELEASING.md, with no historical sections modified or archived.
- Release verification passes cleanly: make release-check, scripts/sync-plugin-skills.sh --check, scripts/smoke-plugin-install.sh, scripts/smoke-npm-install.sh --dry-run-version-assertion, make ci-fast, and make ci-lint.
- The executor follows RELEASING.md and stops before commits, tags, pushes, publishing, branch promotion, version bumps, or CHANGELOG edits without prior authorization.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Exact source and version:
- Previous release baseline: v0.21.0
- Target version: 0.22.0
- Base commit: 443479a5b4ea9e1be23c7e07ce8be3d81c788b10 (165 commits since v0.21.0)

Scope of changes:
- Cargo.toml: bumped [workspace.package].version from 0.21.0 to 0.22.0.
- Cargo.lock: refreshed 17 Orbit workspace member versions to 0.22.0 via `cargo update --workspace` without third-party dependency drift.
- npm/package.json: bumped version from 0.21.0 to 0.22.0.
- server.json: bumped top-level version and packages[0].version from 0.21.0 to 0.22.0.
- plugin/.claude-plugin/plugin.json: bumped version from 0.21.0 to 0.22.0.
- plugin/.codex-plugin/plugin.json: bumped version to 0.22.0 and MCP args launch pin to @orbit-tools/cli@0.22.0.
- plugin/plugin.json: bumped version from 0.21.0 to 0.22.0.
- plugin/mcp.json and plugin/.mcp.json: bumped MCP args launch pin to @orbit-tools/cli@0.22.0.
- scripts/sync-plugin-skills.sh: synchronized and verified plugin skills mirror.
- CHANGELOG.md: compiled and inserted ## 0.22.0 section with 4 breaking changes (task start/approve tools consolidated into update, operation verbs withdrawn from MCP, MCP task listing response shape updated to tasks envelope, routine hosts and source role removed for clock consolidation) and 5 highlights (dashboard inline task editors, unified host clock consolidation, owner-wins cross-host sync, delivery auto-task reset and self-healing, effective provider sandbox visibility). Historical sections from 0.21.0 downwards remain byte-identical without archiving.

Acceptance criteria mapping:
1. Version consistency and no lock drift: PASSED. All 10 version-bearing files and manifests identify 0.22.0; Cargo.lock refreshed with exactly 17 workspace member updates and zero third-party drift.
2. CHANGELOG compilation: PASSED. ## 0.22.0 compiled with breaking changes and highlights since v0.21.0 per RELEASING.md; historical sections unmodified and not archived; style check scripts/check-changelog-style.sh passes.
3. Release verification: PASSED. All required suites executed and passed.
4. Stop before commit/tag/push/publish: PASSED. Changes left uncommitted in worktree; stops before commit, tag, push, publication, or branch promotion per RELEASING.md.

Validation:
- PASSED: scripts/sync-plugin-skills.sh --check (clean committed plugin skill mirror match).
- PASSED: scripts/smoke-plugin-install.sh (Claude Code, Codex, and Cursor plugin install and manifest validation).
- PASSED: scripts/smoke-npm-install.sh --dry-run-version-assertion (mismatched version rejection verified).
- PASSED: make ci-fast (guardrails, asset sync, manifests, doc indexes, plugin smoke, budget/cache tests passed).
- PASSED: make ci-lint (full clippy check across all workspace crates and targets with -D warnings passed in 1m 12s with 0 warnings).
- PASSED: make release-check local verification (all 6 local sources agree on 0.22.0 and launch pins match @orbit-tools/cli@0.22.0). Pre-release limitation: gh release list reports latest published tag v0.21.0 and npm registry is unreachable/unpublished, as expected before release per docs/runbooks/release.md §4.
- PASSED: git diff --check (clean, no trailing whitespace or conflict markers).
- PASSED: git status --short (cleanly modified exactly 10 declared tracked context files, 0 untracked files).
- NOT RUN: make ci (full CI suite reserved for CI pipeline per AGENTS.md policy).
- NOT RUN: git commit, git tag, git push, npm publish, gh release (human/operator-owned downstream steps).

Operator handoff:
- Worktree is ready and clean of untracked files.
- Downstream delivery pipeline will commit, push, and open PR targeting agent-main.
- Post-merge steps follow RELEASING.md and docs/runbooks/release.md: tag v0.22.0, publish npm package @orbit-tools/cli@0.22.0, submit Cursor marketplace follow-up, promote agent-main -> main, and back-merge main -> agent-main.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-12399-6aa5e533`
- Behind base: 0
- Ahead of base: 1