### PR TITLE
feat(auto-tasks): attribute review and CI findings with regression_from

### DIFF
--- a/.orbit/auto_tasks/ci-failure-remediation.yaml
+++ b/.orbit/auto_tasks/ci-failure-remediation.yaml
@@ -67,6 +67,24 @@ template:
     or otherwise obtain green CI by hiding the failure. Informational checks
     remain informational, but they must execute successfully.
 
+    ## Attribute each regression to the task that introduced it
+
+    For every current repository-owned root cause, identify the task whose
+    landed change broke the check. Walk back from the tested checkout commit
+    to the newest commit at which the failing command still passed; the
+    commit that broke it is the culprit, and squash-merge subjects carry its
+    task ID as `[<task-id>]`. Confirm with `orbit tool run orbit.task.show
+    --input '{"id":"<task-id>"}'` that its change is the one at fault rather
+    than a later commit that merely touched the same file. Record the link on
+    this task with `orbit tool run orbit.task.update --input
+    '{"id":"<this task ID>","relations":[<existing relations from
+    orbit.task.show>,{"type":"regression_from","target":"<culprit task
+    ID>"}]}'` — one `regression_from` entry per culprit, and `relations`
+    replaces the whole list, so carry existing entries forward. When the
+    culprit commit carries no task ID, or the failure is transient
+    infrastructure, record that conclusion and its evidence in the execution
+    summary instead of blaming a bystander task.
+
     ## Validation and handoff
 
     For each fixed root cause, rerun the exact command that formerly failed.
@@ -80,7 +98,8 @@ template:
     Persist an `execution_summary` that maps every investigated run/job URL,
     reported head SHA, actual checkout commit, and current ref head to its
     root-cause cluster, disposition (fixed, stale, superseded, or transient),
-    change, local reproduction, exact formerly failing validation, pre-handoff
+    change, culprit task (the `regression_from` target, or why there is none),
+    local reproduction, exact formerly failing validation, pre-handoff
     result, and green GitHub rerun URL. Also map any matching PR-hook-created
     Orbit task. For a successful no-diff pass, list the queries, current heads,
     superseding successes or transient evidence, and why no repository-owned
@@ -110,6 +129,7 @@ template:
   - Every investigated run records its reported SHA, actual checkout commit, current ref head, failed job/step, exact log evidence, and stale or superseding evidence where applicable.
   - Repeated red runs are clustered by root cause, and every current repository-owned failure is reproduced and fixed without weakening or bypassing a check.
   - Transient-only classifications cite infrastructure evidence and a successful same-SHA retry; a single non-reproduction is not treated as sufficient evidence.
+  - Each fixed repository-owned cause is linked from this task by a `regression_from` relation targeting the task whose landed commit introduced it, or the execution_summary states why no task can be held responsible.
   - Each fixed cause passes the exact formerly failing validation and make ci-fast, and every affected required or informational GitHub Actions check executes successfully on the candidate commit.
   - The persisted execution_summary maps each run/job URL and SHA to its root cause, disposition, change, validations, green rerun, and any matching PR-hook task.
   - A no-current-failure or transient-only investigation is a successful no-diff outcome when its current-head queries and superseding or transient evidence are persisted.

--- a/.orbit/auto_tasks/code-review.yaml
+++ b/.orbit/auto_tasks/code-review.yaml
@@ -29,7 +29,8 @@ template:
       and list open review work with
       `orbit tool run orbit.task.list --input '{"status":["backlog","in-progress","proposed","blocked"],"tag":"code-review","model":"<agent-family>"}'`.
       File a finding with
-      `orbit tool run orbit.task.add --input '{"title":"<title>","description":"<markdown>","acceptance_criteria":["<observable outcome>"],"complexity":"medium","tags":["code-review"],"priority":"<low|medium|high|critical>","type":"bug","workspace":"<current workspace path>","model":"<agent-family>"}'`.
+      `orbit tool run orbit.task.add --input '{"title":"<title>","description":"<markdown>","acceptance_criteria":["<observable outcome>"],"complexity":"medium","tags":["code-review"],"priority":"<low|medium|high|critical>","type":"bug","relations":[{"type":"regression_from","target":"<culprit task ID>"}],"workspace":"<current workspace path>","model":"<agent-family>"}'`.
+      Omit `relations` only when no task in the window can be held responsible.
       Do not use direct lifecycle CLI subcommands; they skip agent provenance.
     - Fail open. A window with no confirmed findings is a successful no-op. Do not
       invent work to justify the run.
@@ -51,13 +52,30 @@ template:
     guide, lint configuration). Review the window as a whole — interactions between
     separately merged changes are findings per-change review cannot see.
 
+    ## Attribute each finding to the task that introduced it
+
+    Every finding is a regression from a change that landed in the window, so
+    name the task that caused it. Find the commit that introduced the defect
+    (`git log -L` or `git blame` on the offending lines, restricted to the
+    reviewed range) and read the task ID from that commit: squash-merge subjects
+    carry it as `[<task-id>]`, and the delivery's pull request references it
+    otherwise. Confirm with `orbit.task.show` that the task exists and that its
+    change is the one at fault — blame the commit that introduced the defect, not
+    a later commit that merely touched the same file. When the defect spans
+    several tasks' changes, blame the one whose change made the code wrong.
+    When the culprit commit carries no task ID, or the defect predates the
+    window and was only exposed by it, say so in the finding and file it without
+    the relation rather than blaming a bystander.
+
     ## File confirmed findings
 
     Verify every finding against the live code before filing — a diff that looks
     wrong but is guarded elsewhere is not a finding. Search open Orbit tasks tagged
     `code-review` before filing; skip duplicates and nitpicks. File each confirmed
     finding as its own Orbit task with file:line evidence, a severity-appropriate
-    priority, and the `code-review` tag.
+    priority, the `code-review` tag, and a `regression_from` relation targeting
+    the task identified above. The finding's description names the culprit task
+    and the commit that introduced the defect.
 
     ## Record the cursor
 
@@ -66,6 +84,7 @@ template:
   acceptance_criteria:
   - The review window was derived from the previous sweep's recorded cursor, or the current HEAD was seeded as the baseline on the first run.
   - Every filed finding was verified against live code, is non-duplicate, and carries file:line evidence with a severity-appropriate priority and the `code-review` tag.
+  - Every filed finding carries a `regression_from` relation targeting the task whose landed commit introduced the defect, or its description states why no task in the window can be held responsible.
   - The reviewed range and the new last-reviewed commit are recorded in the persisted execution summary.
   - A window with no confirmed findings succeeds as a no-op.
   task_type: chore

--- a/crates/orbit-core/assets/auto_tasks/code-review.yaml
+++ b/crates/orbit-core/assets/auto_tasks/code-review.yaml
@@ -29,7 +29,8 @@ template:
       and list open review work with
       `orbit tool run orbit.task.list --input '{"status":["backlog","in-progress","proposed","blocked"],"tag":"code-review","model":"<agent-family>"}'`.
       File a finding with
-      `orbit tool run orbit.task.add --input '{"title":"<title>","description":"<markdown>","acceptance_criteria":["<observable outcome>"],"complexity":"medium","tags":["code-review"],"priority":"<low|medium|high|critical>","type":"bug","workspace":"<current workspace path>","model":"<agent-family>"}'`.
+      `orbit tool run orbit.task.add --input '{"title":"<title>","description":"<markdown>","acceptance_criteria":["<observable outcome>"],"complexity":"medium","tags":["code-review"],"priority":"<low|medium|high|critical>","type":"bug","relations":[{"type":"regression_from","target":"<culprit task ID>"}],"workspace":"<current workspace path>","model":"<agent-family>"}'`.
+      Omit `relations` only when no task in the window can be held responsible.
       Do not use direct lifecycle CLI subcommands; they skip agent provenance.
     - Fail open. A window with no confirmed findings is a successful no-op. Do not
       invent work to justify the run.
@@ -51,13 +52,30 @@ template:
     guide, lint configuration). Review the window as a whole — interactions between
     separately merged changes are findings per-change review cannot see.
 
+    ## Attribute each finding to the task that introduced it
+
+    Every finding is a regression from a change that landed in the window, so
+    name the task that caused it. Find the commit that introduced the defect
+    (`git log -L` or `git blame` on the offending lines, restricted to the
+    reviewed range) and read the task ID from that commit: squash-merge subjects
+    carry it as `[<task-id>]`, and the delivery's pull request references it
+    otherwise. Confirm with `orbit.task.show` that the task exists and that its
+    change is the one at fault — blame the commit that introduced the defect, not
+    a later commit that merely touched the same file. When the defect spans
+    several tasks' changes, blame the one whose change made the code wrong.
+    When the culprit commit carries no task ID, or the defect predates the
+    window and was only exposed by it, say so in the finding and file it without
+    the relation rather than blaming a bystander.
+
     ## File confirmed findings
 
     Verify every finding against the live code before filing — a diff that looks
     wrong but is guarded elsewhere is not a finding. Search open Orbit tasks tagged
     `code-review` before filing; skip duplicates and nitpicks. File each confirmed
     finding as its own Orbit task with file:line evidence, a severity-appropriate
-    priority, and the `code-review` tag.
+    priority, the `code-review` tag, and a `regression_from` relation targeting
+    the task identified above. The finding's description names the culprit task
+    and the commit that introduced the defect.
 
     ## Record the cursor
 
@@ -66,6 +84,7 @@ template:
   acceptance_criteria:
   - The review window was derived from the previous sweep's recorded cursor, or the current HEAD was seeded as the baseline on the first run.
   - Every filed finding was verified against live code, is non-duplicate, and carries file:line evidence with a severity-appropriate priority and the `code-review` tag.
+  - Every filed finding carries a `regression_from` relation targeting the task whose landed commit introduced the defect, or its description states why no task in the window can be held responsible.
   - The reviewed range and the new last-reviewed commit are recorded in the persisted execution summary.
   - A window with no confirmed findings succeeds as a no-op.
   task_type: chore

--- a/crates/orbit-core/assets/auto_tasks/delivery-code-review.yaml
+++ b/crates/orbit-core/assets/auto_tasks/delivery-code-review.yaml
@@ -16,6 +16,16 @@ template:
     Review the entire captured code range for correctness, concurrency, error handling and repository standards. Verify findings against the pinned source, search for duplicates and file confirmed findings with precise evidence.
     Use only the frozen automation input appended to this task. Examine every
     captured commit, including unattributed neighbors. Findings may remain open.
+    Attribute every finding to the task that introduced it: locate the commit
+    that made the code wrong, then read its task from the frozen input — each
+    `deliveries[]` entry lists its `commits` and the `task_ids` that landed them.
+    File each confirmed finding with `orbit.task.add` as a `bug` tagged
+    `delivery-code-review`, carrying `relations: [{"type": "regression_from",
+    "target": "<culprit task ID>"}]`. A defect in an unattributed neighbor
+    commit, or one that predates the batch and was merely exposed by it, is filed
+    without the relation and says so — never blame a bystander delivery. Name the
+    culprit task and commit in the finding's description and in the evidence
+    finding text.
     Complete the supplied evidence template, replace action_id with this task ID,
     and attach automation-coverage.json through orbit.task.artifact.put in this
     task's assigned executor run. Supply actual checks (subject, method,
@@ -24,6 +34,7 @@ template:
   acceptance_criteria:
   - Every captured obligation is examined at the exact supplied revisions.
   - Concrete checks and findings are attached as valid automation-coverage.json evidence.
+  - Every filed finding carries a `regression_from` relation targeting the delivery task whose commit introduced the defect, or states why no captured delivery can be held responsible.
   - Missing or skipped examination remains explicitly incomplete.
   task_type: chore
   tags:

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -1369,6 +1369,11 @@ impl FailureCluster {
              is reproduced and then passes locally."
                 .to_string(),
             "The repository's documented pre-handoff gate passes.".to_string(),
+            "This task carries a `regression_from` relation targeting the task whose landed \
+             commit introduced the failure, or its execution summary states why no task can \
+             be held responsible (no task ID on the culprit commit, or the failure is \
+             infrastructure rather than repository-owned)."
+                .to_string(),
             "If the failure turns out to be infrastructure rather than repository-owned, the \
              execution summary cites concrete evidence for that (a same-commit retry that \
              succeeded, or runner/service fault output) rather than a single non-reproduction."
@@ -1569,7 +1574,23 @@ impl FailureCluster {
              broad allow rule, or mark a failing gate non-blocking. Then run the repository's \
              documented pre-handoff gate. Verification happens on this task's own pull request: \
              CI runs there normally, and if the failure is still current the next sweep will see \
-             it again.\n",
+             it again.\n\
+             \n\
+             ## Attribute the regression\n\
+             \n\
+             Identify the task whose landed change introduced this failure and record it on \
+             this task. Start from the commit the runner checked out and walk back to the \
+             newest commit at which the failing command last passed; the commit that broke it \
+             is the culprit. Read the task ID from that commit — squash-merge subjects carry \
+             it as `[<task-id>]` — and confirm with `orbit tool run orbit.task.show --input \
+             '{\"id\":\"<task-id>\"}'` that its change is the one at fault, not a later commit \
+             that merely touched the same file. Then set the relation with `orbit tool run \
+             orbit.task.update --input '{\"id\":\"<this task ID>\",\"relations\":[<existing \
+             relations from orbit.task.show>,{\"type\":\"regression_from\",\"target\":\"<culprit \
+             task ID>\"}]}'` — `relations` replaces the whole list, so carry the existing \
+             entries forward. When the culprit commit carries no task ID, or the failure is \
+             infrastructure rather than repository-owned, record that conclusion and its \
+             evidence in the execution summary instead of blaming a bystander task.\n",
         );
         out
     }


### PR DESCRIPTION
## Summary
- **code-review** (embedded asset + repo-local copy): new "Attribute each finding to the task that introduced it" step — find the culprit commit with `git log -L`/`git blame` within the reviewed range, read the task ID from the `[<task-id>]` squash-merge subject, confirm via `orbit.task.show`, then file the finding with `relations: [{"type":"regression_from","target":"<culprit>"}]`. New acceptance criterion for the link.
- **delivery-code-review**: same rule, using the frozen input's `deliveries[].task_ids` ↔ `commits` mapping; findings on unattributed neighbor commits are filed without the relation and say so.
- **CI-failure sweep** (`ci_failure_tasks.rs` description + acceptance criteria): repair agent walks back from the tested checkout to the last green commit, identifies the culprit task, and sets `regression_from` on the repair task via `orbit.task.update` (carrying existing `relations` forward since it replaces the list). Infrastructure/no-task-ID cases record the conclusion in the execution summary instead.
- **ci-failure-remediation** (repo-local): one `regression_from` per fixed root cause, plus the culprit task in the execution-summary mapping.

Motivation: `orbit-evals` only counts a regression when a later task links to the culprit with `regression_from`; unlinked regressions land on no family and are nobody's.

## Test plan
- [x] `cargo nextest run -p orbit-core ci_failure auto_task managed_asset workspace_sync shipped` — 178 passed (incl. `code_review_default_is_portable_cursor_driven_and_inert`, which pins repo-local ↔ embedded sync)
- [x] `cargo clippy -p orbit-core --all-targets -- -D warnings` clean
- [x] Rendered the CI-failure task description to check the escaped JSON reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)